### PR TITLE
Clear two high-severity npm advisories

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,3 +17,7 @@
 # TypeGen output: dotnet-typegen (Windows) writes CRLF and regenerates on every build.
 # Pin these to CRLF so the generated files don't show up as modified after each build.
 src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated/** text eol=crlf
+
+# npm writes this one; it still has to be committed (it pins every transitive version, which is
+# what makes builds reproducible and `npm audit` meaningful) — just collapsed in diffs.
+src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/package-lock.json linguist-generated=true

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/package-lock.json
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/package-lock.json
@@ -527,9 +527,9 @@
             }
         },
         "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-            "version": "1.1.14",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -609,9 +609,9 @@
             }
         },
         "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-            "version": "1.1.14",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1432,9 +1432,9 @@
             }
         },
         "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "1.1.14",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1676,9 +1676,9 @@
             }
         },
         "node_modules/glob/node_modules/brace-expansion": {
-            "version": "1.1.14",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1838,10 +1838,20 @@
             "license": "ISC"
         },
         "node_modules/js-yaml": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"


### PR DESCRIPTION
Closes #1
Closes #2

Dependabot opened both. `npm audit fix` resolves them together without touching `package.json`.

## Exposure

Both `js-yaml` and `brace-expansion` reach us only through `eslint`, which is a **devDependency** — verified with `npm ls`. Neither appears in the runtime dependency tree, so neither ends up in the bundle shipped to users.

They are still worth clearing: the repo is public, and two open high-severity alerts are the first thing a careful reader checks before installing an extension that touches their code.

## What changed

Only `package-lock.json` — transitive pins move, `package.json` is untouched:

| | from | to |
|---|---|---|
| `js-yaml` | 4.1.1 | 4.3.0 |
| `brace-expansion` | 1.1.14 | 1.1.16 |

This deliberately avoids Dependabot’s route through an eslint 8 → 10 major, which is still blocked on the TypeScript 7 upgrade (`typescript-eslint` does not support TS7 yet).

The lockfile is also marked `linguist-generated` so its 2469 lines collapse in diffs. It stays tracked — pinning every transitive version is exactly what made this fix possible.

## Verification

`npm audit`: **0 vulnerabilities** (was 2 high). Lint unchanged (0 errors, the same 7 pre-existing `no-explicit-any` warnings), typecheck clean, Release build green.