### PR TITLE
Check pull requests in CI

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,96 @@
+name: Quality
+
+on:
+  pull_request:
+    branches: ["master"]
+  push:
+    branches: ["master"]
+  workflow_dispatch:
+
+jobs:
+  webview:
+    name: WebView (TypeScript)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/package-lock.json
+
+      # ci, not install: fails if package.json and the lockfile disagree, which is the point of
+      # committing the lockfile in the first place.
+      - run: npm ci
+
+      # bridge-messages.ts is generated from Host/BridgeMessages.cs and committed. Nothing stops
+      # someone editing the C# and forgetting to regenerate: the stale .ts would still typecheck.
+      # Regenerating and diffing catches that.
+      - name: Bridge messages are up to date
+        run: |
+          npm run gen-bridge
+          git diff --exit-code -- core/bridge-messages.ts \
+            || { echo "::error::bridge-messages.ts is stale — run 'npm run build' and commit it"; exit 1; }
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Format check
+        run: npm run format:check
+
+      # devDependency advisories don't reach the shipped bundle, so they don't fail the build --
+      # but they should be visible in the log rather than found by someone reading the repo.
+      - name: Audit (advisory only)
+        run: npm audit --audit-level=moderate
+        continue-on-error: true
+
+  build:
+    name: Build VSIX
+    # A VSIX needs MSBuild and the VS SDK: .NET Framework 4.8 can't be built on Linux.
+    runs-on: windows-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+
+      # CodeQL needs to watch the compiler work, so it wraps the build below rather than
+      # running on its own.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: csharp
+
+      - uses: microsoft/setup-msbuild@v2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/package-lock.json
+
+      - name: Restore
+        run: msbuild cv4vs-agents.sln -t:Restore -p:Configuration=Release -v:minimal
+
+      # Release also runs the version guard in Directory.Build.targets: the build fails if
+      # Directory.Build.props, the manifest and AssemblyInfo have drifted apart.
+      - name: Build
+        run: msbuild cv4vs-agents.sln -t:Build -p:Configuration=Release -p:DeployExtension=false -v:minimal
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+
+      - name: Upload VSIX
+        uses: actions/upload-artifact@v4
+        with:
+          name: cv4vs-agents-vsix
+          path: src/Corsinvest.VisualStudio.Agents/bin/Release/*.vsix
+          if-no-files-found: error

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/.prettierrc.json
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/.prettierrc.json
@@ -3,5 +3,6 @@
     "tabWidth": 4,
     "trailingComma": "all",
     "printWidth": 100,
-    "semi": true
+    "semi": true,
+    "endOfLine": "auto"
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-prompt.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-prompt.ts
@@ -306,9 +306,8 @@ export class CvPrompt extends LitElement implements CommandHost {
     @query('cv-at-menu') private _atMenu!: import('./cv-at-menu').CvAtMenu;
     @query('cv-command-menu') private _cmdMenu?: import('./cv-command-menu').CvCommandMenu;
     @query('cv-model-list') private _modelList?: import('./cv-model-list').CvModelList;
-    @query('cv-permission-list') private _permissionList?: import(
-        './cv-permission-list'
-    ).CvPermissionList;
+    @query('cv-permission-list')
+    private _permissionList?: import('./cv-permission-list').CvPermissionList;
 
     private _offBusy?: () => void;
     private _offPerm?: () => void;


### PR DESCRIPTION
Modelled on `cv4pve-admin`’s `quality.yml`, but it could not be copied: that one builds .NET on `ubuntu-latest`, and a VSIX targeting .NET Framework 4.8 needs MSBuild and the VS SDK on Windows.

## Two jobs

**WebView — `ubuntu-latest`**
`npm ci`, then typecheck, lint, format check, and an advisory-only `npm audit`.

Plus one check that does not exist upstream: `bridge-messages.ts` is *generated* from `Host/BridgeMessages.cs` and committed, so editing the C# and forgetting to regenerate leaves a stale `.ts` that still typechecks cleanly. The job regenerates it and diffs — `gen-bridge` only reads a C# file, so it runs fine without .NET.

**Build VSIX — `windows-latest`**
MSBuild Release, with CodeQL wrapped around it (init before, analyze after — it has to watch the compiler work). The VSIX is uploaded as an artifact.

Release is the configuration worth building: it triggers the version guard in `Directory.Build.targets`, so a PR that bumps `Directory.Build.props` without the manifest fails here instead of at Marketplace upload time.

## Two things found while writing it

`format:check` reported **78 files**. All but one were line endings — prettier defaults to LF against a CRLF working tree — fixed with `endOfLine: auto` rather than reformatting 78 files for nothing.

The remaining one, `cv-prompt.ts`, was genuinely unformatted: I edited it earlier today with a tool that writes to disk directly, so VS Code’s `formatOnSave` never ran. `npm run build` does not format either (it is only gen-bridge + esbuild), so nothing caught it. That is precisely the gap this job closes.

## Note

`npm audit` does not fail the build. Both current advisories reach us only through `eslint`, a devDependency that never ships in the bundle — worth seeing in the log, not worth blocking a PR over.