### PR TITLE
fix(build): ship the WebView in the VSIX built from a clean check-out

### DIFF
--- a/.claude/skills/cv4vs-ci-install/SKILL.md
+++ b/.claude/skills/cv4vs-ci-install/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: cv4vs-ci-install
+description: Download the VSIX built by the last CI run of this branch and install it into the Visual Studio experimental hives, checking the package is complete first. Use when asked to install the CI build, the artifact, the last build from GitHub, or to test what CI produced. Installs into the Exp hives only.
+---
+
+# Install the CI artifact
+
+Testing what CI actually produced is four manual steps: find the run, download the artifact, open
+the zip to see whether it is intact, then hand it to `tools\extension.ps1`. This does the sequence
+and refuses to install a package that is missing pieces.
+
+Why the check matters: on 2026-07-21 the CI artifact was missing the entire `WebView2/` folder. It
+installed without a word of complaint, and the failure only surfaced as a
+`DirectoryNotFoundException` when the chat pane was opened. A VSIX that installs is not a VSIX that
+works.
+
+## Procedure
+
+### 1. Find the run
+
+```powershell
+gh run list --branch <branch> --limit 1 --json databaseId,headSha,status,conclusion
+```
+
+Same rules as [cv4vs-ci-log](../cv4vs-ci-log/SKILL.md): the run must be `completed`, and `headSha`
+has to be compared with `git rev-parse HEAD`. Two extra conditions here, because this one changes
+the machine:
+
+- **`conclusion` must be `success`.** A failed run may still have uploaded an artifact.
+- **If `headSha` differs from HEAD, stop and say so.** With a report a stale run is merely
+  confusing; installing one puts the wrong commit on disk under the right name, which is exactly
+  the kind of mismatch that costs an afternoon.
+
+### 2. Download
+
+```powershell
+$dir = "C:\temp\cv4vs-ci-vsix"
+Remove-Item -LiteralPath $dir -Recurse -Force -ErrorAction SilentlyContinue
+gh run download <id> --repo Corsinvest/cv4vs-agents --dir $dir
+```
+
+Clear the folder first: `gh run download` does not overwrite, and a leftover from an earlier run
+would be installed instead.
+
+### 3. Check the package before installing
+
+```powershell
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+$vsix = Get-ChildItem $dir -Recurse -Filter *.vsix | Select-Object -First 1
+$zip = [IO.Compression.ZipFile]::OpenRead($vsix.FullName)
+$entries = $zip.Entries.FullName
+$zip.Dispose()
+$entries | Where-Object { $_ -like 'WebView2/*' } | Sort-Object
+```
+
+Refuse to install unless the package has:
+
+- `WebView2/index.html` — without it the chat pane throws on open
+- `WebView2/bundle.js` and `bundle.css`
+- `WebView2/images/plugin-logo.png` — the welcome screen renders a broken image without it
+- no `tgconfig.json` at the root; it is a codegen input that has no business shipping
+
+For reference, a sound package has 25 entries and 9 files under `WebView2/`. Report the count either
+way — a number that has moved is worth knowing even when nothing is missing.
+
+If something is missing, say which files and stop. Do not install and mention it afterwards.
+
+### 4. Install
+
+```powershell
+.\tools\extension.ps1 -Reinstall -Path <path to the .vsix>
+```
+
+The script prints version, packaging date and WebView file count before installing, refuses to run
+while `devenv` is up, and removes every existing copy first — VS keys extensions by `Identity Id`,
+so leftovers install alongside rather than being replaced.
+
+`-Reinstall`, not `-Install`: the point is to test this artifact, and an older copy left in the hive
+would keep loading.
+
+Report what landed, including the packaging date, so it is clear which build is now installed.
+Read that date as relative: zip stores no time zone, so a CI artifact carries the runner's UTC while
+a local build carries local time.
+
+## Limits
+
+- Experimental hives only. `-Normal` exists on the script but installing a test build into the IDE
+  you work in is a separate decision — ask first.
+- Does not start Visual Studio; it must be closed for the install to work anyway.
+- Does not verify the extension behaves once loaded. Nothing outside VS can see the tool windows —
+  that check is manual.

--- a/.claude/skills/cv4vs-ci-log/SKILL.md
+++ b/.claude/skills/cv4vs-ci-log/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: cv4vs-ci-log
+description: Read a GitHub Actions run log for this repo and report whether the run actually did what it should — step outcomes, expected verifications present or missing, and real anomalies with the known noise filtered out. Use when asked to check, read or verify a CI run, a workflow log, a build on GitHub, or why a build passed. Read-only.
+---
+
+# Read a CI run
+
+A green run is not evidence the package is good. On 2026-07-21 three separate defects shipped
+through a `success` build:
+
+- The VSIX was packaged without the `WebView2/` folder — 16 entries instead of 22. It installed
+  cleanly and threw `DirectoryNotFoundException` the moment the chat pane opened.
+- `dotnet-typegen` was not installed on the runners: the `Exec` exited 9009, `ContinueOnError`
+  swallowed it, and the DTO codegen never ran.
+- `tgconfig.json` was shipped inside the VSIX (23 entries instead of 22).
+
+None of them was an error in the log. They were **absences** — a line that should have been printed
+and wasn't, or an `MSB3073` buried under 147 known warnings. Reading the log by hand took five
+attempts and two wrong filters, because CodeQL query *names* contain the word "error".
+
+This skill reads a finished run and answers one question: did every check actually run, and did
+anything real go wrong?
+
+**Read-only.** No fixes, no re-runs, no git commands.
+
+## Procedure
+
+### 1. Find the run
+
+```powershell
+gh run list --branch <branch> --limit 1 --json databaseId,headSha,status,conclusion
+```
+
+No argument given → last run of the current branch. An argument may be a run id, a PR number, or a
+branch name.
+
+Two things to check before going further:
+
+- **`status` must be `completed`.** On a run still going the expected lines have not been printed
+  yet and would read as absences. Say so and stop — this skill does not wait.
+- **Compare `headSha` with `git rev-parse HEAD`.** Called right after a push, the last run of the
+  branch is still the previous commit's: the report would be accurate but about different code.
+  Say so; the user decides whether to continue.
+
+### 2. Collect
+
+```powershell
+gh run view <id> --json jobs        # steps and their conclusions
+gh run view <id> --log              # full log, ~2400 lines
+```
+
+Write the log to a file and filter from there. Keeping 2400 lines in context to find two of them is
+waste.
+
+### 3. Filter the noise
+
+Everything below is background and must not reach the report — except as a count.
+
+| Category | Pattern |
+|---|---|
+| CodeQL banners | `CODEQL_ACTION_CLI_VERSION_INFO`, `CODEQL_DIST`, any `CODEQL_*` |
+| CodeQL query names | `Loaded C:`, `Starting evaluation`, `Evaluation done`, `.qlx`, `.bqrs` |
+| Script echo | lines containing `^[[36;1m` |
+| Known warnings | `VSTHRD*`, `VSSDK*` (147 of them), `no-explicit-any` (7) |
+| Infrastructure deprecations | Node 20→24, CodeQL Action v3, `DEP0169`, `npm warn deprecated` |
+| CodeQL informational | `overlay database`, `TRAP caching` |
+
+Two traps worth naming, both of which produced false positives when this was done by hand:
+
+- **CodeQL query names read like failures.** `MissingASPNETGlobalErrorHandler`, `Missing global
+  error handler` — these are the names of security queries being loaded, not results.
+- **Script echo is not execution.** GitHub prints each step's source before running it, so a step
+  whose script contains `::error::` shows that string even when it passed. The result line comes
+  after, without the escape prefix.
+
+### 4. Check what should be there
+
+For every step in the run that prints an outcome, the matching line must be in the log. Take the
+step list from `--json jobs`, not from `quality.yml` on disk: a run predating a step cannot have
+printed its outcome, and comparing against today's workflow invents absences.
+
+Known outcomes:
+
+| Step | Expected line |
+|---|---|
+| Verify VSIX contains the WebView | `VSIX OK: <n> entries, all <n> WebView files present.` |
+| Build (TypeGen, inside MSBuild) | `Files for project "bin\Release\netstandard2.0" generated successfully.` |
+| Audit (advisory only) | `found 0 vulnerabilities` |
+| Generated DTOs are up to date | `git diff --exit-code` producing no output |
+
+**A step that ran without printing its outcome is a finding, even on a green run.** That is defect
+2 above: `dotnet-typegen` failed, `ContinueOnError` hid it, and the step still reported success.
+
+## Report
+
+```
+Run <id> — <branch> @<sha> — <conclusion>
+
+Steps: <ok>/<total>
+
+Expected checks
+  ok       VSIX OK: 25 entries, all 9 WebView files present.
+  ok       Files for project "bin\Release\netstandard2.0" generated successfully.
+  ok       found 0 vulnerabilities
+  ok       DTOs match the committed files
+  MISSING  <what was expected, and which step should have printed it>
+
+Anomalies
+  <job> / <step>: <line>
+
+Noise skipped: 147 VSTHRD/VSSDK, 7 ESLint, Node 20 + CodeQL v3 deprecations
+```
+
+Lead with anything `MISSING` or any anomaly — at the bottom of a report they get skimmed past, and
+they are the reason this skill exists. If everything is present and nothing anomalous, say so in one
+line rather than padding.
+
+Report the noise as a count, never silently. "147 VSTHRD skipped" and "no warnings" are different
+claims, and only one of them is true.
+
+## Limits
+
+- Reads finished runs only; does not wait for one in progress.
+- No baseline, no comparison with previous runs. The question is whether *this* run did its job.
+- Requires `gh` authenticated for this repo.
+
+## Known-good references
+
+Two runs to check behaviour against:
+
+- **29838886808** — green, 2380 lines. All four checks present, no anomalies.
+- **29826650583** — reports `success` and shipped the broken VSIX. Filtering leaves exactly two
+  lines out of 2122:
+
+  ```
+  'dotnet-typegen' is not recognized as an internal or external command,
+  ...Contracts.csproj(33,5): warning MSB3073: The command "dotnet-typegen generate" exited with code 9009.
+  ```
+
+  No `MISSING` entries for it: that run predates the verification steps. A filter that cleans up the
+  green log but hides those two lines is worse than no filter.

--- a/.claude/skills/cv4vs-verify/SKILL.md
+++ b/.claude/skills/cv4vs-verify/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: cv4vs-verify
+description: Prepare and guide the manual check of this extension in the Visual Studio experimental instance — confirm what is installed, order the checks by risk, and read the log the user pastes back. Use when asked to verify, test or try the extension in VS, or after installing a build. Cannot see the tool windows itself.
+---
+
+# Verify a build in the Exp instance
+
+The gate for this project is a green MSBuild plus a manual pass in the experimental instance. There
+is no test project, and `.vsct` ids, XAML `x:Class` and the manifest all fail at *runtime*, not at
+compile time.
+
+**This skill cannot run the test.** The panes live inside Visual Studio and nothing outside the
+process can see them — same limitation `cv4vs-run` states. What it does is the part around the test:
+confirm the right build is installed before, and read the log after.
+
+## Before: is the right thing installed?
+
+```powershell
+.\tools\extension.ps1
+```
+
+Prints, per hive: instance name, version, and path. What to look for:
+
+- **One copy per hive.** More than one and VS loads both — duplicate menu entries and two MCP
+  servers racing for the same lock file, which reads as a bug in the code. The script flags this in
+  red; `-Reinstall` collapses them.
+- **The expected hive.** Experimental unless there is a reason otherwise. `-Normal` shows the other
+  side.
+- **The build under test.** The status output has no date, because VSIXInstaller restamps extracted
+  files with the install time. The packaging date is printed when installing, not afterwards — so
+  if there is doubt about which build is on disk, reinstall rather than guess.
+
+Then start it:
+
+```powershell
+devenv /rootsuffix Exp
+```
+
+First launch after an install is slow: VS rebuilds the MEF cache.
+
+## The check, by risk
+
+Not in menu order — in the order things actually break:
+
+1. **Chat pane.** Opens without an exception, WebView renders, the welcome logo is there. This is
+   the pane that breaks: everything about packaging shows up here first.
+2. **A prompt round-trip.** The CLI starts, the MCP server comes up, a reply arrives.
+3. **CLI pane.** The other pane type, a separate startup path (ConPTY + `--ide`).
+4. **Options**, all four pages: General, Chat, Profiles, Debug.
+5. **Menu entries and icons.** A mismatched `.vsct` id gives a silent no-op — the entry is there and
+   does nothing.
+6. **History.** Sessions listed and openable.
+
+## After: the log
+
+The log goes to the **Output window** (pane "cv4vs Agents"), held in memory by
+`IVsOutputWindowPane`. It is not written to disk — there is no file to read, so it has to be copied
+out of the window and pasted back.
+
+Two things to say up front, because both cost a round trip when forgotten:
+
+- **The default log level is `None`.** Without raising it in Options → Debug there is nothing to
+  copy. Ask the user to set it before reproducing, not after.
+- **Reproduce first, copy second.** The pane is not cleared between runs, but the interesting lines
+  are the ones after the action.
+
+Reading it: `[client]`, `[mcp]`, `[cli]`, `[sessions]` and similar tags mark the area. `PERF` lines
+give timings. An exception with no context above it usually means the failure happened before
+logging was set up.
+
+## When something is wrong
+
+Get the log before proposing a cause. On 2026-07-21 the `DirectoryNotFoundException` looked like a
+code defect and was a packaging one — the diagnosis came from the log, which named the path being
+resolved.
+
+If the fault is in the package rather than the code, [cv4vs-ci-log](../cv4vs-ci-log/SKILL.md) reads
+the run that built it and [cv4vs-ci-install](../cv4vs-ci-install/SKILL.md) replaces it.

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -85,6 +85,27 @@ jobs:
       - name: Build
         run: msbuild cv4vs-agents.sln -t:Build -p:Configuration=Release -p:DeployExtension=false -v:minimal
 
+      # A VSIX missing the WebView2 folder installs without complaint and then throws
+      # DirectoryNotFoundException the moment the chat pane opens. That shipped once already,
+      # because a green build is not evidence the package is usable -- so check the artifact
+      # itself, not just the exit code.
+      - name: Verify VSIX contains the WebView
+        shell: pwsh
+        run: |
+          $vsix = Get-ChildItem src/Corsinvest.VisualStudio.Agents/bin/Release/*.vsix | Select-Object -First 1
+          Add-Type -AssemblyName System.IO.Compression.FileSystem
+          $zip = [IO.Compression.ZipFile]::OpenRead($vsix.FullName)
+          $entries = $zip.Entries.FullName
+          $zip.Dispose()
+          $required = @('WebView2/index.html', 'WebView2/bundle.js', 'WebView2/bundle.css')
+          $missing = $required | Where-Object { $_ -notin $entries }
+          if ($missing) {
+              Write-Host "::error::VSIX is missing: $($missing -join ', ')"
+              $entries | Sort-Object | ForEach-Object { Write-Host "  $_" }
+              exit 1
+          }
+          Write-Host "VSIX OK: $($entries.Count) entries, WebView2 present."
+
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -105,26 +105,38 @@ jobs:
               exit 1
           }
 
-      # A VSIX missing the WebView2 folder installs without complaint and then throws
-      # DirectoryNotFoundException the moment the chat pane opens. That shipped once already,
-      # because a green build is not evidence the package is usable -- so check the artifact
-      # itself, not just the exit code.
+      # A VSIX missing part of the WebView installs without complaint and breaks at runtime: no
+      # index.html throws DirectoryNotFoundException when the chat pane opens, a missing logo just
+      # renders as a broken image. Both shipped once already -- a green build says nothing about
+      # whether the package is usable.
+      #
+      # Compare the whole of dist\ against the package rather than a list of names: the list would
+      # need updating every time the WebView gains a file, and the one that goes unlisted is exactly
+      # the one that gets dropped.
       - name: Verify VSIX contains the WebView
         shell: pwsh
         run: |
+          $dist = 'src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/dist'
+          $expected = Get-ChildItem $dist -Recurse -File |
+              ForEach-Object { 'WebView2/' + $_.FullName.Substring((Resolve-Path $dist).Path.Length + 1).Replace('\', '/') }
+          if (-not $expected) {
+              Write-Host "::error::$dist is empty — the WebView was never built"
+              exit 1
+          }
+
           $vsix = Get-ChildItem src/Corsinvest.VisualStudio.Agents/bin/Release/*.vsix | Select-Object -First 1
           Add-Type -AssemblyName System.IO.Compression.FileSystem
           $zip = [IO.Compression.ZipFile]::OpenRead($vsix.FullName)
           $entries = $zip.Entries.FullName
           $zip.Dispose()
-          $required = @('WebView2/index.html', 'WebView2/bundle.js', 'WebView2/bundle.css')
-          $missing = $required | Where-Object { $_ -notin $entries }
+
+          $missing = $expected | Where-Object { $_ -notin $entries }
           if ($missing) {
-              Write-Host "::error::VSIX is missing: $($missing -join ', ')"
+              Write-Host "::error::VSIX is missing $($missing.Count) of $($expected.Count) WebView files: $($missing -join ', ')"
               $entries | Sort-Object | ForEach-Object { Write-Host "  $_" }
               exit 1
           }
-          Write-Host "VSIX OK: $($entries.Count) entries, WebView2 present."
+          Write-Host "VSIX OK: $($entries.Count) entries, all $($expected.Count) WebView files present."
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -77,6 +77,13 @@ jobs:
           cache: npm
           cache-dependency-path: src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/package-lock.json
 
+      # The Contracts project regenerates core/generated/*.ts from the C# DTOs on every build,
+      # through a global tool. Without it installed the Exec fails with 9009, ContinueOnError
+      # swallows it, and codegen silently does not run -- so the staleness check below would
+      # compare the committed files against themselves and always pass.
+      - name: Install TypeGen
+        run: dotnet tool install -g dotnet-typegen
+
       - name: Restore
         run: msbuild cv4vs-agents.sln -t:Restore -p:Configuration=Release -v:minimal
 
@@ -84,6 +91,19 @@ jobs:
       # Directory.Build.props, the manifest and AssemblyInfo have drifted apart.
       - name: Build
         run: msbuild cv4vs-agents.sln -t:Build -p:Configuration=Release -p:DeployExtension=false -v:minimal
+
+      # The build just regenerated these from the C# DTOs. If they differ from what is committed,
+      # someone changed a DTO without regenerating -- the TS side would keep compiling against the
+      # old shape and mismatch the wire at runtime. Same gate the WebView job applies to
+      # bridge-messages.ts.
+      - name: Generated DTOs are up to date
+        shell: pwsh
+        run: |
+          git diff --exit-code -- src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated/
+          if ($LASTEXITCODE -ne 0) {
+              Write-Host "::error::core/generated/*.ts is stale — rebuild the solution and commit the regenerated files"
+              exit 1
+          }
 
       # A VSIX missing the WebView2 folder installs without complaint and then throws
       # DirectoryNotFoundException the moment the chat pane opens. That shipped once already,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,12 @@ msbuild cv4vs-agents.sln /t:Build /p:Configuration=Debug   # WebView build is ho
 WebView (`src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/`): `npm run build` / `dev` /
 `typecheck` / `lint`.
 
+**Installs stack up.** VS keys extensions by `Identity Id`, so a build with a changed identity —
+or a changed display name — installs *alongside* the old one: duplicate menu entries, two MCP
+servers, and symptoms that look like bugs in the code. `tools\extension.ps1` is the test cycle
+(remove every copy, then install into the Exp hives); `-Uninstall` clears them and refreshes the
+hives, which deleting the folder alone does not — VS keeps serving the cached menu entries.
+
 **No test project.** The gate is a green MSBuild plus manual verification in the Exp instance
 (F5 → `devenv /rootsuffix Exp`). A green build proves less than it looks: XAML `x:Class`, `.vsct`
 ids and the manifest fail at *runtime*, not compile time — a mismatched `.vsct` id gives a silent

--- a/src/Corsinvest.VisualStudio.Agents.Contracts/Corsinvest.VisualStudio.Agents.Contracts.csproj
+++ b/src/Corsinvest.VisualStudio.Agents.Contracts/Corsinvest.VisualStudio.Agents.Contracts.csproj
@@ -27,10 +27,20 @@
     <PackageReference Include="TypeGen" Version="7.0.0" ExcludeAssets="runtime" />
   </ItemGroup>
 
-  <!-- Regenerate the .ts interfaces from these DTOs on every build (reads the freshly
-       built DLL via tgconfig.json). Needs the global tool: dotnet tool install -g dotnet-typegen. -->
+  <!-- The config travels with the DLL it describes: its paths are relative to the folder it sits
+       in, so copying it to the output means the same file works for Debug and Release without
+       naming either. Keeping it at the project root instead would need a hardcoded bin/<Config>,
+       which fails on the configuration it does not name. -->
+  <ItemGroup>
+    <Content Include="tgconfig.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <!-- Regenerate the .ts interfaces from these DTOs on every build, reading the DLL this build
+       just produced. Needs the global tool: dotnet tool install -g dotnet-typegen. -->
   <Target Name="GenerateBridgeDtoTs" AfterTargets="Build">
-    <Exec Command="dotnet-typegen generate" WorkingDirectory="$(ProjectDir)" ContinueOnError="true" />
+    <Exec Command="dotnet-typegen generate -p &quot;$(OutputPath.TrimEnd('\'))&quot;" WorkingDirectory="$(ProjectDir)" ContinueOnError="true" />
   </Target>
 
 </Project>

--- a/src/Corsinvest.VisualStudio.Agents.Contracts/Corsinvest.VisualStudio.Agents.Contracts.csproj
+++ b/src/Corsinvest.VisualStudio.Agents.Contracts/Corsinvest.VisualStudio.Agents.Contracts.csproj
@@ -27,20 +27,16 @@
     <PackageReference Include="TypeGen" Version="7.0.0" ExcludeAssets="runtime" />
   </ItemGroup>
 
-  <!-- The config travels with the DLL it describes: its paths are relative to the folder it sits
-       in, so copying it to the output means the same file works for Debug and Release without
-       naming either. Keeping it at the project root instead would need a hardcoded bin/<Config>,
-       which fails on the configuration it does not name. -->
-  <ItemGroup>
-    <Content Include="tgconfig.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-
   <!-- Regenerate the .ts interfaces from these DTOs on every build, reading the DLL this build
-       just produced. Needs the global tool: dotnet tool install -g dotnet-typegen. -->
+       just produced. Needs the global tool: dotnet tool install -g dotnet-typegen.
+
+       -p resolves the config's relative paths against the output folder, so tgconfig.json names
+       the DLL sitting next to it and the same config serves Debug and Release without hardcoding
+       either. The config stays at the project root and out of the build output: the VSIX packages
+       whatever a referenced project emits, and a codegen input has no business shipping to
+       users. -->
   <Target Name="GenerateBridgeDtoTs" AfterTargets="Build">
-    <Exec Command="dotnet-typegen generate -p &quot;$(OutputPath.TrimEnd('\'))&quot;" WorkingDirectory="$(ProjectDir)" ContinueOnError="true" />
+    <Exec Command="dotnet-typegen generate -p &quot;$(OutputPath.TrimEnd('\'))&quot; -c &quot;$(ProjectDir)tgconfig.json&quot;" WorkingDirectory="$(ProjectDir)" ContinueOnError="true" />
   </Target>
 
 </Project>

--- a/src/Corsinvest.VisualStudio.Agents.Contracts/tgconfig.json
+++ b/src/Corsinvest.VisualStudio.Agents.Contracts/tgconfig.json
@@ -1,8 +1,8 @@
 ﻿{
     "$schema": "https://raw.githubusercontent.com/jburzynski/TypeGen/master/schema/tgconfig.schema.json",
-    "assemblies": [ "bin/Debug/netstandard2.0/Corsinvest.VisualStudio.Agents.Contracts.dll" ],
+    "assemblies": [ "Corsinvest.VisualStudio.Agents.Contracts.dll" ],
     "generationSpecs": [ "Corsinvest.VisualStudio.Agents.Contracts.BridgeGenerationSpec" ],
-    "outputPath": "../Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated",
+    "outputPath": "../../../../Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated",
     "propertyNameConverters": [ "PascalCaseToCamelCase" ],
     "enumValueNameConverters": [ "PascalCaseToCamelCase" ],
     "enumStringInitializers": true,

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.cs
@@ -99,6 +99,12 @@ internal sealed partial class WebViewBridge(Microsoft.Web.WebView2.Wpf.WebView2 
             // (browser warnings, hljs CSS silently ignored). Virtual host gives same-origin + correct MIME.
             var indexPath = AppPaths.WebViewHtml();
             var folder = Path.GetDirectoryName(indexPath);
+            if (!File.Exists(indexPath))
+            {
+                // Mapping a missing folder throws a bare DirectoryNotFoundException that names
+                // nothing — say which path we resolved before it does.
+                OutputWindowLogger.Warn($"[webview] index.html not found at '{indexPath}' — the chat can't load");
+            }
             webView.CoreWebView2.SetVirtualHostNameToFolderMapping("cv4vs.local", folder, CoreWebView2HostResourceAccessKind.Allow);
 
             // Lazy-served icons: virtual-host would serve from disk and 404 on not-yet-generated PNGs,

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/esbuild.config.mjs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/esbuild.config.mjs
@@ -95,45 +95,47 @@ const config = {
     plugins: [mirrorPlugin],
 };
 
+// Anything missing here reaches the user as a package that installs cleanly and misbehaves at
+// runtime — no index.html throws DirectoryNotFoundException, no diff2html.min.css renders
+// side-by-side diffs as stacked blocks, no logo shows a broken image. Skipping the copy quietly
+// (`if (existsSync(src))`) is what let two of those ship: the build stayed green and a stale dist/
+// from an earlier run hid the gap until someone cleaned it.
+async function copyRequired(src, dest) {
+    if (!existsSync(src)) {
+        throw new Error(`[esbuild] missing ${src} — the VSIX would ship without it`);
+    }
+    await mkdir(path.dirname(dest), { recursive: true });
+    await copyFile(src, dest);
+}
+
 async function copyStatic() {
-    if (!existsSync('dist')) {
-        await mkdir('dist', { recursive: true });
-    }
-    if (existsSync('index.html')) {
-        await copyFile('index.html', path.join('dist', 'index.html'));
-    }
+    await mkdir('dist', { recursive: true });
+    await copyRequired('index.html', path.join('dist', 'index.html'));
+
     // highlight.js themes — loaded as <link> in index.html, toggled via the
     // `disabled` attribute on theme change. Copy them out of node_modules
     // so the VSIX content can pick them up.
-    const hljsDir = path.join('dist', 'hljs');
-    if (!existsSync(hljsDir)) {
-        await mkdir(hljsDir, { recursive: true });
-    }
     for (const f of ['vs.min.css', 'vs2015.min.css']) {
-        const src = path.join('node_modules', 'highlight.js', 'styles', f);
-        if (existsSync(src)) {
-            await copyFile(src, path.join(hljsDir, f));
-        }
+        await copyRequired(path.join('node_modules', 'highlight.js', 'styles', f), path.join('dist', 'hljs', f));
     }
+
     // diff2html layout CSS (`.d2h-files-diff` flex, `.d2h-file-side-diff`
     // inline-block 50%, etc). Without it side-by-side renders as two stacked
     // full-width blocks instead of a real split view.
-    const d2hSrc = path.join('node_modules', 'diff2html', 'bundles', 'css', 'diff2html.min.css');
-    if (existsSync(d2hSrc)) {
-        await copyFile(d2hSrc, path.join('dist', 'diff2html.min.css'));
+    await copyRequired(
+        path.join('node_modules', 'diff2html', 'bundles', 'css', 'diff2html.min.css'),
+        path.join('dist', 'diff2html.min.css'),
+    );
+
+    // Images the WebView loads by relative path (cv-welcome's logo). Copy the whole folder rather
+    // than naming files: a list means a new image silently stays out of dist/ — and out of the VSIX,
+    // since the .csproj packages dist/ wholesale. Resources/ is the single source of truth, shared
+    // with the WPF side, which embeds the same files in the assembly for pack:// URIs.
+    const resources = path.join('..', '..', 'Resources');
+    if (!existsSync(resources)) {
+        throw new Error(`[esbuild] missing ${resources} — the VSIX would ship without it`);
     }
-    // About-dialog logos. They live in the repo root (single source of
-    // truth, also used by README/marketplace).
-    const imagesDir = path.join('dist', 'images');
-    if (!existsSync(imagesDir)) {
-        await mkdir(imagesDir, { recursive: true });
-    }
-    for (const f of ['plugin-logo.png', 'corsinvest-logo.png']) {
-        const src = path.join('..', '..', '..', f);
-        if (existsSync(src)) {
-            await copyFile(src, path.join(imagesDir, f));
-        }
-    }
+    await cp(resources, path.join('dist', 'images'), { recursive: true });
 }
 
 if (watch) {

--- a/src/Corsinvest.VisualStudio.Agents/Corsinvest.VisualStudio.Agents.csproj
+++ b/src/Corsinvest.VisualStudio.Agents/Corsinvest.VisualStudio.Agents.csproj
@@ -322,6 +322,10 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
+    <!-- What VS sees in the IDE, so an F5 (and `npm run dev` in watch) copies fresh bundle output
+         without a project reload. MSBuild evaluates this glob before any target runs, so on a clean
+         check-out — where npm has not created dist\ yet — it matches nothing; BuildWebViewSrc
+         re-adds the files after generating them. -->
     <Content Include="Chat\WebViewSrc\dist\**\*">
       <Link>WebView2\%(RecursiveDir)%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -344,8 +348,7 @@
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>
-  <!-- Compile the TypeScript+Lit WebView (WebViewSrc/) into WebViewSrc/dist/
-       before BeforeBuild, so the Content glob above picks up fresh output.
+  <!-- Compile the TypeScript+Lit WebView (WebViewSrc/) into WebViewSrc/dist/.
        Skipped when WebViewSrc/ is missing (lets the project still build on
        a check-out without npm). -->
   <ItemGroup>
@@ -355,6 +358,28 @@
   <Target Name="BuildWebViewSrc" BeforeTargets="BeforeBuild" Condition="Exists('Chat\WebViewSrc\package.json')">
     <Exec Command="npm install --no-fund --no-audit" WorkingDirectory="$(MSBuildProjectDirectory)\Chat\WebViewSrc" Condition="!Exists('Chat\WebViewSrc\node_modules')" />
     <Exec Command="npm run build" WorkingDirectory="$(MSBuildProjectDirectory)\Chat\WebViewSrc" />
+
+    <!-- Re-add what npm just produced. The static glob above ran during evaluation, before this
+         target: on a clean check-out it found nothing, so without this the VSIX would install fine
+         and then throw DirectoryNotFoundException when the chat pane opens — a green build shipping
+         a package with no chat UI.
+
+         Two steps on purpose: %(RecursiveDir) does not expand when the glob and the metadata are
+         declared together inside a target, which silently flattens dist\hljs\ into WebView2\. Glob
+         first, then attach the metadata to @(_WebViewDist). Remove first so the files the static
+         glob did pick up are not added a second time. -->
+    <ItemGroup>
+      <_WebViewDist Include="Chat\WebViewSrc\dist\**\*" />
+      <Content Remove="Chat\WebViewSrc\dist\**\*" />
+      <Content Include="@(_WebViewDist)">
+        <Link>WebView2\%(RecursiveDir)%(Filename)%(Extension)</Link>
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <IncludeInVSIX>true</IncludeInVSIX>
+      </Content>
+    </ItemGroup>
+
+    <Error Condition="!Exists('Chat\WebViewSrc\dist\index.html')"
+           Text="WebView build produced no dist\index.html — the VSIX would ship without the chat UI." />
   </Target>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />

--- a/tools/extension.ps1
+++ b/tools/extension.ps1
@@ -132,6 +132,9 @@ function Find-InstalledCopies {
                 Where-Object { (Get-Content $_.FullName -Raw -ErrorAction SilentlyContinue) -match $IdentityPattern } |
                 ForEach-Object {
                     $identity = ([xml](Get-Content $_.FullName -Raw)).PackageManifest.Metadata.Identity
+                    # No build date here: VSIXInstaller stamps the extracted files with the install
+                    # time, so the DLL on disk only says when it was unpacked. The date printed when
+                    # installing comes from inside the .vsix, where it survives.
                     [pscustomobject]@{
                         Hive    = $hive.Name
                         Name    = Get-InstanceName $hive.Name
@@ -276,7 +279,30 @@ function Invoke-Install {
         exit 1
     }
 
+    # Say which build this is before installing it: the file name is the same for every build, so
+    # without this there is no way to tell a fresh VSIX from a stale download. The .vsix file date
+    # is no help either -- for a CI artifact it is when it was downloaded.
+    #
+    # The zip entry date is the packaging time, and it is what tells two builds apart. It is printed
+    # verbatim because zip stores a bare clock reading with no time zone: the number is whatever the
+    # machine that built the package saw, so a CI artifact carries the runner's UTC and a local build
+    # carries local time. Converting it would be worse than leaving it alone -- .NET attaches this
+    # machine's offset on read, so ToLocalTime()/UtcDateTime shift a value that was never in this
+    # zone to begin with.
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    $zip = [IO.Compression.ZipFile]::OpenRead($Path)
+    try {
+        $manifest = $zip.Entries | Where-Object Name -eq 'extension.vsixmanifest'
+        $reader = New-Object IO.StreamReader($manifest.Open())
+        $identity = ([xml]$reader.ReadToEnd()).PackageManifest.Metadata.Identity
+        $reader.Dispose()
+        $packaged = ($zip.Entries | Where-Object Name -eq 'Corsinvest.VisualStudio.Agents.dll').LastWriteTime
+        $webView = @($zip.Entries | Where-Object FullName -like 'WebView2/*').Count
+    }
+    finally { $zip.Dispose() }
+
     Write-Host "`ninstalling $(Split-Path $Path -Leaf)"
+    Write-Host "  version $($identity.Version)   packaged $($packaged.ToString('yyyy-MM-dd HH:mm'))   $webView WebView2 files" -ForegroundColor DarkGray
     foreach ($i in $instances) { Write-Host "  -> $($i.displayName) [$($i.instanceId)]" }
 
     $vsixArgs = @()

--- a/tools/extension.ps1
+++ b/tools/extension.ps1
@@ -56,6 +56,10 @@
 
 .EXAMPLE
     .\tools\extension.ps1 -Install -Normal
+
+.EXAMPLE
+    .\tools\extension.ps1 -Reinstall -Path C:\temp\Corsinvest.VisualStudio.Agents.vsix
+    Installs a .vsix from elsewhere -- a CI artifact, say -- instead of the local build output.
 #>
 
 [CmdletBinding(SupportsShouldProcess)]

--- a/tools/extension.ps1
+++ b/tools/extension.ps1
@@ -1,0 +1,332 @@
+# SPDX-FileCopyrightText: Copyright Corsinvest Srl
+# SPDX-License-Identifier: GPL-3.0-only
+
+<#
+.SYNOPSIS
+    Report, install, uninstall or reinstall this extension in Visual Studio.
+
+.DESCRIPTION
+    Wraps VSIXInstaller.exe and the extension folders under
+    %LOCALAPPDATA%\Microsoft\VisualStudio\<instance>\Extensions, so a test cycle is one command
+    instead of a double-click, a dialog and a manual cleanup.
+
+    Experimental hives by default: that is where an extension under test belongs, and it keeps the
+    IDE you actually work in untouched.
+
+    Why this exists rather than "just use Manage Extensions":
+
+    - VS keys extensions by Identity Id, so a build with a changed identity installs *alongside* the
+      old one, giving duplicate menu entries and two MCP servers racing for the same lock file —
+      which reads as a bug in the code.
+    - Deleting the folder is not enough on its own: VS caches menu entries, so a removed extension
+      leaves dead commands behind until devenv /updateconfiguration runs.
+    - VSIXInstaller writes to a randomly named folder, so there is nothing predictable to delete
+      by hand. Every lookup here matches the manifest's Identity Id instead.
+
+.PARAMETER Reinstall
+    Remove every installed copy, then install. This is the normal test cycle.
+
+.PARAMETER Install
+    Install only, leaving any existing copy to be replaced by VSIXInstaller.
+
+.PARAMETER Uninstall
+    Remove every installed copy and refresh the affected hives.
+
+.PARAMETER Path
+    The .vsix to install. Defaults to the Release build output.
+
+.PARAMETER Interactive
+    Show VSIXInstaller's dialog (the instance checkboxes) instead of installing silently.
+
+.PARAMETER Normal
+    Act on the normal hives rather than the experimental ones.
+
+.PARAMETER WhatIf
+    List what would be removed and exit. Uninstall only.
+
+.EXAMPLE
+    .\tools\extension.ps1
+    Lists what is currently installed. No action given means report, never change.
+
+.EXAMPLE
+    .\tools\extension.ps1 -Reinstall
+
+.EXAMPLE
+    .\tools\extension.ps1 -Uninstall -WhatIf
+
+.EXAMPLE
+    .\tools\extension.ps1 -Install -Normal
+#>
+
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [switch]$Reinstall,
+    [switch]$Install,
+    [switch]$Uninstall,
+    [string]$Path,
+    [switch]$Interactive,
+    [switch]$Normal
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (@($Reinstall, $Install, $Uninstall | Where-Object { $_ }).Count -gt 1) {
+    Write-Host "Pick one of -Reinstall, -Install, -Uninstall." -ForegroundColor Red
+    exit 1
+}
+$Status = -not ($Install -or $Uninstall -or $Reinstall)
+
+# Every identity this extension has shipped under: the current one and the former ...ClaudeCode.
+$IdentityPattern = 'Corsinvest\.VisualStudio\.(Agents|ClaudeCode)'
+
+# -products * also returns SQL Server Management Studio, which ships through the VS installer but
+# can't host a VSIX — name the three editions that can instead of filtering it out afterwards.
+$Editions = @(
+    'Microsoft.VisualStudio.Product.Community'
+    'Microsoft.VisualStudio.Product.Professional'
+    'Microsoft.VisualStudio.Product.Enterprise'
+)
+
+$vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
+$hiveRoot = Join-Path $env:LOCALAPPDATA 'Microsoft\VisualStudio'
+
+# Hive folders are named <version>_<instanceId>[Exp] — "17.0_456b4614Exp" names no product a human
+# recognises, so resolve the instance id back to what vswhere calls it.
+$script:instanceNames = $null
+function Get-InstanceName {
+    param([string]$HiveName)
+
+    if ($null -eq $script:instanceNames) {
+        $script:instanceNames = @{}
+        if (Test-Path $vswhere) {
+            foreach ($i in (& $vswhere -products $Editions -format json 2>$null | ConvertFrom-Json)) {
+                $script:instanceNames[$i.instanceId] = $i.displayName
+            }
+        }
+    }
+
+    $id = ($HiveName -replace '^\d+\.\d+_', '') -replace 'Exp$', ''
+    $name = $script:instanceNames[$id]
+    if (-not $name) { $name = $HiveName }
+    if ($HiveName -like '*Exp') { "$name (experimental)" } else { $name }
+}
+
+# Returns the folder of every installed copy, across both layouts: VSIXInstaller writes
+# Extensions\<random>\ while the F5 deploy writes Extensions\Corsinvest\<display name>\, hence
+# -Depth 2 and the match on the manifest rather than on the folder name.
+function Find-InstalledCopies {
+    if (-not (Test-Path $hiveRoot)) { return @() }
+
+    Get-ChildItem $hiveRoot -Directory |
+        Where-Object { $_.Name -match '^\d+\.\d+' -and ($Normal -xor ($_.Name -like '*Exp')) } |
+        ForEach-Object {
+            $hive = $_
+            $extensions = Join-Path $hive.FullName 'Extensions'
+            if (-not (Test-Path $extensions)) { return }
+
+            Get-ChildItem $extensions -Recurse -Depth 2 -Filter 'extension.vsixmanifest' -ErrorAction SilentlyContinue |
+                Where-Object { (Get-Content $_.FullName -Raw -ErrorAction SilentlyContinue) -match $IdentityPattern } |
+                ForEach-Object {
+                    $identity = ([xml](Get-Content $_.FullName -Raw)).PackageManifest.Metadata.Identity
+                    [pscustomobject]@{
+                        Hive    = $hive.Name
+                        Name    = Get-InstanceName $hive.Name
+                        Id      = $identity.Id
+                        Version = $identity.Version
+                        Path    = $_.DirectoryName
+                    }
+                }
+        }
+}
+
+# VS holds its extension folders open, and VSIXInstaller writes into the hive VS reads at startup:
+# either one under a running instance leaves a half-applied state.
+function Assert-VisualStudioClosed {
+    $running = Get-Process devenv -ErrorAction SilentlyContinue
+    if (-not $running) { return }
+
+    Write-Host "Visual Studio is running ($($running.Count) instance(s)). Close it first." -ForegroundColor Red
+    $running | Select-Object Id, MainWindowTitle | Format-Table | Out-String | Write-Host
+    exit 1
+}
+
+# Without this VS keeps serving cached menu entries for an extension that no longer exists.
+function Update-VisualStudioConfiguration {
+    if (-not (Test-Path $vswhere)) {
+        Write-Host "`nvswhere not found — run 'devenv /rootsuffix Exp /updateconfiguration' by hand." -ForegroundColor Yellow
+        return
+    }
+
+    foreach ($devenv in (& $vswhere -products $Editions -property productPath -format value 2>$null)) {
+        if (-not (Test-Path $devenv)) { continue }
+        Write-Host "refreshing $(Split-Path (Split-Path (Split-Path $devenv -Parent) -Parent) -Parent | Split-Path -Leaf)..."
+
+        # -Wait matters: devenv detaches like VSIXInstaller does, and a still-running one makes the
+        # next command fail its "Visual Studio is running" guard.
+        $devenvArgs = if ($Normal) { @('/updateconfiguration') } else { @('/rootsuffix', 'Exp', '/updateconfiguration') }
+        Start-Process $devenv -ArgumentList $devenvArgs -Wait
+    }
+}
+
+function Show-Status {
+    $hives = if ($Normal) { 'normal' } else { 'experimental' }
+    $copies = @(Find-InstalledCopies)
+    if (-not $copies) {
+        Write-Host "Nothing installed in the $hives hives." -ForegroundColor Yellow
+        Write-Host "Install it with:  .\tools\extension.ps1 -Install"
+        return
+    }
+
+    Write-Host "Installed ($hives hives):`n"
+    foreach ($group in ($copies | Group-Object Hive | Sort-Object Name)) {
+        Write-Host "  $(Get-InstanceName $group.Name)" -ForegroundColor Cyan
+
+        foreach ($copy in $group.Group) {
+            # The identity is always the same one — printing it every time is noise. It earns a
+            # line only when it is the former ...ClaudeCode, which is a leftover to remove.
+            $version = "v$($copy.Version)"
+            if ($copy.Id -notlike '*.Agents') { $version += "  [$($copy.Id)]" }
+            Write-Host "    $version"
+            # Path on its own line: Format-Table would truncate it to the console width, dropping
+            # exactly the random folder name you need to look at.
+            Write-Host "      $($copy.Path)" -ForegroundColor DarkGray
+        }
+
+        # More than one copy in a hive is the failure this script exists for: VS loads both, so menu
+        # entries double up and two MCP servers race for the same lock file.
+        if ($group.Count -gt 1) {
+            Write-Host "    $($group.Count) copies — run -Reinstall to collapse them." -ForegroundColor Red
+        }
+    }
+
+    # An instance missing from the list is worth saying out loud: it reads as "not installed
+    # anywhere" only if you already knew how many instances you have.
+    if (Test-Path $vswhere) {
+        # Compare instance ids, not hive names: a hive is <version>_<id>[Exp] and only the id is
+        # known here. Find-InstalledCopies has already filtered to the right Normal/Exp set.
+        $installedIds = $copies.Hive | ForEach-Object { ($_ -replace '^\d+\.\d+_', '') -replace 'Exp$', '' }
+        foreach ($i in (& $vswhere -products $Editions -format json 2>$null | ConvertFrom-Json)) {
+            if ($installedIds -notcontains $i.instanceId) {
+                Write-Host "`n  $($i.displayName): not installed" -ForegroundColor DarkYellow
+            }
+        }
+    }
+}
+
+# SkipRefresh: during a reinstall the install that follows refreshes anyway, so doing it here too
+# just pays for a second devenv run.
+function Invoke-Uninstall {
+    param([switch]$SkipRefresh)
+
+    $copies = @(Find-InstalledCopies)
+    if (-not $copies) {
+        Write-Host "Nothing installed." -ForegroundColor Green
+        return
+    }
+
+    $removed = $false
+    foreach ($copy in $copies) {
+        if ($PSCmdlet.ShouldProcess($copy.Path, 'Remove extension folder')) {
+            Write-Host "removing  $($copy.Path)"
+            Remove-Item $copy.Path -Recurse -Force
+            $removed = $true
+        }
+    }
+
+    # -WhatIf: found something but removed nothing, so there is no hive to refresh either.
+    if (-not $removed) {
+        Write-Host "`n$($copies.Count) extension folder(s) would be removed. Re-run without -WhatIf." -ForegroundColor Yellow
+        return
+    }
+
+    if (-not $SkipRefresh) { Update-VisualStudioConfiguration }
+    Write-Host "`nRemoved from: $(($copies.Name | Sort-Object -Unique) -join ', ')" -ForegroundColor Green
+}
+
+function Invoke-Install {
+    if (-not $Path) {
+        $repoRoot = Split-Path $PSScriptRoot -Parent
+        $Path = Join-Path $repoRoot 'src\Corsinvest.VisualStudio.Agents\bin\Release\Corsinvest.VisualStudio.Agents.vsix'
+    }
+    if (-not (Test-Path $Path)) {
+        Write-Host "VSIX not found: $Path" -ForegroundColor Red
+        Write-Host "Build it first:  msbuild cv4vs-agents.sln -t:Build -p:Configuration=Release" -ForegroundColor Yellow
+        exit 1
+    }
+    $Path = (Resolve-Path $Path).Path
+
+    if (-not (Test-Path $vswhere)) {
+        Write-Host "vswhere not found — install by double-clicking the .vsix instead." -ForegroundColor Yellow
+        exit 1
+    }
+
+    $instances = & $vswhere -products $Editions -format json 2>$null | ConvertFrom-Json
+    if (-not $instances) {
+        Write-Host "No Visual Studio installation found." -ForegroundColor Red
+        exit 1
+    }
+
+    $installer = Join-Path (Split-Path $instances[0].productPath -Parent) 'VSIXInstaller.exe'
+    if (-not (Test-Path $installer)) {
+        Write-Host "VSIXInstaller.exe not found next to $($instances[0].productPath)" -ForegroundColor Red
+        exit 1
+    }
+
+    Write-Host "`ninstalling $(Split-Path $Path -Leaf)"
+    foreach ($i in $instances) { Write-Host "  -> $($i.displayName) [$($i.instanceId)]" }
+
+    $vsixArgs = @()
+    if (-not $Interactive) { $vsixArgs += '/quiet' }
+    if (-not $Normal) { $vsixArgs += '/rootSuffix:Exp' }
+    $vsixArgs += "/instanceIds:$($instances.instanceId -join ',')"
+    $vsixArgs += $Path
+
+    # VSIXInstaller.exe is a GUI process: called directly it detaches and $LASTEXITCODE stays empty,
+    # so the script would report success before the install had even started.
+    $code = (Start-Process $installer -ArgumentList $vsixArgs -PassThru -Wait).ExitCode
+
+    # 1001 means "already installed at this version" — not a failure worth stopping a test cycle for.
+    switch ($code) {
+        0 { Write-Host "`nInstalled." -ForegroundColor Green }
+        1001 { Write-Host "`nAlready installed at this version. Uninstall first, or bump VsixVersion." -ForegroundColor Yellow }
+        default {
+            Write-Host "`nVSIXInstaller exited with $code" -ForegroundColor Red
+            exit $code
+        }
+    }
+
+    # /quiet means the installer says nothing, so confirm the folders exist rather than trusting the
+    # exit code alone.
+    $landed = @(Find-InstalledCopies)
+    if (-not $landed) {
+        Write-Host "...but no installed copy was found. Check the log in %TEMP%\dd_VSIXInstaller_*.log" -ForegroundColor Red
+        exit 1
+    }
+    foreach ($copy in $landed) {
+        Write-Host "  $($copy.Name)" -ForegroundColor Cyan
+        Write-Host "    $($copy.Path)" -ForegroundColor DarkGray
+    }
+
+    # Copying the files is not enough: until the configuration is refreshed VS ignores the pkgdef,
+    # so the extension is on disk but absent from the menus and from Manage Extensions.
+    Write-Host ""
+    Update-VisualStudioConfiguration
+
+    Write-Host "`nStart VS to pick it up." -ForegroundColor Green
+}
+
+# Reporting doesn't touch anything, so it works with VS open — which is when you most want to ask
+# what is installed.
+if ($Status) {
+    Show-Status
+    return
+}
+
+Assert-VisualStudioClosed
+
+if ($Uninstall) { Invoke-Uninstall }
+elseif ($Install) { Invoke-Install }
+else {
+    Invoke-Uninstall -SkipRefresh
+    Invoke-Install
+}


### PR DESCRIPTION
Every VSIX produced by CI shipped broken. Chasing why turned up three more defects of the same shape: **a green build that quietly produced the wrong thing**.

## What was wrong

**1. The VSIX had no chat UI.** MSBuild expands globs during evaluation, before any target runs, so `Chat\WebViewSrc\dist\**\*` was evaluated before `BuildWebViewSrc` could create `dist\`. On a clean check-out it matched nothing — 16 entries instead of 22. The package installed cleanly and threw `DirectoryNotFoundException` the moment the chat pane opened.

Locally it never showed: `dist\` survives from an earlier build, so the glob always found the *previous* run's file list. CI clones fresh, so every CI artifact was broken.

**2. The DTO codegen never ran in CI.** `dotnet-typegen` is a global tool the runners do not have. The `Exec` exited 9009, `ContinueOnError` swallowed it. Installing the tool exposed the next layer: `tgconfig.json` hardcoded `bin/Debug`, so a Release build failed with "assembly not found" — swallowed again. A DTO changed without regenerating would have gone unnoticed, leaving TypeScript compiling against the old wire shape.

**3. `tgconfig.json` shipped to users.** Fixing (2) by copying the config to the output directory put it in the package: a VSIX bundles everything a `Private=True` ProjectReference emits.

**4. The welcome screen's logo was missing.** `copyStatic` looked for the images three levels up instead of in `Resources/`, behind `if (existsSync(src))` — so the wrong path skipped silently. Only visible after wiping `dist\`, because copies made when the path still matched had survived every rebuild.

## Fixes

Re-add the WebView files inside `BuildWebViewSrc`, after npm generates them — the [documented approach for generated files](https://learn.microsoft.com/en-us/visualstudio/msbuild/customize-builds-for-generated-files). Two steps, because `%(RecursiveDir)` does not expand when the glob and the metadata are declared together inside a target, which silently flattens `dist\hljs\`:

```xml
<_WebViewDist Include="Chat\WebViewSrc\dist\**\*" />
<Content Include="@(_WebViewDist)">
  <Link>WebView2\%(RecursiveDir)%(Filename)%(Extension)</Link>
```

For TypeGen, `-p` points at the output folder so the config resolves relative paths against the DLL next to it — one config for both configurations, and it stays out of the build output.

Every static copy in `esbuild.config.mjs` is now `copyRequired()`, which throws instead of skipping. `Resources/` is copied whole rather than by name, so a new image cannot be left behind.

## What stops this recurring

The common thread is that a passing build proved nothing about the artifact. CI now checks the product, not just the exit code:

- **The VSIX is compared against `dist\` file by file** — not a hand-written list, which would need updating for every new WebView file, and the one that goes unlisted is exactly the one that gets dropped.
- **The generated DTOs are diffed** after the build, the same gate already applied to `bridge-messages.ts`.
- **`WebViewBridge`** names the path it resolved when `index.html` is absent, instead of letting `SetVirtualHostNameToFolderMapping` throw a `DirectoryNotFoundException` that identifies nothing.

## Also here

`tools/extension.ps1` for the install/uninstall cycle. Cleanup is harder than deleting a folder: VS serves cached menu entries until `devenv /updateconfiguration` runs, and VSIXInstaller writes to a randomly named folder — every lookup matches the manifest's Identity Id instead. Defaults to reporting what is installed; an action has to be asked for.

Three skills covering the loop this PR was debugged through: `cv4vs-ci-log` (read a run and report whether each check actually ran), `cv4vs-ci-install` (download and install the artifact, refusing an incomplete package), `cv4vs-verify` (prepare and guide the manual pass in the Exp instance).

## Verified

| Case | Result |
|---|---|
| Clean check-out, single build | 25 entries, all 9 WebView files |
| Local build with `dist\` present | same, no duplicates |
| CI (run 29843580133) | `VSIX OK: 25 entries, all 9 WebView files present.` |
| Missing source file | build fails naming the file, instead of shipping without it |

The artifact from the last run was installed into both Exp hives and the chat opens — MCP server up, 49 tools, no exception.
