### PR TITLE
fix(sessions): title sessions whose first prompt carries editor context

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/MetaInjection.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/MetaInjection.cs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
+using System.Text.RegularExpressions;
+
 namespace Corsinvest.VisualStudio.Agents.Chat;
 
 /// <summary>Single source of truth for CLI-injected meta entries that ride in a role:user
@@ -41,4 +43,17 @@ public static class MetaInjection
         }
         return false;
     }
+
+    // cv-prompt.ts prepends the active editor context to the user's message as an
+    // <ide_selection>/<ide_opened_file> block followed by a newline. It is not the user's words:
+    // strip a leading block so callers see the prompt itself — otherwise a message sent with editor
+    // context looks like it starts with "<", and title generation (which rejects "<") drops it.
+    private static readonly Regex LeadingIdeContext = new(
+        @"^\s*<(ide_selection|ide_opened_file)>.*?</\1>\s*",
+        RegexOptions.Singleline | RegexOptions.Compiled);
+
+    /// <summary>Remove a leading IDE-context block, returning the user's own text. No block → the
+    /// text is returned unchanged.</summary>
+    public static string StripIdeContext(string text)
+        => string.IsNullOrEmpty(text) ? text : LeadingIdeContext.Replace(text, string.Empty);
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.ClientEvents.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.ClientEvents.cs
@@ -341,7 +341,21 @@ public partial class ChatPaneControl
             var title = await client.GenerateSessionTitleAsync(firstPrompt, persist: false);
             if (!string.IsNullOrWhiteSpace(title))
             {
-                sessions.SetAiTitle(sid, title);
+                // SetAiTitle no-ops (returns true) if a title already exists — e.g. the user
+                // renamed the session while generation was in flight. Don't overwrite the toolbar
+                // in that case: read back what actually stuck.
+                var wasNoOp = sessions.SetAiTitle(sid, title);
+                var effective = wasNoOp ? sessions.ScanTitle(sid) : title;
+
+                // Push it to this pane's toolbar now. The turn-end RefreshTitleOnTurnEnd already
+                // ran and found nothing — the title is only written here, and asynchronously, so
+                // without this a brand-new session shows no title until it is reopened. Guarded on
+                // the session id so a client swap mid-generation cannot mistitle the new session.
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                if (_client?.SessionId == sid && !string.IsNullOrWhiteSpace(effective))
+                {
+                    SetSessionTitle(effective);
+                }
             }
         }).FileAndForget(nameof(ChatPaneControl));
     }

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneToolbar.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneToolbar.xaml.cs
@@ -53,21 +53,26 @@ public partial class PaneToolbar : UserControl
     // refresh (turn-end re-read) overwrite what the user is typing.
     private bool _titleFocused;
 
-    /// <summary>Reflect the pane's current title. Hidden when the pane doesn't
-    /// support a title (CLI) or there's no session yet (fresh chat). Skipped while
-    /// the box is focused, so a turn-end refresh doesn't clobber the user's edit.</summary>
+    // Shown when a titleable pane has no title yet — a fresh chat, or one whose ai-title has not
+    // been generated (or written) yet. Like VS Code's "Untitled": the box stays visible and
+    // editable rather than vanishing, so there is always something to click to rename.
+    private const string UntitledPlaceholder = "Untitled";
+
+    /// <summary>Reflect the pane's current title. Hidden only when the pane doesn't support a title
+    /// (CLI); a titleable pane with no title shows the Untitled placeholder. Skipped while the box
+    /// is focused, so a turn-end refresh doesn't clobber the user's edit.</summary>
     private void UpdateTitle()
     {
         if (_titleFocused) { return; }
-        var title = _pane.SupportsTitleEditing ? _pane.SessionTitle : null;
-        if (string.IsNullOrWhiteSpace(title))
+        if (!_pane.SupportsTitleEditing)
         {
             TitleHost.Visibility = Visibility.Collapsed;
             TitleBox.Text = string.Empty;
             return;
         }
+        var title = _pane.SessionTitle;
         TitleHost.Visibility = Visibility.Visible;
-        TitleBox.Text = title;
+        TitleBox.Text = string.IsNullOrWhiteSpace(title) ? UntitledPlaceholder : title;
     }
 
     private void OnTitleGotFocus(object sender, RoutedEventArgs e) => _titleFocused = true;
@@ -98,7 +103,11 @@ public partial class PaneToolbar : UserControl
     private void CommitTitle()
     {
         var newTitle = TitleBox.Text?.Trim();
-        if (!string.IsNullOrEmpty(newTitle) && newTitle != _pane.SessionTitle)
+        // Compare against what the box was showing, placeholder included: leaving "Untitled"
+        // untouched must not rename the session to "Untitled". This mirrors VS Code, which shows
+        // the placeholder as the input's value and commits only a real change against it.
+        var current = string.IsNullOrWhiteSpace(_pane.SessionTitle) ? UntitledPlaceholder : _pane.SessionTitle;
+        if (!string.IsNullOrEmpty(newTitle) && newTitle != current)
         {
             _pane.RenameSession(newTitle);
         }

--- a/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.Common.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.Common.cs
@@ -68,6 +68,10 @@ public sealed partial class SessionManager
                 text = (string)content;
             }
             if (string.IsNullOrWhiteSpace(text)) { return null; }
+            // Drop the editor-context block cv-prompt prepends, so a real prompt sent with IDE
+            // context is not mistaken for a "<"-tag meta line and discarded.
+            text = Chat.MetaInjection.StripIdeContext(text).TrimStart();
+            if (string.IsNullOrWhiteSpace(text)) { return null; }
             return text.StartsWith("<") || text.StartsWith("[Request interrupted") ? null : text;
         }
         catch { return null; }


### PR DESCRIPTION
A session started while a file was open in the editor never got a title — the box in the toolbar stayed hidden, and reopening it showed nothing. An older session, opened later, had its title fine.

## Cause

The chat prepends the active-editor context to each message as an `<ide_opened_file>…</ide_opened_file>` block (see `cv-prompt.ts`), so the first user prompt on disk begins with `<`. `ExtractUserText` — which reads the prompts that feed title generation — rejects any user text starting with `<`, a rule meant to drop CLI meta lines. It discarded the whole prompt, context and words together, so there was nothing to generate a title from.

Confirmed against a real session file: one `user` entry, its text `<ide_opened_file>…</ide_opened_file>\nciamo mi chiamo danele`, and no `ai-title` row anywhere.

## Fix

`MetaInjection.StripIdeContext` removes a leading `<ide_selection>`/`<ide_opened_file>` block before the `<`-check, so the user's own words are what gets read. A genuine meta line (`system-reminder`, `task-notification`) still starts with `<` after stripping and is still dropped — verified with a throwaway harness across four cases.

Two follow-ups so a session with no ai-title *yet* still reads sensibly:

- **The title box stayed hidden** when there was no title, so a fresh chat had nothing to click. It now shows an **"Untitled"** placeholder, the way VS Code does (`summary.value || "Untitled"`, confirmed in their `2.1.217` bundle) — visible and editable, and a commit compares against the shown value so leaving "Untitled" untouched does not rename the session to it. Still hidden for the CLI pane, which has no editable title.
- **The generated ai-title reached disk but not the live toolbar.** `MaybeGenerateTitle` writes it asynchronously, after the turn-end refresh has already run and found nothing, so the title only appeared on reopen. It now pushes to the pane once written — guarded on the session id, and yielding to a user rename that landed mid-generation.

## Verified

Builds clean on `master`. The strip regex passes on the real prompt (`→ ciamo mi chiamo danele`), on an `<ide_selection>` prompt, on a plain prompt (unchanged), and leaves a real `<system-reminder>` untouched. Manual check in the Exp instance: a new session, started with a file open, now gets a title.
