### PR TITLE
fix(sessions): stop the picker from closing on delete-confirm and rename-Esc

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneToolbar.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneToolbar.xaml.cs
@@ -179,14 +179,22 @@ public partial class PaneToolbar : UserControl
     // The live session-picker popup, so Esc (which VS routes through IOleCommandTarget, never
     // reaching the popup) can dismiss it. Null when closed.
     private Popup _historyPopup;
+    private SessionManagerControl _historyPicker;
 
-    /// <summary>Close the session picker if open; true when it was. Called by the pane's Esc
-    /// handler before it forwards Esc anywhere else.</summary>
+    /// <summary>Handle Esc for the session picker: routed here from the pane because VS's
+    /// IOleCommandTarget swallows Esc before it reaches the popup. If a rename edit is open, revert
+    /// it and keep the picker up; otherwise close the picker. Returns true when it consumed the
+    /// Esc (either case), false when the picker wasn't open.</summary>
     public bool DismissSessionHistory()
     {
         if (_historyPopup?.IsOpen != true) { return false; }
+
+        // Esc while renaming exits the edit and leaves the list up, rather than closing everything.
+        if (_historyPicker?.TryCancelInlineEdit() == true) { return true; }
+
         _historyPopup.IsOpen = false;
         _historyPopup = null;
+        _historyPicker = null;
         _pane.FocusInput();
         return true;
     }
@@ -223,8 +231,9 @@ public partial class PaneToolbar : UserControl
             popup.IsOpen = false;
             _pane.FocusInput();
         };
-        popup.Closed += (_, _) => { if (ReferenceEquals(_historyPopup, popup)) { _historyPopup = null; } };
+        popup.Closed += (_, _) => { if (ReferenceEquals(_historyPopup, popup)) { _historyPopup = null; _historyPicker = null; } };
         _historyPopup = popup;
+        _historyPicker = picker;
         popup.IsOpen = true;
         // Opened from the chat command the caret sits in WebView2 — a separate HWND. Blurring it
         // only clears the DOM caret (and asynchronously at that), so Win32 focus has to be pulled

--- a/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManagerControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManagerControl.xaml.cs
@@ -117,6 +117,32 @@ public partial class SessionManagerControl : UserControl
         e.Handled = true;
     }
 
+    /// <summary>Handle Esc when it reaches us from the host rather than from the keyboard: in VS,
+    /// Esc is routed through IOleCommandTarget and never fires PreviewKeyDown on the popup. Returns
+    /// true if a rename edit was open and got reverted — the caller must then NOT dismiss the
+    /// picker, so Esc exits the edit and leaves the list up. Returns false when nothing was being
+    /// edited, so the caller closes the picker as before.</summary>
+    public bool TryCancelInlineEdit()
+    {
+        var editing = _allSessions.FirstOrDefault(r => r.IsEditing);
+        if (editing == null) { return false; }
+        CancelEditAndRefocus(editing);
+        return true;
+    }
+
+    /// <summary>Leave inline-edit mode and put focus back on the search box, or the keystroke goes
+    /// nowhere — the edit TextBox is collapsing and the picker keeps typing. Deferred so the focus
+    /// lands after the collapse.</summary>
+    private void CancelEditAndRefocus(SessionRow row)
+    {
+        row.CancelEdit();
+        Dispatcher.BeginInvoke(new Action(() =>
+        {
+            SearchBox.Focus();
+            SearchBox.CaretIndex = SearchBox.Text?.Length ?? 0;
+        }));
+    }
+
     private void OnSearchKeyDown(object sender, KeyEventArgs e)
     {
         if (e.Key == Key.Down)
@@ -216,7 +242,7 @@ public partial class SessionManagerControl : UserControl
         }
         else if (e.Key == Key.Escape)
         {
-            row.CancelEdit();
+            CancelEditAndRefocus(row);
             e.Handled = true;
         }
     }
@@ -273,16 +299,47 @@ public partial class SessionManagerControl : UserControl
         e.Handled = true;
         if (sender is not FrameworkElement el || el.Tag is not SessionRow row) { return; }
 
-        // Always confirm: delete unlinks the JSONL from disk, no undo.
-        var preview = string.IsNullOrEmpty(row.DisplayTitle) ? row.Id : row.DisplayTitle;
-        var ok = MessageBox.Show(
-            $"Delete session \"{preview}\"?\nThis cannot be undone.",
-            "Delete session",
-            MessageBoxButton.YesNo,
-            MessageBoxImage.Warning,
-            MessageBoxResult.No);
-        if (ok != MessageBoxResult.Yes) { return; }
+        // The picker lives in a StaysOpen=false Popup, which light-dismisses the instant it loses
+        // focus. A modal MessageBox takes that focus, so the Popup — and the dialog with it —
+        // vanishes before the user can answer. Pin the Popup open across the prompt.
+        var hostPopup = FindAncestorPopup();
+        var wasStaysOpen = hostPopup?.StaysOpen ?? true;
+        if (hostPopup != null) { hostPopup.StaysOpen = true; }
+        try
+        {
+            // Always confirm: delete unlinks the JSONL from disk, no undo.
+            var preview = string.IsNullOrEmpty(row.DisplayTitle) ? row.Id : row.DisplayTitle;
+            var ok = MessageBox.Show(
+                $"Delete session \"{preview}\"?\nThis cannot be undone.",
+                "Delete session",
+                MessageBoxButton.YesNo,
+                MessageBoxImage.Warning,
+                MessageBoxResult.No);
+            if (ok != MessageBoxResult.Yes) { return; }
 
+            DeleteRow(row);
+        }
+        finally
+        {
+            if (hostPopup != null) { hostPopup.StaysOpen = wasStaysOpen; }
+        }
+    }
+
+    /// <summary>Walk up the logical tree to the Popup hosting this control, or null when the
+    /// control is shown some other way (e.g. a future docked Manage Sessions dialog).</summary>
+    private System.Windows.Controls.Primitives.Popup FindAncestorPopup()
+    {
+        DependencyObject d = this;
+        while (d != null)
+        {
+            if (d is System.Windows.Controls.Primitives.Popup p) { return p; }
+            d = System.Windows.LogicalTreeHelper.GetParent(d) ?? System.Windows.Media.VisualTreeHelper.GetParent(d);
+        }
+        return null;
+    }
+
+    private void DeleteRow(SessionRow row)
+    {
         try
         {
             new SessionManager(_paths, _workingDirectory).Delete(row.Id);


### PR DESCRIPTION
Two ways the session picker dismissed itself when it shouldn't, both traced to the same root: it lives in a `StaysOpen=false` Popup, so anything that pulls focus away or routes Esc past WPF tears the whole popup down.

## Delete confirmation vanished

Clicking the delete icon on a row flashed a dialog that closed on its own, and nothing was deleted. The confirmation is a modal `MessageBox`; opening it takes focus, the Popup light-dismisses, and the dialog goes with it before the user can click Yes/No.

Pin the Popup open (`StaysOpen=true`) across the prompt, restoring the previous value in a `finally`.

## Esc while renaming closed the picker

Renaming a session inline, then pressing Esc to cancel, closed the whole picker instead of just leaving the edit. Esc in VS is routed through `IOleCommandTarget` to the pane's `HandleEscape`, which calls straight into `DismissSessionHistory` — the edit box's own `OnEditKeyDown` never runs.

`DismissSessionHistory` now asks the picker first via `TryCancelInlineEdit()`: if a rename is open it reverts that and keeps the list up, and only closes the picker when nothing is being edited. The keyboard path (`OnEditKeyDown`, for contexts where Esc does reach WPF) shares the same revert. Either way focus returns to the search box, so the next keystroke lands somewhere instead of on the collapsing edit box.

## Verified

Builds clean on `master`. Manual check in the Exp instance: delete now shows the confirmation and waits; Esc during a rename exits the edit and leaves the picker up with the search box focused.

Independent of the release/marketplace work on the other branch — different files, preexisting UI bugs.
