### PR TITLE
fix(webview): pin Prettier to LF, and fix a stray NUL byte in cv-popover-list

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/.prettierrc.json
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/.prettierrc.json
@@ -4,5 +4,5 @@
     "trailingComma": "all",
     "printWidth": 100,
     "semi": true,
-    "endOfLine": "auto"
+    "endOfLine": "lf"
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-popover-list.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-popover-list.ts
@@ -292,7 +292,7 @@ export class CvPopoverList extends LitElement {
                 const o = it as { label?: string; name?: string; path?: string; id?: string };
                 return o.id ?? o.path ?? o.label ?? o.name ?? '';
             })
-            .join(' ');
+            .join('\0');
     }
     private _lastNavSig = '';
 

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/init.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/init.ts
@@ -88,8 +88,10 @@ function wireBridgeHandlers(): void {
             // state.ui is not observable — it was rendered once before this payload arrived, so
             // without a nudge it keeps the empty seed until some other event re-renders it (which
             // is why New Session made the copyright appear). Re-render it now.
-            (document.querySelector('cv-welcome') as (HTMLElement & { requestUpdate?(): void }) | null)
-                ?.requestUpdate?.();
+            (
+                document.querySelector('cv-welcome') as
+                    (HTMLElement & { requestUpdate?(): void }) | null
+            )?.requestUpdate?.();
         }
 
         const firstInit = !wasInitialized;


### PR DESCRIPTION
CI's `Format check` failed on `init.ts` while a local `npm run format` reported the same file unchanged. The cause was Prettier's `endOfLine: "auto"`: it accepts whatever line ending a file has on disk, so a Windows working copy (CRLF) and the CI runner's LF checkout disagreed on the same file.

## Fix

Set `endOfLine` to `"lf"` in `.prettierrc.json`, matching what `.gitattributes` already enforces (`* text=auto eol=lf`). With that, format is deterministic regardless of the checkout.

That change surfaced a real defect in `cv-popover-list.ts`: `_navSignature()` joined on a **literal NUL byte** (`0x00`) written straight into the source, not the `"\0"` escape. Git saw the NUL and marked the whole file **binary** (`-text`), so `.gitattributes` never normalised it and Prettier could never settle on it. Rewritten as `"\0"` — same behaviour (a separator that can't appear in a label/path/id), and the file is text again.

## Reviewing the diff

`cv-popover-list.ts` shows ~930 changed lines, but the **real change is two lines** — the `.join`. The rest is git normalising the file from CRLF to LF now that it is no longer treated as binary. Turn on **Hide whitespace** in the diff view, or check locally:

```
git diff --ignore-space-at-eol -- .../cv-popover-list.ts   # → 2 lines
```

`init.ts` is the reflow of the earlier welcome-refresh line under LF.

## Verified

`npm run format:check` passes locally on all files. The NUL is gone; git now reports `cv-popover-list.ts` as text (`i/lf`), not `-text`.
