### PR TITLE
fix(webview): mirror the dev bundle to every publisher folder

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/esbuild.config.mjs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/esbuild.config.mjs
@@ -37,12 +37,19 @@ async function mirrorTargets() {
         try {
             for (const inst of await readdir(vsRoot)) {
                 if (!inst.endsWith('Exp')) { continue; }
-                const wv = path.join(vsRoot, inst, 'Extensions', 'Corsinvest', 'cv4vs Agents');
-                if (!existsSync(wv)) { continue; }
-                // version subfolder(s) (e.g. 1.0.0) → WebView2
-                for (const ver of await readdir(wv)) {
-                    const dest = path.join(wv, ver, 'WebView2');
-                    if (existsSync(dest)) { targets.push(dest); }
+                // The publisher folder is the manifest Publisher, which changed from
+                // "Corsinvest" to "Corsinvest Srl" for the Marketplace — don't hardcode it.
+                // Scan every publisher for a "cv4vs Agents\<ver>\WebView2".
+                const exts = path.join(vsRoot, inst, 'Extensions');
+                if (!existsSync(exts)) { continue; }
+                for (const pub of await readdir(exts)) {
+                    const wv = path.join(exts, pub, 'cv4vs Agents');
+                    if (!existsSync(wv)) { continue; }
+                    // version subfolder(s) (e.g. 1.0.0) → WebView2
+                    for (const ver of await readdir(wv)) {
+                        const dest = path.join(wv, ver, 'WebView2');
+                        if (existsSync(dest)) { targets.push(dest); }
+                    }
                 }
             }
         } catch { /* vsRoot missing: no experimental VS installed */ }


### PR DESCRIPTION
The hot-reload mirror in `esbuild.config.mjs` scanned a hardcoded `Extensions\Corsinvest\cv4vs Agents\` path. When the manifest Publisher changed to "Corsinvest Srl" for the Marketplace, VS started deploying the F5 build under `Extensions\Corsinvest Srl\...` instead, which the mirror no longer matched — a rebuild wrote `dist\` but never copied it to the running experimental instance, so a reopened chat pane kept loading the stale bundle.

Scan every publisher folder for a `cv4vs Agents\<ver>\WebView2` instead of hardcoding the publisher name, so the mirror follows the deploy path across the rename.

Dev-only tooling (hot-reload copy); no runtime/shipped code affected.
