### PR TITLE
feat(webview): tidy the sub-agent block and unify the expand affordance

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
@@ -697,8 +697,23 @@ export class CvApp extends LitElement {
                 if (e.kind !== 'tool') {
                     continue;
                 }
-                const children = childrenByParent.get(e.toolUseId);
+                let children = childrenByParent.get(e.toolUseId);
                 if (children?.length) {
+                    // The sub-agent's first message echoes the launch prompt, already shown as
+                    // the Agent row's IN — drop it here too, matching the live path (_appendEntry).
+                    // History replay bypasses that filter, so without this the echo reappears as
+                    // a user bubble when a session is reopened.
+                    const prompt = String(e.data?.input?.prompt ?? '').trim();
+                    if (prompt) {
+                        children = children.filter(
+                            (c) =>
+                                !(
+                                    c.kind === 'text' &&
+                                    c.role === 'user' &&
+                                    c.text?.trim() === prompt
+                                ),
+                        );
+                    }
                     // Child tool rows inherit the Agent's agentId so the open-output path
                     // routes to the sub-agent transcript file (agent-<agentId>.jsonl).
                     if (e.agentId) {
@@ -844,8 +859,20 @@ export class CvApp extends LitElement {
                         return;
                     }
                     const full = this._replayEvents(data.events ?? []);
+                    // The full transcript's first user message echoes the launch prompt (already
+                    // shown as the Agent row's IN). Its events carry no parentToolUseId, so the
+                    // _replayEvents post-pass filter doesn't reach them — drop the echo here.
+                    const prompt = String(p.data?.input?.prompt ?? '').trim();
                     let list = p.subagentChildren ?? [];
                     for (const child of full) {
+                        if (
+                            prompt &&
+                            child.kind === 'text' &&
+                            child.role === 'user' &&
+                            child.text?.trim() === prompt
+                        ) {
+                            continue;
+                        }
                         list = this._upsertChild(list, child);
                     }
                     p.subagentChildren = list;

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-message.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-message.ts
@@ -6,8 +6,8 @@ import { LitElement, html, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import BranchFork16Regular from '@fluentui/svg-icons/icons/branch_fork_16_regular.svg';
-import ChevronDoubleDown16Regular from '@fluentui/svg-icons/icons/chevron_double_down_16_regular.svg';
-import ChevronDoubleUp16Regular from '@fluentui/svg-icons/icons/chevron_double_up_16_regular.svg';
+import ChevronDown16Regular from '@fluentui/svg-icons/icons/chevron_down_16_regular.svg';
+import ChevronUp16Regular from '@fluentui/svg-icons/icons/chevron_up_16_regular.svg';
 import './cv-copy-btn';
 import './cv-attach-chip';
 import { renderMarkdown, renderMarkdownStreaming } from '../../core/markdown';
@@ -170,7 +170,7 @@ export class CvMessage extends LitElement {
                               title=${this.expanded ? 'Reduce' : 'Expand'}
                               @click=${this._onToggleExpand}
                           >
-                              ${unsafeHTML(this.expanded ? ChevronDoubleUp16Regular : ChevronDoubleDown16Regular)}
+                              ${unsafeHTML(this.expanded ? ChevronUp16Regular : ChevronDown16Regular)}
                           </fluent-button>`
                         : nothing
                 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-thinking.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-thinking.ts
@@ -7,6 +7,8 @@ import { customElement, property } from 'lit/decorators.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { renderMarkdown } from '../../core/markdown';
 import { statusDotStyles } from '../styles/shared';
+import ChevronDown16Regular from '@fluentui/svg-icons/icons/chevron_down_16_regular.svg';
+import ChevronUp16Regular from '@fluentui/svg-icons/icons/chevron_up_16_regular.svg';
 
 // <1000 → integer; >=1000 → X.Yk (one decimal). Mirrors VS Code's token format.
 function fmtTokens(n: number): string {
@@ -57,15 +59,22 @@ export class CvThinking extends LitElement {
                 font-variant-numeric: tabular-nums;
             }
             .chevron {
-                /* Full opacity so it stays visible against the dimmed (0.8) italic summary. Collapsed
-               points right (-90°); open points down. */
+                /* Full opacity so it stays visible against the dimmed (0.8) italic summary.
+                   Down when collapsed, up when open — same single-chevron toggle as the tool
+                   rows and expandable messages (no double chevron, no tree-style rotation). */
                 opacity: 1;
-                font-size: 10px;
-                transform: rotate(-90deg);
-                transition: transform 0.15s;
+                display: inline-flex;
+                width: 16px;
+                height: 16px;
             }
-            details[open] .chevron {
-                transform: rotate(0deg);
+            .chevron .up {
+                display: none;
+            }
+            details[open] .chevron .down {
+                display: none;
+            }
+            details[open] .chevron .up {
+                display: inline-flex;
             }
             .body {
                 /* Indent under the label (past the dot + gap: ~8px dot + 6px gap), like the assistant
@@ -110,7 +119,10 @@ export class CvThinking extends LitElement {
                     ${dot}
                     <span class="label">${label}</span>
                     ${tokens}
-                    <span class="chevron">▾</span>
+                    <span class="chevron"
+                        ><span class="down">${unsafeHTML(ChevronDown16Regular)}</span
+                        ><span class="up">${unsafeHTML(ChevronUp16Regular)}</span></span
+                    >
                 </summary>
                 <div class="body">${unsafeHTML(renderMarkdown(this.text))}</div>
             </details>

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-tool-row.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-tool-row.ts
@@ -5,8 +5,8 @@
 import { LitElement, html, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
-import ChevronDoubleDown16Regular from '@fluentui/svg-icons/icons/chevron_double_down_16_regular.svg';
-import ChevronDoubleUp16Regular from '@fluentui/svg-icons/icons/chevron_double_up_16_regular.svg';
+import ChevronDown16Regular from '@fluentui/svg-icons/icons/chevron_down_16_regular.svg';
+import ChevronUp16Regular from '@fluentui/svg-icons/icons/chevron_up_16_regular.svg';
 import './cv-message';
 import './cv-thinking';
 import './cv-copy-btn';
@@ -118,10 +118,10 @@ export class CvToolRow extends LitElement implements ToolRowState {
             ? this.subagentChildren
             : this.subagentChildren.slice(-3);
         const hasToggle = this.hasMore || this.subagentChildren.length > 3;
-        const title = String(this.data?.input?.description ?? '');
+        // No title here: the Agent row header already shows the description.
+        // The toolbar carries only the actions (copy + expand), pushed right.
         return html`
             <div class="cv-subagent-toolbar">
-                ${title ? html`<span class="cv-subagent-toolbar-title" title=${title}>${title}</span>` : html`<span class="cv-subagent-toolbar-title"></span>`}
                 <cv-copy-btn
                     .text=${this._subagentToMarkdown()}
                     title="Copy subagent output"
@@ -135,12 +135,14 @@ export class CvToolRow extends LitElement implements ToolRowState {
                               title=${this.subagentExpanded ? 'Reduce' : 'Show all'}
                               @click=${this._onToggleSubagent}
                           >
-                              ${unsafeHTML(this.subagentExpanded ? ChevronDoubleUp16Regular : ChevronDoubleDown16Regular)}
+                              ${unsafeHTML(this.subagentExpanded ? ChevronUp16Regular : ChevronDown16Regular)}
                           </fluent-button>`
                         : nothing
                 }
             </div>
-            <div class="cv-subagent-children">
+            <div
+                class="cv-subagent-children ${this.subagentExpanded ? '' : 'cv-subagent-collapsed'}"
+            >
                 ${
                     hasToggle && !this.subagentExpanded
                         ? html`<div class="cv-subagent-more" title="Earlier children — Show all">

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/base.css
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/base.css
@@ -79,6 +79,13 @@ fluent-link svg[fill='none'],
 fluent-option svg[fill='none'] {
     fill: none;
 }
+/* Fluent's small icon-only button scales its glyph to 20px; pin it to the nominal 16px
+ * so the action icons read as one size (shadow-DOM components do the same via iconStyles).
+ * Only icon-only buttons — labelled ones keep their sizing. */
+fluent-button[icon-only] svg {
+    width: 16px;
+    height: 16px;
+}
 
 
 /* cv-attach-menu is Shadow DOM: its fluent-menu-list/item styling (sizing, icon

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/chat.css
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/chat.css
@@ -274,10 +274,19 @@ body.sticky-user .cv-exchange > cv-message[role="user"]:first-child .cv-message.
     border-left: 2px solid var(--colorNeutralStroke1);
     margin-top: 2px;
 }
-/* Fixed toolbar above the nested box: title left, controls right. */
+/* Collapsed keeps the last 3 children but caps the box so one long child
+ * (a big tool output) can't dominate the transcript — scroll inside instead.
+ * Expanded is uncapped: showing the full transcript is the point. */
+.cv-subagent-children.cv-subagent-collapsed {
+    max-height: 320px;
+    overflow-y: auto;
+}
+/* Fixed toolbar above the nested box: actions only (copy + expand), right-aligned.
+ * The Agent row header already carries the description, so no title here. */
 .cv-subagent-toolbar {
     display: flex;
     align-items: center;
+    justify-content: flex-end;
     gap: 6px;
     margin-left: 16px;
     margin-top: 4px;
@@ -304,15 +313,6 @@ body.sticky-user .cv-exchange > cv-message[role="user"]:first-child .cv-message.
     cursor: default;
     user-select: none;
 }
-.cv-subagent-toolbar-title {
-    flex: 1;
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    font-weight: 500;
-    color: var(--colorNeutralForeground2);
-}
 .cv-tool-row-count-clickable {
     cursor: pointer;
 }
@@ -331,23 +331,26 @@ body.sticky-user .cv-exchange > cv-message[role="user"]:first-child .cv-message.
     color: inherit;
 }
 
+/* The chevron toggle is a fluent-button (icon-only). Hidden at rest, revealed on row
+ * hover — except .always-shown (Agent), kept visible so a near-empty collapsed row reads
+ * as expandable. The button rotates 180° when open. */
 .cv-tool-row-chev {
     flex-shrink: 0;
-    color: var(--colorNeutralForeground3);
     opacity: 0;
     transition:
         transform 0.15s,
         opacity 0.15s;
-    display: flex;
-    align-items: center;
-    /* Match the first text line so it stays aligned with the dot/name. */
-    height: 18px;
 }
 .cv-tool-wrap:hover .cv-tool-row-chev {
     opacity: 1;
 }
 .cv-tool-row-chev.expanded {
     transform: rotate(180deg);
+    opacity: 1;
+}
+/* Kept visible at rest (Agent rows): a near-empty collapsed row needs the chevron
+ * as its only "expandable" cue, so it doesn't wait for hover. */
+.cv-tool-row-chev.always-shown {
     opacity: 1;
 }
 .cv-tool-actions {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/shared.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/shared.ts
@@ -18,6 +18,13 @@ export const iconStyles = css`
     svg[fill='none'] {
         fill: none;
     }
+    /* Fluent's small icon-only button scales its glyph to 20px; pin it to the nominal
+     * 16px so the action icons (copy, chevron, toggles) read as one size in the dense
+     * chat and don't look oversized. Only icon-only buttons — labelled ones keep theirs. */
+    fluent-button[icon-only] svg {
+        width: 16px;
+        height: 16px;
+    }
 `;
 
 /**

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/base.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/base.ts
@@ -76,12 +76,18 @@ export abstract class ToolRenderer {
     protected rowStandard(): TemplateResult {
         const body = this.body();
         const hasBody = body !== null && this.host.status !== 'pending';
-        const open = hasBody && (this.autoOpen() || this.host.expanded);
+        // Only defaultCollapsed rows (Agent) are collapsible: they start closed regardless of
+        // the preview setting and show a chevron (kept visible at rest) to toggle. Every other
+        // tool opens per autoOpen and shows no chevron — its body just stays open.
+        const collapsed = this.defaultCollapsed();
+        const open =
+            hasBody && (collapsed ? this.host.expanded : this.autoOpen() || this.host.expanded);
         return this.chrome({
             body: hasBody ? body : null,
             open,
-            onClick: hasBody ? () => this.host.toggleExpanded() : null,
-            chevron: hasBody,
+            onClick: hasBody && collapsed ? () => this.host.toggleExpanded() : null,
+            chevron: hasBody && collapsed,
+            chevronAlwaysShown: collapsed,
         });
     }
 
@@ -142,14 +148,27 @@ export abstract class ToolRenderer {
         return this.host.status === 'error' || this.host.previewLines > 0;
     }
 
+    /** Whether this row starts collapsed, ignoring the preview auto-open setting.
+     *  Default: false — a tool row follows autoOpen (error/previews). A row that holds
+     *  a lot (Agent: a whole sub-agent transcript) overrides this to start closed and
+     *  keep its chevron visible at rest, so it clearly reads as expandable. */
+    protected defaultCollapsed(): boolean {
+        return false;
+    }
+
     private chrome(opts: {
         body: TemplateResult | null;
         open: boolean;
         onClick: (() => void) | null;
         chevron: boolean;
+        chevronAlwaysShown?: boolean;
         actions?: TemplateResult;
     }): TemplateResult {
-        const clickable = opts.onClick !== null;
+        // When the chevron is present it is the toggle (a real button), so the row itself
+        // is not clickable — otherwise the two double-trigger. Rows without a chevron keep
+        // their row-level click (e.g. diff rows opening the file).
+        const rowClick = opts.chevron ? null : opts.onClick;
+        const clickable = rowClick !== null;
         const actions =
             opts.actions ?? (this.host.status === 'error' ? this.errorButton() : nothing);
         const elapsed = this.host.elapsedSec;
@@ -159,7 +178,7 @@ export abstract class ToolRenderer {
                 <div
                     class="cv-tool-row"
                     style=${clickable ? 'cursor:pointer' : ''}
-                    @click=${opts.onClick}
+                    @click=${rowClick}
                 >
                     <span class="cv-tool-row-dot ${this.dotClass()}"></span>
                     ${this.header()}
@@ -173,13 +192,25 @@ export abstract class ToolRenderer {
                     ${actions}
                     ${
                         opts.chevron && opts.body !== null
-                            ? html`<span class="cv-tool-row-chev ${opts.open ? 'expanded' : ''}"
-                                  >${unsafeHTML(ChevronDown16Regular)}</span
+                            ? html`<fluent-button
+                                  appearance="subtle"
+                                  size="small"
+                                  icon-only
+                                  class="cv-tool-row-chev ${opts.open ? 'expanded' : ''} ${
+                                      opts.chevronAlwaysShown ? 'always-shown' : ''
+                                  }"
+                                  title=${opts.open ? 'Collapse' : 'Expand'}
+                                  @click=${(e: Event) => {
+                                      e.stopPropagation();
+                                      opts.onClick?.();
+                                  }}
+                                  >${unsafeHTML(ChevronDown16Regular)}</fluent-button
                               >`
                             : nothing
                     }
                 </div>
-                ${opts.open ? opts.body : nothing} ${this.host.renderSubagentChildren()}
+                ${opts.open ? opts.body : nothing}
+                ${opts.open ? this.host.renderSubagentChildren() : nothing}
             </div>
         `;
     }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/renderers.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/renderers.ts
@@ -216,6 +216,13 @@ export class AgentRenderer extends ToolRenderer {
         const inText = this.inputText();
         return inText ? this.ioGrid(inText, false) : null;
     }
+    // A sub-agent's whole transcript (prompt IN + nested rows) is a lot of content, so the
+    // row starts collapsed even when previews are on — dot + description until expanded — and
+    // keeps its chevron visible at rest so it reads as expandable. A click toggles it like
+    // any other tool. This is the only tool that opts into it.
+    override defaultCollapsed(): boolean {
+        return true;
+    }
 }
 
 export class SkillRenderer extends ToolRenderer {


### PR DESCRIPTION
Reworks how a sub-agent (Agent tool) reads in the chat, and lines the
chevron/action icons up across the transcript.

Sub-agent block:
- Drop the duplicated launch-prompt bubble. The sub-agent's first message
  echoes the prompt, already shown as the Agent row's IN. The live path
  filtered it; history replay and expand-full did not, so it reappeared as
  a blue user bubble on reopen. Filter it in both replay paths too.
- Agent rows start collapsed via a new `defaultCollapsed()` on the base
  renderer (the only tool that opts in): a whole transcript is a lot of
  content, so the row shows just dot + description until expanded, and keeps
  its chevron visible at rest so it clearly reads as expandable. Every other
  tool is unchanged (opens per the preview setting, no chevron).
- Collapsed, the nested box caps at 320px and scrolls, so one long child
  can't dominate the transcript. Expanded is uncapped.
- Drop the repeated description title from the sub-agent toolbar (the Agent
  header already carries it); the toolbar keeps only the actions.

Icons:
- The expand chevron is now a real fluent-button (focusable, keyboarded,
  titled) instead of a bare span, and it is the toggle — the row itself is
  no longer click-to-expand, so the two can't double-trigger.
- One chevron style everywhere: single down/up, no more double-chevron
  (cv-message, sub-agent show-all) and no tree-style rotation (cv-thinking
  moves from a glyph to the icon).
- Pin every icon-only button's glyph to its nominal 16px; Fluent's small
  button was scaling it to 20px, which read as oversized next to the 16px
  chevron.
- Inherit the row colour on the chevron SVG (Fluent ships a fixed black
  fill, invisible on the dark theme).
