### PR TITLE
feat(webview): move sub-agent actions onto the header row

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-tool-row.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-tool-row.ts
@@ -5,8 +5,8 @@
 import { LitElement, html, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
-import ChevronDown16Regular from '@fluentui/svg-icons/icons/chevron_down_16_regular.svg';
-import ChevronUp16Regular from '@fluentui/svg-icons/icons/chevron_up_16_regular.svg';
+import ArrowExpandAll16Regular from '@fluentui/svg-icons/icons/arrow_expand_all_16_regular.svg';
+import ArrowCollapseAll16Regular from '@fluentui/svg-icons/icons/arrow_collapse_all_16_regular.svg';
 import './cv-message';
 import './cv-thinking';
 import './cv-copy-btn';
@@ -106,40 +106,46 @@ export class CvToolRow extends LitElement implements ToolRowState {
         );
     };
 
-    /** Nested sub-agent rows/messages (Agent tool). Lit-owned, so it stays in
-     *  the component; the host exposes it to the renderer via renderSubagentChildren(). */
-    renderSubagentChildren() {
+    /** Actions for the Agent header row (copy output + expand/reduce), exposed to the
+     *  renderer via the host. Rendered on the row, not above the children — so there's no
+     *  empty toolbar band. Expand is always offered while the box is expanded: even with
+     *  ≤3 children the collapsed view caps the height and scrolls, so the user still needs
+     *  a way to lift the cap and see the whole transcript. */
+    renderHeaderActions() {
+        if (this.subagentChildren.length === 0) {
+            return nothing;
+        }
+        return html`
+            <cv-copy-btn
+                .text=${this._subagentToMarkdown()}
+                title="Copy subagent output"
+            ></cv-copy-btn>
+            <fluent-button
+                appearance="subtle"
+                size="small"
+                icon-only
+                title=${this.subagentExpanded ? 'Reduce' : 'Show all'}
+                @click=${this._onToggleSubagent}
+                >${unsafeHTML(
+                    this.subagentExpanded ? ArrowCollapseAll16Regular : ArrowExpandAll16Regular,
+                )}</fluent-button
+            >
+        `;
+    }
+
+    /** Nested child rows/messages (Agent tool). Lit-owned, so it stays in the
+     *  component; the host exposes it to the renderer via renderChildren(). */
+    renderChildren() {
         if (this.subagentChildren.length === 0) {
             return nothing;
         }
         // Collapsed shows the last 3; expanded shows whatever subagentChildren holds
-        // (the full list once fetched). The "…"/toggle appears when more exist.
+        // (the full list once fetched). The "…" marker appears when more exist.
         const shown = this.subagentExpanded
             ? this.subagentChildren
             : this.subagentChildren.slice(-3);
         const hasToggle = this.hasMore || this.subagentChildren.length > 3;
-        // No title here: the Agent row header already shows the description.
-        // The toolbar carries only the actions (copy + expand), pushed right.
         return html`
-            <div class="cv-subagent-toolbar">
-                <cv-copy-btn
-                    .text=${this._subagentToMarkdown()}
-                    title="Copy subagent output"
-                ></cv-copy-btn>
-                ${
-                    hasToggle
-                        ? html`<fluent-button
-                              appearance="subtle"
-                              size="small"
-                              icon-only
-                              title=${this.subagentExpanded ? 'Reduce' : 'Show all'}
-                              @click=${this._onToggleSubagent}
-                          >
-                              ${unsafeHTML(this.subagentExpanded ? ChevronUp16Regular : ChevronDown16Regular)}
-                          </fluent-button>`
-                        : nothing
-                }
-            </div>
             <div
                 class="cv-subagent-children ${this.subagentExpanded ? '' : 'cv-subagent-collapsed'}"
             >

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/chat.css
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/chat.css
@@ -281,29 +281,6 @@ body.sticky-user .cv-exchange > cv-message[role="user"]:first-child .cv-message.
     max-height: 320px;
     overflow-y: auto;
 }
-/* Fixed toolbar above the nested box: actions only (copy + expand), right-aligned.
- * The Agent row header already carries the description, so no title here. */
-.cv-subagent-toolbar {
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-    gap: 6px;
-    margin-left: 16px;
-    margin-top: 4px;
-    font-size: 12px;
-    color: var(--colorNeutralForeground3);
-}
-/* Copy + expand reveal on hover over the sub-agent block (like the message copy). The
- * title stays; only the action buttons fade in. cv-tool-wrap is the hover scope. */
-.cv-subagent-toolbar cv-copy-btn,
-.cv-subagent-toolbar fluent-button {
-    opacity: 0;
-    transition: opacity 0.15s;
-}
-.cv-tool-wrap:hover .cv-subagent-toolbar cv-copy-btn,
-.cv-tool-wrap:hover .cv-subagent-toolbar fluent-button {
-    opacity: 1;
-}
 /* "…" marker above the collapsed list = "there are earlier tools". */
 .cv-subagent-more {
     color: var(--colorNeutralForeground4);

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/base.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/base.ts
@@ -189,7 +189,7 @@ export abstract class ToolRenderer {
                               >`
                             : nothing
                     }
-                    ${actions}
+                    ${actions} ${opts.open ? this.host.renderHeaderActions() : nothing}
                     ${
                         opts.chevron && opts.body !== null
                             ? html`<fluent-button
@@ -210,7 +210,7 @@ export abstract class ToolRenderer {
                     }
                 </div>
                 ${opts.open ? opts.body : nothing}
-                ${opts.open ? this.host.renderSubagentChildren() : nothing}
+                ${opts.open ? this.host.renderChildren() : nothing}
             </div>
         `;
     }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/tool-host.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/tool-host.ts
@@ -63,8 +63,11 @@ export class BridgeToolHost implements ToolHost {
     get elapsedSec(): number {
         return this.row.elapsedSec;
     }
-    renderSubagentChildren() {
-        return this.row.renderSubagentChildren();
+    renderChildren() {
+        return this.row.renderChildren();
+    }
+    renderHeaderActions() {
+        return this.row.renderHeaderActions();
     }
     get showInlineToolErrors(): boolean {
         return appState.ui.showInlineToolErrors;

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/types.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/types.ts
@@ -25,8 +25,12 @@ export interface ToolRowState {
     readonly agentId: string;
     clipsOutput: boolean;
     toggleExpanded(): void;
-    /** Nested sub-agent rows/messages (Agent tool), or nothing. */
-    renderSubagentChildren(): TemplateResult | typeof nothing;
+    /** Nested child rows/messages (Agent tool's transcript), or nothing. Generic:
+     *  any tool with nested children can return them here. */
+    renderChildren(): TemplateResult | typeof nothing;
+    /** Actions rendered on the tool's header row (right side, before the chevron).
+     *  Default nothing; the Agent uses it for copy + show-all. */
+    renderHeaderActions(): TemplateResult | typeof nothing;
 }
 
 export interface ToolHost {
@@ -46,8 +50,12 @@ export interface ToolHost {
     readonly expanded: boolean;
     /** Always clip output to previewLines, even when expanded (shell tools). */
     clipsOutput: boolean;
-    /** Nested sub-agent rows/messages (Agent tool), or nothing. */
-    renderSubagentChildren(): TemplateResult | typeof nothing;
+    /** Nested child rows/messages (Agent tool's transcript), or nothing. Generic:
+     *  any tool with nested children can return them here. */
+    renderChildren(): TemplateResult | typeof nothing;
+    /** Actions rendered on the tool's header row (right side, before the chevron).
+     *  Default nothing; the Agent uses it for copy + show-all. */
+    renderHeaderActions(): TemplateResult | typeof nothing;
 
     /** Open a file in VS, optionally selecting a line range. */
     openFile(filePath: string, startLine?: number, endLine?: number): void;


### PR DESCRIPTION
The sub-agent's copy + show-all controls lived in a `.cv-subagent-toolbar` band rendered above the children. With the title gone, that band was an empty full-width row carrying only right-aligned buttons — a visual hole between the Agent's IN box and its first child.

Add a generic `renderHeaderActions()` to the tool host seam: `chrome` renders it on the tool's header row (before the chevron) while the row is expanded. Only `cv-tool-row` (the Agent) returns content — copy of the transcript plus an expand/reduce toggle — so every other tool is unchanged. The toggle uses `arrow_expand_all` / `arrow_collapse_all`, distinct from the single chevron that opens/closes the whole box.

Rename `renderSubagentChildren()` → `renderChildren()` for symmetry: both host slots are now generic (any tool with nested children or header actions can use them), and the sub-agent-specific markup stays in the component.

The expand toggle is offered whenever the box is expanded, even with ≤3 children: the collapsed view caps the height at 320px and scrolls, so the user still needs a way to lift the cap and read the whole transcript.

Drop the `.cv-subagent-toolbar` markup and its CSS; the nested box now renders only the children (the "…" marker and the collapsed max-height cap are unchanged).

Design + plan: `docs/internal/specs/todo/subagent-row-content-{design,plan}.md` (gitignored).
