### PR TITLE
Render slash-command output from system/local_command records

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.ClientEvents.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.ClientEvents.cs
@@ -517,6 +517,22 @@ public partial class ChatPaneControl
                 // "finished" — we notify only when this is empty (updates on finish AND on cancel).
                 _hasBackgroundTasks = obj["tasks"] is JArray tasks && tasks.Count > 0;
             }
+            else if (subtype == ClientMessages.SystemSubtype.LocalCommand)
+            {
+                // A slash command's local output arrives as a system record; forward the raw
+                // <local-command-stdout>/-stderr envelope as a UserText so the WebView parses it into
+                // a slash-result pill (parseLocalCommandOutput). Empty output → the WebView renders nothing.
+                var content = obj.Val("content", "");
+                if (content.IndexOf("<local-command-std", System.StringComparison.Ordinal) >= 0)
+                {
+                    _bridge.Send(BridgeMessages.ToWebView.Chat.UserText, new Contracts.UserTextNotification
+                    {
+                        Text = content,
+                        Uuid = obj.Val("uuid", ""),
+                        Timestamp = obj.ValTimestampMs("timestamp"),
+                    });
+                }
+            }
         });
 
     // Map rate_limit_info to a banner: "allowed" clears it, else a message

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/types.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/types.ts
@@ -273,6 +273,9 @@ interface UiEntryBase {
     kind: 'text';
     id: number;
     text: string;
+    /** Message time (epoch ms) from the record/event; absent when the wire had none. Drives the
+     *  actions row's "x ago". Not every role shows it (thinking/compact/status don't). */
+    timestamp?: number;
 }
 
 /** A real user turn: the prompt text plus optional image/file chips. */
@@ -281,16 +284,12 @@ export interface UiUserEntry extends UiEntryBase {
     uuid?: string;
     images?: UiImage[];
     files?: UiFile[];
-    /** Message time (epoch ms) from the record/event; absent when the wire had none. */
-    timestamp?: number;
 }
 
 /** An assistant turn; `streaming` is UI-only (true while the delta text is still growing). */
 export interface UiAssistantEntry extends UiEntryBase {
     role: 'assistant';
     streaming?: boolean;
-    /** Message time (epoch ms) from the record/event; absent when the wire had none. */
-    timestamp?: number;
 }
 
 /** A thinking block: the model's reasoning, live-only (never persisted). `streaming` true while
@@ -321,7 +320,7 @@ export interface UiCompactEntry extends UiEntryBase {
 }
 
 /** A slash command's local output (<local-command-stdout>/<stderr>), parsed TS-side from a user
- *  message — a ViewModel-only role (no DTO/SDK peer). Rendered as a centered berry pill. */
+ *  message — a ViewModel-only role (no DTO/SDK peer). Rendered as a preformatted monospace block. */
 export interface UiSlashResultEntry extends UiEntryBase {
     role: 'slash-result';
     isError: boolean;

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
@@ -992,6 +992,7 @@ export class CvApp extends LitElement {
                       role: 'slash-result',
                       text: lco.text,
                       isError: lco.isError,
+                      timestamp: d.timestamp ?? undefined,
                   }
                 : null;
         }
@@ -1306,7 +1307,11 @@ export class CvApp extends LitElement {
             .files=${e.role === 'user' ? (e.files ?? []) : []}
             ?streaming=${e.role === 'assistant' ? !!e.streaming : false}
             ?isError=${e.role === 'slash-result' ? e.isError : false}
-            .timestamp=${e.role === 'user' || e.role === 'assistant' ? (e.timestamp ?? 0) : 0}
+            .timestamp=${
+                e.role === 'user' || e.role === 'assistant' || e.role === 'slash-result'
+                    ? (e.timestamp ?? 0)
+                    : 0
+            }
         ></cv-message>`;
     }
 

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
@@ -1279,19 +1279,26 @@ export class CvApp extends LitElement {
         </section>`;
     }
 
-    // One actions row at the end of a whole response: copy the whole answer (every finished assistant
-    // block joined) + "x ago" (the last block, i.e. when the response finished). Just two elements, so
-    // inline here — no component. Nothing while the last block still streams, or with no assistant text.
+    // One actions row at the end of a whole exchange's response: copy every finished text block
+    // (assistant answers AND slash-command outputs like /config) joined + "x ago" (the last block).
+    // Nothing while the last assistant block still streams, or with no copyable text (e.g. a bare
+    // tool-only response). A slash-result-only exchange (a command with no assistant reply) still
+    // gets the row — its output is worth copying.
     private renderResponseActions(group: UiEntry[]) {
         const blocks = group.filter(
-            (e): e is UiAssistantEntry => e.kind === 'text' && e.role === 'assistant',
+            (e): e is UiAssistantEntry | UiSlashResultEntry =>
+                e.kind === 'text' && (e.role === 'assistant' || e.role === 'slash-result'),
         );
-        if (blocks.length === 0 || blocks[blocks.length - 1].streaming) {
+        if (blocks.length === 0) {
+            return nothing;
+        }
+        const last = blocks[blocks.length - 1];
+        if (last.role === 'assistant' && last.streaming) {
             return nothing;
         }
         const text = blocks.map((b) => b.text).join('\n\n');
-        const ts = blocks[blocks.length - 1].timestamp ?? 0;
-        return renderActionsRow(text, ts, 'Copy response');
+        const ts = last.timestamp ?? 0;
+        return renderActionsRow(text, ts, 'Copy');
     }
 
     private renderMessage(e: Exclude<UiEntry, UiToolEntry | UiThinkingEntry>) {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-message.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-message.ts
@@ -21,7 +21,6 @@ import { parseIdeContextTags } from '../../core/ide';
 import { renderSlashCommand } from '../../core/slash-commands';
 import { openLightbox } from '../../core/dialog-host';
 import { formatTimeAgo, formatAbsolute } from '../../core/time';
-import { renderActionsRow } from '../helpers/actions-row';
 import type {
     IdeContextRef,
     ForkNotification,
@@ -315,12 +314,11 @@ export class CvMessage extends LitElement {
         switch (this.role) {
             case 'slash-result':
                 // A slash command's own output (<local-command-stdout>/stderr>, already parsed into
-                // `text` by buildUserEntry) — a preformatted monospace block, not a user bubble, with
-                // the shared bottom actions row (copy + "x ago"), hover-gated.
+                // `text` by buildUserEntry) — a preformatted monospace block, not a user bubble. No
+                // per-message copy: the exchange's single end-of-response actions row copies it too.
                 return this.text
                     ? html`<div class="cv-message slash-result${this.isError ? ' error' : ''}">
                           <pre>${this.text}</pre>
-                          ${renderActionsRow(this.text, this.timestamp, 'Copy output', 'cv-slash-actions')}
                       </div>`
                     : nothing;
 

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-message.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-message.ts
@@ -21,6 +21,7 @@ import { parseIdeContextTags } from '../../core/ide';
 import { renderSlashCommand } from '../../core/slash-commands';
 import { openLightbox } from '../../core/dialog-host';
 import { formatTimeAgo, formatAbsolute } from '../../core/time';
+import { renderActionsRow } from '../helpers/actions-row';
 import type {
     IdeContextRef,
     ForkNotification,
@@ -314,10 +315,12 @@ export class CvMessage extends LitElement {
         switch (this.role) {
             case 'slash-result':
                 // A slash command's own output (<local-command-stdout>/stderr>, already parsed into
-                // `text` by buildUserEntry) — a centered berry pill, not a user bubble.
+                // `text` by buildUserEntry) — a preformatted monospace block, not a user bubble, with
+                // the shared bottom actions row (copy + "x ago"), hover-gated.
                 return this.text
                     ? html`<div class="cv-message slash-result${this.isError ? ' error' : ''}">
                           <pre>${this.text}</pre>
+                          ${renderActionsRow(this.text, this.timestamp, 'Copy output', 'cv-slash-actions')}
                       </div>`
                     : nothing;
 

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/chat.css
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/chat.css
@@ -681,11 +681,6 @@ cv-message:focus-within .cv-msg-actions {
 .cv-message.slash-result.error pre {
     border-left-color: var(--colorPaletteRedForeground1);
 }
-/* Copy + timestamp below the output, revealed on hovering the block. */
-.cv-message.slash-result:hover .cv-slash-actions,
-.cv-message.slash-result:focus-within .cv-slash-actions {
-    opacity: 1;
-}
 
 .cv-message.error {
     align-self: flex-start;

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/chat.css
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/chat.css
@@ -574,7 +574,7 @@ body.sticky-user .cv-exchange > cv-message[role="user"]:first-child .cv-message.
     display: flex;
     align-items: center;
     gap: 4px;
-    margin: 2px 0 0 2px;
+    margin: 5px 0 0 2px;
     min-height: 20px;
     opacity: 0;
     transition: opacity 0.15s;
@@ -658,28 +658,20 @@ cv-message:focus-within .cv-msg-actions {
 /* A slash command's local output (<local-command-stdout>, e.g. "Set model to X"): a centered
  * berry/purple pill with hairline rules either side — same "special action" language as the
  * model-switch notice, and centered like the VS Code compact divider. stderr → red. */
+/* A slash command's own output (/config, /model, "Unknown command"…) — the CLI's raw terminal
+ * text. Rendered as a preformatted monospace block (left-aligned, wraps), faithful to the terminal
+ * (no markdown reinterpretation, which would break /config's aligned key=value list). A subtle left
+ * rail + muted colour marks it as command output, not conversation. stderr tints red. */
 .cv-message.slash-result {
-    display: flex;
-    align-items: center;
-    gap: 8px;
     margin: 6px 0;
-    color: var(--colorPaletteBerryBorderActive);
+    color: var(--colorNeutralForeground3);
     font-size: 11px;
     font-family: var(--fontFamilyMonospace, monospace);
 }
-.cv-message.slash-result::before,
-.cv-message.slash-result::after {
-    content: '';
-    flex: 1;
-    height: 1px;
-    background: color-mix(in srgb, var(--colorPaletteBerryBorderActive) 30%, transparent);
-}
 .cv-message.slash-result pre {
     margin: 0;
-    padding: 1px 10px;
-    border-radius: 999px;
-    background: color-mix(in srgb, var(--colorPaletteBerryBorderActive) 12%, transparent);
-    border: 1px solid color-mix(in srgb, var(--colorPaletteBerryBorderActive) 35%, transparent);
+    padding: 2px 0 2px 10px;
+    border-left: 2px solid var(--colorNeutralStroke1);
     white-space: pre-wrap;
     word-break: break-word;
 }
@@ -687,8 +679,12 @@ cv-message:focus-within .cv-msg-actions {
     color: var(--colorPaletteRedForeground1);
 }
 .cv-message.slash-result.error pre {
-    background: color-mix(in srgb, var(--colorPaletteRedForeground1) 12%, transparent);
-    border-color: color-mix(in srgb, var(--colorPaletteRedForeground1) 35%, transparent);
+    border-left-color: var(--colorPaletteRedForeground1);
+}
+/* Copy + timestamp below the output, revealed on hovering the block. */
+.cv-message.slash-result:hover .cv-slash-actions,
+.cv-message.slash-result:focus-within .cv-slash-actions {
+    opacity: 1;
 }
 
 .cv-message.error {

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClientMessages.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClientMessages.cs
@@ -46,6 +46,10 @@ internal static class ClientMessages
         public const string BackgroundTasksChanged = "background_tasks_changed";
         // Authoritative cumulative thinking-token estimate for the in-flight thinking block.
         public const string ThinkingTokens = "thinking_tokens";
+        // A slash command's own output ("Current model: …", "Unknown command: …", "/x isn't available",
+        // /config|/context usage). content = "<local-command-stdout>…</local-command-stdout>" (or -stderr).
+        // The WebView renders it as a slash-result pill (parseLocalCommandOutput on the UserText text).
+        public const string LocalCommand = "local_command";
     }
 
     // ----- subtype on control_request messages -----

--- a/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.History.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.History.cs
@@ -384,7 +384,8 @@ public sealed partial class SessionManager
                 return false;
 
             case ClientMessages.Type.System:
-                if (obj.Val("subtype", "") == ClientMessages.SystemSubtype.CompactBoundary)
+                var systemSubtype = obj.Val("subtype", "");
+                if (systemSubtype == ClientMessages.SystemSubtype.CompactBoundary)
                 {
                     // sink is null once the page is full and we're only scanning older lines
                     // for the opening user prompt/metadata — don't add a compact row then.
@@ -398,6 +399,28 @@ public sealed partial class SessionManager
                             ["trigger"] = meta?.Val("trigger") ?? "auto",
                             ["preTokens"] = meta?.Val("preTokens", 0) ?? 0,
                         });
+                    }
+                    return true;
+                }
+                if (systemSubtype == ClientMessages.SystemSubtype.LocalCommand)
+                {
+                    // A slash command's local output persisted as a system record. Replay it as a
+                    // user-text line: EmitUser accepts the bare "<local-command-stdout>…" string and
+                    // the WebView turns it into a slash-result pill (same as the live path).
+                    if (messagesNewestFirst != null)
+                    {
+                        var content = obj.Val("content", "");
+                        if (content.IndexOf("<local-command-std", System.StringComparison.Ordinal) >= 0)
+                        {
+                            messagesNewestFirst.Add(new JObject
+                            {
+                                ["role"] = "user",
+                                ["content"] = content,
+                                ["uuid"] = obj.Val("uuid", ""),
+                                // Carry the ISO timestamp so ReplayPage → the actions row shows "x ago".
+                                ["timestamp"] = obj.Val("timestamp", (string)null),
+                            });
+                        }
                     }
                     return true;
                 }


### PR DESCRIPTION
## Problema

Un output di slash-command (`/config`, `/model`, `/context`, `/status`, `Unknown command: /x`, `/plugin isn't available`, `/btw isn't available`…) arriva/viene persistito come record **`type:system`, `subtype:local_command`**, content `<local-command-stdout>…`. Gestivamo solo il vecchio envelope `user/<local-command-stdout>`, quindi quegli output erano **invisibili** — il comando sembrava non rispondere.

Verificato sui `.jsonl`: i due formati **coesistono** (tutte le versioni CLI, entrypoint `claude-vscode` incluso — non è Desktop-only, non è cambio versione). `user/` = comandi con EFFETTO ("Set model to X", "Compacted"); `system/local_command` = INFORMATIVI/errore. Mai lo stesso output in entrambi → nessun rischio di doppione dedup.

## Fix

Inoltro il record sul canale `chat_user_text` **esistente** (nessun bridge message nuovo, nessun DTO): il WebView già parsa `<local-command-stdout>` in uno slash-result. Sia il path live (`OnSystemMessage`) sia il replay history (`SessionManager.History`) ora lo emettono, portando il timestamp ISO così la actions row mostra "x ago".

## Rendering

- Lo slash-result passa da **pill berry centrata** (si rompeva sull'output multi-riga di `/config` — i rail flex diventavano un arco enorme) a un **blocco monospace preformattato** con rail sinistro discreto, fedele al terminale (niente reinterpretazione markdown, che romperebbe l'allineamento `key=value` di `/config`). stderr tinge rosso.
- Copy/timestamp **non** per singolo slash-result: la **unica** actions row a fine exchange ora copre testo assistant **e** output slash-command (join), con "x ago" dell'ultimo blocco. Un exchange di solo-comando (senza risposta assistant) ha comunque la row.
- `timestamp` sale su `UiEntryBase` (era duplicato su user/assistant/slash-result). Riga azioni utente staccata 2px→5px dalla bolla.

## Note

- **C#**: `SystemSubtype.LocalCommand` const + inoltro live + replay history. Build MSBuild verde (0 errori).
- **WebView**: `npm run check` verde (0 errori, 7 warning `no-explicit-any` pre-esistenti), Prettier ok.
- **Noto, non risolto qui**: alcuni comandi client-side (`/btw`, `/plugin`) mostrano l'output ×2 — il CLI emette due eventi live (Claude Desktop lo mostra ×2 anch'esso; è a monte, non nel `.jsonl`). Un dedup difensivo si può aggiungere in seguito.
- Spec/plan: `docs/internal/specs/todo/system-local-command-output-*` (gitignored, non committati).