### PR TITLE
Code cleanup: C#12 collections + no-BOM + drop dead TS fields

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents.Contracts/UsageDtos.cs
+++ b/src/Corsinvest.VisualStudio.Agents.Contracts/UsageDtos.cs
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
-using System.Collections.Generic;
-
 namespace Corsinvest.VisualStudio.Agents.Contracts;
 
 /// <summary>One rate-limit window from get_usage (the 5-hour / 7-day plan windows): a label,

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.Payloads.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.Payloads.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -8,7 +8,6 @@ using Corsinvest.VisualStudio.Agents.Options;
 using Newtonsoft.Json.Linq;
 using System;
 using System.IO;
-using System.Reflection;
 
 namespace Corsinvest.VisualStudio.Agents.Chat.Host;
 

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Chat.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Chat.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -9,7 +9,6 @@ using Corsinvest.VisualStudio.Agents.Options;
 using Microsoft.VisualStudio.Shell;
 using Newtonsoft.Json.Linq;
 using System;
-using System.IO;
 using System.Threading.Tasks;
 
 namespace Corsinvest.VisualStudio.Agents.Chat.Host;

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/types.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/types.ts
@@ -228,7 +228,6 @@ export interface Attachment {
 export interface SubagentTask {
     taskId: string;
     description: string;
-    taskType?: string;
     toolUseId?: string;
     recentTools: string[]; // last 3 tool names (cosa fa ora = at(-1))
     summary?: string;
@@ -297,7 +296,6 @@ export interface UiAssistantEntry extends UiEntryBase {
  *  thinking_tokens value). `redacted` = cipher-only block, no text → static, not expandable. */
 export interface UiThinkingEntry extends UiEntryBase {
     role: 'thinking';
-    parentToolUseId?: string;
     streaming?: boolean;
     tokens?: number;
     durationMs?: number;

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
@@ -495,7 +495,6 @@ export class CvApp extends LitElement {
                     m.set(d.taskId, {
                         taskId: d.taskId,
                         description: d.description ?? '',
-                        taskType: d.taskType,
                         toolUseId: d.toolUseId ?? undefined,
                         recentTools: [],
                         usage: { totalTokens: 0, toolUses: 0, durationMs: 0 },

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeInstall.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeInstall.cs
@@ -1,9 +1,8 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
-using Corsinvest.VisualStudio.Agents.Helpers;
 using Corsinvest.VisualStudio.Agents.Options;
 using System;
 using System.Collections.Generic;

--- a/src/Corsinvest.VisualStudio.Agents/Core/Context/ContextDocument.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Context/ContextDocument.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.IO;
-using Corsinvest.VisualStudio.Agents.Helpers;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;

--- a/src/Corsinvest.VisualStudio.Agents/Core/Context/ContextProbe.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Context/ContextProbe.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Corsinvest.VisualStudio.Agents.Contracts;
 using Corsinvest.VisualStudio.Agents.Core.Client;
 using Corsinvest.VisualStudio.Agents.Core.Profiles;
-using Corsinvest.VisualStudio.Agents.Helpers;
 
 namespace Corsinvest.VisualStudio.Agents.Core.Context;
 

--- a/src/Corsinvest.VisualStudio.Agents/Core/Context/ContextUsageControl.Render.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Context/ContextUsageControl.Render.cs
@@ -9,12 +9,10 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Documents;
-using System.Windows.Media;
 using System.Windows.Shapes;
 using Corsinvest.VisualStudio.Agents.Contracts;
 using Corsinvest.VisualStudio.Agents.Core.Controls;
 using Corsinvest.VisualStudio.Agents.Core.Stats;
-using Corsinvest.VisualStudio.Agents.Helpers;
 using Microsoft.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.Shell;
 

--- a/src/Corsinvest.VisualStudio.Agents/Core/Context/ContextUsageControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Context/ContextUsageControl.xaml.cs
@@ -12,8 +12,6 @@ using System.Windows.Controls;
 using Corsinvest.VisualStudio.Agents.Contracts;
 using Corsinvest.VisualStudio.Agents.Core.Profiles;
 using Corsinvest.VisualStudio.Agents.Core.Stats;
-using Corsinvest.VisualStudio.Agents.Helpers;
-using Corsinvest.VisualStudio.Agents.Utils;
 using Microsoft.VisualStudio.Shell;
 
 namespace Corsinvest.VisualStudio.Agents.Core.Context;

--- a/src/Corsinvest.VisualStudio.Agents/Core/Context/CvMemoryMap.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Context/CvMemoryMap.cs
@@ -6,7 +6,6 @@
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
-using System.Windows.Media;
 using System.Windows.Shapes;
 using Corsinvest.VisualStudio.Agents.Contracts;
 using Corsinvest.VisualStudio.Agents.Core.Stats;

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneControlBase.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneControlBase.cs
@@ -1,10 +1,9 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
 using Corsinvest.VisualStudio.Agents.Core.Client;
-using Corsinvest.VisualStudio.Agents.Helpers;
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneToolbar.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneToolbar.xaml.cs
@@ -1,11 +1,10 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
 using Corsinvest.VisualStudio.Agents.Core.Sessions;
 using Corsinvest.VisualStudio.Agents.Helpers;
-using Corsinvest.VisualStudio.Agents.Menu;
 using Corsinvest.VisualStudio.Agents.Options;
 using Microsoft.VisualStudio.Imaging;
 using System;

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatisticsControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatisticsControl.xaml.cs
@@ -11,8 +11,6 @@ using System.Windows;
 using System.Windows.Controls;
 using Corsinvest.VisualStudio.Agents.Contracts;
 using Corsinvest.VisualStudio.Agents.Core.Profiles;
-using Corsinvest.VisualStudio.Agents.Helpers;
-using Corsinvest.VisualStudio.Agents.Utils;
 using Microsoft.VisualStudio.Shell;
 
 namespace Corsinvest.VisualStudio.Agents.Core.Stats;

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatisticsDocument.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatisticsDocument.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.IO;
-using Corsinvest.VisualStudio.Agents.Helpers;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsChart.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsChart.cs
@@ -162,11 +162,10 @@ internal static class StatsChart
 
         var infos = BuildDayInfos(r);
         // One bar per day that has token data, in chronological order.
-        return days
+        return [.. days
             .Where(d => d.Date != null && infos.ContainsKey(d.Date))
             .OrderBy(d => d.Date, StringComparer.Ordinal)
-            .Select(d => new DayBar { Info = infos[d.Date] })
-            .ToList();
+            .Select(d => new DayBar { Info = infos[d.Date] })];
     }
 
     private static Dictionary<string, long> ToMap(object tokensByModel)

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsService.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -254,9 +254,7 @@ internal static class StatsService
     private static List<string> SplitPath(string path)
     {
         if (string.IsNullOrEmpty(path)) { return new List<string> { "(unknown)" }; }
-        return path.Replace('/', '\\').TrimEnd('\\')
-            .Split(new[] { '\\' }, StringSplitOptions.RemoveEmptyEntries)
-            .ToList();
+        return [.. path.Replace('/', '\\').TrimEnd('\\').Split(new[] { '\\' }, StringSplitOptions.RemoveEmptyEntries)];
     }
 
     // The Project subtree: a "Days" branch (real per-day tokens, matching the chart) and a
@@ -687,7 +685,7 @@ internal static class StatsService
 
         var slices = BreakdownSessions(children, range) ?? BreakdownGeneric(children, range);
 
-        slices = slices.OrderByDescending(s => s.Tokens).ToList();
+        slices = [.. slices.OrderByDescending(s => s.Tokens)];
         if (slices.Count <= DonutTopN) { return slices; }
 
         // Roll everything past the top N into a single grey "Others" slice.

--- a/src/Corsinvest.VisualStudio.Agents/Core/Usage/UsageControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Usage/UsageControl.xaml.cs
@@ -12,8 +12,6 @@ using System.Windows;
 using System.Windows.Controls;
 using Corsinvest.VisualStudio.Agents.Contracts;
 using Corsinvest.VisualStudio.Agents.Core.Profiles;
-using Corsinvest.VisualStudio.Agents.Helpers;
-using Corsinvest.VisualStudio.Agents.Utils;
 using Microsoft.VisualStudio.Shell;
 
 namespace Corsinvest.VisualStudio.Agents.Core.Usage;

--- a/src/Corsinvest.VisualStudio.Agents/Core/Usage/UsageDocument.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Usage/UsageDocument.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.IO;
-using Corsinvest.VisualStudio.Agents.Helpers;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;

--- a/src/Corsinvest.VisualStudio.Agents/Core/Usage/UsageMapper.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Usage/UsageMapper.cs
@@ -50,7 +50,7 @@ internal static class UsageMapper
                     });
                 }
             }
-            dto.Windows = windows.ToArray();
+            dto.Windows = [.. windows];
         }
 
         if (raw?["behaviors"] is JObject behaviors)
@@ -68,12 +68,11 @@ internal static class UsageMapper
         {
             // Only insights we have copy for are kept; the headline/body are composed here so the
             // clients just render them.
-            Insights = (period["behaviors"] as JArray ?? new JArray())
+            Insights = [.. (period["behaviors"] as JArray ?? new JArray())
                 .OfType<JObject>()
                 .Select(b => InsightCopy(b.Val("key", ""), b.Val("pct", 0)))
                 .Where(c => c != null)
-                .Select(c => new UsageInsightDto { Headline = c.Value.Headline, Body = c.Value.Body })
-                .ToArray(),
+                .Select(c => new UsageInsightDto { Headline = c.Value.Headline, Body = c.Value.Body })],
             Skills = Attribution(period["skills"]),
             // The CLI sends subagents under "agents"; some builds also use "subagents".
             Subagents = Attribution(period["subagents"] ?? period["agents"]),
@@ -83,10 +82,9 @@ internal static class UsageMapper
     }
 
     private static UsageAttributionDto[] Attribution(JToken arr)
-        => (arr as JArray ?? new JArray())
+        => [.. (arr as JArray ?? new JArray())
             .OfType<JObject>()
-            .Select(x => new UsageAttributionDto { Name = x.Val("name", "—"), Pct = x.Val("pct", 0) })
-            .ToArray();
+            .Select(x => new UsageAttributionDto { Name = x.Val("name", "—"), Pct = x.Val("pct", 0) })];
 
     // Headline + body for an insight key (pct fills the headline). Null for unknown keys → dropped.
     private static (string Headline, string Body)? InsightCopy(string key, int pct) => key switch

--- a/src/Corsinvest.VisualStudio.Agents/Core/Usage/UsageProbe.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Usage/UsageProbe.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Corsinvest.VisualStudio.Agents.Contracts;
 using Corsinvest.VisualStudio.Agents.Core.Client;
 using Corsinvest.VisualStudio.Agents.Core.Profiles;
-using Corsinvest.VisualStudio.Agents.Helpers;
 
 namespace Corsinvest.VisualStudio.Agents.Core.Usage;
 

--- a/src/Corsinvest.VisualStudio.Agents/Core/Workspace/WorkspaceStore.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Workspace/WorkspaceStore.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -27,15 +27,14 @@ internal static class WorkspaceStore
             {
                 Version = 1,
                 SavedAt = savedAtIso,
-                Panes = PaneRegistry.Instance.Entries
+                Panes = [.. PaneRegistry.Instance.Entries
                     .OrderBy(e => e.SeqNo)
                     .Select(e => new PaneState
                     {
                         Kind = e.Kind == PaneKind.Cli ? "Cli" : "Chat",
                         Profile = e.Profile.Name,
                         SessionId = e.ActiveSessionId,
-                    })
-                    .ToList(),
+                    })],
             };
 
             var path = AppPaths.WorkspaceFile(solutionFolder);

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.Operations.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.Operations.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -7,7 +7,6 @@ using EnvDTE;
 using EnvDTE80;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Shell.Interop;
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeDiagnosticsTracker.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeDiagnosticsTracker.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -81,7 +81,7 @@ internal sealed class IdeDiagnosticsTracker
         {
             var uri = PathHelpers.ToFileUri(filePath);
             var files = await IdeContextService.Instance.GetDiagnosticsAsync(uri);
-            return files.SelectMany(f => f.Diagnostics).ToList();
+            return [.. files.SelectMany(f => f.Diagnostics)];
         }
         catch (Exception ex)
         {

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/McpServerHost.LockFile.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/McpServerHost.LockFile.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -61,7 +61,7 @@ internal sealed partial class McpServerHost
     private void DeleteAllLockFiles()
     {
         string[] folders;
-        lock (_lockFoldersGate) { folders = _lockFolders.ToArray(); _lockFolders.Clear(); }
+        lock (_lockFoldersGate) { folders = [.. _lockFolders]; _lockFolders.Clear(); }
         foreach (var folder in folders)
         {
             try

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/McpServerHost.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/McpServerHost.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -75,10 +75,9 @@ internal sealed partial class McpServerHost
     /// on any configured config-dir discovers it. Two profiles on the same CLAUDE_CONFIG_DIR collapse
     /// to one folder (Distinct).</summary>
     private static List<string> ProfileIdeFolders() =>
-        ProfileStore.Load(forEdit: false)
+        [.. ProfileStore.Load(forEdit: false)
             .Select(p => ClaudePaths.ForProfile(p).IdeFolder)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToList();
+            .Distinct(StringComparer.OrdinalIgnoreCase)];
 
     public void Start()
     {
@@ -175,7 +174,7 @@ internal sealed partial class McpServerHost
             await Task.Run(() =>
             {
                 string[] folders;
-                lock (_lockFoldersGate) { folders = _lockFolders.ToArray(); }
+                lock (_lockFoldersGate) { folders = [.. _lockFolders]; }
                 // A pane closing concurrently could remove a folder from _lockFolders (and delete
                 // its lock) between this snapshot and the write below, resurrecting an orphan lock.
                 // Tolerated: the lock still points at this live VS pid, so the CLI accepts it, and

--- a/src/Corsinvest.VisualStudio.Agents/Menu/AboutDialog.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Menu/AboutDialog.xaml.cs
@@ -1,11 +1,10 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
 using Microsoft.VisualStudio.PlatformUI;
 using System;
-using System.Reflection;
 using System.Windows;
 using System.Windows.Documents;
 


### PR DESCRIPTION
Housekeeping, behaviour-preserving. Two independent commits.

## `chore(dotnet)` — modernize collections + BOM
A VS Code Cleanup pass over 25 files: C#12 collection expressions (`[.. x]`) in place of `.ToList()` / `new[]{...}`, and the UTF-8 BOM stripped from the 12 files it touched to match `.editorconfig` (`charset = utf-8`, i.e. no BOM). `LangVersion=latest` already, so the collection expressions compile on net48. MSBuild green (0 errors).

## `refactor(webview)` — drop two dead UiEntry fields
An audit cross-referenced every interface property against the whole WebView tree (the TS compiler's `noUnusedLocals` doesn't flag unused *interface members*, so this was manual). Only two were truly dead:
- `SubagentTask.taskType` — written from the DTO, never read.
- `UiThinkingEntry.parentToolUseId` — never written, never read (thinking parents are tracked via the `_thinkingMsgs` map).

Both removed, plus the `taskType` write-site. Everything else came back live — several fields read only via Lit template bindings, which a naive grep would miss. `npm run check` green (0 errors, 7 pre-existing `no-explicit-any` warnings).