### PR TITLE
Clickable file references (path:line) in assistant messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ own.
 - **[Review changes in VS's own diff](docs/chat/diff.md)** — every Edit/Write shows as an inline diff,
   and opens in Visual Studio's native, **editable** side-by-side diff: **save (Ctrl+S) to accept** or
   **close to reject**, the CLI applies it only if you saved.
+- **[Clickable file references](docs/file-links.md)** — when Claude writes `ClientEvents.cs:208` (or a
+  whole list, `Package.cs:124,185,202`) the reference becomes a link that opens the file in VS at that
+  line. Every line in a list is its own link — something the VS Code extension and Claude Desktop
+  don't do. Code blocks stay untouched; clocks and host:ports never become dead links.
 - **The same sessions as VS Code and the terminal** — no separate database: it reads and writes the
   CLI's own session store, so a conversation started in the VS Code extension or in a terminal shows
   up here, and vice versa. Resume, fork and rename all work on those shared files, so you can switch

--- a/docs/file-links.md
+++ b/docs/file-links.md
@@ -1,0 +1,62 @@
+<!--
+SPDX-FileCopyrightText: Copyright Corsinvest Srl
+SPDX-License-Identifier: GPL-3.0-only
+-->
+
+# Clickable file references
+
+When Claude mentions a source location in its answer — `ClientEvents.cs:208`,
+`Core/Stats/StatsService.cs:45`, a whole list like `McpServerHost.cs:192,214,230` — the extension
+turns it into a **link**. Click it and the file opens in Visual Studio at that line, in your own
+editor, with your own extensions and theme.
+
+No copy-pasting a path into Go-To-File, no hunting for the line. The reference the model already
+wrote *is* the navigation.
+
+## What gets linked
+
+The parser follows the same two-phase approach Visual Studio's terminal uses (peel the `:line`
+suffix off the end, validate the path in front) and recognises every shape Claude actually writes:
+
+| You see | Opens |
+|---|---|
+| `ClientEvents.cs:208` | that file at line 208 |
+| `Core/Stats/StatsService.cs:45` | relative path, at line 45 |
+| `StatsService.cs:35–48` | a range — opens at the first line |
+| `AgentsPackage.cs:124,185,202` | **each line is its own link** |
+| `(NdjsonTransport.cs:91)` · `foo.cs(339)` · `bar.ts[45:12]` | parentheses/brackets, in prose |
+| `[McpServerHost.cs:192](src/…/McpServerHost.cs:192)` | a markdown link — uses the full path |
+| `file://C:\…\report.html` | absolute path (the `file://` is dropped from the label) |
+
+Only real code/text extensions are linked (`.cs`, `.ts`, `.css`, `.xaml`, `.json`, `.md`, `.cpp`,
+`.py`, …), so a clock (`10:30`), a host:port (`localhost:4040`) or a bare file name mid-sentence
+never becomes a dead link. Anything inside a fenced or inline **code block is left untouched** — a
+path in an example command stays literal text.
+
+## Where it opens
+
+A click routes by what the reference is:
+
+- an **`.html` report or a `file://` link** (e.g. the page `/insights` produces) opens in your
+  **default browser** — you want it rendered, not its source in the editor;
+- **everything else** (code and text) opens in **Visual Studio** at the line.
+
+## How the file is found
+
+For an editor open, the click carries the raw reference to Visual Studio, which resolves it against
+your solution:
+
+1. an **absolute path** that exists → opened directly;
+2. a **path relative to the working directory** → resolved and opened;
+3. a **bare file name** (`ClientEvents.cs`, no folders) → searched under the working directory
+   (skipping `bin` / `obj` / `.git` / `node_modules`), first match wins.
+
+Because Claude usually writes just the file name, step 3 is what makes the common case work — the
+model means "the `ClientEvents.cs` in this project", and that is exactly what opens.
+
+## Not in the other tools
+
+The multi-line list — `AgentsPackage.cs:124,185,202` rendered as three separate, individually
+clickable links to the same file — is something neither the Claude Code VS Code extension nor Claude
+Desktop do: they link the first location and leave the rest as text. Here every line in the list is
+its own jump.

--- a/docs/marketplace-overview.md
+++ b/docs/marketplace-overview.md
@@ -42,8 +42,9 @@ configure.
 
 ## Two panes, one session
 
-**Chat** — streaming replies, thinking blocks, collapsible tool output, inline diffs, image
-attachments, and a composer with slash commands, an `@` file picker and prompt history.
+**Chat** — streaming replies, thinking blocks, collapsible tool output, inline diffs, clickable file
+references (`ClientEvents.cs:208` opens the file at that line), image attachments, and a composer with
+slash commands, an `@` file picker and prompt history.
 
 **CLI** — the real `claude.exe` in an embedded terminal, connected to the IDE over the same channel
 the official VS Code extension uses.

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Helpers.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Helpers.cs
@@ -216,12 +216,71 @@ internal sealed partial class WebViewMessageHandler
     private string ResolveFilePath(string filePath)
     {
         if (string.IsNullOrEmpty(filePath)) { return null; }
-        var normalized = filePath.Replace('/', Path.DirectorySeparatorChar);
+        // Strip a file:// prefix (a chat file link may carry one) before path logic.
+        var stripped = filePath;
+        if (stripped.StartsWith("file:///", System.StringComparison.OrdinalIgnoreCase)) { stripped = stripped.Substring(8); }
+        else if (stripped.StartsWith("file://", System.StringComparison.OrdinalIgnoreCase)) { stripped = stripped.Substring(7); }
+        var normalized = stripped.Replace('/', Path.DirectorySeparatorChar);
         if (Path.IsPathRooted(normalized) && File.Exists(normalized)) { return normalized; }
         var combined = Path.Combine(client.WorkingDirectory ?? string.Empty, normalized);
         if (File.Exists(combined)) { return combined; }
         if (File.Exists(normalized)) { return normalized; }
+        // Bare name (a "X.cs:20" link carries just the file name): search the workspace by name.
+        // The model almost always means a file under the working directory (see the chat file-link
+        // design), so a recursive search of the workdir resolves it. First unique match wins; a
+        // deeper path in the link (Core/Stats/X.cs) already resolved above via the workdir-combine.
+        var wd = client.WorkingDirectory;
+        var name = Path.GetFileName(normalized);
+        if (!string.IsNullOrEmpty(wd) && !string.IsNullOrEmpty(name) && Directory.Exists(wd))
+        {
+            var found = FindFileByNameUnderRoot(wd, name);
+            if (found != null) { return found; }
+        }
         OutputWindowLogger.Debug(() => $"[OpenFile] Path not found. raw='{filePath}' normalized='{normalized}' combined='{combined}' workingDir='{client.WorkingDirectory}'");
+        return null;
+    }
+
+    /// <summary>First file named <paramref name="name"/> under <paramref name="root"/>, skipping the
+    /// usual noise dirs (bin/obj/.git/node_modules) to keep the walk fast. Null if none.</summary>
+    private static string FindFileByNameUnderRoot(string root, string name)
+    {
+        try
+        {
+            var stack = new System.Collections.Generic.Stack<string>();
+            stack.Push(root);
+            while (stack.Count > 0)
+            {
+                var dir = stack.Pop();
+                string match = null;
+                try
+                {
+                    foreach (var f in Directory.EnumerateFiles(dir))
+                    {
+                        if (string.Equals(Path.GetFileName(f), name, System.StringComparison.OrdinalIgnoreCase))
+                        {
+                            match = f;
+                            break;
+                        }
+                    }
+                    if (match != null) { return match; }
+                    foreach (var sub in Directory.EnumerateDirectories(dir))
+                    {
+                        var leaf = Path.GetFileName(sub);
+                        if (leaf.Length > 0 && leaf[0] == '.') { continue; }
+                        if (string.Equals(leaf, "bin", System.StringComparison.OrdinalIgnoreCase)
+                            || string.Equals(leaf, "obj", System.StringComparison.OrdinalIgnoreCase)
+                            || string.Equals(leaf, "node_modules", System.StringComparison.OrdinalIgnoreCase))
+                        {
+                            continue;
+                        }
+                        stack.Push(sub);
+                    }
+                }
+                catch (System.UnauthorizedAccessException) { }
+                catch (System.IO.IOException) { }
+            }
+        }
+        catch (System.Exception) { }
         return null;
     }
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/file-links.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/file-links.ts
@@ -1,0 +1,169 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+// Find "file:line" references in assistant text so the UI can turn them into clickable links that
+// open the file in VS. Pure, side-effect free, no DOM.
+//
+// Approach follows VS Code's terminalLinkParsing (two phases, not one mega-regex):
+//   1. peel an optional :line[:col] / (line,col) / [line:col] / "line N" suffix off the END,
+//   2. what's left in front is the path candidate — non-space, no bracket openers.
+// We diverge from VS Code on ONE point: we REQUIRE a known code/text extension on the path. VS Code
+// (a terminal, paths everywhere) links anything and lets click-time resolution filter; in a chat the
+// model always writes an extension (X.cs:20), so the allow-list kills false positives (10:30 clock,
+// localhost.net:4040 host:port) up-front instead of rendering dead links. URLs are NOT handled here —
+// marked's autolink/renderer.link consumes http(s) before this ever runs.
+
+/** Extensions we linkify — code/text files that make sense to open in the editor. Hardcoded (these
+ *  are universal; no user option needed). Extensionless files (Makefile, Dockerfile) aren't covered
+ *  by design — add here if they ever come up. */
+const LINKABLE_EXT = new Set([
+    'cs',
+    'ts',
+    'tsx',
+    'js',
+    'jsx',
+    'mjs',
+    'cjs',
+    'css',
+    'scss',
+    'html',
+    'xaml',
+    'xml',
+    'json',
+    'md',
+    'yml',
+    'yaml',
+    'cpp',
+    'cc',
+    'h',
+    'hpp',
+    'c',
+    'py',
+    'go',
+    'rs',
+    'java',
+    'sql',
+    'sh',
+    'ps1',
+    'razor',
+    'cshtml',
+    'vb',
+    'txt',
+    'csproj',
+    'sln',
+    'props',
+    'targets',
+    'config',
+    'editorconfig',
+    'gitignore',
+]);
+
+/** One found reference: the exact matched substring (so the caller can wrap it in place), the parsed
+ *  path, and the 1-based line(s) — usually one, but a "file.cs:124,185,202" list yields several
+ *  (each becomes its own link at the same path). Empty `lines` = no line (open at top).
+ *  start/end are indices into the source text. */
+export interface FileRef {
+    match: string;
+    path: string;
+    lines: number[];
+    start: number;
+    end: number;
+}
+
+// Phase 1 — a line[:col] suffix, matched at the END of a single (space-delimited) token. Covers:
+//   :339  :339:12  :35-48 (range, opens at the first line)  :124,185,202 (list → one link per line)
+//   (339)  (339,12)  [339]  [339:12].
+// The col/range-end are captured but unused (we open at the start line). A range uses a hyphen or an
+// en/em-dash ("35–48"); a list uses commas ("124,185"). The verbose ", line 339" form spans a space
+// and can't ride in one token — dropped on purpose (the model writes X.cs:20, never "X.cs, line 20").
+const SUFFIX =
+    /(?::(?<r1>\d+(?:,\d+)*)(?:[-–—]\d+)?(?::\d+)?|\((?<r2>\d+)(?:,\d+)?\)|\[(?<r3>\d+)(?::\d+)?\])$/;
+
+// A path candidate: no whitespace, and not starting with a bracket/pipe/angle (VS Code's set). We
+// additionally require it to CONTAIN a dot (so there's an extension to check). Slashes/backslashes,
+// drive letters and file:// are all allowed inside.
+const PATH = /(?:file:\/\/\/?)?[^\s|<>[({][^\s|<>]*/g;
+
+function extOf(path: string): string {
+    const clean = path.replace(/[\\/]+$/, '');
+    const dot = clean.lastIndexOf('.');
+    if (dot < 0) {
+        return '';
+    }
+    return clean.slice(dot + 1).toLowerCase();
+}
+
+/** Scan `text` for "path:line" references whose path has a linkable extension. Returns them in order,
+ *  non-overlapping. The caller wraps each [start,end) in a link. */
+export function findFileRefs(text: string): FileRef[] {
+    const refs: FileRef[] = [];
+    if (!text) {
+        return refs;
+    }
+    // Walk word-ish tokens (non-space runs). For each, peel the suffix, validate the remaining path.
+    // A token is any maximal run of non-space characters — the space is the delimiter (so
+    // "pippo.txt :020" splits into two tokens and never links). A ; inside a token splits it too:
+    // prose like "(a.cs:1; b.cs:2)" packs two refs in one run, so break on ; as well.
+    const TOKEN = /[^\s;]+/g;
+    let m: RegExpExecArray | null;
+    while ((m = TOKEN.exec(text)) !== null) {
+        let tok = m[0];
+        let lead = 0;
+        // Strip a leading ( [ { the model wraps a ref in — "(a.cs:1)" → "a.cs:1)". Track `lead` so
+        // start/end stay accurate.
+        const lm = tok.match(/^[([{]+/);
+        if (lm) {
+            lead = lm[0].length;
+            tok = tok.slice(lead);
+        }
+        // Strip a trailing ) ] } , . that is prose punctuation — BUT only if the token has no
+        // matching opener left (we already removed a leading one, or there was none). A genuine
+        // (339)/[45] line suffix keeps its bracket because that bracket has no leading partner here.
+        tok = tok.replace(/[)\]},.]+$/, (t) => {
+            const hasOpener = /[([{]/.test(tok);
+            return hasOpener ? t : '';
+        });
+        const tokStart = m.index + lead;
+        // Peel the line[:col] suffix off the token's tail; what's left in front is the path candidate.
+        const sm = tok.match(SUFFIX);
+        let lines: number[] = [];
+        let pathPart = tok;
+        if (sm) {
+            const raw = sm.groups?.r1 ?? sm.groups?.r2 ?? sm.groups?.r3 ?? '';
+            // r1 may be a comma list ("124,185,202"); r2/r3 are single. Split and de-dup.
+            lines = [
+                ...new Set(
+                    raw
+                        .split(',')
+                        .map(Number)
+                        .filter((n) => n > 0),
+                ),
+            ];
+            pathPart = tok.slice(0, sm.index);
+        }
+        // Validate the path: single PATH match spanning the whole remaining part, with a known ext.
+        PATH.lastIndex = 0;
+        const pm = PATH.exec(pathPart);
+        if (!pm || pm.index !== 0 || pm[0] !== pathPart) {
+            continue;
+        }
+        if (!LINKABLE_EXT.has(extOf(pathPart))) {
+            continue;
+        }
+        // A path with no line is still linkable (open at top). But require SOME structure: either a
+        // separator (/ or \) or the suffix — a bare "README.md" mid-sentence is too noisy to link.
+        if (lines.length === 0 && !/[\\/]/.test(pathPart)) {
+            continue;
+        }
+        const matchStr = sm ? pathPart + tok.slice(sm.index) : pathPart;
+        refs.push({
+            match: matchStr,
+            path: pathPart,
+            lines,
+            start: tokStart,
+            end: tokStart + matchStr.length,
+        });
+    }
+    return refs;
+}

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/markdown.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/markdown.ts
@@ -10,6 +10,7 @@ import DOMPurify from 'dompurify';
 import hljs from 'highlight.js';
 import { resolveLang } from './lang';
 import { escapeHtml } from './html';
+import { findFileRefs } from './file-links';
 
 // CLI-internal tags that look like HTML but are content; DOMPurify would
 // drop them silently, so escape up-front to render as literal text.
@@ -50,12 +51,67 @@ renderer.link = function (token: Tokens.Link): string {
     if (/^(https?|mailto):/.test(href)) {
         return `<a href="${escapeHtml(href)}" title="${escapeHtml(title)}" target="_blank" rel="noopener noreferrer">${text}</a>`;
     }
-    // Local file paths render as plain text — `<cv-message>` adds its own
-    // click handlers; don't smuggle file:// URLs through the renderer.
+    // A markdown link to a local file — the model writes [X.cs:192](src/.../X.cs:192). If the href
+    // parses as a file ref, render a clickable file link (cv-message routes the click to VS) using
+    // the LABEL text as-is. Otherwise fall back to plain text.
+    const ref = findFileRefs(href).find((r) => r.start === 0 && r.match === href);
+    if (ref) {
+        const line = ref.lines[0] ?? 0;
+        return `<a class="cv-file-link" data-file="${escapeHtml(ref.path)}" data-line="${line}" title="Open in editor">${escapeHtml(text)}</a>`;
+    }
+    // Other local paths render as plain text.
     return text;
 };
 
-marked.use({ gfm: true, breaks: true, renderer });
+// Inline extension: turn a bare "path:line" reference (ClientEvents.cs:208, Core/x.ts:45) into a
+// clickable link that cv-message routes to VS. It runs on inline TEXT only — marked tokenizes fenced
+// code and inline `code` first, so those are never touched, and http(s) autolinks are consumed by
+// marked's own inline link/url rules before this. The heavy lifting (which substrings qualify, the
+// allow-list, the :line[:col] suffix shapes) lives in findFileRefs; here we just anchor it to the
+// current cursor. Idempotent by construction: marked always re-parses from the markdown source.
+const fileLinkExtension = {
+    name: 'fileLink',
+    level: 'inline' as const,
+    // Speed hint: only bother where a path-ish char run could begin.
+    start(src: string): number | undefined {
+        const m = src.match(/[A-Za-z0-9._/\\-]+\.[A-Za-z0-9]+(?::\d|\(\d|\[\d)/);
+        return m?.index;
+    },
+    tokenizer(src: string) {
+        // A file-ref only counts if it starts at the cursor (offset 0 of the remaining src).
+        const refs = findFileRefs(src);
+        const ref = refs.find((r) => r.start === 0);
+        if (!ref) {
+            return undefined;
+        }
+        return {
+            type: 'fileLink',
+            raw: ref.match,
+            path: ref.path,
+            lines: ref.lines,
+        };
+    },
+    renderer(token: { path: string; lines: number[]; raw: string }): string {
+        const file = escapeHtml(token.path);
+        const anchor = (label: string, line: number): string =>
+            `<a class="cv-file-link" data-file="${file}" data-line="${line}" title="Open in editor">${label}</a>`;
+        // No line → single link on the whole path (file:// scheme dropped from the label as noise).
+        if (token.lines.length === 0) {
+            return anchor(escapeHtml(token.path.replace(/^file:\/\/\/?/i, '')), 0);
+        }
+        // "file.cs:124,185,202" → the first link carries "file.cs:124", the rest are just the bare
+        // line numbers (same file, different line), commas as plain text between them.
+        const name = escapeHtml(token.path.replace(/^file:\/\/\/?/i, ''));
+        const [first, ...rest] = token.lines;
+        let html = anchor(`${name}:${first}`, first);
+        for (const ln of rest) {
+            html += ',' + anchor(String(ln), ln);
+        }
+        return html;
+    },
+};
+
+marked.use({ gfm: true, breaks: true, renderer, extensions: [fileLinkExtension] });
 
 /**
  * Render markdown to sanitized HTML for `unsafeHTML` (DOMPurify has run).
@@ -66,7 +122,7 @@ export function renderMarkdown(text: string | undefined | null): string {
     try {
         const html = marked.parse(normalized, { async: false }) as string;
         return DOMPurify.sanitize(html, {
-            ADD_ATTR: ['target', 'frompre'],
+            ADD_ATTR: ['target', 'frompre', 'data-file', 'data-line'],
             ADD_TAGS: ['cv-copy-btn'],
         });
     } catch (err) {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-message.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-message.ts
@@ -25,6 +25,7 @@ import type {
     IdeContextRef,
     ForkNotification,
     IdeFileNotification,
+    ExternalUrlNotification,
     UiImage,
     UiFile,
     MessageRole,
@@ -212,6 +213,41 @@ export class CvMessage extends LitElement {
         });
     };
 
+    // Delegated click on the rendered markdown: a "path:line" file link (added by the fileLink
+    // marked extension). Route by kind: a standalone document (an .html/.htm report, or anything the
+    // model wrote with a file:// scheme) opens in the default browser via the shell — you want it
+    // rendered, not its source. Everything else (code/text) opens in VS at the line; the host
+    // resolves the path (absolute/relative to the workdir, else searched by name in the workspace).
+    private _onMdClick = (e: Event): void => {
+        const a = (e.target as HTMLElement | null)?.closest('a.cv-file-link') as HTMLElement | null;
+        if (!a) {
+            return;
+        }
+        e.preventDefault();
+        e.stopPropagation();
+        const filePath = a.getAttribute('data-file') ?? '';
+        const line = Number(a.getAttribute('data-line') ?? 0) || 0;
+        if (!filePath) {
+            return;
+        }
+        const isDocument = /^file:\/\//i.test(filePath) || /\.html?($|[?#])/i.test(filePath);
+        if (isDocument) {
+            // Normalize backslashes to a proper file:// URL the shell opens in the browser.
+            const url = /^file:\/\//i.test(filePath)
+                ? filePath
+                : 'file:///' + filePath.replace(/\\/g, '/').replace(/^\/+/, '');
+            bridge.sendNotification<ExternalUrlNotification>(Msg.fromWebView.open.externalUrl, {
+                url,
+            });
+            return;
+        }
+        bridge.sendNotification<IdeFileNotification>(Msg.fromWebView.open.ideFile, {
+            filePath,
+            startLine: line,
+            endLine: line,
+        });
+    };
+
     private _onToggleExpand = (e: Event): void => {
         e.stopPropagation();
         const wasExpanded = this.expanded;
@@ -382,7 +418,7 @@ export class CvMessage extends LitElement {
                 return html`
                     <div class="cv-message assistant">
                         <span class="cv-tool-row-dot ${dotClass}"></span>
-                        <div class="cv-msg-body">
+                        <div class="cv-msg-body" @click=${this._onMdClick}>
                             ${
                                 this.streaming
                                     ? html`<div class="md">

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/chat.css
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/chat.css
@@ -321,6 +321,15 @@ body.sticky-user .cv-exchange > cv-message[role="user"]:first-child .cv-message.
     text-decoration: underline;
     color: inherit;
 }
+/* "path:line" file link inside rendered markdown (fileLink marked extension) — opens in VS on click. */
+.cv-file-link {
+    color: var(--colorBrandForegroundLink);
+    text-decoration: none;
+    cursor: pointer;
+}
+.cv-file-link:hover {
+    text-decoration: underline;
+}
 
 /* The chevron toggle is a fluent-button (icon-only). Hidden at rest, revealed on row
  * hover — except .always-shown (Agent), kept visible so a near-empty collapsed row reads


### PR DESCRIPTION
When Claude mentions a source location, make it a link that opens the file in VS at that line.

## What it does
`ClientEvents.cs:208`, `Core/Stats/StatsService.cs:45`, a list `Package.cs:124,185,202`, a markdown link `[X.cs:31](src/…/X.cs:31)`, a `file://…report.html` — all become clickable. Code files open in Visual Studio at the line; an `.html` report or a `file://` link opens in the browser (rendered, not its source).

## How
- **`core/file-links.ts`** — a pure two-phase parser modelled on VS Code's `terminalLinkParsing`: peel the `:line[:col]` suffix off the end, validate the path in front. Handles ranges (`:35-48`, incl. en/em-dash), comma lists (each line becomes its own link), `(339)`/`[45:12]` brackets, surrounding prose punctuation, and `;` as a separator. Requires a known code/text extension, so `10:30` (clock) and `localhost:4040` (host:port) never render as dead links. Tested against every `file:line` shape found in a real session transcript.
- **`markdown.ts`** — a marked **inline extension** anchors the parser to the cursor: fenced/inline code is skipped for free, and `http(s)` autolinks are consumed by marked first. `renderer.link` additionally turns a `[X.cs:31](path)` markdown link into a file link (full path from the href).
- **`cv-message`** — a delegated click routes code files to VS (`IdeFile`) and `.html`/`file://` to the browser (`ExternalUrl`).
- **`ResolveFilePath` (C#)** — strips `file://`, then resolves: absolute → workdir-relative → recursive search by file name under the working directory (skipping `bin`/`obj`/`.git`/`node_modules`, first match wins). The model usually writes just the file name, so the search is what makes the common case work.

## Not in the other tools
The multi-line list — `Package.cs:124,185,202` rendered as three individually clickable links to the same file — is something neither the Claude Code VS Code extension nor Claude Desktop do.

## Notes
- WebView + C#. `npm run check` green (0 errors, 7 pre-existing `no-explicit-any`), MSBuild green (0 errors). No new DTO.
- Docs: `docs/file-links.md` (new) + README feature list + marketplace note.
- Worth an F5: click a `path:line`, a list, and a `file://…html` to confirm editor vs browser routing.