### PR TITLE
Read a response aloud (TTS) with pause/resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ own.
   whole list, `Package.cs:124,185,202`) the reference becomes a link that opens the file in VS at that
   line. Every line in a list is its own link — something the VS Code extension and Claude Desktop
   don't do. Code blocks stay untouched; clocks and host:ports never become dead links.
+- **Read a response aloud** — a speaker button on each answer reads it out with the system voice
+  (Web Speech, no extra install); click to pause, click to resume. The markdown is spoken as plain
+  prose — no "asterisk asterisk", no code blocks recited.
 - **The same sessions as VS Code and the terminal** — no separate database: it reads and writes the
   CLI's own session store, so a conversation started in the VS Code extension or in a terminal shows
   up here, and vice versa. Resume, fork and rename all work on those shared files, so you can switch

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
@@ -1297,7 +1297,7 @@ export class CvApp extends LitElement {
         }
         const text = blocks.map((b) => b.text).join('\n\n');
         const ts = last.timestamp ?? 0;
-        return renderActionsRow(text, ts, 'Copy');
+        return renderActionsRow(text, ts, 'Copy', '', /* speak */ true);
     }
 
     private renderMessage(e: Exclude<UiEntry, UiToolEntry | UiThinkingEntry>) {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-speak-btn.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-speak-btn.ts
@@ -1,0 +1,166 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+import { LitElement, html, css, nothing } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import Speaker216Regular from '@fluentui/svg-icons/icons/speaker_2_16_regular.svg';
+import Pause16Regular from '@fluentui/svg-icons/icons/pause_16_regular.svg';
+import { iconStyles } from '../styles/shared';
+import { renderMarkdown } from '../../core/markdown';
+
+// Web Speech synthesis is a single global engine — only one utterance plays at a time. Track which
+// button owns the current speech so a new click can stop the previous one and every button reflects
+// the real state (a click elsewhere, or speech ending, flips the icon back). speechSynthesis itself
+// is the source of truth; this set just lets active buttons re-render.
+const active = new Set<CvSpeakBtn>();
+function stopAll(except?: CvSpeakBtn): void {
+    for (const b of active) {
+        if (b !== except) {
+            b._stopSpeaking();
+        }
+    }
+}
+
+/** Flatten markdown to speakable plain text — otherwise the engine reads "**", "##", backticks and
+ *  link URLs aloud. Reuses the real markdown parser (marked) → HTML → textContent, so tables, nested
+ *  lists, links (label kept, URL dropped) etc. all come out right. Code blocks are removed first: you
+ *  don't want a fenced snippet recited character by character. */
+function toSpeech(md: string): string {
+    if (!md) {
+        return '';
+    }
+    const div = document.createElement('div');
+    div.innerHTML = renderMarkdown(md);
+    div.querySelectorAll('pre').forEach((el) => el.remove());
+    return (div.textContent ?? '').replace(/\n{3,}/g, '\n\n').trim();
+}
+
+/**
+ * Read-aloud icon button (Web Speech API `speechSynthesis`, native in WebView2, zero deps). Click the
+ * speaker to read the `text`; while reading the icon is a pause — click it to pause, click again to
+ * resume from where it left off. Starting another button stops this one. Hidden when the API is
+ * unavailable. Shadow DOM + static styles; host is display:contents so it sits in the parent flex.
+ */
+@customElement('cv-speak-btn')
+export class CvSpeakBtn extends LitElement {
+    static override styles = [
+        iconStyles,
+        css`
+            :host {
+                display: contents;
+            }
+            .icon-btn {
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                padding: 3px;
+                border: 0;
+                border-radius: var(--borderRadiusSmall);
+                background: transparent;
+                color: inherit;
+                cursor: pointer;
+                opacity: 0.75;
+            }
+            .icon-btn:hover {
+                background: var(--colorSubtleBackgroundHover, rgba(127, 127, 127, 0.12));
+                opacity: 1;
+            }
+            .icon-btn:focus-visible {
+                outline: 1px solid var(--colorStrokeFocus2, currentColor);
+                outline-offset: 1px;
+            }
+            .icon-btn svg {
+                width: 14px;
+                height: 14px;
+                display: block;
+            }
+            /* Speaking: a tinted pause icon — click to pause (the speaker icon returns; click resumes). */
+            .icon-btn.speaking svg {
+                color: var(--colorBrandForeground1);
+                fill: var(--colorBrandForeground1);
+            }
+        `,
+    ];
+
+    @property() text = '';
+    @property() override title = 'Read aloud';
+
+    // idle = not reading (speaker icon) · speaking = reading (pause icon) · paused = held mid-read
+    // (speaker icon — click resumes from where it left off).
+    @state() private _state: 'idle' | 'speaking' | 'paused' = 'idle';
+
+    private static readonly _supported =
+        typeof window !== 'undefined' && 'speechSynthesis' in window;
+
+    override disconnectedCallback(): void {
+        super.disconnectedCallback();
+        this._stopSpeaking();
+        active.delete(this);
+    }
+
+    /** Fully stop this button's speech and reset to idle. Used when another button starts, or on
+     *  unmount. (cancel() clears the queue — only one utterance is ever queued.) */
+    _stopSpeaking(): void {
+        if (this._state !== 'idle') {
+            this._state = 'idle';
+            window.speechSynthesis.cancel();
+        }
+    }
+
+    private _onClick = (e: Event): void => {
+        e.stopPropagation();
+        if (this._state === 'speaking') {
+            window.speechSynthesis.pause();
+            this._state = 'paused';
+            return;
+        }
+        if (this._state === 'paused') {
+            window.speechSynthesis.resume();
+            this._state = 'speaking';
+            return;
+        }
+        // idle → start reading
+        const text = toSpeech(this.text);
+        if (!text) {
+            return;
+        }
+        stopAll(this); // one engine — stop whatever else was reading
+        window.speechSynthesis.cancel();
+        const u = new SpeechSynthesisUtterance(text);
+        // Reset to idle when the engine finishes or errors so the icon never stays stuck on "pause".
+        u.onend = () => {
+            this._state = 'idle';
+        };
+        u.onerror = () => {
+            this._state = 'idle';
+        };
+        this._state = 'speaking';
+        active.add(this);
+        window.speechSynthesis.speak(u);
+    };
+
+    override render() {
+        if (!CvSpeakBtn._supported) {
+            return nothing;
+        }
+        const speaking = this._state === 'speaking';
+        return html`
+            <button
+                part="button"
+                class="icon-btn ${speaking ? 'speaking' : ''}"
+                title=${speaking ? 'Pause' : this._state === 'paused' ? 'Resume' : this.title}
+                @click=${this._onClick}
+            >
+                ${unsafeHTML(speaking ? Pause16Regular : Speaker216Regular)}
+            </button>
+        `;
+    }
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'cv-speak-btn': CvSpeakBtn;
+    }
+}

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/helpers/actions-row.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/helpers/actions-row.ts
@@ -3,19 +3,29 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 // The bottom actions row shared by a normal response (cv-app) and a sub-agent transcript
-// (cv-tool-row): a Copy button plus the "x ago" timestamp. Pure render — no state, no component.
+// (cv-tool-row): a Copy button, an optional Read-aloud button, and the "x ago" timestamp. Pure
+// render — no state, no component.
 
 import { html, nothing } from 'lit';
 import '../components/cv-copy-btn';
+import '../components/cv-speak-btn';
 import { formatTimeAgo, formatAbsolute } from '../../core/time';
 
-/** Copy button + "x ago" timestamp. Hover-gating is CSS: `.cv-response-actions` has base opacity 0
- *  and a hover rule on the container reveals it — pass that container's reveal class in `extraClass`.
- *  ts=0 hides the timestamp. */
-export function renderActionsRow(text: string, ts: number, title: string, extraClass = '') {
+/** Copy button (+ optional Read-aloud when `speak`) + "x ago" timestamp. Hover-gating is CSS:
+ *  `.cv-response-actions` has base opacity 0 and a hover rule on the container reveals it — pass that
+ *  container's reveal class in `extraClass`. ts=0 hides the timestamp. `speak` adds the TTS button
+ *  (prose answers want it; a tool transcript doesn't). */
+export function renderActionsRow(
+    text: string,
+    ts: number,
+    title: string,
+    extraClass = '',
+    speak = false,
+) {
     return html`
         <div class="cv-response-actions ${extraClass}">
             <cv-copy-btn .text=${text} title=${title}></cv-copy-btn>
+            ${speak ? html`<cv-speak-btn .text=${text}></cv-speak-btn>` : nothing}
             ${
                 ts > 0
                     ? html`<span class="cv-ts" title=${formatAbsolute(ts)}


### PR DESCRIPTION
A speaker button in the response actions row reads the answer aloud.

## What it does
Click the speaker in a response's bottom actions row → it reads the answer via the Web Speech API (`speechSynthesis`, native in WebView2, zero dependencies). While reading the icon is a **pause** — click to pause, click again (the speaker returns) to **resume from where it left off**. Starting another button stops this one — there is a single global speech engine. Hidden when the API is unavailable.

- **Responses only**, not the user's own messages.
- **Markdown flattened for speech** via the real parser (`renderMarkdown` → `textContent`, `<pre>` code blocks removed) so the engine never recites `**`, `##`, backticks or a fenced snippet character by character.

## Files
- `ui/components/cv-speak-btn.ts` (new) — the toggle button + a small global coordinator (one engine, stop-others), Shadow DOM like the other icon buttons.
- `ui/helpers/actions-row.ts` — `renderActionsRow` gains an opt-in `speak` flag.
- `cv-app.ts` — the response row passes `speak: true` (the sub-agent transcript does not).

## Notes
- WebView only. `npm run check` green (0 errors, 7 pre-existing `no-explicit-any`), Prettier clean, bundle built.
- Uses the system default voice/rate for now — a configurable voice/speed option, and word-by-word highlight while reading, are possible follow-ups (Edge's own Read-Aloud UI is not exposed to a WebView2 page — only the speech engine is).
- Worth an F5: read a response, pause, resume; read another to confirm the first stops.