### PR TITLE
fix(chat): anchor file-link parsing on the extension, widen to ~270 extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,11 @@ own.
   and opens in Visual Studio's native, **editable** side-by-side diff: **save (Ctrl+S) to accept** or
   **close to reject**, the CLI applies it only if you saved.
 - **[Clickable file references](docs/file-links.md)** — when Claude writes `ClientEvents.cs:208` (or a
-  whole list, `Package.cs:124,185,202`) the reference becomes a link that opens the file in VS at that
-  line. Every line in a list is its own link — something the VS Code extension and Claude Desktop
-  don't do. Code blocks stay untouched; clocks and host:ports never become dead links.
+  range, `Stats.cs:35-48`, or a whole list, `Package.cs:124,185,202`) the reference becomes a link that
+  opens the file in VS — a range **selects those lines**, and every line in a list is its own link. It
+  works **in plain prose**, not just in markdown links — neither is true in the VS Code extension or
+  Claude Desktop. ~270 extensions out of the box, extendable from Options; code blocks stay untouched,
+  and clocks, host:ports and version numbers never become dead links.
 - **Read a response aloud** — a speaker button on each answer reads it out with the system voice
   (Web Speech, no extra install); click to pause, click to resume. The markdown is spoken as plain
   prose — no "asterisk asterisk", no code blocks recited.

--- a/docs/file-links.md
+++ b/docs/file-links.md
@@ -15,23 +15,43 @@ wrote *is* the navigation.
 
 ## What gets linked
 
-The parser follows the same two-phase approach Visual Studio's terminal uses (peel the `:line`
-suffix off the end, validate the path in front) and recognises every shape Claude actually writes:
+The **extension is the anchor**: it is the only part of a reference that says "this is a file" (a
+`:` is also a host:port and a clock, a `,` is also punctuation). The parser scans for `.ext`, then
+grows outwards — backwards for the path, forwards for the line — and recognises every shape Claude
+actually writes:
 
 | You see | Opens |
 |---|---|
 | `ClientEvents.cs:208` | that file at line 208 |
 | `Core/Stats/StatsService.cs:45` | relative path, at line 45 |
-| `StatsService.cs:35–48` | a range — opens at the first line |
+| `StatsService.cs:35–48` | a range — **selects lines 35 to 48** |
 | `AgentsPackage.cs:124,185,202` | **each line is its own link** |
+| `StatsService.cs:100-120,130` | a list whose elements may be ranges — each keeps its own span |
 | `(NdjsonTransport.cs:91)` · `foo.cs(339)` · `bar.ts[45:12]` | parentheses/brackets, in prose |
+| `ClaudeInstall.cs#L103` · `bar.ts#45` · `x.ts#L35-L48` | the GitHub form |
+| `markdown.ts:57,file-links.ts:130` | two files in one run — **two separate links** |
 | `[McpServerHost.cs:192](src/…/McpServerHost.cs:192)` | a markdown link — uses the full path |
 | `file://C:\…\report.html` | absolute path (the `file://` is dropped from the label) |
 
-Only real code/text extensions are linked (`.cs`, `.ts`, `.css`, `.xaml`, `.json`, `.md`, `.cpp`,
-`.py`, …), so a clock (`10:30`), a host:port (`localhost:4040`) or a bare file name mid-sentence
-never becomes a dead link. Anything inside a fenced or inline **code block is left untouched** — a
-path in an example command stays literal text.
+The label always keeps what the model wrote, so a range stays readable as `100-120` instead of being
+trimmed to its first line. A column (`x.ts:47:12`) is parsed and dropped — it never becomes the end
+of a selection.
+
+In prose, only real code/text extensions are linked — about **270** of them, covering .NET, C/C++,
+the JS/TS ecosystem, JVM, scripting, systems and functional languages, shells (POSIX and PowerShell),
+shaders, data/config formats and build files. That list is what keeps a clock (`10:30`), a host:port
+(`localhost.net:4040`), a version (`2.1.220:5`) or a price (`19.99:2`) from becoming a dead link:
+`.net` and `.com` are lexically identical to `.cs`, so only a list can tell them apart. If a language
+you use is missing, add it under **Options → Chat → Extra linkable extensions** (one per line,
+without the dot) — no need to wait for a release.
+
+A **markdown link is different**: there the model already declared "this is a link", so any
+extension works — `[label](src/utils/helper.rb#L12)` links even though `.rb` is not the point. What
+still does not link is a target with no plausible file shape at all (`[x](19.99#L2)`): rather than
+render a blue link that does nothing when clicked, it degrades to plain text.
+
+Anything inside a fenced or inline **code block is left untouched** — a path in an example command
+stays literal text.
 
 ## Where it opens
 
@@ -40,6 +60,11 @@ A click routes by what the reference is:
 - an **`.html` report or a `file://` link** (e.g. the page `/insights` produces) opens in your
   **default browser** — you want it rendered, not its source in the editor;
 - **everything else** (code and text) opens in **Visual Studio** at the line.
+
+A reference that names a range (`StatsService.cs:35-48`, `x.ts#L35-L48`) opens the file and
+**selects those lines**, so the block Claude is talking about is highlighted rather than just
+scrolled to. A single line places the caret there. Selection follows *Options → Chat → Select lines
+when opening file*; with it off, the file simply opens at the first line.
 
 ## How the file is found
 
@@ -54,9 +79,33 @@ your solution:
 Because Claude usually writes just the file name, step 3 is what makes the common case work — the
 model means "the `ClientEvents.cs` in this project", and that is exactly what opens.
 
+## Adding an extension
+
+**Options → Chat → Extra linkable extensions** (`…` to edit, one per line, no leading dot).
+
+Use it when Claude names a file in prose and it stays plain text — the language just isn't in the
+built-in list yet. Entries are added on top of the built-ins, never replace them, so a later release
+that widens the list still reaches you. The change applies to the open chat immediately; no restart.
+
+```
+zig
+gleam
+wgsl
+```
+
+This only affects **prose**. A markdown link written by the model is linked whatever its extension,
+so there is nothing to configure for that case.
+
 ## Not in the other tools
 
-The multi-line list — `AgentsPackage.cs:124,185,202` rendered as three separate, individually
-clickable links to the same file — is something neither the Claude Code VS Code extension nor Claude
-Desktop do: they link the first location and leave the rest as text. Here every line in the list is
-its own jump.
+**References in prose.** The Claude Code VS Code extension only turns *markdown links* into file
+links — a bare `ClaudeInstall.cs:103` written in a sentence stays plain text there. Here it is a
+link, which is the case the model produces most often.
+
+**Multi-line lists.** `AgentsPackage.cs:124,185,202` renders as three separate, individually
+clickable links to the same file. The other tools link the first location, if any, and leave the
+rest as text.
+
+**No dead links.** Elsewhere every markdown link is rendered blue whether or not the target is a
+file, and the check happens on click — so `[x](19.99#L2)` looks like a link and then does nothing.
+Here the check happens while rendering: if it cannot be a file, it stays text.

--- a/docs/options.md
+++ b/docs/options.md
@@ -37,6 +37,7 @@ go to `%LOCALAPPDATA%` — see [Settings and data](settings-and-data.md).
 | Diff — show "Open diff in Visual Studio" button | bool | `true` | Show the VS-icon button on Edit/Write rows that opens the change in VS's native diff viewer. |
 | Respect `.gitignore` | bool | `true` | Also hide `.gitignore`-matched files/folders from the `@` picker (re-read on change, cached otherwise). |
 | Ignored patterns | string[] | ~30 defaults | Patterns hidden from the `@` picker: exact name, `.ext`, or `*`/`?` glob. Editable list. |
+| Extra linkable extensions | string[] | *(empty)* | Extensions to also linkify when Claude names a file **in prose** (`render.wgsl:20`), on top of the ~270 built-in ones — needed only for a language not shipped yet. A markdown link written by the model is always linked, whatever its extension. One per line, without the dot. See [Clickable file references](file-links.md). |
 
 ## Debug
 

--- a/src/Corsinvest.VisualStudio.Agents.Contracts/ToWebViewDtos.cs
+++ b/src/Corsinvest.VisualStudio.Agents.Contracts/ToWebViewDtos.cs
@@ -477,6 +477,7 @@ public class VsOptionsDto
     public bool DiffIgnoreWhitespace { get; set; }
     public bool ShowOpenDiffInVsButton { get; set; }
     public string[] AllowedUploadExtensions { get; set; }
+    public string[] ExtraLinkableExtensions { get; set; }
     public string AppVersion { get; set; }
     public string AppCopyright { get; set; }
     public bool PerfEnabled { get; set; }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.Payloads.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.Payloads.cs
@@ -42,12 +42,34 @@ internal sealed partial class WebViewBridge
             DiffIgnoreWhitespace = chat.DiffIgnoreWhitespace,
             ShowOpenDiffInVsButton = chat.ShowOpenDiffInVsButton,
             AllowedUploadExtensions = NormalizeExtensions(chat.AllowedUploadFileExtensions),
+            // Bare (no dot, lowercase): the webview matches these against a parsed extension, not
+            // against a file name, so the dot-prefixed shape used for uploads would never hit.
+            ExtraLinkableExtensions = NormalizeBareExtensions(chat.ExtraLinkableExtensions),
             AppVersion = BuildInfo.Version,
             AppCopyright = BuildInfo.Copyright,
             PerfEnabled = dbg.EnablePerfLog,
             // Always honour the Debug-page LogLevel setting (default None); previously DEBUG forced Trace ignoring it.
             LogLevel = (int)dbg.LogLevel,
         };
+    }
+
+    /// <summary>Normalize extra linkable extensions to lowercase, WITHOUT the dot, de-duplicated —
+    /// the shape `findFileRefs` compares against. A user entry may be written either way (`zig` or
+    /// `.zig`), and a leading `*.` glob is tolerated too.</summary>
+    private static string[] NormalizeBareExtensions(string[] exts)
+    {
+        if (exts == null) { return []; }
+        var set = new System.Collections.Generic.HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var raw in exts)
+        {
+            if (string.IsNullOrWhiteSpace(raw)) { continue; }
+            var e = raw.Trim().TrimStart('*').TrimStart('.').ToLowerInvariant();
+            // Same shape the parser can produce: letters/digits only, and never all digits (an
+            // all-digit tail is a version or a price, never a file).
+            if (e.Length is 0 or > 10 || !System.Text.RegularExpressions.Regex.IsMatch(e, "^[a-z0-9+#-]*[a-z][a-z0-9+#-]*$")) { continue; }
+            set.Add(e);
+        }
+        return [.. set];
     }
 
     /// <summary>Normalize allowed upload extensions to lowercase, dot-prefixed,

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.ClientEvents.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.ClientEvents.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/file-links.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/file-links.ts
@@ -5,165 +5,457 @@
 // Find "file:line" references in assistant text so the UI can turn them into clickable links that
 // open the file in VS. Pure, side-effect free, no DOM.
 //
-// Approach follows VS Code's terminalLinkParsing (two phases, not one mega-regex):
-//   1. peel an optional :line[:col] / (line,col) / [line:col] / "line N" suffix off the END,
-//   2. what's left in front is the path candidate — non-space, no bracket openers.
-// We diverge from VS Code on ONE point: we REQUIRE a known code/text extension on the path. VS Code
-// (a terminal, paths everywhere) links anything and lets click-time resolution filter; in a chat the
-// model always writes an extension (X.cs:20), so the allow-list kills false positives (10:30 clock,
-// localhost.net:4040 host:port) up-front instead of rendering dead links. URLs are NOT handled here —
-// marked's autolink/renderer.link consumes http(s) before this ever runs.
+// The EXTENSION is the anchor — it is the only part that says "this is a file" (a ':' is also
+// host:port and a clock, a ',' is also punctuation). So we scan for ".ext" occurrences and grow
+// outwards from each one:
+//   1. anchor  — ".ext", validated against LINKABLE_EXT (prose) or "has a letter" (hrefs),
+//   2. back    — the path, up to the first char that can't sit in one (space, comma, bracket, …),
+//   3. forward — the :line / (line) / [line] / #Lline suffix; anything past it is just text.
+// Growing from the anchor is what keeps two refs in one run apart ("a.ts:57,b.ts:57" → two links):
+// an end-anchored suffix regex would match the LAST ':57' and swallow everything before it.
+// URLs are NOT handled here — marked's autolink/renderer.link consumes http(s) before this runs.
 
-/** Extensions we linkify — code/text files that make sense to open in the editor. Hardcoded (these
- *  are universal; no user option needed). Extensionless files (Makefile, Dockerfile) aren't covered
- *  by design — add here if they ever come up. */
-const LINKABLE_EXT = new Set([
+/** Extensions linkified in PROSE ("x.cs:20" written mid-sentence). A markdown link written by the
+ *  model is checked differently — see RefStrictness — so this list only guards the blind scan, where
+ *  it is the one thing separating ".cs" from ".net"/".com". Grouped by area; the user adds anything
+ *  missing via Options -> Chat -> "Extra linkable extensions" (merged in by setExtraLinkableExtensions).
+ *  Extensionless files (Makefile, Dockerfile) aren't covered by design. */
+const BUILT_IN_EXT = [
+    // .NET / Visual Studio
     'cs',
-    'ts',
-    'tsx',
-    'js',
-    'jsx',
-    'mjs',
-    'cjs',
-    'css',
-    'scss',
-    'html',
-    'xaml',
-    'xml',
-    'json',
-    'md',
-    'yml',
-    'yaml',
-    'cpp',
-    'cc',
-    'h',
-    'hpp',
-    'c',
-    'py',
-    'go',
-    'rs',
-    'java',
-    'sql',
-    'sh',
-    'ps1',
+    'csx',
+    'vb',
+    'vbs',
+    'fs',
+    'fsi',
+    'fsx',
+    'fsscript',
     'razor',
     'cshtml',
-    'vb',
-    'txt',
+    'vbhtml',
     'csproj',
+    'vbproj',
+    'fsproj',
     'sln',
     'props',
     'targets',
     'config',
+    'resx',
+    'xaml',
+    'axaml',
+    'aspx',
+    'ascx',
+    'asax',
+    'ashx',
+    'asmx',
+    'master',
+    'sitemap',
+    'skin',
+    'browser',
+    'vsct',
+    'vsixmanifest',
+    'vstemplate',
+    'ruleset',
+    'settings',
+    'shproj',
+    'projitems',
+    'slnf',
+    'slnx',
+    'sqlproj',
+    'wixproj',
+    'wxs',
+    'wxi',
+    // web / TypeScript
+    'ts',
+    'tsx',
+    'mts',
+    'cts',
+    'js',
+    'jsx',
+    'mjs',
+    'cjs',
+    'coffee',
+    'vue',
+    'svelte',
+    'astro',
+    'njk',
+    'liquid',
+    'twig',
+    'html',
+    'htm',
+    'xhtml',
+    'shtml',
+    'css',
+    'scss',
+    'sass',
+    'less',
+    'styl',
+    'hbs',
+    'handlebars',
+    'mustache',
+    'pug',
+    'jade',
+    'ejs',
+    'webmanifest',
+    // C / C++
+    'c',
+    'h',
+    'cc',
+    'cpp',
+    'cxx',
+    'c++',
+    'hh',
+    'hpp',
+    'hxx',
+    'h++',
+    'ixx',
+    'cppm',
+    'inl',
+    'ipp',
+    'tlh',
+    'tli',
+    'idl',
+    'odl',
+    'rc',
+    'rc2',
+    'def',
+    'cu',
+    'cuh',
+    // JVM / .NET-adjacent
+    'java',
+    'jsp',
+    'jspx',
+    'aj',
+    'kt',
+    'kts',
+    'scala',
+    'sc',
+    'clj',
+    'cljs',
+    'cljc',
+    'groovy',
+    'gradle',
+    'sbt',
+    // scripting
+    'py',
+    'pyi',
+    'rb',
+    'rbs',
+    'rake',
+    'gemspec',
+    'php',
+    'phtml',
+    'pl',
+    'pm',
+    'lua',
+    'tcl',
+    // systems
+    'go',
+    'rs',
+    'zig',
+    'nim',
+    'odin',
+    'cr',
+    'v',
+    'd',
+    'swift',
+    'dart',
+    'pas',
+    'asm',
+    // functional
+    'hs',
+    'lhs',
+    'elm',
+    'erl',
+    'hrl',
+    'ex',
+    'exs',
+    'gleam',
+    'ml',
+    'mli',
+    'purs',
+    'res',
+    'resi',
+    'rkt',
+    'scm',
+    'ss',
+    'lisp',
+    'el',
+    'fnl',
+    // scientific
+    'jl',
+    'r',
+    'm',
+    'mm',
+    'f90',
+    'f95',
+    'f03',
+    'ipynb',
+    // web3
+    'sol',
+    'move',
+    'cairo',
+    // shell and system scripting (unix + windows)
+    'sh',
+    'bash',
+    'zsh',
+    'fish',
+    'nu',
+    'ps1',
+    'psm1',
+    'psd1',
+    'ps1xml',
+    'psrc',
+    'pssc',
+    'bat',
+    'cmd',
+    'btm',
+    'ksh',
+    'csh',
+    'tcsh',
+    'ahk',
+    'awk',
+    'sed',
+    'service',
+    'timer',
+    'socket',
+    'desktop',
+    'reg',
+    'inf',
+    'wsf',
+    'vbe',
+    'jse',
+    // shaders
+    'glsl',
+    'hlsl',
+    'hlsli',
+    'wgsl',
+    'metal',
+    'cginc',
+    'compute',
+    'usf',
+    'ush',
+    'fx',
+    'fxh',
+    // data / markup / config
+    'json',
+    'jsonc',
+    'json5',
+    'jsonld',
+    'xml',
+    'xsd',
+    'xsl',
+    'xslt',
+    'dtd',
+    'yml',
+    'yaml',
+    'toml',
+    'ini',
+    'cfg',
+    'conf',
+    'properties',
+    'env',
+    'csv',
+    'tsv',
+    'sql',
+    'graphql',
+    'gql',
+    'proto',
+    'thrift',
+    'avsc',
+    'wsdl',
+    'http',
+    'rest',
+    'plist',
+    'nuspec',
+    // docs
+    'md',
+    'mdx',
+    'markdown',
+    'rst',
+    'adoc',
+    'asciidoc',
+    'tex',
+    'txt',
+    'text',
+    // build / tooling
+    'cmake',
+    'mk',
+    'mak',
+    'ninja',
+    'bazel',
+    'bzl',
+    'just',
+    'lock',
+    'tf',
+    'tfvars',
+    'hcl',
+    'bicep',
+    'dockerfile',
+    'nix',
+    'containerfile',
     'editorconfig',
     'gitignore',
-]);
+    'gitattributes',
+    'npmrc',
+    'eslintrc',
+    'prettierrc',
+    'babelrc',
+    // editors
+    'vim',
+    'vimrc',
+];
+
+/** Built-ins plus whatever the user added in Options. Rebuilt by setExtraLinkableExtensions. */
+let LINKABLE_EXT = new Set(BUILT_IN_EXT);
+
+/** Merge the user's "Extra linkable extensions" (bare, lowercase — normalized host-side) on top of
+ *  the built-ins. Called when VS options arrive, and again whenever they change. */
+export function setExtraLinkableExtensions(extra: readonly string[] | null | undefined): void {
+    LINKABLE_EXT = new Set(BUILT_IN_EXT);
+    for (const e of extra ?? []) {
+        if (e) {
+            LINKABLE_EXT.add(e.toLowerCase());
+        }
+    }
+}
 
 /** One found reference: the exact matched substring (so the caller can wrap it in place), the parsed
  *  path, and the 1-based line(s) — usually one, but a "file.cs:124,185,202" list yields several
  *  (each becomes its own link at the same path). Empty `lines` = no line (open at top).
+ *  `ends` is parallel to `lines`: the last line of a range ("100-120" → lines[0]=100, ends[0]=120),
+ *  or the same value when the element is a single line. The host selects lines..ends on open.
  *  start/end are indices into the source text. */
 export interface FileRef {
     match: string;
     path: string;
     lines: number[];
+    ends: number[];
     start: number;
     end: number;
 }
 
-// Phase 1 — a line[:col] suffix, matched at the END of a single (space-delimited) token. Covers:
-//   :339  :339:12  :35-48 (range, opens at the first line)  :124,185,202 (list → one link per line)
-//   (339)  (339,12)  [339]  [339:12].
-// The col/range-end are captured but unused (we open at the start line). A range uses a hyphen or an
-// en/em-dash ("35–48"); a list uses commas ("124,185"). The verbose ", line 339" form spans a space
-// and can't ride in one token — dropped on purpose (the model writes X.cs:20, never "X.cs, line 20").
-const SUFFIX =
-    /(?::(?<r1>\d+(?:,\d+)*)(?:[-–—]\d+)?(?::\d+)?|\((?<r2>\d+)(?:,\d+)?\)|\[(?<r3>\d+)(?::\d+)?\])$/;
+// Step 1, the anchor: every ".ext" in the text (1-10 chars, VS Code's cap), not followed by more
+// word chars. Global — one run of text can hold several refs.
+const ANCHOR = /\.([A-Za-z0-9]{1,10})(?![A-Za-z0-9])/g;
 
-// A path candidate: no whitespace, and not starting with a bracket/pipe/angle (VS Code's set). We
-// additionally require it to CONTAIN a dot (so there's an extension to check). Slashes/backslashes,
-// drive letters and file:// are all allowed inside.
-const PATH = /(?:file:\/\/\/?)?[^\s|<>[({][^\s|<>]*/g;
+// Step 2, backwards: the path chars that may precede the dot. Excludes the separators that delimit a
+// ref from its neighbours (space, comma, semicolon, brackets) and the suffix introducers (: #), so a
+// second ref in the same run is never swallowed. Anchored to the end of the slice = grows leftwards.
+const BACK = /[^\s|<>[({,;:#'"`]*$/;
 
-function extOf(path: string): string {
-    const clean = path.replace(/[\\/]+$/, '');
-    const dot = clean.lastIndexOf('.');
-    if (dot < 0) {
-        return '';
-    }
-    return clean.slice(dot + 1).toLowerCase();
-}
+// Step 3, forwards: the line suffix right after the extension. Covers
+//   :339  :339:12  :35-48 (range → opens at the first line)  :124,185,202 (list → one link per line)
+//   :100-120,130 and :10,20-30,40 (the two mixed — every element of the list may be a range)
+//   (339)  (339,12)  [339]  [339:12]  #339  #L339  #L35-L48 (GitHub form, common in markdown hrefs).
+// The column and the range ends are matched but dropped — we open at each start line. A range takes a
+// hyphen or an en/em-dash; a list takes commas. The verbose ", line 339" form is out by design (the
+// model writes X.cs:20, never "X.cs, line 20").
+const RANGE_LIST = String.raw`\d+(?:[-–—]\d+)?(?:,\d+(?:[-–—]\d+)?)*`;
+const FWD = new RegExp(
+    `^(?::(?<r1>${RANGE_LIST})(?::\\d+)?|\\((?<r2>\\d+)(?:,\\d+)?\\)|\\[(?<r3>\\d+)(?::\\d+)?\\]|#L?(?<r4>\\d+(?:[-–—]L?\\d+)?))`,
+);
 
-/** Scan `text` for "path:line" references whose path has a linkable extension. Returns them in order,
+// A windows drive letter, which BACK cuts off because of its ':' — re-attached when it sits right
+// before the path ("k:\src\README.md:5").
+const DRIVE = /[A-Za-z]:$/;
+
+/** How strict the path check is. Prose is scanned blind, so it needs the extension allow-list to keep
+ *  "localhost.net:4040" / "19.99:2" from rendering as dead links; a markdown href was written as a link
+ *  by the model on purpose, so any plausible path shape is enough (that's the case VS Code covers and
+ *  we used to drop). See the file-link entry in docs/internal/TODO.md for the measurements. */
+export type RefStrictness = 'known-ext' | 'plausible-path';
+
+/** Scan `text` for file references, growing outwards from each ".ext" anchor. Returns them in order,
  *  non-overlapping. The caller wraps each [start,end) in a link. */
-export function findFileRefs(text: string): FileRef[] {
+export function findFileRefs(text: string, strictness: RefStrictness = 'known-ext'): FileRef[] {
     const refs: FileRef[] = [];
     if (!text) {
         return refs;
     }
-    // Walk word-ish tokens (non-space runs). For each, peel the suffix, validate the remaining path.
-    // A token is any maximal run of non-space characters — the space is the delimiter (so
-    // "pippo.txt :020" splits into two tokens and never links). A ; inside a token splits it too:
-    // prose like "(a.cs:1; b.cs:2)" packs two refs in one run, so break on ; as well.
-    const TOKEN = /[^\s;]+/g;
+    ANCHOR.lastIndex = 0;
     let m: RegExpExecArray | null;
-    while ((m = TOKEN.exec(text)) !== null) {
-        let tok = m[0];
-        let lead = 0;
-        // Strip a leading ( [ { the model wraps a ref in — "(a.cs:1)" → "a.cs:1)". Track `lead` so
-        // start/end stay accurate.
-        const lm = tok.match(/^[([{]+/);
-        if (lm) {
-            lead = lm[0].length;
-            tok = tok.slice(lead);
-        }
-        // Strip a trailing ) ] } , . that is prose punctuation — BUT only if the token has no
-        // matching opener left (we already removed a leading one, or there was none). A genuine
-        // (339)/[45] line suffix keeps its bracket because that bracket has no leading partner here.
-        tok = tok.replace(/[)\]},.]+$/, (t) => {
-            const hasOpener = /[([{]/.test(tok);
-            return hasOpener ? t : '';
-        });
-        const tokStart = m.index + lead;
-        // Peel the line[:col] suffix off the token's tail; what's left in front is the path candidate.
-        const sm = tok.match(SUFFIX);
-        let lines: number[] = [];
-        let pathPart = tok;
-        if (sm) {
-            const raw = sm.groups?.r1 ?? sm.groups?.r2 ?? sm.groups?.r3 ?? '';
-            // r1 may be a comma list ("124,185,202"); r2/r3 are single. Split and de-dup.
-            lines = [
-                ...new Set(
-                    raw
-                        .split(',')
-                        .map(Number)
-                        .filter((n) => n > 0),
-                ),
-            ];
-            pathPart = tok.slice(0, sm.index);
-        }
-        // Validate the path: single PATH match spanning the whole remaining part, with a known ext.
-        PATH.lastIndex = 0;
-        const pm = PATH.exec(pathPart);
-        if (!pm || pm.index !== 0 || pm[0] !== pathPart) {
+    while ((m = ANCHOR.exec(text)) !== null) {
+        const ext = m[1].toLowerCase();
+        // Prose needs the allow-list (it is scanned blind); an href only needs an extension that
+        // isn't all digits — "2.1.220#L5" and "19.99#L2" are a version and a price, never a file.
+        if (strictness === 'known-ext' ? !LINKABLE_EXT.has(ext) : !/[a-z]/.test(ext)) {
             continue;
         }
-        if (!LINKABLE_EXT.has(extOf(pathPart))) {
+        const dot = m.index;
+        const afterExt = m.index + m[0].length;
+        // A separator right after the "extension" means it was a dotted DIRECTORY name, not the end
+        // of the file ("src/Corsinvest.VisualStudio.Agents/…/x.ts" — the real anchor is the last one).
+        if (/^[\\/]/.test(text.slice(afterExt))) {
             continue;
         }
-        // A path with no line is still linkable (open at top). But require SOME structure: either a
-        // separator (/ or \) or the suffix — a bare "README.md" mid-sentence is too noisy to link.
-        if (lines.length === 0 && !/[\\/]/.test(pathPart)) {
+        let head = text.slice(0, dot).match(BACK)?.[0] ?? '';
+        if (!head) {
+            continue; // a bare ".ts" with no name in front
+        }
+        let start = dot - head.length;
+        const drive = DRIVE.test(text.slice(0, start));
+        if (drive && /^[\\/]/.test(head)) {
+            start -= 2;
+            head = text.slice(start, dot);
+        }
+        const fm = text.slice(afterExt).match(FWD);
+        const raw = fm
+            ? (fm.groups?.r1 ?? fm.groups?.r2 ?? fm.groups?.r3 ?? fm.groups?.r4 ?? '')
+            : '';
+        // r1 may be a comma list whose elements are ranges ("100-120,130"); r2/r3 are single, r4 may
+        // be a "35-L48" range. Each element yields a start line (where the link opens) and an end
+        // line (the host selects down to it) — equal when the element is a single line.
+        const lines: number[] = [];
+        const ends: number[] = [];
+        for (const part of raw.split(',')) {
+            const [a, b] = part.split(/[-–—]/).map((n) => Number(n.replace(/^L/i, '')));
+            if (!(a > 0) || lines.includes(a)) {
+                continue; // drop junk and duplicates, keeping the first occurrence
+            }
+            lines.push(a);
+            ends.push(b > a ? b : a);
+        }
+        // A path with no line is still linkable (open at top). In prose, require SOME structure —
+        // either a separator or the suffix — since a bare "README.md" mid-sentence is too noisy.
+        // An href is explicit, so "[label](notes.md)" links fine.
+        if (strictness === 'known-ext' && lines.length === 0 && !/[\\/]/.test(head)) {
             continue;
         }
-        const matchStr = sm ? pathPart + tok.slice(sm.index) : pathPart;
+        const end = afterExt + (fm ? fm[0].length : 0);
         refs.push({
-            match: matchStr,
-            path: pathPart,
+            match: text.slice(start, end),
+            path: text.slice(start, afterExt),
             lines,
-            start: tokStart,
-            end: tokStart + matchStr.length,
+            ends,
+            start,
+            end,
         });
+        ANCHOR.lastIndex = end; // never let the next anchor land inside this ref
     }
     return refs;
+}
+
+/** Parse a standalone token (a markdown href) as a single file reference, or null. */
+export function parseFileRef(token: string, strictness: RefStrictness): FileRef | null {
+    const [ref] = findFileRefs(token, strictness);
+    return ref && ref.start === 0 && ref.match === token ? ref : null;
+}
+
+/** Cheap lower bound for where the first ref could start — for marked's `start()`, which wants a
+ *  *potential* index, not an exact one. The full scan costs ~2ms on a long message and marked calls
+ *  start() once per inline token, which streaming multiplies by every re-render. Derived from the same
+ *  ANCHOR/BACK pair as the real parser so it can't drift: a hand-written hint that misses a shape
+ *  silently stops the tokenizer from ever being offered that position. */
+export function firstRefHint(text: string): number | undefined {
+    ANCHOR.lastIndex = 0;
+    const m = ANCHOR.exec(text);
+    if (!m) {
+        return undefined;
+    }
+    // Back up over the path characters in front of the dot — the ref starts there, not at the dot.
+    const start = m.index - (text.slice(0, m.index).match(BACK)?.[0].length ?? 0);
+    // BACK stops at the ':' of a windows drive, so the real ref can begin 2 chars earlier. The hint
+    // must never sit past the real start or marked would cut the drive off.
+    return DRIVE.test(text.slice(0, start)) ? start - 2 : start;
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated/VsOptionsDto.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated/VsOptionsDto.ts
@@ -17,6 +17,7 @@ export interface VsOptionsDto {
     diffIgnoreWhitespace: boolean;
     showOpenDiffInVsButton: boolean;
     allowedUploadExtensions: string[];
+    extraLinkableExtensions: string[];
     appVersion: string;
     appCopyright: string;
     perfEnabled: boolean;

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/markdown.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/markdown.ts
@@ -10,7 +10,7 @@ import DOMPurify from 'dompurify';
 import hljs from 'highlight.js';
 import { resolveLang } from './lang';
 import { escapeHtml } from './html';
-import { findFileRefs } from './file-links';
+import { findFileRefs, firstRefHint, parseFileRef } from './file-links';
 
 // CLI-internal tags that look like HTML but are content; DOMPurify would
 // drop them silently, so escape up-front to render as literal text.
@@ -54,13 +54,16 @@ renderer.link = function (token: Tokens.Link): string {
     // A markdown link to a local file — the model writes [X.cs:192](src/.../X.cs:192). If the href
     // parses as a file ref, render a clickable file link (cv-message routes the click to VS) using
     // the LABEL text as-is. Otherwise fall back to plain text.
-    const ref = findFileRefs(href).find((r) => r.start === 0 && r.match === href);
+    // 'plausible-path', not the prose allow-list: the model wrote this AS a link, so any extension is
+    // fine (.rb/.kt/.tf … used to be dropped here). Unlike VS Code we still degrade to text when the
+    // href isn't path-shaped at all, instead of leaving a blue link that does nothing on click.
+    const ref = parseFileRef(href, 'plausible-path');
     if (ref) {
         const line = ref.lines[0] ?? 0;
         return `<a class="cv-file-link" data-file="${escapeHtml(ref.path)}" data-line="${line}" title="Open in editor">${escapeHtml(text)}</a>`;
     }
     // Other local paths render as plain text.
-    return text;
+    return escapeHtml(text);
 };
 
 // Inline extension: turn a bare "path:line" reference (ClientEvents.cs:208, Core/x.ts:45) into a
@@ -72,16 +75,15 @@ renderer.link = function (token: Tokens.Link): string {
 const fileLinkExtension = {
     name: 'fileLink',
     level: 'inline' as const,
-    // Speed hint: only bother where a path-ish char run could begin.
-    start(src: string): number | undefined {
-        const m = src.match(/[A-Za-z0-9._/\\-]+\.[A-Za-z0-9]+(?::\d|\(\d|\[\d)/);
-        return m?.index;
-    },
+    // Where marked should jump to next — a potential index, per marked's contract. firstRefHint
+    // shares ANCHOR/BACK with the parser, so it can't drift the way a parallel hand-written regex
+    // did (that is how "#L10" in prose stayed unlinked once already).
+    start: firstRefHint,
     tokenizer(src: string) {
-        // A file-ref only counts if it starts at the cursor (offset 0 of the remaining src).
-        const refs = findFileRefs(src);
-        const ref = refs.find((r) => r.start === 0);
-        if (!ref) {
+        // A file-ref only counts if it starts at the cursor (offset 0 of the remaining src). Only the
+        // first ref can qualify — findFileRefs returns them in order — so stop at it.
+        const ref = findFileRefs(src)[0];
+        if (!ref || ref.start !== 0) {
             return undefined;
         }
         return {
@@ -89,24 +91,43 @@ const fileLinkExtension = {
             raw: ref.match,
             path: ref.path,
             lines: ref.lines,
+            ends: ref.ends,
         };
     },
-    renderer(token: { path: string; lines: number[]; raw: string }): string {
+    renderer(token: { path: string; lines: number[]; ends: number[]; raw: string }): string {
         const file = escapeHtml(token.path);
-        const anchor = (label: string, line: number): string =>
-            `<a class="cv-file-link" data-file="${file}" data-line="${line}" title="Open in editor">${label}</a>`;
+        // data-line-end carries the last line of a range so the host selects the whole block
+        // (Options → Chat → SelectLinesOnOpen); it equals data-line for a single line.
+        const anchor = (label: string, line: number, end = line): string =>
+            `<a class="cv-file-link" data-file="${file}" data-line="${line}" data-line-end="${end}" title="Open in editor">${label}</a>`;
         // No line → single link on the whole path (file:// scheme dropped from the label as noise).
         if (token.lines.length === 0) {
             return anchor(escapeHtml(token.path.replace(/^file:\/\/\/?/i, '')), 0);
         }
-        // "file.cs:124,185,202" → the first link carries "file.cs:124", the rest are just the bare
-        // line numbers (same file, different line), commas as plain text between them.
-        const name = escapeHtml(token.path.replace(/^file:\/\/\/?/i, ''));
-        const [first, ...rest] = token.lines;
-        let html = anchor(`${name}:${first}`, first);
-        for (const ln of rest) {
-            html += ',' + anchor(String(ln), ln);
+        // Single line → label the link with what the model actually wrote, so a range keeps its end
+        // ("x.ts:100-120" stays readable) and "#L128" keeps its GitHub shape. Only the file:// scheme
+        // is dropped, as noise.
+        if (token.lines.length === 1) {
+            return anchor(
+                escapeHtml(token.raw.replace(/^file:\/\/\/?/i, '')),
+                token.lines[0],
+                token.ends[0],
+            );
         }
+        // "file.cs:124,185,202" → the first link carries "file.cs:124", the rest are just the bare
+        // line numbers (same file, different line), commas as plain text between them. Each label is
+        // the element as written, so a range inside the list keeps its end ("100-120,130").
+        const name = escapeHtml(token.path.replace(/^file:\/\/\/?/i, ''));
+        const written = token.raw.slice(token.raw.indexOf(':') + 1).split(',');
+        const [first, ...rest] = token.lines;
+        let html = anchor(
+            `${name}:${escapeHtml(written[0] ?? String(first))}`,
+            first,
+            token.ends[0],
+        );
+        rest.forEach((ln, i) => {
+            html += ',' + anchor(escapeHtml(written[i + 1] ?? String(ln)), ln, token.ends[i + 1]);
+        });
         return html;
     },
 };

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/state.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/state.ts
@@ -194,6 +194,7 @@ const _impl = new StoreImpl<AppState>({
         diffIgnoreWhitespace: false,
         showOpenDiffInVsButton: true,
         allowedUploadExtensions: [],
+        extraLinkableExtensions: [],
         appVersion: '',
         appCopyright: '',
         logLevel: 0,

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-message.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-message.ts
@@ -227,6 +227,9 @@ export class CvMessage extends LitElement {
         e.stopPropagation();
         const filePath = a.getAttribute('data-file') ?? '';
         const line = Number(a.getAttribute('data-line') ?? 0) || 0;
+        // Last line of a "100-120" range, so the host selects the block instead of just placing the
+        // caret; equal to `line` for a plain reference.
+        const lineEnd = Number(a.getAttribute('data-line-end') ?? 0) || line;
         if (!filePath) {
             return;
         }
@@ -244,7 +247,7 @@ export class CvMessage extends LitElement {
         bridge.sendNotification<IdeFileNotification>(Msg.fromWebView.open.ideFile, {
             filePath,
             startLine: line,
-            endLine: line,
+            endLine: lineEnd,
         });
     };
 

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/init.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/init.ts
@@ -11,6 +11,7 @@ import { state } from '../core/state';
 import type { IdeContextNotification } from '../core/types';
 import { normPath } from '../core/path';
 import { closeTopDialog } from '../core/dialog-focus';
+import { setExtraLinkableExtensions } from '../core/file-links';
 import type {
     InitPayload,
     ModelsNotification,
@@ -50,6 +51,8 @@ function applyVsOptions(o: VsOptionsConfig): void {
     logger.setPerfEnabled(!!state.ui.perfEnabled);
     document.body.classList.toggle('sticky-user', !!o.stickyUserMessages);
     applyFontScale(o.chatFontSize);
+    // The file-link parser keeps its own set (module-level, not read from state at render time).
+    setExtraLinkableExtensions(o.extraLinkableExtensions);
 }
 
 function wireBridgeHandlers(): void {

--- a/src/Corsinvest.VisualStudio.Agents/Options/AgentsChatPage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Options/AgentsChatPage.cs
@@ -47,6 +47,12 @@ public class AgentsChatPage : AgentsOptionsPage
     [Description("Number of lines shown in preview areas (tool output and user messages). 0 = no preview.")]
     public int PreviewLines { get; set; } = 3;
 
+    [Category("File links")]
+    [DisplayName("Extra linkable extensions")]
+    [Description("Extensions to also turn into clickable links when Claude mentions a file in prose (e.g. `render.wgsl:20`), on top of the ~270 built-in ones. Needed only for a language we don't ship yet — a markdown link written by the model is always linked, whatever its extension. Click `…` to edit one entry per line, without the leading dot.")]
+    [Editor("System.Windows.Forms.Design.StringArrayEditor, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", typeof(UITypeEditor))]
+    public string[] ExtraLinkableExtensions { get; set; } = [];
+
     [Category("Display")]
     [DisplayName("Chat font size")]
     [Description("Font size (px) of the chat message text. Default: 13.")]


### PR DESCRIPTION
## What

File links in chat were built on a suffix-peeling parser: it looked for the `:line` suffix at the **end** of a token and took whatever came before as the path. With two references in one run, the last `:57` won and the path came from the first — `a.ts:57,b.ts:57` rendered as **one** link to `a.ts` that swallowed the rest of the text.

Rewritten to grow outwards from the **`.ext` anchor** — the only part of a reference that says "this is a file" (a `:` is also a host:port and a clock, a `,` is also punctuation). Adjacent references stay apart by construction.

## Fixed

| Case | Before | After |
|---|---|---|
| `a.ts:57,b.ts:57` | one link, wrong path, text swallowed | two correct links |
| `[x](src/utils/helper.rb#L12)` | degraded to text (`.rb` not in the prose list) | link |
| `x.ts#L103`, `x.ts#123` | not recognised | link |
| `src/Corsinvest.VisualStudio.Agents/…/x.ts:130` | path cut at the first dotted folder | full path |
| `x.ts:100-120` | displayed as `x.ts:100`, range vanished | label kept, **selects 100→120** |
| `x.ts:100-120,130` | stopped at the hyphen, `130` lost | every element linked |

Host side needed no change: `IdeFileNotification` and `OpenFileInEditorAsync` already took a range — the end line was being dropped in the WebView.

## Extensions

The prose allow-list covered 63 extensions, so a file named in a sentence stayed plain text for most languages outside .NET/web. Now ~270, grouped by area.

Kept hardcoded rather than derived, and both alternatives were checked first:

- **GitHub Linguist** (~1200 extensions) registers `.com` `.org` `.io` `.fr` `.es` `.me` as real languages — exactly the TLDs that would turn `db.example.com:5432` into a dead link.
- **VS's own `IFileExtensionRegistryService`**, probed in a running instance, returns 135 entries and misses `md py go rs java sql sh txt` — it maps editor-registered content types, not "languages VS can show".

**Options → Chat → Extra linkable extensions** covers what is missing: a separate `string[]`, empty by default, merged *on top of* the built-ins so a later release that widens the list still reaches users who saved settings. Applied through `applyVsOptions`, so a live change takes effect without reopening the pane.

Prose only — a markdown link written by the model is linked whatever its extension. Unlike the VS Code extension, a target that cannot be a file (`[x](19.99#L2)`) degrades to text instead of rendering a blue link that does nothing on click.

## Why the allow-list stays

Measured on 15 prose sentences with the "any extension" rule: **8 false positives** — `2.1.220:5`, `v1.2:3` (versions), `localhost.net:4040`, `db.example.com:5432` (host:port), `192.168.1.10:8080`, `19.99:2` (price), `RFC.2119:4`, `abc.1234:5`. Requiring a letter in the extension drops it to 4, but the TLDs remain: `.net` and `.com` are lexically identical to `.cs`, so only a list separates them.

`linkify-it` (behind GitHub's autolink) reached the same conclusion from the other side — its changelog restricts 2-char TLDs for `node.js` and disables IP links because they conflict with version numbers.

## Verification

- unit 64 cases + end-to-end through marked 25 cases, both green
- manually checked in the Exp instance across 82 rendered cases (prose, hrefs, ranges, lists, multiple files per line, punctuation, code blocks, noise) — several of the bugs above were found that way, not by the tests
- range selection confirmed on the wire: `open_ide_file {startLine:100, endLine:120}` and the editor selecting those lines
- `msbuild /t:Build /p:Configuration=Debug` green, `npm run typecheck` / `lint` / `format` clean

## Commits

1. `fix(chat)` — the parser rewrite and the seven parsing bugs
2. `feat(chat)` — ~270 extensions and the new option
3. `docs` — README, `docs/file-links.md`, `docs/options.md`
