### PR TITLE
Call the generated DTOs by their generated names

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/state.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/state.ts
@@ -17,7 +17,7 @@ import type {
     SlashCommandDto,
     SubagentTask,
     Theme,
-    VsOptionsConfig,
+    VsOptionsDto,
 } from './types';
 
 interface AppState {
@@ -81,8 +81,8 @@ interface AppState {
 
     // UI options from the C# Options page, as one group (the init payload's
     // `vsOptions` block, also re-pushed via `vs_settings`). Read at render time
-    // (not observed per-field). Adding an option = one field in VsOptionsConfig, nothing here.
-    ui: VsOptionsConfig;
+    // (not observed per-field). Adding an option = one field in VsOptionsDto, nothing here.
+    ui: VsOptionsDto;
 }
 
 type Listener<T> = (value: T) => void;

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/types.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/types.ts
@@ -134,11 +134,10 @@ export type { AssistantTextNotification } from './generated/AssistantTextNotific
 export type { ExchangeEndedNotification } from './generated/ExchangeEndedNotification';
 
 // Init payload from the host — generated from C# (Contracts.InitPayloadNotification and its
-// nested InitConfigDto/VsOptionsDto) by TypeGen. Aliased to the historical names the
-// UI consumes; do not hand-edit the generated files.
-export type { InitConfigDto as InitConfig } from './generated/InitConfigDto';
-export type { VsOptionsDto as VsOptionsConfig } from './generated/VsOptionsDto';
-export type { InitPayloadNotification as InitPayload } from './generated/InitPayloadNotification';
+// nested InitConfigDto/VsOptionsDto) by TypeGen. Same names as the C# side, so a DTO stays
+// greppable across both languages; do not hand-edit the generated files.
+export type { VsOptionsDto } from './generated/VsOptionsDto';
+export type { InitPayloadNotification } from './generated/InitPayloadNotification';
 
 export type PermissionMode = 'default' | 'acceptEdits' | 'plan' | 'auto' | 'bypassPermissions';
 
@@ -209,7 +208,7 @@ export type { ContextUsageDto } from './generated/ContextUsageDto';
 
 /** Spinner-verb override from settings (nested in the init ui payload). Generated from
  *  C# (Contracts.SpinnerVerbsConfigDto); mode is a raw string ("append"/"replace"). */
-export type { SpinnerVerbsConfigDto as SpinnerVerbsConfig } from './generated/SpinnerVerbsConfigDto';
+export type { SpinnerVerbsConfigDto } from './generated/SpinnerVerbsConfigDto';
 
 /** A file picked/dropped for upload. Always read as base64 (one code path);
  *  the host decides by extension whether to send it as an image, a PDF, or

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-spinner.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-spinner.ts
@@ -4,7 +4,7 @@
  */
 import { LitElement, html, css } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
-import type { SpinnerVerbsConfig } from '../../core/types';
+import type { SpinnerVerbsConfigDto } from '../../core/types';
 import { state as appState } from '../../core/state';
 
 // Verbs the spinner cycles; replace/extend via setVerbsConfig at runtime.
@@ -94,7 +94,7 @@ let _activeVerbs: readonly string[] = DEFAULT_VERBS;
  * Set the verb pool for every <cv-spinner>. 'replace' overrides defaults,
  * 'append' adds to them, `null` resets to defaults.
  */
-export function setVerbsConfig(cfg: SpinnerVerbsConfig | null): void {
+export function setVerbsConfig(cfg: SpinnerVerbsConfigDto | null): void {
     if (!cfg) {
         _activeVerbs = DEFAULT_VERBS;
         return;

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/init.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/init.ts
@@ -13,7 +13,7 @@ import { normPath } from '../core/path';
 import { closeTopDialog } from '../core/dialog-focus';
 import { setExtraLinkableExtensions } from '../core/file-links';
 import type {
-    InitPayload,
+    InitPayloadNotification,
     ModelsNotification,
     PermissionMode,
     PermissionModeChangedNotification,
@@ -22,7 +22,7 @@ import type {
     ThemeChangedNotification,
     ExchangeEndedNotification,
     Theme,
-    VsOptionsConfig,
+    VsOptionsDto,
 } from '../core/types';
 import { installDebugApi } from './debug';
 import { logger } from '../core/logger';
@@ -44,8 +44,8 @@ function applyTheme(theme: Theme): void {
 }
 
 // Applies the VS Options category (init payload's `vsOptions` and the standalone
-// `vs_settings` re-push share this — both carry the full VsOptionsConfig).
-function applyVsOptions(o: VsOptionsConfig): void {
+// `vs_settings` re-push share this — both carry the full VsOptionsDto).
+function applyVsOptions(o: VsOptionsDto): void {
     state.ui = o;
     logger.setLevel(state.ui.logLevel ?? 0);
     logger.setPerfEnabled(!!state.ui.perfEnabled);
@@ -56,7 +56,7 @@ function applyVsOptions(o: VsOptionsConfig): void {
 }
 
 function wireBridgeHandlers(): void {
-    bridge.onNotification<InitPayload>(Msg.toWebView.ui.init, (data) => {
+    bridge.onNotification<InitPayloadNotification>(Msg.toWebView.ui.init, (data) => {
         if (!data?.config) {
             return;
         }
@@ -111,7 +111,7 @@ function wireBridgeHandlers(): void {
 
     // VS Options re-pushed standalone when the user changes the Options page while
     // the pane is open (independent of CLI state / a respawn).
-    bridge.onNotification<VsOptionsConfig>(Msg.toWebView.ui.vsSettings, (data) => {
+    bridge.onNotification<VsOptionsDto>(Msg.toWebView.ui.vsSettings, (data) => {
         if (data) {
             applyVsOptions(data);
         }


### PR DESCRIPTION
## Why

`core/types.ts` re-exported four generated DTOs under shorter names:

```ts
export type { InitConfigDto as InitConfig } from './generated/InitConfigDto';
export type { VsOptionsDto as VsOptionsConfig } from './generated/VsOptionsDto';
export type { InitPayloadNotification as InitPayload } from './generated/InitPayloadNotification';
export type { SpinnerVerbsConfigDto as SpinnerVerbsConfig } from './generated/SpinnerVerbsConfigDto';
```

Two problems with that.

**It breaks cross-language grep.** Searching `VsOptionsDto` turned up the C# DTO and the generated `.ts`, but none of its four uses in the WebView — and following a DTO from `Contracts` through TypeGen to its consumers is the normal way to work in this repo.

**The `Dto` suffix carries information.** It says "generated, don't hand-edit". Strip it and the comment above has to say so in prose instead — which it did.

**`InitConfig` had no consumers at all.** The comment described these as "the historical names the UI consumes", but `init.ts` reads `data.config.workingDirectory` without ever naming the nested type. Dead export.

## What changed

| was | now | call sites |
|---|---|---|
| `InitConfig` | *(deleted — unused)* | 0 |
| `InitPayload` | `InitPayloadNotification` | 2 |
| `VsOptionsConfig` | `VsOptionsDto` | 4 |
| `SpinnerVerbsConfig` | `SpinnerVerbsConfigDto` | 2 |

Types only — no behaviour, no runtime code, no C#.

## What deliberately stays

`import { state as appState }`, in 20 files. Inside a Lit component a bare `state` reads as the `@state()` decorator, so that alias earns its keep. It's also uniform across every consumer, which is the opposite of the situation above.

## Verification

- `npm run check`: 0 errors, Prettier clean (7 pre-existing `no-explicit-any` warnings in untouched files)
- Bundle builds
- No references to the old names remain
