### PR TITLE
Rename a session through the CLI, not behind its back

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
@@ -45,8 +45,34 @@ public partial class ChatPaneControl : PaneControlBase
         var sid = _client?.SessionId;
         var wd = _client?.WorkingDirectory;
         if (string.IsNullOrEmpty(sid) || string.IsNullOrEmpty(wd) || string.IsNullOrWhiteSpace(newTitle)) { return; }
-        Sessions.Rename(sid, newTitle);
+
+        // Show it straight away — the write below is the slow part, and it can't fail in a way
+        // the user could act on.
         SetSessionTitle(newTitle);
+
+        // A live CLI holds the JSONL open and keeps the title in memory: appending to the file
+        // behind its back races its own writes and leaves it believing the old title. Ask it to
+        // rename instead, and let it persist. Only write the file ourselves when there is no CLI
+        // to compete with, or when it is too old to know the request.
+        if (_client?.IsRunning != true)
+        {
+            Sessions.Rename(sid, newTitle);
+            return;
+        }
+        _ = RenameThroughClientAsync(sid, newTitle);
+    }
+
+    private async Task RenameThroughClientAsync(string sessionId, string newTitle)
+    {
+        try
+        {
+            if (await _client.RenameSessionAsync(newTitle)) { return; }
+        }
+        catch (Exception ex)
+        {
+            OutputWindowLogger.LogException("[chat] rename_session", ex);
+        }
+        Sessions.Rename(sessionId, newTitle);
     }
 
     /// <summary>Fresh conversation in THIS pane. Mirrors the Session.New

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.cs
@@ -499,6 +499,28 @@ public sealed partial class ClaudeClient : IClaudeClient
         return resp.Val("title");
     }
 
+    /// <summary>
+    /// Sets the session's user-facing title through the live CLI, which persists it to the JSONL
+    /// itself (a <c>custom-title</c> entry — the same shape <see cref="SessionManager.Rename"/>
+    /// writes). Going through the CLI keeps it the single writer of a file it holds open, and
+    /// leaves its in-memory title in step with what is on disk.
+    /// Returns false when the CLI rejects the request — a version that predates the subtype —
+    /// so the caller can fall back to writing the file directly.
+    /// </summary>
+    public async Task<bool> RenameSessionAsync(string title)
+    {
+        try
+        {
+            await SendControlRequestAsync(ClientMessages.ControlSubtype.RenameSession, new { title });
+            return true;
+        }
+        catch (Exception ex)
+        {
+            OutputWindowLogger.Warn($"[client] rename_session refused ({ex.Message}) — falling back to the JSONL");
+            return false;
+        }
+    }
+
     public async Task<McpStatus> GetMcpStatusAsync()
     {
         var resp = await SendControlRequestAsync(ClientMessages.ControlSubtype.McpStatus, null);

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClientMessages.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClientMessages.cs
@@ -79,6 +79,7 @@ internal static class ClientMessages
         public const string ApplyFlagSettings = "apply_flag_settings";
         public const string GetSettings = "get_settings";
         public const string GenerateSessionTitle = "generate_session_title";
+        public const string RenameSession = "rename_session";
 
         // Inbound (the CLI sends these to us)
         public const string CanUseTool = "can_use_tool";


### PR DESCRIPTION
## The problem

`RenameSession` appended a `custom-title` entry straight to the session's JSONL:

```csharp
File.AppendAllText(path, "\n" + JsonConvert.SerializeObject(entry));
```

That file belongs to the running CLI. It holds it open and writes to it on its own schedule, so this makes two independent writers on one append-only file with nothing coordinating them:

- the CLI keeps the old title in memory and can write it back over ours on its next flush
- in the worst case a line lands interleaved and the JSONL is corrupt

Not reproducible on demand — it depends on when the CLI flushes — which is exactly why it's worth fixing rather than waiting to see it.

## The fix

`rename_session` is the control_request for this. The live CLI takes the title, updates its own state, and persists it. Same hot-swap channel as `set_model` / `set_permission_mode`.

```csharp
// no CLI to compete with → write the file ourselves
if (_client?.IsRunning != true) { Sessions.Rename(sid, newTitle); return; }
_ = RenameThroughClientAsync(sid, newTitle);
```

`RenameSessionAsync` returns false instead of throwing when the CLI refuses, so a version predating the subtype falls back to the old path. Timeouts and hard failures fall back too.

Writing the file directly stays correct in one case and is kept for it: renaming from the History list without the session open, where there is no CLI to tell.

The title is applied to the toolbar first and the write happens behind it — the write is the slow half and can't fail in a way the user could act on.

## Verified against the real CLI

Probed 2.1.220 directly rather than trusting the schema:

```
$ node probe.mjs rename_session '{"title":"probe-rename-test"}'
{ "subtype": "success", "request_id": "probe_1785139913370" }
```

and the CLI persisted:

```json
{"type":"custom-title","customTitle":"probe-rename-test","sessionId":"7f440766-…"}
```

**Byte-identical to the line we were writing by hand**, so `ScanTitle`, `ScanMetadata` and `HasTitle` need no changes — they already read this shape.

## Notes

- `SendControlRequestAsync` completes the TCS with an exception on a `subtype: "error"` response (`ClaudeClient.Protocol.cs:155`) and on timeout, so both land in the fallback.
- `Options.title` — starting a *new* session with a chosen name — is deliberately not adopted: the auto-title generated from the first prompt describes what the session is actually about, and `rename_session` covers renaming afterwards.

## Verification

MSBuild Debug: 0 errors. No WebView changes.

Runtime check in the experimental instance still to do: rename with the CLI running, rename from History with no CLI, and confirm the title survives the next CLI write.
