### PR TITLE
fix(ui): let the Info dialog's Copy icon follow the theme

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/AgentsPackage.vsct
+++ b/src/Corsinvest.VisualStudio.Agents/AgentsPackage.vsct
@@ -94,7 +94,13 @@
 
     <Buttons>
       <!-- Dynamic range inside the submenu: one item per enabled profile, the native "Claude"
-           profile prepended (unless a profile is itself named "Claude"). Seeded by DynamicItemStart. -->
+           profile prepended (unless a profile is itself named "Claude"). Seeded by DynamicItemStart.
+           NO <Icon> here, deliberately: "a dynamic command cannot have an icon associated with it"
+           (MS docs on dynamically adding menu items), and OleMenuCommand exposes no image property
+           either. Adding one decorates the SEED item only and leaves every generated profile bare —
+           an asymmetry that reads as a bug. Per-item icons would mean dropping DynamicItemStart for
+           N pre-declared Buttons (fixed ceiling on profiles) or a WPF picker, as VS itself does for
+           its branch picker; not worth it for a cosmetic. Tried and reverted 2026-07. -->
       <Button guid="guidAgentsCommandSet" id="ShowToolWindowCommandId" priority="0x0100" type="Button">
         <Parent guid="guidAgentsCommandSet" id="ProfilesGroup"/>
         <CommandFlag>DynamicItemStart</CommandFlag>

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/DevInfoDialog.xaml
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/DevInfoDialog.xaml
@@ -8,6 +8,7 @@
         xmlns:toolkit="clr-namespace:Community.VisualStudio.Toolkit;assembly=Community.VisualStudio.Toolkit"
         xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"
         xmlns:catalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"
+        xmlns:platformui="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Imaging"
         toolkit:Themes.UseVsTheme="True"
         Title="Info"
         Width="760" SizeToContent="Height"
@@ -17,7 +18,11 @@
         HasMaximizeButton="False"
         HasMinimizeButton="False"
         HasHelpButton="False">
-  <Grid Margin="16">
+  <!-- CrispImage biases its icon against the background it is TOLD about, not the one it is drawn
+       on: with no ImageBackgroundColor in the tree it assumes the light default, so the Copy icon
+       stays dark on a dark dialog. Feed it the themed window background the dialog actually has. -->
+  <Grid Margin="16"
+        platformui:ImageThemingUtilities.ImageBackgroundColor="{DynamicResource {x:Static vsui:EnvironmentColors.ToolWindowBackgroundColorKey}}">
     <Grid.RowDefinitions>
       <RowDefinition Height="*" />
       <RowDefinition Height="Auto" />


### PR DESCRIPTION
## What

The Copy button in the **Info** dialog (Developer → Info) used a `CrispImage` that stayed dark on a dark theme, making it barely visible.

`CrispImage` grayscale-biases its icon against the background it is *told* about via `ImageThemingUtilities.ImageBackgroundColor`, not the one it is actually drawn on. With that attached property absent from the tree it falls back to the light default — hence a dark icon on a dark dialog.

Fixed by declaring the real background on the dialog's root `Grid`, bound to `EnvironmentColors.ToolWindowBackgroundColorKey`.

## Also

A comment in `AgentsPackage.vsct` recording **why the profiles submenu has no icons**, so it is not attempted again:

- Microsoft's docs on dynamically adding menu items state it plainly: *"a dynamic command cannot have an icon associated with it"*.
- Confirmed by reflection against the real VS18 `Microsoft.VisualStudio.Shell.15.0.dll`: `OleMenuCommand` exposes `Text`, `Checked`, `Enabled`, `Visible`, `Supported`, … and **no image property**.
- Setting `<Icon>` on the `DynamicItemStart` button was tried: it decorates the *seed* item only, leaving every generated profile bare — an asymmetry that reads as a bug. Reverted.

Per-item icons would require dropping `DynamicItemStart` for N pre-declared Buttons (a fixed ceiling on the number of profiles) or a WPF picker — which is how VS itself does its branch picker. Not worth it for a cosmetic.

No behaviour change from that half: the `.vsct` is functionally identical to before.

## Verification

Verified by the author in the experimental instance: the Info dialog's Copy icon reads correctly in dark and light.
