### PR TITLE
refactor(client): give the CLI's replies types instead of JSON

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.ClientEvents.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.ClientEvents.cs
@@ -163,8 +163,8 @@ public partial class ChatPaneControl
                     FastModeState = e.FastModeState,
                     SpinnerVerbsConfig = e.SpinnerVerbs == null ? null : new Contracts.SpinnerVerbsConfigDto
                     {
-                        Mode = e.SpinnerVerbs.Val("mode"),
-                        Verbs = e.SpinnerVerbs["verbs"]?.ToObject<string[]>(),
+                        Mode = e.SpinnerVerbs.Mode,
+                        Verbs = e.SpinnerVerbs.Verbs,
                     },
                 },
                 VsOptions = WebViewBridge.BuildVsOptions(),
@@ -190,43 +190,41 @@ public partial class ChatPaneControl
                     Models = [.. ProjectModels(e.Models, disabled: false), .. ProjectModels(e.UnavailableModels, disabled: true)],
                 });
             }
-            if (e.Commands != null)
+            // Count, not null: the parse flattens "absent" to an empty list, and publishing that
+            // would wipe the commands the WebView already has.
+            if (e.Commands?.Count > 0)
             {
                 _bridge.Send(BridgeMessages.ToWebView.Chat.SlashCommands, new Contracts.SlashCommandsNotification { Commands = ProjectCommands(e.Commands) });
             }
         });
 
-    private static Contracts.SlashCommandDto[] ProjectCommands(JArray commands)
-        => [.. commands.OfType<JObject>()
-            .Select(c => new Contracts.SlashCommandDto
+    private static Contracts.SlashCommandDto[] ProjectCommands(IReadOnlyList<SlashCommand> commands)
+        => [.. commands.Select(c => new Contracts.SlashCommandDto
             {
-                Name = c.Val("name", ""),
-                Description = c.Val("description", ""),
-                ArgumentHint = c.Val("argumentHint", ""),
-                Aliases = (c["aliases"] as JArray)?.Select(x => (string)x).ToArray() ?? [],
-            })
-            .Where(c => !string.IsNullOrEmpty(c.Name))];
+                Name = c.Name,
+                Description = c.Description,
+                ArgumentHint = c.ArgumentHint,
+                Aliases = c.Aliases,
+            })];
 
-    private static IEnumerable<Contracts.ModelInfoDto> ProjectModels(JArray models, bool disabled)
-    {
-        if (models == null) { yield break; }
-        foreach (var m in models.OfType<JObject>())
-        {
-            yield return new Contracts.ModelInfoDto
+    /// <summary>Client catalogue → WebView DTO. `disabled` is ours, not the CLI's: it records which
+    /// of the two arrays the row came from (models vs unavailable_models).</summary>
+    private static IEnumerable<Contracts.ModelInfoDto> ProjectModels(IReadOnlyList<ModelInfo> models, bool disabled)
+        => models == null
+            ? []
+            : models.Select(m => new Contracts.ModelInfoDto
             {
-                Value = m.Val("value", ""),
-                ResolvedModel = m.Val("resolvedModel", ""),
-                DisplayName = m.Val("displayName", ""),
-                Description = m.Val("description", ""),
-                SupportsEffort = m.ValBool("supportsEffort") ?? false,
-                SupportedEffortLevels = (m["supportedEffortLevels"] as JArray)?.Select(x => (string)x).ToArray() ?? [],
-                SupportsFastMode = m.ValBool("supportsFastMode") ?? false,
-                SupportsAdaptiveThinking = m.ValBool("supportsAdaptiveThinking") ?? false,
-                SupportsAutoMode = m.ValBool("supportsAutoMode") ?? false,
+                Value = m.Value,
+                ResolvedModel = m.ResolvedModel,
+                DisplayName = m.DisplayName,
+                Description = m.Description,
+                SupportsEffort = m.SupportsEffort,
+                SupportedEffortLevels = m.SupportedEffortLevels,
+                SupportsFastMode = m.SupportsFastMode,
+                SupportsAdaptiveThinking = m.SupportsAdaptiveThinking,
+                SupportsAutoMode = m.SupportsAutoMode,
                 Disabled = disabled,
-            };
-        }
-    }
+            });
 
     private void OnAssistantMessage(object sender, AssistantMessageEventArgs e)
         => Dispatcher.Invoke(() =>
@@ -269,8 +267,11 @@ public partial class ChatPaneControl
             // on a fresh init. After any model switch the exact-key lookup misses, so fall back to
             // the single entry (a turn is single-model on the wire) to keep the gauge denominator.
             var mu = e.ModelUsage;
-            var modelUsage = (mu?[_client?.Model ?? ""] as JObject)
-                ?? (mu?.Count == 1 ? mu.Properties().First().Value as JObject : null);
+            ModelUsage modelUsage = null;
+            if (mu != null && !mu.TryGetValue(_client?.Model ?? "", out modelUsage) && mu.Count == 1)
+            {
+                modelUsage = mu.Values.First();
+            }
             _bridge.Send(BridgeMessages.ToWebView.Chat.ExchangeEnded, new Contracts.ExchangeEndedNotification
             {
                 CostUsd = e.TotalCostUsd ?? 0,
@@ -283,8 +284,8 @@ public partial class ChatPaneControl
                     CacheReadTokens = e.Usage.Val("cache_read_input_tokens", 0),
                     CacheCreationTokens = e.Usage.Val("cache_creation_input_tokens", 0),
                 },
-                ContextWindow = modelUsage?.Val<long>("contextWindow", 0) ?? 0,
-                MaxOutputTokens = modelUsage?.Val<long>("maxOutputTokens", 0) ?? 0,
+                ContextWindow = modelUsage?.ContextWindow ?? 0,
+                MaxOutputTokens = modelUsage?.MaxOutputTokens ?? 0,
                 ErrorText = e.ErrorText ?? "",
                 // terminal_reason is the finer cause when present; the subtype always identifies
                 // the failure family, so it's the fallback rather than nothing.
@@ -496,7 +497,8 @@ public partial class ChatPaneControl
                 // same bridge channel; the WebView replaces its list.
                 if (obj["commands"] is JArray commands)
                 {
-                    _bridge.Send(BridgeMessages.ToWebView.Chat.SlashCommands, new Contracts.SlashCommandsNotification { Commands = ProjectCommands(commands) });
+                    _bridge.Send(BridgeMessages.ToWebView.Chat.SlashCommands,
+                        new Contracts.SlashCommandsNotification { Commands = ProjectCommands(ClaudeClient.ParseCommands(commands)) });
                 }
             }
             else if (subtype == ClientMessages.SystemSubtype.ThinkingTokens)
@@ -574,9 +576,9 @@ public partial class ChatPaneControl
     private void OnRateLimit(object sender, RateLimitEventArgs e)
         => Dispatcher.Invoke(() =>
         {
-            var info = e.RateLimitInfo;
-            var status = info.Val("status", "");
-            var type = info.Val("rateLimitType", "");
+            var info = e.Info;
+            var status = info?.Status ?? "";
+            var type = info?.RateLimitType ?? "";
             var key = status + ":" + type;
             if (status == "allowed" || string.IsNullOrEmpty(status))
             {
@@ -588,7 +590,7 @@ public partial class ChatPaneControl
             {
                 Key = key,
                 Severity = status == "rejected" ? Contracts.NoticeVariantDto.Error : Contracts.NoticeVariantDto.Warning,
-                Message = FormatRateLimit(status, type, info.Val<double?>("utilization", null), info.Val<long?>("resetsAt", null)),
+                Message = FormatRateLimit(status, type, info?.Utilization, info?.ResetsAt),
             });
         });
 

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.Protocol.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.Protocol.cs
@@ -395,7 +395,7 @@ public sealed partial class ClaudeClient
                 ? (double?)obj.Val<double>("total_cost_usd", 0) : null,
             StopReason = obj.Val("stop_reason"),
             Usage = obj["usage"] as JObject,
-            ModelUsage = obj["modelUsage"] as JObject,
+            ModelUsage = ParseModelUsage(obj["modelUsage"] as JObject),
             ErrorText = ResultErrorText(obj, subtype),
             TerminalReason = obj.Val("terminal_reason", ""),
         });
@@ -415,7 +415,7 @@ public sealed partial class ClaudeClient
     }
 
     private void HandleRateLimit(JObject obj)
-        => RateLimitReceived?.Invoke(this, new RateLimitEventArgs { RateLimitInfo = obj["rate_limit_info"] as JObject });
+        => RateLimitReceived?.Invoke(this, new RateLimitEventArgs { Info = ParseRateLimitInfo(obj["rate_limit_info"] as JObject) });
 
     /// <summary>Fail every in-flight control_request and forget tracked tool
     /// requests. Called when the process exits (so awaiters don't hang to their

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Corsinvest.VisualStudio.Agents.Core.Client;
@@ -313,13 +314,15 @@ public sealed partial class ClaudeClient : IClaudeClient
                     ApiProvider = acct.Val("apiProvider"),
                 };
             }
+            // Gate on the raw arrays, not on the parsed lists: ParseModels flattens "absent" and
+            // "empty" to the same [], and an absent catalogue must not fire the event.
             if (models != null || unavailable != null || commands != null)
             {
                 ModelsReceived?.Invoke(this, new ModelsReceivedEventArgs
                 {
-                    Models = models,
-                    UnavailableModels = unavailable,
-                    Commands = commands,
+                    Models = ParseModels(models),
+                    UnavailableModels = ParseModels(unavailable),
+                    Commands = ParseCommands(commands),
                 });
             }
             // fast_mode_state is present in the initialize reply only when fast mode is available for
@@ -341,7 +344,7 @@ public sealed partial class ClaudeClient : IClaudeClient
                 AlwaysThinkingEnabled = eff?.ValBool("alwaysThinkingEnabled"),
                 Ultracode = applied?.ValBool("ultracode"),
                 SwitchModelsOnFlag = eff?.ValBool("switchModelsOnFlag"),
-                SpinnerVerbs = eff?["spinnerVerbs"] as JObject,
+                SpinnerVerbs = ParseSpinnerVerbs(eff?["spinnerVerbs"] as JObject),
                 FastModeState = fastModeState,
             });
         }
@@ -540,6 +543,101 @@ public sealed partial class ClaudeClient : IClaudeClient
         }
         return status;
     }
+
+    /// <summary>Asks the live CLI for the model catalogue — the same list `initialize` seeds us with
+    /// (the CLI builds both from getModelOptions), but askable at any time, which `initialize` is not:
+    /// the catalogue follows the account/provider/settings cascade and the CLI never pushes a change.
+    /// Empty when the CLI predates the subtype or answers without models.
+    /// Deliberately does NOT raise ModelsReceived: that path publishes only on the first init
+    /// (see ChatPaneControl.OnModelsReceived), so an event here would be silently dropped.</summary>
+    public async Task<IReadOnlyList<ModelInfo>> ListModelsAsync()
+    {
+        try
+        {
+            var resp = await SendControlRequestAsync(ClientMessages.ControlSubtype.ListModels, null);
+            return ParseModels(resp?["models"] as JArray);
+        }
+        catch (Exception ex)
+        {
+            OutputWindowLogger.Warn($"[client] list_models refused ({ex.Message}) — keeping the catalogue from initialize");
+            return [];
+        }
+    }
+
+    /// <summary>Maps the wire rows of the slash-command list onto <see cref="SlashCommand"/>.
+    /// Nameless rows are dropped — they would render as an unclickable blank in the palette.
+    /// internal, unlike the model parse: `commands_changed` carries the same shape and is handled in
+    /// the pane, which parses it through here rather than growing a second reader of the wire.</summary>
+    internal static IReadOnlyList<SlashCommand> ParseCommands(JArray commands)
+        => commands == null
+            ? []
+            : [.. commands.OfType<JObject>().Select(c => new SlashCommand
+            {
+                Name = c.Val("name", ""),
+                Description = c.Val("description", ""),
+                ArgumentHint = c.Val("argumentHint", ""),
+                Aliases = (c["aliases"] as JArray)?.Select(x => (string)x).ToArray() ?? [],
+            })
+            .Where(c => !string.IsNullOrEmpty(c.Name))];
+
+    /// <summary>Maps `effective.spinnerVerbs`; null when the CLI configures none.</summary>
+    private static SpinnerVerbs ParseSpinnerVerbs(JObject verbs)
+        => verbs == null
+            ? null
+            : new SpinnerVerbs
+            {
+                Mode = verbs.Val("mode"),
+                Verbs = verbs["verbs"]?.ToObject<string[]>() ?? [],
+            };
+
+    /// <summary>Maps `rate_limit_event.rate_limit_info`. Only the fields we act on: the payload also
+    /// carries the overage/credits block, which no surface of ours reads yet.</summary>
+    internal static RateLimitInfo ParseRateLimitInfo(JObject info)
+        => info == null
+            ? null
+            : new RateLimitInfo
+            {
+                Status = info.Val("status", ""),
+                ResetsAt = info.Val<long?>("resetsAt", null),
+                RateLimitType = info.Val("rateLimitType", ""),
+                Utilization = info.Val<double?>("utilization", null),
+            };
+
+    /// <summary>Maps `result.modelUsage` (an object keyed by model id) onto its typed form. These
+    /// keys are camelCase, unlike the snake_case of `message.usage` — the wire is inconsistent by
+    /// design, so don't reuse one reader for both.</summary>
+    internal static IReadOnlyDictionary<string, ModelUsage> ParseModelUsage(JObject modelUsage)
+        => modelUsage?.Properties()
+            .Where(p => p.Value is JObject)
+            .ToDictionary(p => p.Name, p => new ModelUsage
+            {
+                InputTokens = ((JObject)p.Value).Val("inputTokens", 0),
+                OutputTokens = ((JObject)p.Value).Val("outputTokens", 0),
+                CacheReadInputTokens = ((JObject)p.Value).Val("cacheReadInputTokens", 0),
+                CacheCreationInputTokens = ((JObject)p.Value).Val("cacheCreationInputTokens", 0),
+                WebSearchRequests = ((JObject)p.Value).Val("webSearchRequests", 0),
+                CostUsd = ((JObject)p.Value).Val("costUSD", 0d),
+                ContextWindow = ((JObject)p.Value).Val("contextWindow", 0),
+                MaxOutputTokens = ((JObject)p.Value).Val("maxOutputTokens", 0),
+            });
+
+    /// <summary>Maps the wire rows of a model catalogue onto <see cref="ModelInfo"/>. The capability
+    /// flags are absent (not false) when unsupported — the CLI omits them — so every one defaults off.</summary>
+    private static IReadOnlyList<ModelInfo> ParseModels(JArray models)
+        => models == null
+            ? []
+            : [.. models.OfType<JObject>().Select(m => new ModelInfo
+            {
+                Value = m.Val("value", ""),
+                ResolvedModel = m.Val("resolvedModel", ""),
+                DisplayName = m.Val("displayName", ""),
+                Description = m.Val("description", ""),
+                SupportsEffort = m.ValBool("supportsEffort") ?? false,
+                SupportedEffortLevels = (m["supportedEffortLevels"] as JArray)?.Select(x => (string)x).ToArray() ?? [],
+                SupportsAdaptiveThinking = m.ValBool("supportsAdaptiveThinking") ?? false,
+                SupportsFastMode = m.ValBool("supportsFastMode") ?? false,
+                SupportsAutoMode = m.ValBool("supportsAutoMode") ?? false,
+            })];
 
     public Task McpReconnectAsync(string serverName)
         => SendControlRequestAsync(ClientMessages.ControlSubtype.McpReconnect, new { serverName });

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClientMessages.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClientMessages.cs
@@ -80,6 +80,7 @@ internal static class ClientMessages
         public const string GetSettings = "get_settings";
         public const string GenerateSessionTitle = "generate_session_title";
         public const string RenameSession = "rename_session";
+        public const string ListModels = "list_models";
 
         // Inbound (the CLI sends these to us)
         public const string CanUseTool = "can_use_tool";

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/Events.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/Events.cs
@@ -4,16 +4,9 @@
  */
 
 using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
 
 namespace Corsinvest.VisualStudio.Agents.Core.Client;
-
-public sealed class AccountInfo
-{
-    public string Email { get; set; }
-    public string Organization { get; set; }
-    public string SubscriptionType { get; set; }
-    public string ApiProvider { get; set; }
-}
 
 public sealed class InitializedEventArgs
 {
@@ -27,9 +20,9 @@ public sealed class InitializedEventArgs
 
 /// <summary>The CLI's full startup state, gathered from `initialize` (fast_mode_state) + `get_settings`
 /// (model + toggles) right after StartProcess — WITHOUT a user turn (system/init only arrives on the
-/// first turn, so it can't seed the UI on open). Raw values (strings/JObject); the pane maps them to
-/// the webview DTO and adds PermissionMode (which the CLI doesn't report — we pass it via
-/// --permission-mode). Fired on every startup (open + respawn). Fields are null when get_settings fails.</summary>
+/// first turn, so it can't seed the UI on open). The pane maps these onto the webview DTO and adds
+/// PermissionMode (which the CLI doesn't report — we pass it via --permission-mode). Fired on every
+/// startup (open + respawn). Fields are null when get_settings fails.</summary>
 public sealed class CliStateReceivedEventArgs
 {
     // From get_settings.applied.model (resume = the session's own model, new = the settings default,
@@ -44,8 +37,8 @@ public sealed class CliStateReceivedEventArgs
     public bool? AlwaysThinkingEnabled { get; set; }   // effective.alwaysThinkingEnabled
     public bool? Ultracode { get; set; }               // applied.ultracode
     public bool? SwitchModelsOnFlag { get; set; }      // effective.switchModelsOnFlag (absent in CLI → null → webview default)
-    // effective.spinnerVerbs ({ mode, verbs }) or null. Raw JObject — the pane builds the DTO.
-    public JObject SpinnerVerbs { get; set; }
+    // effective.spinnerVerbs, or null when the CLI configures none.
+    public SpinnerVerbs SpinnerVerbs { get; set; }
     // From initialize.fast_mode_state (present only if fast is available for the account/org) or "off".
     public string FastModeState { get; set; }
 }
@@ -119,7 +112,7 @@ public sealed class ResultEventArgs
     public JObject Usage { get; set; }
     /// <summary>Per-model usage, keyed by model id; each carries contextWindow /
     /// maxOutputTokens. Source of the context-window limits. Null when absent.</summary>
-    public JObject ModelUsage { get; set; }
+    public IReadOnlyDictionary<string, ModelUsage> ModelUsage { get; set; }
     /// <summary>Why the turn failed, when IsError: `result` on a success-subtype result,
     /// otherwise the joined `errors[]`. Empty when the turn succeeded.</summary>
     public string ErrorText { get; set; } = "";
@@ -133,9 +126,16 @@ public sealed class ResultEventArgs
 /// description + argumentHint). The CLI's only source for both.</summary>
 public sealed class ModelsReceivedEventArgs
 {
-    public JArray Models { get; set; }
-    public JArray UnavailableModels { get; set; }
-    public JArray Commands { get; set; }
+    /// <summary>Selectable models. Parsed here rather than passed as raw JSON so every consumer
+    /// reads the same shape `list_models` returns (ClaudeClient.ParseModels builds both).</summary>
+    public IReadOnlyList<ModelInfo> Models { get; set; }
+
+    /// <summary>Models the account cannot use — shown greyed out, not hidden.</summary>
+    public IReadOnlyList<ModelInfo> UnavailableModels { get; set; }
+
+    /// <summary>Slash commands (built-in, skills, plugins). Re-published on every init, unlike the
+    /// catalogue — they don't get dirtied by a --resume.</summary>
+    public IReadOnlyList<SlashCommand> Commands { get; set; }
 }
 
 public sealed class ToolPermissionRequestEventArgs
@@ -169,30 +169,8 @@ public sealed class HookCallbackEventArgs
 
 public sealed class RateLimitEventArgs
 {
-    public JObject RateLimitInfo { get; set; }
+    public RateLimitInfo Info { get; set; }
 }
-
-/// <summary>Connection state of a single MCP (Model Context Protocol) server.</summary>
-public sealed class McpServerStatus
-{
-    public string Name { get; set; }
-
-    /// <summary>One of "connected", "failed", "needs-auth", "pending", "disabled".</summary>
-    public string Status { get; set; }
-
-    public string Error { get; set; }
-
-    /// <summary>Configuration scope (project / user / local / claudeai / managed).</summary>
-    public string Scope { get; set; }
-}
-
-/// <summary>Aggregate status of all configured MCP servers.</summary>
-public sealed class McpStatus
-{
-    public System.Collections.Generic.List<McpServerStatus> Servers { get; set; }
-        = [];
-}
-
 
 public sealed class ProcessStartedEventArgs
 {

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/IClaudeClient.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/IClaudeClient.cs
@@ -5,6 +5,7 @@
 
 using Newtonsoft.Json.Linq;
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Corsinvest.VisualStudio.Agents.Core.Client;
@@ -72,6 +73,10 @@ public interface IClaudeClient : IDisposable
 
     /// <summary>Generates a short AI title for the session via CLI (uses Haiku under the hood).</summary>
     Task<string> GenerateSessionTitleAsync(string description, bool persist = false);
+
+    /// <summary>Asks the live CLI for the model catalogue (the list `initialize` seeds at startup),
+    /// on demand. Empty when the CLI predates `list_models` or answers without models.</summary>
+    Task<IReadOnlyList<ModelInfo>> ListModelsAsync();
 
     // ----- MCP -----
     Task<McpStatus> GetMcpStatusAsync();

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/Models.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/Models.cs
@@ -1,0 +1,122 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using System.Collections.Generic;
+
+namespace Corsinvest.VisualStudio.Agents.Core.Client;
+
+// Data the CLI reports about itself — the client's own shapes, deliberately NOT the generated
+// Contracts DTOs: those describe what we send to the WebView, and this layer talks to the process,
+// not to the UI. The pane maps between the two. Event payloads live in Events.cs.
+
+/// <summary>Logged-in account, from the `initialize` reply.</summary>
+public sealed class AccountInfo
+{
+    public string Email { get; set; }
+    public string Organization { get; set; }
+    public string SubscriptionType { get; set; }
+    public string ApiProvider { get; set; }
+}
+
+/// <summary>Connection state of a single MCP (Model Context Protocol) server.</summary>
+public sealed class McpServerStatus
+{
+    public string Name { get; set; }
+
+    /// <summary>One of "connected", "failed", "needs-auth", "pending", "disabled".</summary>
+    public string Status { get; set; }
+
+    public string Error { get; set; }
+
+    /// <summary>Configuration scope (project / user / local / claudeai / managed).</summary>
+    public string Scope { get; set; }
+}
+
+/// <summary>Aggregate status of all configured MCP servers.</summary>
+public sealed class McpStatus
+{
+    public List<McpServerStatus> Servers { get; set; } = [];
+}
+
+/// <summary>Spinner verbs the CLI suggests for the thinking indicator (`effective.spinnerVerbs`).</summary>
+public sealed class SpinnerVerbs
+{
+    /// <summary>"append" (add to ours) or "replace" (use only these).</summary>
+    public string Mode { get; set; }
+
+    public string[] Verbs { get; set; } = [];
+}
+
+/// <summary>Per-model totals of a finished turn (`result.modelUsage`, keyed by model id). Cost is
+/// the CLI's own figure — we never compute it, so a provider with its own pricing stays correct.
+/// NOT the same shape as `message.usage`, which is snake_case and carries the four token counts
+/// only: the wire is inconsistent here on purpose, so the two do not share a type.</summary>
+public sealed class ModelUsage
+{
+    public int InputTokens { get; set; }
+    public int OutputTokens { get; set; }
+    public int CacheReadInputTokens { get; set; }
+    public int CacheCreationInputTokens { get; set; }
+    public int WebSearchRequests { get; set; }
+    public double CostUsd { get; set; }
+    public int ContextWindow { get; set; }
+    public int MaxOutputTokens { get; set; }
+}
+
+/// <summary>Subscription rate-limit state (`rate_limit_event`). Only claude.ai plans emit it —
+/// an API-key or 3P provider session never sees one.</summary>
+public sealed class RateLimitInfo
+{
+    /// <summary>"allowed", "allowed_warning" or "rejected".</summary>
+    public string Status { get; set; }
+
+    /// <summary>Unix seconds when the window resets. Nullable on purpose: the banner says nothing
+    /// about a reset it wasn't told about, which is not the same as one at epoch 0.</summary>
+    public long? ResetsAt { get; set; }
+
+    /// <summary>Which window: "five_hour", "seven_day", "seven_day_opus", … Open string on purpose:
+    /// the CLI adds plan types, and an unknown one must not break the banner.</summary>
+    public string RateLimitType { get; set; }
+
+    /// <summary>Fraction of the window consumed (0..1). Null when unreported — distinct from 0%.</summary>
+    public double? Utilization { get; set; }
+}
+
+/// <summary>A slash command the CLI advertises (built-in, skill or plugin), from `initialize`.</summary>
+public sealed class SlashCommand
+{
+    /// <summary>Command name without the leading slash.</summary>
+    public string Name { get; set; }
+
+    public string Description { get; set; }
+
+    /// <summary>Argument hint, e.g. "&lt;file&gt;". Empty when the command takes none.</summary>
+    public string ArgumentHint { get; set; }
+
+    /// <summary>Alternate names resolving to this command (/cost and /stats both reach /usage).</summary>
+    public string[] Aliases { get; set; } = [];
+}
+
+/// <summary>One selectable model, as the CLI advertises it (`initialize` and `list_models` carry
+/// the same rows). The catalogue is never a static table on our side: the CLI derives it from the
+/// account, the API provider and the settings cascade, so alternative providers work unchanged.</summary>
+public sealed class ModelInfo
+{
+    /// <summary>Catalogue key to pass back to `set_model` (e.g. "default", "opus[1m]", "sonnet").</summary>
+    public string Value { get; set; }
+
+    /// <summary>The served model id this entry maps to (e.g. "claude-opus-5[1m]"). Several entries
+    /// can share one — "default" is usually an alias of a named row.</summary>
+    public string ResolvedModel { get; set; }
+
+    public string DisplayName { get; set; }
+    public string Description { get; set; }
+
+    public bool SupportsEffort { get; set; }
+    public string[] SupportedEffortLevels { get; set; } = [];
+    public bool SupportsAdaptiveThinking { get; set; }
+    public bool SupportsFastMode { get; set; }
+    public bool SupportsAutoMode { get; set; }
+}

--- a/src/Corsinvest.VisualStudio.Agents/Corsinvest.VisualStudio.Agents.csproj
+++ b/src/Corsinvest.VisualStudio.Agents/Corsinvest.VisualStudio.Agents.csproj
@@ -217,6 +217,7 @@
     <Compile Include="Core\Client\ClientOptions.cs" />
     <Compile Include="Core\Client\ContextUsage.cs" />
     <Compile Include="Core\Client\Events.cs" />
+    <Compile Include="Core\Client\Models.cs" />
     <Compile Include="Core\Client\IClaudeClient.cs" />
     <Compile Include="Core\Client\ClaudeClient.cs" />
     <Compile Include="Core\Client\ClaudeClient.Protocol.cs" />


### PR DESCRIPTION
## What

The client handed raw `JObject`/`JArray` to its callers, so every consumer re-read the wire itself. The pane had to know that usage keys are camelCase in `modelUsage` but snake_case in `message.usage`, that a nameless slash command must be dropped, that an absent capability flag means `false`. Wire knowledge living in layers that only wanted the values.

`Core/Client/Models.cs` now holds the shapes the CLI reports, parsed once in the client.

These are the **client's own types, deliberately not the generated `Contracts` DTOs**: those describe what we send to the WebView, and this layer talks to the process. `Core/Client/` had no reference to `Contracts` before this PR and still doesn't. The pane keeps mapping between the two, exactly as it already did for `McpStatus`.

## Typed

| | Was | Now |
| :-- | :-- | :-- |
| Model catalogue | `JArray` | `IReadOnlyList<ModelInfo>` |
| Slash commands | `JArray` | `IReadOnlyList<SlashCommand>` |
| Spinner verbs | `JObject` | `SpinnerVerbs` |
| Rate-limit info | `JObject` | `RateLimitInfo` |
| Per-model usage | `JObject` | `IReadOnlyDictionary<string, ModelUsage>` |

Names follow `sdk.d.ts` (`ModelInfo`, `SlashCommand`, `ModelUsage`) so the two can be compared field by field — every shape here was checked against that file rather than inferred from what we happened to read.

`AccountInfo`, `McpStatus` and `McpServerStatus` move out of `Events.cs` on the way past: they are data the CLI reports, not event arguments.

## Left as raw JSON, on purpose

The SDK agrees on every one of these:

- **`tool_use_result` and tool `input`** — per-tool shapes. `sdk.d.ts` declares `tool_use_result?: unknown` and says why: *"MCP and dynamic tools carry their own shapes, so the field stays unknown-typed."*
- **`permission_suggestions`** — a six-way union in the SDK, but we never read a field: they go to the WebView and come back verbatim as `updatedPermissions` (the DTO is already `object[]`, documented as "echoed back verbatim"). Typing them would mean deserialising into six classes to re-serialise them unchanged — and a seventh variant added by the CLI would be silently dropped instead of passed through.
- **System messages** — ~20 subtypes, dispatched by subtype in the pane.
- **`message.usage`** — snake_case, four fields; `result.modelUsage` is camelCase with eight. Two different shapes, so no shared type: one name for both would have hidden that. This is one of the wire's deliberate inconsistencies (see CLAUDE.md).
- **`message.content` / `usage`** — typed as `MessageParam` / `BetaUsage`, imported from `@anthropic-ai/sdk`. Outside this contract.

The rule that emerged: type it when we read fields, leave it opaque when it only passes through.

## Also

Adds the **`list_models`** control_request — the same catalogue `initialize` seeds, askable at any time without a respawn. Verified against the real binary with the probe: identical rows, same `resolvedModel` values.

It returns the list rather than raising `ModelsReceived`, because that event publishes only on the first init (guarded by `_catalogPublished`, so a `--resume` cannot graft the session's model id onto the catalogue and dirty the picker) — an event raised there would be dropped without a trace. No caller yet; wiring one needs a publication path that bypasses that gate, recorded in the internal TODO.

## Verification

`msbuild /t:Build /p:Configuration=Debug` → **0 errors** (161 warnings, all pre-existing threading analyzers; no `CS`).

**Not yet exercised in the experimental instance.** This rewrites parsing that fails at runtime rather than compile time — worth a look at the rate-limit banner, the spinner verbs, the model picker, and especially the context gauge, whose denominator comes from the `modelUsage` lookup (exact key by model id, falling back to the single entry after a model switch — behaviour preserved, but re-implemented).
