### PR TITLE
feat(chat): put the turn's settings in the composer, on their own row

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/ai-models.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/ai-models.ts
@@ -13,9 +13,9 @@ import { state as appState } from './state';
 /** Resolve a served model id to a catalogue `value`. The CLI reports the served id
  *  (e.g. `claude-opus-4-8[1m]`), which the catalogue keys (`default`, `opus[1m]`, …)
  *  don't match directly — but each catalogue entry carries a `resolvedModel` (the served id
- *  it maps to). We match on that (exact, then without the [1m] suffix), preferring the
- *  recommended `default` row when several entries share the same resolvedModel — like the
- *  VS Code extension. No family-name guessing, so alternative providers work too. */
+ *  it maps to). We match on that (exact, then without the [1m] suffix), preferring a NAMED entry
+ *  over `default` when several share the same resolvedModel — the picker hides that duplicated
+ *  `default` (see displayModels). No family-name guessing, so alternative providers work too. */
 export function resolveModelValue(value: string | null | undefined): string {
     if (!value || value === 'default') {
         return 'default';
@@ -34,10 +34,43 @@ export function resolveModelValue(value: string | null | undefined): string {
         models.find((m) => m.value === value) ??
         models.find((m) => m.value === bare) ??
         // Several entries can share a resolvedModel (default and opus[1m] both point at the same
-        // opus id) — prefer the recommended "default" row, like VS Code, else the first match.
-        models.find((m) => m.value === 'default' && rm(m) === bare) ??
+        // opus id). Prefer the NAMED one over `default`: the picker hides a duplicated `default`
+        // (see displayModels), so resolving to it would leave no row checked.
+        models.find((m) => m.value !== 'default' && rm(m) === bare) ??
         models.find((m) => rm(m) === bare);
     return hit?.value ?? (models.some((m) => m.value === 'default') ? 'default' : value);
+}
+
+/** The catalogue as the picker should SHOW it: `default` is dropped when another entry resolves to
+ *  the same model, because the two are then the same choice under two names — and picking either
+ *  writes the same served id to the transcript, so a resumed session can no longer tell them apart
+ *  (the picker would say "Default" for an explicit "Opus"). Claude Desktop sidesteps this by never
+ *  listing a Default row at all; we only hide it when it IS a duplicate.
+ *
+ *  Kept conditional on the data, never on a name: if `default` resolves to something no other entry
+ *  offers (plausible on an env-remapped provider), it stays — dropping it would make that model
+ *  unreachable. The surviving twin inherits the "(recommended)" hint so nothing is lost.
+ *
+ *  Filters the DISPLAY list only — `appState.models` keeps every entry, so lookups by value
+ *  (currentModelInfo, effort levels) still resolve for sessions that stored `default`. */
+export function displayModels<
+    T extends { value: string; resolvedModel?: string; description: string },
+>(models: readonly T[]): T[] {
+    const def = models.find((m) => m.value === 'default');
+    if (!def) {
+        return [...models];
+    }
+    const strip = (s: string): string => s.replace(/\[1m\]$/i, '');
+    const target = strip(def.resolvedModel ?? '');
+    const twin = target
+        ? models.find((m) => m.value !== 'default' && strip(m.resolvedModel ?? '') === target)
+        : undefined;
+    if (!twin) {
+        return [...models];
+    }
+    return models
+        .filter((m) => m.value !== 'default')
+        .map((m) => (m === twin ? { ...m, description: def.description || m.description } : m));
 }
 
 /** Trigger-button label for the current model id. Prefers the CLI's displayName;
@@ -52,6 +85,19 @@ export function modelLabel(value: string | null | undefined): string {
         return 'Default';
     }
     return resolved;
+}
+
+/** Short form of modelLabel() for the composer toolbar, where the full name ("Opus (1M context)",
+ *  "Default (recommended)") would eat the row. Drops a trailing parenthesised qualifier and any
+ *  [1m] tag — a shape rule, not a name list, so provider-supplied labels shorten too. Falls back to
+ *  the full label when the trim would leave nothing. Pair it with the full name in a title. */
+export function modelLabelShort(value: string | null | undefined): string {
+    const full = modelLabel(value);
+    const short = full
+        .replace(/\s*\[1m\]/i, '')
+        .replace(/\s*\([^)]*\)\s*$/, '')
+        .trim();
+    return short || full;
 }
 
 /** Tokens that occupy the prompt window. `output_tokens` is GENERATED,

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/commands/model-controls.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/commands/model-controls.ts
@@ -22,7 +22,12 @@ import {
 } from './base';
 import { state as appState } from '../state';
 import { resolveModelValue } from '../ai-models';
-import { EFFORT_LEVEL_LABELS, type EffortLevelDto, type EffortSliderLevel } from '../types';
+import {
+    effortLabel,
+    ULTRACODE_VALUE,
+    type EffortLevelDto,
+    type EffortSliderLevel,
+} from '../types';
 
 /** The current model's catalogue entry (from the CLI), or undefined before init. */
 function currentModelInfo() {
@@ -31,8 +36,9 @@ function currentModelInfo() {
 }
 
 /** Effort levels the current model supports (from the CLI), or null when the
- *  model has no effort (e.g. Haiku) — the slider is then hidden. */
-function currentEffortLevels(): EffortSliderLevel[] | null {
+ *  model has no effort (e.g. Haiku) — the slider is then hidden. Exported so the
+ *  composer's effort chip hides on exactly the same condition as this row. */
+export function currentEffortLevels(): EffortSliderLevel[] | null {
     const m = currentModelInfo();
     const levels = (m?.supportedEffortLevels ?? []) as EffortSliderLevel[];
     return m?.supportsEffort && levels.length > 0 ? levels : null;
@@ -126,10 +132,10 @@ export class EffortCommand extends ChatCommand {
     private stopValues(): string[] {
         const levels = currentEffortLevels() ?? [];
         const ultraAvailable = levels.includes('xhigh');
-        return ultraAvailable ? [...levels, 'ultracode'] : [...levels];
+        return ultraAvailable ? [...levels, ULTRACODE_VALUE] : [...levels];
     }
     private ultraIdx(stops: string[]): number {
-        return stops.indexOf('ultracode');
+        return stops.indexOf(ULTRACODE_VALUE);
     }
 
     /** Hidden when the current model has no effort levels (e.g. Haiku). */
@@ -149,7 +155,7 @@ export class EffortCommand extends ChatCommand {
         return Math.max(0, stops.indexOf(appState.effortLevel));
     }
     get levelLabel(): string {
-        return appState.ultracodeEnabled ? 'ultracode' : appState.effortLevel;
+        return effortLabel(appState.effortLevel, appState.ultracodeEnabled);
     }
     /** Set the active stop. The ultracode stop is effort=xhigh + the ultracode
      *  flag (like VS Code); any other stop clears ultracode. `max` is selectable
@@ -157,7 +163,7 @@ export class EffortCommand extends ChatCommand {
     setLevel(host: CommandHost, idx: number): void {
         const stops = this.stopValues();
         const value = stops[Math.max(0, Math.min(idx, stops.length - 1))];
-        if (value === 'ultracode') {
+        if (value === ULTRACODE_VALUE) {
             appState.effortLevel = 'xhigh';
             appState.ultracodeEnabled = true;
             host.applyFlagSettings({ effortLevel: 'xhigh', ultracode: true });
@@ -172,11 +178,10 @@ export class EffortCommand extends ChatCommand {
         const ultra = this.ultraIdx(stops);
         return {
             kind: 'slider',
+            // false: a stop is labelled by its own value — the ultracode stop already IS
+            // ULTRACODE_VALUE, so it needs no flag to be named.
             stops: stops.map((lvl, i) => ({
-                label:
-                    lvl === 'ultracode'
-                        ? 'ultracode'
-                        : EFFORT_LEVEL_LABELS[lvl as EffortSliderLevel],
+                label: effortLabel(lvl, false),
                 value: i,
                 accent: i === ultra,
             })),

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/turn-errors.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/turn-errors.ts
@@ -33,3 +33,20 @@ const LABELS: Record<string, string> = {
 export function turnErrorLabel(kind: string): string {
     return LABELS[kind] || 'Turn failed';
 }
+
+/** Reasons that are the user's own doing. The CLI flags them is_error like any other failure, but
+ *  pressing stop is not a failure — and the transcript already shows "[Request interrupted by
+ *  user]", so a red notice on top of it reads as though something went wrong. */
+const USER_ABORTED = new Set(['aborted_streaming', 'aborted_tools']);
+
+export function isUserAbort(kind: string): boolean {
+    return USER_ABORTED.has(kind);
+}
+
+/** The CLI's `result` text sometimes carries an internal diagnostic rather than a message
+ *  ("[ede_diagnostic] result_type=user last_content_type=n/a stop_reason=null"). It means nothing
+ *  to a reader, so keep the label alone rather than pasting a debug line into the chat. */
+export function turnErrorDetail(detail: string): string {
+    const t = detail.trim();
+    return /^\[[a-z_]+_diagnostic\]/i.test(t) ? '' : t;
+}

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/types.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/types.ts
@@ -23,6 +23,27 @@ export const EFFORT_LEVEL_LABELS: Readonly<Record<EffortSliderLevel, string>> = 
     max: 'Max',
 };
 
+/** Slider-stop value for ultracode. Deliberately NOT a key of EFFORT_LEVEL_LABELS: ultracode is not
+ *  an effort level the CLI accepts — it is effort=xhigh plus a separate flag, so putting it in the
+ *  union would make a state representable that the wire has no value for. Lowercase because it is
+ *  an identifier, not display text (VS Code keeps the same split). */
+export const ULTRACODE_VALUE = 'ultracode';
+
+/** Display text for ultracode, capitalised like every other effort label. */
+export const ULTRACODE_LABEL = 'Ultracode';
+
+/** The one place that turns effort state into display text, so the composer chip and the menu's
+ *  slider can never word it differently. `ultracode` is required, not defaulted: the flag is what
+ *  separates ultracode from a plain xhigh (both store effortLevel='xhigh'), so every caller has to
+ *  say which it means — the slider's own ultracode stop is recognised by value instead. Anything
+ *  with no label of its own shows its raw value. */
+export function effortLabel(level: string, ultracode: boolean): string {
+    if (ultracode || level === ULTRACODE_VALUE) {
+        return ULTRACODE_LABEL;
+    }
+    return EFFORT_LEVEL_LABELS[level as EffortSliderLevel] ?? level;
+}
+
 /** A model as reported by the CLI's `initialize` response (via `chat_models`).
  *  Shape generated from C# (Contracts.ModelInfoDto) by TypeGen — re-exported here.
  *  `supportedEffortLevels` is empty for models without effort (e.g. Haiku);

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
@@ -61,7 +61,7 @@ import type {
 } from '../../core/types';
 import { GetHistoryReq } from '../../core/request-types';
 import { modelLabel } from '../../core/ai-models';
-import { turnErrorLabel } from '../../core/turn-errors';
+import { turnErrorLabel, turnErrorDetail, isUserAbort } from '../../core/turn-errors';
 import { parseLocalCommandOutput } from '../../core/slash-commands';
 
 let _entryIdSeq = 0;
@@ -315,9 +315,12 @@ export class CvApp extends LitElement {
                     // refusal produce no failing tool row, so without this the stream just stops and
                     // the user is left guessing. (VS Code only uses this text to improve a crash
                     // message; in a chat surface a notice is the useful form.)
-                    if (data?.isError) {
+                    // …but a turn the user stopped is not one of those: the transcript already
+                    // carries "[Request interrupted by user]", so a red notice under it would
+                    // report their own decision back to them as a failure.
+                    if (data?.isError && !isUserAbort(data.errorKind ?? '')) {
                         const label = turnErrorLabel(data.errorKind ?? '');
-                        const detail = (data.errorText ?? '').trim();
+                        const detail = turnErrorDetail(data.errorText ?? '');
                         this._addText<UiSlashResultEntry>({
                             role: 'slash-result',
                             text: detail ? `${label} — ${detail}` : label,

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-attach-menu.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-attach-menu.ts
@@ -5,7 +5,9 @@
 import { LitElement, html, css } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
-import Attach16Regular from '@fluentui/svg-icons/icons/attach_16_regular.svg';
+// A plus, not a paperclip: the menu offers "Add content" as well as a file upload, so it means
+// "add something to the message" rather than strictly "attach a file".
+import Add16Regular from '@fluentui/svg-icons/icons/add_16_regular.svg';
 import ArrowUpload16Regular from '@fluentui/svg-icons/icons/arrow_upload_16_regular.svg';
 import DocumentText16Regular from '@fluentui/svg-icons/icons/document_text_16_regular.svg';
 import { iconStyles } from '../styles/shared';
@@ -72,9 +74,9 @@ export class CvAttachMenu extends LitElement {
                     appearance="subtle"
                     size="small"
                     icon-only
-                    title="Attach"
+                    title="Add files or content"
                 >
-                    ${unsafeHTML(Attach16Regular)}
+                    ${unsafeHTML(Add16Regular)}
                 </fluent-button>
                 <fluent-menu-list>
                     <fluent-menu-item @click=${this._onUpload}>

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-context-gauge.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-context-gauge.ts
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
-import { LitElement, html, css, nothing, svg } from 'lit';
+import { LitElement, html, css, svg } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { iconStyles } from '../styles/shared';
 import { state as appState } from '../../core/state';
@@ -206,22 +206,21 @@ export class CvContextGauge extends LitElement {
 
     override render() {
         const u = this._usage;
-        // Hidden until both the usage and the model's real window are known
-        // (the window arrives with the first result), like VS Code.
-        if (!u || this._window <= 0) {
-            return nothing;
-        }
+        // The real window only arrives with the first result, so a fresh (or just-resumed) session
+        // has no numbers yet. Show the ring anyway, empty: it keeps its slot in the toolbar instead
+        // of appearing after the first turn and shifting everything beside it.
+        const known = !!u && this._window > 0;
         // Gauge fill tracks raw consumption of the model's full window; the
         // tooltip headline tracks the AUTO-COMPACT window (limit − output − buffer),
         // matching VS Code's "{n}% of context remaining until auto-compact".
-        const percent = contextPercent(u);
+        const percent = known ? contextPercent(u) : 0;
         const color = gaugeColor(percent);
         // Arc: stroke-dashoffset runs CIRC (empty) → 0 (full).
         const offset = CIRC * (1 - percent / 100);
 
-        const used = consumedTokens(u);
+        const used = known ? consumedTokens(u) : 0;
         const limit = appState.contextWindow;
-        const remainingPct = remainingPercent(u);
+        const remainingPct = known ? remainingPercent(u) : 100;
         const window = autoCompactWindow();
 
         // Clickable ring (<button>) → opens a light-dismiss popover with the usage detail + actions
@@ -262,13 +261,17 @@ export class CvContextGauge extends LitElement {
             </button>
             <div id="cv-gauge-popover" class="popover" ?hidden=${!this._open}>
                 <div class="tip-head">
-                    ${remainingPct.toFixed(0)}% of context remaining until auto-compact
+                    ${
+                        known
+                            ? `${remainingPct.toFixed(0)}% of context remaining until auto-compact`
+                            : 'Context usage is reported after the first reply'
+                    }
                 </div>
                 <fluent-progress-bar
                     class="bar"
                     min="0"
                     max="100"
-                    value=${Math.min(100, (used / limit) * 100)}
+                    value=${limit > 0 ? Math.min(100, (used / limit) * 100) : 0}
                     validation-state=${gaugeValidationState(percent)}
                 ></fluent-progress-bar>
                 <div class="bar-legend">
@@ -304,7 +307,7 @@ export class CvContextGauge extends LitElement {
                 </div>
             </div>
             <fluent-tooltip anchor="cv-context-gauge-btn" positioning="above-end">
-                ${remainingPct.toFixed(0)}% of context remaining
+                ${known ? `${remainingPct.toFixed(0)}% of context remaining` : 'Context usage'}
             </fluent-tooltip>
         `;
     }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-effort-selector.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-effort-selector.ts
@@ -1,0 +1,194 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+import { LitElement, html, css, nothing } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+// Same icon the menu's "Effort" row uses — one glyph for one concept.
+import Dumbbell16Regular from '@fluentui/svg-icons/icons/dumbbell_16_regular.svg';
+import { state as appState } from '../../core/state';
+import { iconStyles } from '../styles/shared';
+import { currentEffortLevels, EffortCommand } from '../../core/commands/model-controls';
+import type { CommandHost } from '../../core/commands/base';
+import { effortLabel } from '../../core/types';
+import './cv-segmented-slider';
+import type { SliderStop } from './cv-segmented-slider';
+
+/**
+ * Effort trigger in the input toolbar, beside the model selector: shows the active reasoning effort
+ * and opens a small popover holding the same `cv-segmented-slider` the menu's Effort row uses.
+ *
+ * A popover rather than "open the command palette on that row": the palette is forty rows deep for
+ * one setting, and it would have to scroll to and highlight the right one. The neighbouring model
+ * and permission triggers open their own list too, so this keeps the toolbar consistent.
+ *
+ * The stops and the set logic come from EffortCommand — ultracode is a special case in three places
+ * (a synthetic stop, effort=xhigh plus a flag, cleared by any other stop) and must not be written
+ * twice. This component is presentation only.
+ *
+ * Hidden when the model has no effort levels (Haiku), on the same condition that hides the menu row.
+ */
+@customElement('cv-effort-selector')
+export class CvEffortSelector extends LitElement {
+    static override styles = [
+        iconStyles,
+        css`
+            /* Relative host so the popover can sit above the chip — plain absolute positioning,
+               like cv-context-gauge (CSS anchor-positioning misplaces top-layer popovers in the
+               VS WebView2's Chromium). */
+            :host {
+                position: relative;
+                display: inline-flex;
+            }
+            /* Trigger is a <fluent-button> — keep it pure (layout only). */
+            .trigger svg {
+                width: 16px;
+                height: 16px;
+                margin-right: 4px;
+            }
+            /* "Extra high" is the only two-word level, and it must not wrap the button onto a
+               second row. */
+            .trigger {
+                white-space: nowrap;
+            }
+            .popover {
+                position: absolute;
+                bottom: calc(100% + 4px);
+                /* Anchored right, not left: the chip sits in the right-hand toolbar, so its right
+                   edge is the one that stays put while the label changes width. */
+                right: 0;
+                z-index: 1000;
+                padding: 8px 10px;
+                display: flex;
+                flex-direction: column;
+                gap: 6px;
+                white-space: nowrap;
+                background: var(--colorNeutralBackground1);
+                color: var(--colorNeutralForeground1);
+                border: 1px solid var(--colorNeutralStroke1);
+                border-radius: var(--borderRadiusMedium);
+                box-shadow: var(--shadow16);
+            }
+            .popover[hidden] {
+                display: none;
+            }
+            /* Header: says what the slider regulates — on its own the control is unlabelled. */
+            .head {
+                display: flex;
+                align-items: baseline;
+                justify-content: space-between;
+                gap: 12px;
+                font-size: var(--fontSizeBase200);
+            }
+            .head-title {
+                font-weight: var(--fontWeightSemibold);
+                color: var(--colorNeutralForeground1);
+            }
+            /* The active stop's name. Right-aligned in a fixed box so stepping through the levels
+               doesn't resize the popover under the pointer. */
+            .value {
+                color: var(--colorNeutralForeground2);
+                min-width: 10ch;
+                text-align: right;
+            }
+        `,
+    ];
+
+    /** The command host (cv-prompt), which owns applyFlagSettings. Passed as a property because
+     *  cv-prompt renders into a shadow root: `closest()` would stop at our own boundary. Same way
+     *  cv-command-menu receives it. */
+    @property({ attribute: false }) host!: CommandHost;
+
+    @state() private _open = false;
+    @state() private _effort = appState.effortLevel;
+    @state() private _ultracode = appState.ultracodeEnabled;
+    // The catalogue decides whether this model has effort at all.
+    @state() private _models = appState.models;
+    @state() private _current = appState.currentModel;
+
+    private _offs: Array<() => void> = [];
+    private readonly _command = new EffortCommand();
+
+    override connectedCallback(): void {
+        super.connectedCallback();
+        this._offs = [
+            appState.on('effortLevel', (v) => {
+                this._effort = v;
+            }),
+            appState.on('ultracodeEnabled', (v) => {
+                this._ultracode = v;
+            }),
+            appState.on('models', (v) => {
+                this._models = v;
+            }),
+            appState.on('currentModel', (v) => {
+                this._current = v;
+            }),
+        ];
+        document.addEventListener('pointerdown', this._onDocPointerDown, true);
+    }
+
+    override disconnectedCallback(): void {
+        super.disconnectedCallback();
+        this._offs.forEach((off) => off());
+        this._offs = [];
+        document.removeEventListener('pointerdown', this._onDocPointerDown, true);
+    }
+
+    /** Light dismiss. composedPath crosses the shadow boundary, so a click on our own
+     *  trigger is "inside" and leaves the toggle to handle it. */
+    private _onDocPointerDown = (e: PointerEvent): void => {
+        if (this._open && !e.composedPath().includes(this)) {
+            this._open = false;
+        }
+    };
+
+    private _toggle = (): void => {
+        this._open = !this._open;
+    };
+
+    override render() {
+        // Read so the availability check re-runs when either changes.
+        void this._models;
+        void this._current;
+        if (currentEffortLevels() === null) {
+            return nothing;
+        }
+        const label = effortLabel(this._effort, this._ultracode);
+        const ctrl = this._command.trailingControl;
+        return html`
+            <fluent-button
+                class="trigger"
+                appearance="subtle"
+                size="small"
+                title=${`${this._command.label}: ${label}\n${this._command.description}`}
+                @click=${this._toggle}
+            >
+                ${unsafeHTML(Dumbbell16Regular)}
+                <span>${label}</span>
+            </fluent-button>
+            <div class="popover" ?hidden=${!this._open}>
+                <div class="head">
+                    <span class="head-title">Effort</span>
+                    <span class="value">${label}</span>
+                </div>
+                <cv-segmented-slider
+                    .stops=${ctrl.kind === 'slider' ? ctrl.stops : []}
+                    .activeValue=${ctrl.kind === 'slider' ? ctrl.value : 0}
+                    @change=${(e: CustomEvent<SliderStop<number>>) => {
+                        if (this.host && ctrl.kind === 'slider') {
+                            ctrl.onSet(this.host, e.detail.value);
+                        }
+                    }}
+                ></cv-segmented-slider>
+            </div>
+        `;
+    }
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'cv-effort-selector': CvEffortSelector;
+    }
+}

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-model-list.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-model-list.ts
@@ -7,7 +7,7 @@ import { customElement, property, query, state } from 'lit/decorators.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import Checkmark16Regular from '@fluentui/svg-icons/icons/checkmark_16_regular.svg';
 import { state as appState } from '../../core/state';
-import { resolveModelValue } from '../../core/ai-models';
+import { displayModels, resolveModelValue } from '../../core/ai-models';
 import type { ModelInfoDto } from '../../core/types';
 import './cv-popover-list';
 import type { CvPopoverList } from './cv-popover-list';
@@ -22,7 +22,9 @@ import type { CvPopoverList } from './cv-popover-list';
 export class CvModelList extends LitElement {
     @property({ type: Boolean, reflect: true }) open = false;
 
-    @state() private _models = appState.models;
+    // The picker's own view of the catalogue (a duplicated `default` collapsed away) — the
+    // navigation index and the rendered rows must come from the SAME list to stay aligned.
+    @state() private _models = displayModels(appState.models);
     @state() private _current = appState.currentModel;
 
     private _offModels?: () => void;
@@ -38,7 +40,7 @@ export class CvModelList extends LitElement {
     override connectedCallback(): void {
         super.connectedCallback();
         this._offModels = appState.on('models', (v) => {
-            this._models = v;
+            this._models = displayModels(v);
         });
         this._offCurrent = appState.on('currentModel', (v) => {
             this._current = v;
@@ -55,7 +57,7 @@ export class CvModelList extends LitElement {
         // On open, resync from app state and put the cursor on the active model.
         if (changed.has('open') && this.open) {
             this._current = appState.currentModel;
-            this._models = appState.models;
+            this._models = displayModels(appState.models);
         }
     }
 

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-model-selector.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-model-selector.ts
@@ -1,0 +1,108 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+import { LitElement, html, css } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+// Same icon the menu's "Switch model…" row uses — one glyph for one concept.
+import Brain16Regular from '@fluentui/svg-icons/icons/brain_16_regular.svg';
+import { state as appState } from '../../core/state';
+import { iconStyles } from '../styles/shared';
+import { modelLabel, modelLabelShort, resolveModelValue } from '../../core/ai-models';
+import { SwitchModelCommand } from '../../core/commands/builtin-commands';
+
+/**
+ * Model trigger in the input toolbar, next to the permission selector: shows the active model and
+ * asks cv-prompt to open the picker (cv-model-list, above the textarea). The list, not this button,
+ * owns the menu — same split as cv-permission-selector.
+ *
+ * The label is deliberately the SHORT name: the toolbar row is narrow and already carries attach,
+ * slash, gauge, sub-agent, IDE badge, permission, mic and send. The full name and the model's
+ * description go in the title, where there is no space pressure.
+ */
+@customElement('cv-model-selector')
+export class CvModelSelector extends LitElement {
+    static override styles = [
+        iconStyles,
+        css`
+            :host {
+                display: contents;
+            }
+            /* Trigger is a <fluent-button> — keep it pure (layout only). */
+            .trigger svg {
+                width: 16px;
+                height: 16px;
+                margin-right: 4px;
+            }
+            /* A provider can return a long id as the display name; cap it rather than
+               letting the toolbar reflow. */
+            .trigger span {
+                max-width: 14ch;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+            }
+        `,
+    ];
+
+    @state() private _current = appState.currentModel;
+    @state() private _models = appState.models;
+
+    // The menu row for the same thing: its description is the one place that says what picking a
+    // model does, so the tooltip borrows it instead of wording it a second time.
+    private readonly _command = new SwitchModelCommand();
+
+    private _off?: () => void;
+    private _offModels?: () => void;
+
+    override connectedCallback(): void {
+        super.connectedCallback();
+        this._off = appState.on('currentModel', (v) => {
+            this._current = v;
+        });
+        // The label comes from the catalogue, so it resolves only once that has arrived.
+        this._offModels = appState.on('models', (v) => {
+            this._models = v;
+        });
+    }
+
+    override disconnectedCallback(): void {
+        super.disconnectedCallback();
+        this._off?.();
+        this._offModels?.();
+    }
+
+    private _onClick = (): void => {
+        this.dispatchEvent(new CustomEvent('open-models', { bubbles: true, composed: true }));
+    };
+
+    override render() {
+        // Read so the label re-resolves when the catalogue lands (it maps value → displayName).
+        void this._models;
+        const full = modelLabel(this._current);
+        // Full name + the CLI's own description of THIS model ("Opus 5 with 1M context · Best for
+        // everyday, complex tasks"), then the command's line for what clicking does. The button has
+        // no room for any of it; the tooltip has plenty.
+        const info = this._models.find((m) => m.value === resolveModelValue(this._current));
+        const tip = [full, info?.description, this._command.description].filter(Boolean).join('\n');
+        return html`
+            <fluent-button
+                class="trigger"
+                appearance="subtle"
+                size="small"
+                title=${tip}
+                @click=${this._onClick}
+            >
+                ${unsafeHTML(Brain16Regular)}
+                <span>${modelLabelShort(this._current)}</span>
+            </fluent-button>
+        `;
+    }
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'cv-model-selector': CvModelSelector;
+    }
+}

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-permission-selector.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-permission-selector.ts
@@ -9,11 +9,15 @@ import { state as appState } from '../../core/state';
 import { iconStyles } from '../styles/shared';
 import type { PermissionMode } from '../../core/types';
 import { permissionItems } from '../../core/permission-modes';
+import { SwitchPermissionModeCommand } from '../../core/commands/builtin-commands';
 
 /**
  * Permission-mode trigger in the input toolbar: shows the active mode and asks cv-prompt to
  * open the picker (cv-permission-list, above the textarea — same place as the model picker
  * and the `/` palette). The list, not this button, owns the menu.
+ *
+ * The title carries the mode's full description as well as its name: which mode is active decides
+ * whether a command runs unattended, so "Edit automatically" alone is not enough to choose by.
  */
 @customElement('cv-permission-selector')
 export class CvPermissionSelector extends LitElement {
@@ -29,11 +33,22 @@ export class CvPermissionSelector extends LitElement {
                 height: 16px;
                 margin-right: 4px;
             }
+            /* Two-word labels ("Edit automatically") otherwise wrap inside the button and make the
+               whole toolbar two rows tall. On the span too: the label is our own light-DOM node,
+               so it takes the rule even where the Fluent shadow wouldn't inherit it. */
+            .trigger,
+            .trigger span {
+                white-space: nowrap;
+            }
         `,
     ];
 
     @state() private _current: PermissionMode = appState.permissionMode;
     @state() private _models = appState.models;
+
+    // The menu row for the same thing: its description is the one place that says what picking a
+    // mode does, so the tooltip borrows it instead of wording it a second time.
+    private readonly _command = new SwitchPermissionModeCommand();
 
     private _off?: () => void;
     private _offModels?: () => void;
@@ -70,7 +85,7 @@ export class CvPermissionSelector extends LitElement {
                 class="trigger"
                 appearance="subtle"
                 size="small"
-                title=${`${item.label} — Shift+Tab to switch`}
+                title=${`${item.label}\n${item.description}\n${this._command.description} — Shift+Tab to switch`}
                 @click=${this._onClick}
             >
                 ${unsafeHTML(item.icon)}

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-prompt.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-prompt.ts
@@ -39,7 +39,10 @@ import './cv-attach-chip';
 import './cv-context-gauge';
 import './cv-ide-context-badge';
 import './cv-subagent-chip';
+import './cv-effort-selector';
+import './cv-thinking-toggle';
 import './cv-model-list';
+import './cv-model-selector';
 import './cv-permission-list';
 import './cv-permission-selector';
 import './cv-mic-button';
@@ -230,6 +233,17 @@ export class CvPrompt extends LitElement implements CommandHost {
                 display: flex;
                 align-items: center;
                 gap: 6px;
+            }
+            /* Turn settings on their own row: effort, model and permission mode answer "how should
+               this turn run", while the row above is about the message itself (attach, commands,
+               context, send). Splitting them means the labels always fit, at any pane width — no
+               truncation and no width-dependent hiding. */
+            #toolbar-settings {
+                display: flex;
+                align-items: center;
+                gap: 6px;
+                padding: 4px;
+                border-top: 1px solid var(--colorNeutralStroke2);
             }
             /* Send button: shrink the inline icon to 16px (Fluent default 20px dominates
              * a small button); turn it red when the CLI is busy so it reads as "stop". */
@@ -460,12 +474,17 @@ export class CvPrompt extends LitElement implements CommandHost {
     /** Outside-click closes the searchable (lightning) palette. The lightning
      *  button's own click toggles, so ignore clicks on it (it handles itself). */
     private _onDocPointerDown = (e: PointerEvent): void => {
-        // Outside-click closes the model list (clicks on it are handled by its rows).
+        // Outside-click closes the model list (clicks on it are handled by its rows). As with the
+        // mode list, the toolbar trigger toggles itself — closing here too would reopen-then-close.
         if (this._modelListOpen) {
-            const onList = e
+            const onListOrTrigger = e
                 .composedPath()
-                .some((n) => n instanceof Element && n.tagName === 'CV-MODEL-LIST');
-            if (!onList) {
+                .some(
+                    (n) =>
+                        n instanceof Element &&
+                        (n.tagName === 'CV-MODEL-LIST' || n.tagName === 'CV-MODEL-SELECTOR'),
+                );
+            if (!onListOrTrigger) {
                 this._modelListOpen = false;
             }
         }
@@ -1309,6 +1328,20 @@ export class CvPrompt extends LitElement implements CommandHost {
         this._ta?.focus();
     };
 
+    /** Toolbar trigger asked for the model picker. Toggles (unlike openModelPicker(), which the
+     *  menu's "Switch model…" row calls to always open) and closes the menus it is exclusive with. */
+    private _onOpenModels = (): void => {
+        this._permissionListOpen = false;
+        this._closeCommandMenu();
+        this._atOpen = false;
+        this._modelListOpen = !this._modelListOpen;
+        // Same reason as the permission trigger: navigation is driven from the textarea's
+        // keydown, so give focus back after the click for the list to be keyboard-navigable.
+        if (this._modelListOpen) {
+            this._ta?.focus();
+        }
+    };
+
     /** Trigger asked for the mode picker; the other above-textarea menus are exclusive with it. */
     private _onOpenPermissions = (): void => {
         this._modelListOpen = false;
@@ -1428,8 +1461,7 @@ export class CvPrompt extends LitElement implements CommandHost {
                         <cv-subagent-chip .tasks=${this._subagentTasks}></cv-subagent-chip>
                         <cv-ide-context-badge></cv-ide-context-badge>
                     </div>
-                    <div id="toolbar-right" @open-permissions=${this._onOpenPermissions}>
-                        <cv-permission-selector></cv-permission-selector>
+                    <div id="toolbar-right">
                         <cv-mic-button
                             @transcript=${this._onMicTranscript}
                             @recording-start=${this._onMicStart}
@@ -1448,6 +1480,16 @@ export class CvPrompt extends LitElement implements CommandHost {
                             ${unsafeHTML(this._isBusy ? Stop16Filled : Send16Filled)}
                         </fluent-button>
                     </div>
+                </div>
+                <div
+                    id="toolbar-settings"
+                    @open-models=${this._onOpenModels}
+                    @open-permissions=${this._onOpenPermissions}
+                >
+                    <cv-thinking-toggle .host=${this}></cv-thinking-toggle>
+                    <cv-effort-selector .host=${this}></cv-effort-selector>
+                    <cv-model-selector></cv-model-selector>
+                    <cv-permission-selector></cv-permission-selector>
                 </div>
                 <input
                     data-cv-file-picker

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-thinking-toggle.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-thinking-toggle.ts
@@ -1,0 +1,111 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+import { LitElement, html, css, nothing } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+// Filled when on, regular when off: the shape carries the state, so it still reads on a poor
+// display or for someone who can't rely on the colour.
+import Lightbulb16Filled from '@fluentui/svg-icons/icons/lightbulb_16_filled.svg';
+import Lightbulb16Regular from '@fluentui/svg-icons/icons/lightbulb_16_regular.svg';
+import { state as appState } from '../../core/state';
+import { iconStyles } from '../styles/shared';
+import { ThinkingCommand } from '../../core/commands/model-controls';
+import type { CommandHost } from '../../core/commands/base';
+
+/**
+ * Thinking toggle in the composer's settings row. Icon only: thinking is on or off, so unlike the
+ * effort and model selectors there is no value worth spelling out beside the glyph.
+ *
+ * Wraps ThinkingCommand — the same object the menu's Thinking row uses — so the two can never
+ * disagree about the label, the description, when the toggle applies, or what gets sent to the CLI.
+ *
+ * Note this state is per-process, not persisted: the CLI takes it over set_max_thinking_tokens and
+ * a reopened pane goes back to what settings.json says.
+ */
+@customElement('cv-thinking-toggle')
+export class CvThinkingToggle extends LitElement {
+    static override styles = [
+        iconStyles,
+        css`
+            :host {
+                display: contents;
+            }
+            /* Trigger is a <fluent-button> — keep it pure (layout only). */
+            .trigger svg {
+                width: 16px;
+                height: 16px;
+            }
+        `,
+    ];
+
+    /** cv-prompt, which owns setMaxThinkingTokens. A property because cv-prompt renders into a
+     *  shadow root — the same way cv-command-menu and cv-effort-selector receive it. */
+    @property({ attribute: false }) host!: CommandHost;
+
+    @state() private _enabled = appState.thinkingEnabled;
+    // The catalogue decides whether this model thinks at all.
+    @state() private _models = appState.models;
+    @state() private _current = appState.currentModel;
+
+    private _offs: Array<() => void> = [];
+    private readonly _command = new ThinkingCommand();
+
+    override connectedCallback(): void {
+        super.connectedCallback();
+        this._offs = [
+            appState.on('thinkingEnabled', (v) => {
+                this._enabled = v;
+            }),
+            appState.on('models', (v) => {
+                this._models = v;
+            }),
+            appState.on('currentModel', (v) => {
+                this._current = v;
+            }),
+        ];
+    }
+
+    override disconnectedCallback(): void {
+        super.disconnectedCallback();
+        this._offs.forEach((off) => off());
+        this._offs = [];
+    }
+
+    private _onClick = (): void => {
+        if (this.host) {
+            this._command.run(this.host);
+        }
+    };
+
+    override render() {
+        // Read so the availability check re-runs when either changes.
+        void this._models;
+        void this._current;
+        // Hidden on models without adaptive thinking, on the same condition as the menu row.
+        if (!this._command.isEnabled()) {
+            return nothing;
+        }
+        const on = this._enabled;
+        return html`
+            <fluent-button
+                class="trigger"
+                appearance="subtle"
+                size="small"
+                icon-only
+                aria-pressed=${on ? 'true' : 'false'}
+                title=${`${this._command.label}: ${on ? 'on' : 'off'}\n${this._command.description}`}
+                @click=${this._onClick}
+            >
+                ${unsafeHTML(on ? Lightbulb16Filled : Lightbulb16Regular)}
+            </fluent-button>
+        `;
+    }
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'cv-thinking-toggle': CvThinkingToggle;
+    }
+}


### PR DESCRIPTION
## What

Thinking, effort, model and permission mode all decide how a turn runs, but only the permission mode was visible — the rest sat three levels down the command palette. They now share a second toolbar row under the message actions.

```
┌────────────────────────────────────────┐
│ Send a message…                        │
├────────────────────────────────────────┤
│ ＋ / ◔  👁 file.cs             🎤  ➤   │  the message
├────────────────────────────────────────┤
│ 💡  🏋 High  🧠 Opus  🛡 Ask before…    │  the turn
└────────────────────────────────────────┘
```

**Why a row of its own, not more chips beside attach/send.** With labels they overflowed a pane of any realistic width; hiding the labels below a threshold meant measuring the composer and picking a number that is wrong at some font size or locale (I tried 850, 700, 620, 600, 560 — all of them wrong somewhere). The split has no threshold to get wrong, and it reads as what it is. Cost: ~28px of height.

## No duplicated wording

Each control wraps the command that already backs its palette row — `ThinkingCommand`, `EffortCommand`, `SwitchModelCommand`, `SwitchPermissionModeCommand` — so the label, the description, when the control applies and what reaches the CLI cannot drift between the toolbar and the menu.

- **Thinking** is icon-only: it is on or off, so there is no value to spell out. Filled bulb when on, regular when off — the shape carries the state, not just the colour.
- **Effort** opens a popover holding the same `cv-segmented-slider` the palette row uses. A popover rather than "open the palette on that row": forty rows for one setting, and it would have to scroll to and highlight the right one.
- **Effort and thinking hide themselves** on models that support neither (Haiku), through `currentEffortLevels()` / `ThinkingCommand.isEnabled()` — the same condition that hides their palette rows, so they can't disagree.
- **Tooltips** carry the full description. For the model and the permission mode, also the description of the *active value* ("Opus 5 with 1M context · Best for everyday, complex tasks"), which is what tells you whether it's the one you want — from the CLI catalogue and `permissionItems()`, the sources the pickers already read.

## Three things the row made obvious

**The picker listed the same model twice.** `default` resolves to the same served id as a named row — on this account both are `claude-opus-5[1m]` — so one model appeared under two names. And since the transcript records the served id, a resumed session couldn't tell them apart: choose "Opus", reopen, the picker says "Default".

`displayModels()` drops a duplicated `default` and hands its "(recommended)" to the surviving twin; `resolveModelValue` now prefers the named row (resolving to a row the picker no longer lists would leave nothing checked). Conditional on the data, never on a name: a `default` resolving to something no other row offers — plausible once `ANTHROPIC_BASE_URL` points elsewhere — is kept, or that model becomes unreachable. Filters the *displayed* list only; `appState.models` keeps every entry, so lookups by value still resolve for sessions that stored `default`.

Verified against the live CLI with the probe, including the orphan and no-`default` cases. Claude Desktop sidesteps this by never listing a Default row; VS Code lists it and has the same ambiguity we did.

**The context gauge appeared after the first reply** and shifted everything beside it. It now holds its slot from the start, empty — and says "Context usage is reported after the first reply" rather than claiming "100% of context remaining" before it knows what the context is. (That path also divided by a zero window.)

**Stopping a turn reported itself as a failure.** The CLI flags an interrupted turn `is_error` and puts an internal diagnostic in its result text, which we pasted into the chat — in red, under the `[Request interrupted by user]` notice that already said it:

> Response interrupted — [ede_diagnostic] result_type=user last_content_type=n/a stop_reason=null

User aborts (`aborted_streaming`, `aborted_tools`) no longer raise the error notice, and a `[…_diagnostic]` detail is dropped whatever the reason. Real failures — turn limit, budget, prompt too long, API errors — still show. VS Code shows nothing here at all: that notice is our own addition.

## Also

The attach button is a plus rather than a paperclip: its menu offers "Add content" as well as a file upload, so the paperclip promised less than the button does.

## Verification

`npm run typecheck`, `lint`, `build`, `format` — clean (the 7 lint warnings are pre-existing `no-explicit-any` in `bridge.ts` and `cv-mic-button.ts`).

**Not yet exercised in the experimental instance.** Worth a look at: the effort popover opening and not drifting as you drag the slider; both controls disappearing on Haiku; the gauge from a fresh pane and from a resume; and the second row's alignment against the one above (the settings row uses the same 4px padding, but its buttons carry labels where the row above is icon-only, so the leading glyphs sit slightly apart).
