### PR TITLE
release: 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,59 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-07-27
+
+First stable release. Everything from the preview, plus the work below.
+
+### Added
+
+- **Statistics**: a full window showing where your tokens went — by profile, folder, project, day
+  or single session. Daily chart, activity heatmap, per-model breakdown, and a tile summary.
+  Reads the session files already on your disk; nothing is sent anywhere.
+
+- **Usage**: your plan's limits and how much of them you have used, per profile.
+
+- **Context usage**: what is actually filling the model's context in a session — system prompt,
+  tools, memory files, messages — as a map you can read at a glance, so it is clear what to trim
+  before compacting.
+
+- **Turn settings in the composer**: thinking, effort, model and permission mode now sit on their
+  own row under the message box. What the model is and what it may do without asking used to be
+  three levels down a menu.
+
+- **Read a reply aloud**: any assistant message can be spoken, with pause and resume.
+
+- **Clickable file references**: when the assistant mentions a file — with or without a line number
+  — it becomes a link that opens in the editor at that spot. Recognises around 270 extensions.
+
+- **Session notices**: rate limits, CLI advisories and warnings stack in one place instead of
+  replacing each other, and can be dismissed individually.
+
+### Changed
+
+- **The context gauge is always there**, empty until the first reply instead of appearing
+  afterwards and shifting the toolbar around it.
+
+- **The model picker no longer lists the same model twice.** "Default" is hidden when it is just
+  another name for a model already in the list — which also means a reopened session shows the
+  model you actually picked.
+
+- **Renaming a session** now goes through the CLI rather than editing its file directly, so the
+  running session and what you see agree.
+
+- The attach button is a plus rather than a paperclip: its menu adds content as well as files.
+
+### Fixed
+
+- **Stopping a turn no longer looks like a crash.** It used to print a red error with an internal
+  diagnostic line underneath the notice that already said you had interrupted it.
+
+- The Copy icon in the Info dialog was nearly invisible on a dark theme.
+
+- The image viewer opened with the wrong window chrome, and its copy button did nothing.
+
+- Slash-command output (`/config`, `/context`, …) is shown instead of being silently dropped.
+
 ## [1.0.0-rc1] - 2026-07-22
 
 First public preview. Requires the Claude Code CLI, installed separately with

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
       AssemblyInformationalVersion carries so a preview build can say it is one at runtime. Ship a
       stable release by dropping the suffix.
     -->
-    <Version>1.0.0-rc1</Version>
+    <Version>1.0.0</Version>
 
     <!--
       The same version without the suffix, for the places that take digits only: the VSIX Identity

--- a/docs/marketplace-overview.md
+++ b/docs/marketplace-overview.md
@@ -44,7 +44,11 @@ configure.
 
 **Chat** — streaming replies, thinking blocks, collapsible tool output, inline diffs, clickable file
 references (`ClientEvents.cs:208` opens the file at that line), image attachments, and a composer with
-slash commands, an `@` file picker and prompt history.
+slash commands, an `@` file picker and prompt history. Any reply can be read aloud.
+
+Under the message box, a row for the turn itself: **thinking**, **effort**, **model** and
+**permission mode**, each a click away. Which model is answering, and what it may do without asking,
+are the two things that change a turn the most — they belong in sight, not three levels down a menu.
 
 **CLI** — the real `claude.exe` in an embedded terminal, connected to the IDE over the same channel
 the official VS Code extension uses.


### PR DESCRIPTION
First stable release. Forty-four commits have landed since `v1.0.0-rc1` was tagged on 22 July, and none of them were written down.

## The version

`Directory.Build.props` is where the version actually lives — `VsixVersion`, `AssemblyVersion`, `FileVersion` and `AssemblyInformationalVersion` all derive from it. Dropping the suffix is the whole change:

```diff
-<Version>1.0.0-rc1</Version>
+<Version>1.0.0</Version>
```

The manifest already read `1.0.0` (the suffix never reached it — `VsixVersion` strips it), so nothing else moves. The build's own consistency check in `Directory.Build.targets` passes; `msbuild` is green, 0 errors.

What changes at runtime: `AssemblyInformationalVersion` no longer says the build is a preview.

## The changelog

Written for someone using the extension, not for someone reading the diff — "the model picker no longer lists the same model twice" rather than the mechanics of collapsing catalogue entries that resolve to the same served model.

**Added** — Statistics, Usage and Context usage as full windows; the composer's settings row (thinking, effort, model, permission mode); read-aloud replies; clickable file references (~270 extensions); stacking session notices.

**Changed** — the context gauge holds its slot from the start instead of appearing after the first reply; the model picker drops the duplicated "Default"; renaming a session goes through the CLI rather than editing its file behind its back; the attach button is a plus, since its menu adds content as well as files.

**Fixed** — stopping a turn no longer reads as a crash (it printed a red error with an internal diagnostic under the notice that already said you had interrupted it); the Info dialog's Copy icon on dark themes; the image viewer's window chrome and its copy button; slash-command output being silently dropped.

## The Marketplace overview

Gains the composer's settings row. Statistics, Usage and Context usage were already described there.

## Verification

`msbuild /t:Build` → 0 errors (161 threading-analyzer warnings, all known). The CI artifact from the last run was installed into both experimental hives and exercised by the author before this was cut.

## After merging

The tag goes on the merge commit, not on this branch: releases here are cut from the tag, so `v1.0.0` is what publishes.
