### PR TITLE
fix(chat): anchor the effort popover to the chip's left edge

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-effort-selector.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-effort-selector.ts
@@ -55,9 +55,10 @@ export class CvEffortSelector extends LitElement {
             .popover {
                 position: absolute;
                 bottom: calc(100% + 4px);
-                /* Anchored right, not left: the chip sits in the right-hand toolbar, so its right
-                   edge is the one that stays put while the label changes width. */
-                right: 0;
+                /* Anchored left: the chip leads the settings row, so its left edge is the one
+                   against the composer's. Anchoring right would grow the panel outwards from a
+                   chip whose width changes with the level's name, off the left of the box. */
+                left: 0;
                 z-index: 1000;
                 padding: 8px 10px;
                 display: flex;


### PR DESCRIPTION
The effort popover opened off the left edge of the composer and was mostly invisible.

It was anchored `right: 0`, which was correct when the chip lived in the right-hand toolbar: there its right edge was the one that stayed put while the label changed width ("Low" → "Extra high" → "Ultracode"), so a right-anchored panel did not drift as you dragged the slider.

Moving the turn settings onto their own row made the chip the **first item on the left**. A right-anchored panel then grows outwards from that chip — off the composer.

`left: 0` now, which is the edge that cannot move: it sits against the composer's own. The drift the right anchor was there to prevent does not come back, because the chip's left edge is fixed regardless of how wide its label gets.

One line of CSS, plus the comment above it, which had gone stale ("the chip sits in the right-hand toolbar") and was itself the clue.

## Verification

`typecheck`, `build`, `format:check` — clean. The behaviour is visual: worth opening the popover and dragging the slider through every level, including `Ultracode`, the longest label.
