### PR TITLE
fix(panes): bring the panes back when the debugger starts

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/AgentsPackage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/AgentsPackage.cs
@@ -31,12 +31,18 @@ namespace Corsinvest.VisualStudio.Agents;
 // pane open, and the submenu shows just the native "Claude" seed until then.
 [ProvideAutoLoad(VSConstants.UICONTEXT.ShellInitialized_string, PackageAutoLoadFlags.BackgroundLoad)]
 // Multi-instance per-session panes (each "New" spawns a fresh pane).
-// Tabbed + Window=own-GUID: same-kind instances group as tabs, and Chat/CLI
-// stay in SEPARATE dock areas (sharing one host mixed them up / floated CLI).
+// Docked against windows VS itself owns, rather than a GUID of our own: a private GUID gives VS a
+// dock area it only knows in the layout the pane was opened in, and design and debug layouts are
+// kept apart — so starting the debugger left our panes with nowhere to be and closed them, while
+// the built-in windows stayed put. These groups exist in every layout.
+// Chat beside Solution Explorer (tall and narrow, like the tree it sits with), CLI beside Output
+// (wide and short, where a terminal belongs and where VS users already look for one). That also
+// keeps the two apart by their nature rather than by a GUID: an earlier attempt at sharing one
+// host mixed them up and floated the CLI.
 // Transient: don't persist panes across solution open-close (avoid orphans
 // against a stale workdir).
-[ProvideToolWindow(typeof(ChatPaneWindow), MultiInstances = true, Transient = true, Style = VsDockStyle.Tabbed, Window = "e4f5a6b7-c8d9-0123-efab-de3456789012")]
-[ProvideToolWindow(typeof(CliPaneWindow), MultiInstances = true, Transient = true, Style = VsDockStyle.Tabbed, Window = "f5a6b7c8-d9e0-1234-fabc-ef4567890123")]
+[ProvideToolWindow(typeof(ChatPaneWindow), MultiInstances = true, Transient = true, Style = VsDockStyle.Tabbed, Window = EnvDTE.Constants.vsWindowKindSolutionExplorer)]
+[ProvideToolWindow(typeof(CliPaneWindow), MultiInstances = true, Transient = true, Style = VsDockStyle.Tabbed, Window = EnvDTE.Constants.vsWindowKindOutput)]
 [ProvideOptionPage(typeof(AgentsGeneralPage), AppConstants.AppName, "General", 0, 0, true)]
 [ProvideOptionPage(typeof(AgentsChatPage), AppConstants.AppName, "Chat", 0, 0, true)]
 [ProvideOptionPage(typeof(AgentsDebugPage), AppConstants.AppName, "Debug", 0, 0, true)]
@@ -54,10 +60,12 @@ namespace Corsinvest.VisualStudio.Agents;
 [ProvideEditorExtension(typeof(Core.Context.ContextEditorFactory), Core.Context.ContextDocument.Extension, 50)]
 [ProvideEditorLogicalView(typeof(Core.Context.ContextEditorFactory), "{00000000-0000-0000-0000-000000000000}")]
 [Guid(PackageGuids.AgentsPackageString)]
-public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolutionLoadEvents
+public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolutionLoadEvents, IVsDebuggerEvents
 {
     private uint _solutionEventsCookie;
     private IVsSolution _solution;
+    private uint _debuggerEventsCookie;
+    private IVsDebugger _debugger;
 
     static AgentsPackage() =>
         // Microsoft.Terminal.Wpf ships with VS but isn't on any VSIX probing
@@ -186,6 +194,31 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
         });
     }
 
+    /// <summary>Debugger mode changed. VS keeps window layouts per mode, so panes opened at design
+    /// time are absent from the run-time layout and look as though the debugger closed them — the
+    /// frames are still there, just not shown. Bring back the ones the registry knows are open.
+    ///
+    /// Only ever shows what was already open: a pane the user closed stays closed, because it is
+    /// not in the registry. StartOnIdle for the same reason as the solution-open restore — the
+    /// shell is mid-transition and showing a frame from inside its event freezes it.</summary>
+    public int OnModeChange(DBGMODE dbgmodeNew)
+    {
+        try
+        {
+            if (Core.Panes.PaneRegistry.Instance.Entries.Count == 0) { return VSConstants.S_OK; }
+            _ = JoinableTaskFactory.StartOnIdle(() =>
+            {
+                try { Core.Panes.PaneLauncher.ShowExisting(); }
+                catch (Exception ex) { OutputWindowLogger.LogException("Pkg.OnModeChange.Show", ex); }
+            });
+        }
+        catch (Exception ex)
+        {
+            OutputWindowLogger.LogException("Pkg.OnModeChange", ex);
+        }
+        return VSConstants.S_OK;
+    }
+
     /// <summary>Re-read the solution folder from <see cref="IVsSolution"/> into <see cref="CurrentSolutionFolder"/>; call on every solution-state change.</summary>
     private void RefreshCurrentSolutionFolder()
     {
@@ -229,6 +262,12 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
         _solution = await GetServiceAsync(typeof(SVsSolution)) as IVsSolution;
         _solution?.AdviseSolutionEvents(this, out _solutionEventsCookie);
 
+        // VS keeps one window layout for design time and another for run time, and a pane opened
+        // while writing code is simply not in the run-time one — so starting the debugger appears
+        // to close it. The frames are still alive, so bring them back up on the mode change.
+        _debugger = await GetServiceAsync(typeof(SVsShellDebugger)) as IVsDebugger;
+        _debugger?.AdviseDebuggerEvents(this, out _debuggerEventsCookie);
+
         // Prime from current state: VS may already have a solution open before
         // our package activates, so we'd miss OnAfterOpenSolution.
         if (_solution?.GetProperty((int)__VSPROPID.VSPROPID_IsSolutionOpen, out var isOpenObj) == VSConstants.S_OK
@@ -249,6 +288,11 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
             {
                 _solution?.UnadviseSolutionEvents(_solutionEventsCookie);
                 _solutionEventsCookie = 0;
+            }
+            if (_debuggerEventsCookie != 0)
+            {
+                _debugger?.UnadviseDebuggerEvents(_debuggerEventsCookie);
+                _debuggerEventsCookie = 0;
             }
             Mcp.McpServerHost.Instance.Stop();
             AgentsOptions.Applied -= ProfilesMenuCommand.InvalidateCache;

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneLauncher.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneLauncher.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -11,6 +11,7 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Corsinvest.VisualStudio.Agents.Core.Panes;
 
@@ -24,6 +25,38 @@ internal static class PaneLauncher
 {
     private static Type WindowType(PaneKind kind)
         => kind == PaneKind.Cli ? typeof(CliPaneWindow) : typeof(ChatPaneWindow);
+
+    /// <summary>Re-show the panes the registry already knows about, without creating any. VS holds a
+    /// separate window layout for design time and run time, so panes opened while writing code are
+    /// missing from the run-time one and look closed when the debugger starts — the frames are alive,
+    /// they are simply not in that layout. Called on debugger mode changes.
+    ///
+    /// create: false throughout: a pane the user closed is gone from the registry and must stay
+    /// closed, and a frame we cannot find is not one to conjure up.
+    /// Main thread only — IVsWindowFrame is not free-threaded.</summary>
+    public static void ShowExisting()
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        var pkg = AgentsPackage.Instance;
+        if (pkg == null) { return; }
+
+        foreach (var entry in PaneRegistry.Instance.Entries.ToList())
+        {
+            try
+            {
+                var pane = pkg.FindToolWindow(WindowType(entry.Kind), entry.PaneId, create: false);
+                if (pane?.Frame is IVsWindowFrame frame && frame.IsVisible() != VSConstants.S_OK)
+                {
+                    frame.Show();
+                }
+            }
+            catch (Exception ex)
+            {
+                // One pane failing to come back must not stop the others.
+                OutputWindowLogger.LogException($"PaneLauncher.ShowExisting({entry.Title})", ex);
+            }
+        }
+    }
 
     /// <summary>The pane's working directory: the open solution's folder, else the user profile
     /// (so claude.exe always has a real cwd). Resolved once here, then injected into the entry and


### PR DESCRIPTION
Starting a debug session made every Chat and CLI pane vanish, while Solution Explorer, Output and the rest stayed put.

## Why

They were never closed. Visual Studio keeps **one window layout for design time and another for run time** — [documented behaviour](https://learn.microsoft.com/en-us/visualstudio/ide/customizing-window-layouts-in-visual-studio), not a bug — and a pane opened while writing code is simply absent from the run-time layout. The frames stay alive behind it; VS just doesn't show them.

That also explains why only our panes went: the built-in windows are in both layouts already.

Two earlier guesses that turned out wrong, recorded so they aren't retried:

- **`Transient`** — it governs whether a window returns after an *IDE restart*, not a debugger transition.
- **The dock anchor alone** — changing `Window =` did not fix it on its own (tested).

## What

The package now implements `IVsDebuggerEvents` and, on a mode change, re-shows what `PaneRegistry` says is open:

- **Only what was open.** A pane the user closed is not in the registry, so it stays closed.
- **Nothing already visible.** The `IsVisible()` check means a breakpoint doesn't raise panes or steal focus — `OnModeChange` fires on every transition, including Run↔Break.
- **`create: false` throughout.** A frame we can't find is not one to conjure up.
- **Deferred through `StartOnIdle`**, for the same reason the solution-open restore is: showing a frame from inside the shell's own event freezes it. That reason is already documented on `RestorePanesDeferred`.

## Also

The panes now dock against windows VS owns rather than a GUID of our own:

| Pane | Docks with | Why |
| :-- | :-- | :-- |
| Chat | Solution Explorer | tall and narrow, like the tree it sits beside |
| CLI | Output | wide and short — where a terminal belongs, and where VS users already look for one |

A private GUID gives VS a dock area it only knows in the layout the pane was first opened in, which is what left them with nowhere to be. This also keeps the two kinds apart *by their shape* rather than by an identifier — the original reason for separate GUIDs was that sharing one host mixed them up and floated the CLI.

## Verification

`msbuild /t:Build` → 0 errors. No new warnings in either changed file.

**Runtime behaviour is unverified.** Worth checking in the experimental instance:

- open a Chat pane, start debugging → it should stay
- set a breakpoint while debugging → panes should not flicker or take focus
- close a pane, then start debugging → it should stay closed
- open Chat and CLI together → they should land in different dock areas, and the CLI should not float

If the panes come back but flicker at every breakpoint, the fix is to narrow `OnModeChange` to `DBGMODE_Run` rather than reacting to all transitions.
