### PR TITLE
docs: the extension now builds itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 
 [![License](https://img.shields.io/badge/license-GPL--3.0-blue.svg)](LICENSE)
 [![Visual Studio](https://img.shields.io/badge/Visual%20Studio-2022%20%7C%202026-5C2D91.svg)](https://visualstudio.microsoft.com/)
-[![Marketplace installs](https://img.shields.io/visual-studio-marketplace/i/Corsinvest.cv4vs-agents?label=marketplace%20installs)](https://marketplace.visualstudio.com/items?itemName=Corsinvest.cv4vs-agents)
+[![Marketplace](https://img.shields.io/badge/marketplace-cv4vs%20Agents-5C2D91.svg)](https://marketplace.visualstudio.com/items?itemName=Corsinvest.cv4vs-agents)
+[![Self-hosting](https://img.shields.io/badge/self--hosting-since%202026--07--27-brightgreen.svg)](#why)
 
 A Visual Studio 2022 / 2026 extension that brings the **Claude Code** CLI inside the IDE — a rich
 chat experience plus an interactive terminal, both wired into Visual Studio's editor,
@@ -202,6 +203,11 @@ And yes — I built this CLI/chat *for* Claude *with* Claude. There's something 
 it was a genuinely fun little adventure: watching it sometimes deny things about itself, only to
 turn around and build them. That's just part of the LLM game. The code here was written with
 Claude's help.
+
+**Since 27 July 2026 the extension is self-hosting.** It is developed inside itself: no VS Code, no
+external terminal, no other editor — the Chat and CLI panes in the screenshots above are the ones
+writing the next version. Which is also the toughest test there is: every rough edge turns up in the
+day's work, not in a bug report.
 
 — *Daniele Corsini (Frank Lupo)*
 


### PR DESCRIPTION
Two small things in the README.

## Self-hosting

Since 27 July 2026 the extension is developed inside itself — no VS Code, no external terminal. Recorded at the end of the **Why** section, where the rest of that story already is, plus a badge in the header.

It follows on from the paragraph about having built the thing with Claude's help: from *built with* to *builds itself*.

## The Marketplace badge said "retired badge"

Not our slug, and not the publisher id: **shields.io has retired its Visual Studio Marketplace badges**. There is no publicly documented API for install counts, and the endpoints they were using brought rate-limiting and compliance problems — there is an [open request](https://github.com/microsoft/vsmarketplace/issues/1776) asking Microsoft for a public one.

The badge URL still returns HTTP 200; the image it returns just reads `retired badge`.

Replaced with a static badge linking to the same page:

```
marketplace | cv4vs Agents
```

Same purple as the Visual Studio badge beside it, no dependency on an API that no longer answers. A third-party service (`vsmarketplacebadges.dev`) does still serve install counts — worth revisiting once the extension is published and there is a real number to show.
