### PR TITLE
feat(menu): list the open panes under View → cv4vs Agents

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/AgentsPackage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/AgentsPackage.cs
@@ -247,6 +247,7 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
         await this.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
         OutputWindowLogger.EnsurePaneOnUIThread();
         await ProfilesMenuCommand.InitializeAsync(this);
+        await ActiveSessionsMenuCommand.InitializeAsync(this);
         await GlobalMenuCommands.InitializeAsync(this);
         // Register the Statistics document-tab editor factory (opened by the View → Statistics command).
         RegisterEditorFactory(new Core.Stats.StatisticsEditorFactory());

--- a/src/Corsinvest.VisualStudio.Agents/AgentsPackage.vsct
+++ b/src/Corsinvest.VisualStudio.Agents/AgentsPackage.vsct
@@ -32,6 +32,21 @@
         </Strings>
       </Menu>
 
+      <!-- Active sessions: one entry per open pane, to bring it forward. Between the profiles
+           (which open a pane) and Analytics (which reads their data): open, go to, then look at.
+           No DynamicVisibility on the menu itself — nothing would drive it, since submenus have no
+           command behind them. VS hides a submenu whose every item is invisible, and the dynamic
+           range below reports exactly that when no pane is open. -->
+      <Menu guid="guidAgentsCommandSet" id="ActiveSessionsSubMenu" priority="0x0170" type="Menu">
+        <Parent guid="guidAgentsCommandSet" id="ActiveSessionsAnchorGroup"/>
+        <Icon guid="ImageCatalogGuid" id="ApplicationGroup"/>
+        <CommandFlag>IconIsMoniker</CommandFlag>
+        <CommandFlag>IconAndText</CommandFlag>
+        <Strings>
+          <ButtonText>Active sessions</ButtonText>
+        </Strings>
+      </Menu>
+
       <!-- Analytics: the three full-window data tabs (Statistics / Usage / Context usage). -->
       <Menu guid="guidAgentsCommandSet" id="AnalyticsSubMenu" priority="0x0180" type="Menu">
         <Parent guid="guidAgentsCommandSet" id="StatisticsGroup"/>
@@ -63,6 +78,14 @@
       <!-- Group inside the submenu holding the entries. -->
       <Group guid="guidAgentsCommandSet" id="ProfilesGroup" priority="0x0100">
         <Parent guid="guidAgentsCommandSet" id="ProfilesSubMenu"/>
+      </Group>
+      <!-- Active-sessions submenu anchor, ahead of Analytics in the same band. -->
+      <Group guid="guidAgentsCommandSet" id="ActiveSessionsAnchorGroup" priority="0x0170">
+        <Parent guid="guidAgentsCommandSet" id="ProfilesSubMenu"/>
+      </Group>
+      <!-- The dynamic entries inside the Active sessions submenu. -->
+      <Group guid="guidAgentsCommandSet" id="ActiveSessionsGroup" priority="0x0100">
+        <Parent guid="guidAgentsCommandSet" id="ActiveSessionsSubMenu"/>
       </Group>
       <!-- Analytics submenu anchor, between profiles and the global actions (auto separators). -->
       <Group guid="guidAgentsCommandSet" id="StatisticsGroup" priority="0x0180">
@@ -108,6 +131,19 @@
         <CommandFlag>TextChanges</CommandFlag>
         <Strings>
           <ButtonText>Claude</ButtonText>
+        </Strings>
+      </Button>
+
+      <!-- Dynamic range inside the Active sessions submenu: one item per open pane, seeded by
+           DynamicItemStart. No <Icon>, for the same reason as the profiles range above: a dynamic
+           command cannot carry one. -->
+      <Button guid="guidAgentsCommandSet" id="ActiveSessionCommandId" priority="0x0100" type="Button">
+        <Parent guid="guidAgentsCommandSet" id="ActiveSessionsGroup"/>
+        <CommandFlag>DynamicItemStart</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <CommandFlag>TextChanges</CommandFlag>
+        <Strings>
+          <ButtonText>Session</ButtonText>
         </Strings>
       </Button>
 
@@ -202,6 +238,9 @@
       <IDSymbol name="GlobalGroup" value="0x1050" />
       <IDSymbol name="HelpGroup" value="0x1060" />
       <IDSymbol name="HelpSubMenu" value="0x1070" />
+      <IDSymbol name="ActiveSessionsSubMenu" value="0x1048" />
+      <IDSymbol name="ActiveSessionsGroup" value="0x1049" />
+      <IDSymbol name="ActiveSessionsAnchorGroup" value="0x104A" />
       <IDSymbol name="DeveloperSubMenu" value="0x1075" />
       <IDSymbol name="DeveloperGroup" value="0x1076" />
       <IDSymbol name="HelpDocsGroup" value="0x1080" />
@@ -220,6 +259,9 @@
       <IDSymbol name="StatisticsCommandId" value="0x0209" />
       <IDSymbol name="UsageCommandId" value="0x020A" />
       <IDSymbol name="ContextUsageCommandId" value="0x020B" />
+      <!-- Seed of the open-panes dynamic range. Its own 0x03xx block: the range grows with the
+           number of open panes and must not run into the fixed ids above. -->
+      <IDSymbol name="ActiveSessionCommandId" value="0x0300" />
     </GuidSymbol>
     <GuidSymbol name="guidImages" value="{c3d4e5f6-a7b8-9012-defa-bc1234567890}">
       <IDSymbol name="bmpPic1" value="1" />

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneLauncher.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneLauncher.cs
@@ -44,8 +44,7 @@ internal static class PaneLauncher
         {
             try
             {
-                var pane = pkg.FindToolWindow(WindowType(entry.Kind), entry.PaneId, create: false);
-                if (pane?.Frame is IVsWindowFrame frame && frame.IsVisible() != VSConstants.S_OK)
+                if (Frame(pkg, entry) is IVsWindowFrame frame && frame.IsVisible() != VSConstants.S_OK)
                 {
                     frame.Show();
                 }
@@ -56,6 +55,32 @@ internal static class PaneLauncher
                 OutputWindowLogger.LogException($"PaneLauncher.ShowExisting({entry.Title})", ex);
             }
         }
+    }
+
+    /// <summary>Bring one open pane forward — what the Active sessions menu does. Unlike
+    /// <see cref="ShowExisting"/> this shows even an already-visible pane, so picking a session
+    /// buried under its siblings' tabs raises it. Main thread only.</summary>
+    public static void Activate(PaneEntry entry)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        var pkg = AgentsPackage.Instance;
+        if (pkg == null || entry == null) { return; }
+        try
+        {
+            if (Frame(pkg, entry) is IVsWindowFrame frame) { ErrorHandler.ThrowOnFailure(frame.Show()); }
+        }
+        catch (Exception ex)
+        {
+            OutputWindowLogger.LogException($"PaneLauncher.Activate({entry.Title})", ex);
+        }
+    }
+
+    /// <summary>The window frame hosting an open pane, or null when VS no longer has it.
+    /// create: false — this only ever finds what is already there.</summary>
+    private static object Frame(AgentsPackage pkg, PaneEntry entry)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        return pkg.FindToolWindow(WindowType(entry.Kind), entry.PaneId, create: false)?.Frame;
     }
 
     /// <summary>The pane's working directory: the open solution's folder, else the user profile

--- a/src/Corsinvest.VisualStudio.Agents/Corsinvest.VisualStudio.Agents.csproj
+++ b/src/Corsinvest.VisualStudio.Agents/Corsinvest.VisualStudio.Agents.csproj
@@ -273,6 +273,7 @@
     <Compile Include="Chat\HistoryReplay.cs" />
     <Compile Include="Chat\MetaInjection.cs" />
     <Compile Include="Chat\ThumbnailGenerator.cs" />
+    <Compile Include="Menu\ActiveSessionsMenuCommand.cs" />
     <Compile Include="Menu\ProfilesMenuCommand.cs" />
     <Compile Include="Menu\GlobalMenuCommands.cs" />
     <Compile Include="Core\Panes\PaneLauncher.cs" />

--- a/src/Corsinvest.VisualStudio.Agents/Menu/ActiveSessionsMenuCommand.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Menu/ActiveSessionsMenuCommand.cs
@@ -1,0 +1,100 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using Corsinvest.VisualStudio.Agents.Core.Panes;
+using Microsoft.VisualStudio.Shell;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Design;
+using System.Linq;
+using Task = System.Threading.Tasks.Task;
+
+namespace Corsinvest.VisualStudio.Agents.Menu;
+
+/// <summary>
+/// View-menu entry point: one item per open pane, listed under an "Active sessions" submenu, to
+/// bring that pane forward. VS's own Window list mixes tool windows in with every open document,
+/// and the docked tab caption is stuck at "Chat 1"/"Chat 2" — VS derives it from the window name
+/// and ignores every caption property — so with several panes open this is the only place their
+/// full titles (session and profile) are visible together.
+///
+/// Same DynamicItemStart mechanism as <see cref="ProfilesMenuCommand"/>, minus its cache: the
+/// entries come from PaneRegistry, which is already in memory, so VS's constant polling costs
+/// nothing to serve.
+/// </summary>
+internal sealed class ActiveSessionsMenuCommand : OleMenuCommand
+{
+    private readonly int _baseId;
+
+    private ActiveSessionsMenuCommand(CommandID rootId)
+        : base(OnInvoke, changeHandler: null, OnBeforeQueryStatus, rootId)
+    {
+        _baseId = rootId.ID;
+    }
+
+    public static async Task InitializeAsync(AsyncPackage package)
+    {
+        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+        var commandService = await package.GetServiceAsync(typeof(IMenuCommandService)) as OleMenuCommandService;
+
+        var rootId = new CommandID(PackageGuids.AgentsCommandSet, PackageIds.ActiveSessionCommandId);
+        commandService?.AddCommand(new ActiveSessionsMenuCommand(rootId));
+    }
+
+    /// <summary>The open panes, in the order they were opened. Read live — no cache, unlike the
+    /// profiles menu: this list changes whenever a pane opens or closes, and it costs a field read.</summary>
+    private static IReadOnlyList<PaneEntry> Items() => [.. PaneRegistry.Instance.Entries];
+
+    /// <summary>Matches the seed id plus the whole dynamic range (base..base+Count-1),
+    /// which is how VS discovers how many entries to render in the submenu.</summary>
+    public override bool DynamicItemMatch(int cmdId)
+    {
+        var count = Items().Count;
+        if (cmdId < _baseId || cmdId >= _baseId + count) { return false; }
+        // Required by the VS dynamic-item-range contract: a matched command must
+        // record its own id here so BeforeQueryStatus/Invoke below can read it back.
+        MatchedCommandId = cmdId;
+        return true;
+    }
+
+    private static void OnBeforeQueryStatus(object sender, EventArgs e)
+    {
+        var cmd = (ActiveSessionsMenuCommand)sender;
+        var items = Items();
+        var index = GetIndex(cmd);
+
+        if (index < items.Count)
+        {
+            cmd.Enabled = true;
+            cmd.Visible = true;
+            cmd.Text = items[index].Title;
+        }
+        else
+        {
+            cmd.Enabled = false;
+            cmd.Visible = false;
+        }
+
+        // Reset so the next query re-derives MatchedCommandId from DynamicItemMatch
+        // instead of reusing this call's id — without this, VS keeps re-querying the
+        // same matched id and only the first item in the range ever gets shown.
+        cmd.MatchedCommandId = 0;
+    }
+
+    private static void OnInvoke(object sender, EventArgs e)
+    {
+        var cmd = (ActiveSessionsMenuCommand)sender;
+        var items = Items();
+        var index = GetIndex(cmd);
+        if (index >= 0 && index < items.Count) { PaneLauncher.Activate(items[index]); }
+        cmd.MatchedCommandId = 0;
+    }
+
+    private static int GetIndex(ActiveSessionsMenuCommand cmd)
+    {
+        var matched = cmd.MatchedCommandId;
+        return matched == 0 ? 0 : matched - cmd._baseId;
+    }
+}

--- a/src/Corsinvest.VisualStudio.Agents/PackageGuids.cs
+++ b/src/Corsinvest.VisualStudio.Agents/PackageGuids.cs
@@ -46,4 +46,8 @@ internal static class PackageIds
     public const int StatisticsCommandId = 0x0209;
     public const int UsageCommandId = 0x020A;
     public const int ContextUsageCommandId = 0x020B;
+
+    // Seeds the dynamic open-panes range, which grows with the number of open panes — its own
+    // 0x0300 block, clear of the fixed ids above.
+    public const int ActiveSessionCommandId = 0x0300;
 }


### PR DESCRIPTION
Docked panes hide each other behind tabs, and the tab caption is stuck at "Chat 1" / "Chat 2" — VS builds it from the window name and instance number, and ignores every caption property an extension can set (there is a comment in `PaneWindowBase.SetSessionCaption` about exactly this). With several panes open there was no way to tell which was which, or to reach one that had drifted behind its siblings.

**View → cv4vs Agents → Active sessions** now lists them by their full title — session and profile included — and picking one brings it forward.

```
View → cv4vs Agents
  Claude                    ← profiles: open a pane
  New profile
  ─────────────
  Active sessions  ›        ← this: go to one
      Chat 1 (Claude)
      CLI 2 (z.ai)
      Chat 3 (Claude)
  Analytics        ›        ← their data
  ─────────────
  Settings…
```

Between the profiles that open a pane and the Analytics tabs that read their data: open, go to, look at.

## How

Same `DynamicItemStart` range as `ProfilesMenuCommand`, minus its cache — those entries come from `profiles.json` on disk, so VS's idle-loop polling had to be kept off it; these come from `PaneRegistry`, which is already in memory and costs a field read.

`PaneLauncher.Activate(entry)` brings one pane forward. It shares a `Frame()` helper with `ShowExisting()` (added for the debugger fix) but differs deliberately: `ShowExisting` skips anything already visible, so a breakpoint doesn't steal focus, while `Activate` shows regardless — picking a session buried under its siblings' tabs is exactly when you need it raised.

**The submenu hides itself when nothing is open.** Not through `DynamicVisibility` on the menu — nothing would drive it, since submenus have no command behind them — but because VS hides a submenu whose every item reports itself invisible, which is what the range does at zero panes.

**No icons on the entries.** A dynamic command cannot carry one: `<Icon>` on the seed decorates only the first item and leaves the rest bare. Verified earlier today on the profiles range, and noted in the `.vsct` so it isn't retried. The submenu itself has one.

## Verification

`msbuild /t:Build` → 0 errors, with the new file added to the explicit `<Compile>` list (this project has no glob, and a missing entry compiles in VS but not in the packaged VSIX).

**Not exercised in the IDE.** A `.vsct` fails at runtime rather than at compile time — a mismatched id is a silently dead menu entry — so this needs a look in the experimental instance:

- no panes open → the submenu should not appear at all
- one or more → an entry each, showing the full title
- pick one → that pane comes forward, including when it is behind a sibling's tab
- close a pane → its entry goes
