### PR TITLE
fix(chat): keep WebView DevTools on Debug builds

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
@@ -196,15 +196,22 @@ public partial class ChatPaneControl : PaneControlBase
         return true;
     }
 
-    /// <summary>Chat-only extra for the toolbar's "More" menu: the WebView DevTools, on preview
-    /// builds only. Testers on a release candidate are exactly who needs to inspect the WebView to
-    /// report a bug; a stable Marketplace build should not expose it. (Info is shared, so it lives
-    /// on the base; the CLI returns none.)</summary>
+    /// <summary>Chat-only extra for the toolbar's "More" menu: the WebView DevTools, on preview and
+    /// Debug builds. Testers on a release candidate are exactly who needs to inspect the WebView to
+    /// report a bug, and so is anyone building the extension — the DEBUG arm is what keeps it around
+    /// once a version drops its -rc suffix, which is when it silently disappeared. A stable
+    /// Marketplace build, which is neither, should not expose it. (Info is shared, so it lives on
+    /// the base; the CLI returns none.)</summary>
     public override IEnumerable<ButtonAction> MoreMenuActions
     {
         get
         {
-            if (BuildInfo.IsPreRelease)
+#if DEBUG
+            const bool devBuild = true;
+#else
+            const bool devBuild = false;
+#endif
+            if (BuildInfo.IsPreRelease || devBuild)
             {
                 yield return new ButtonAction("WebView DevTools", () => _bridge?.OpenDevTools(), "DevTools");
             }


### PR DESCRIPTION
The **WebView DevTools** entry vanished from the pane toolbar's ⋯ menu.

It was gated on `BuildInfo.IsPreRelease`, which reads the suffix off `AssemblyInformationalVersion`. Cutting 1.0.0 dropped `-rc1` from `Directory.Build.props`, so that turned `false` — and the entry went with it, on development builds too. Nothing about cutting a release suggests it would take DevTools away, which is why it took a while to connect the two.

Debug builds now show it as well:

```csharp
#if DEBUG
    const bool devBuild = true;
#else
    const bool devBuild = false;
#endif
    if (BuildInfo.IsPreRelease || devBuild)
```

The rule the gate was written for still holds, and is in the comment: testers on a release candidate are exactly who needs to inspect the WebView to report a bug, and so is anyone building the extension — a stable Marketplace build is neither, and should not expose it.

A `const bool` rather than wrapping the `if` in `#if DEBUG`, so the condition stays readable as one expression.

## Verification

Built **both** configurations, since the two arms differ:

- `Configuration=Debug` → 0 errors
- `Configuration=Release` → 0 errors, and no unreachable-code warning on the file (the thing worth checking, with `devBuild` constant-false there)
