### PR TITLE
fix(chat): refresh the "x ago" stamp when the pointer reaches it

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/time.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/time.ts
@@ -4,7 +4,10 @@
  */
 
 // Human "time ago" + absolute date/time for message action rows. Uses the platform Intl APIs
-// (browser locale). The relative form is computed once per render — no ticking timer.
+// (browser locale). The relative form is computed on render and refreshed on hover — see
+// renderTimeAgo; there is no ticking timer.
+
+import { html, type TemplateResult } from 'lit';
 
 const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
 
@@ -33,4 +36,26 @@ export function formatTimeAgo(ms: number): string {
 /** Full localized date + time, for the tooltip. */
 export function formatAbsolute(ms: number): string {
     return new Date(ms).toLocaleString();
+}
+
+/** The "x ago" stamp for an action row, refreshing itself when the pointer arrives.
+ *
+ *  Lit renders on property change, and elapsed time is not a property — so a stamp rendered when
+ *  the message arrived said "1 second ago" for as long as the message stayed on screen. The action
+ *  row is always in the DOM and only revealed by `opacity` on hover, so the hover alone changed
+ *  nothing: no re-render came with it.
+ *
+ *  Writing the text straight onto the element on `mouseenter` is enough, and is why this is a plain
+ *  function rather than a timer: the stamp is only legible while the row is revealed, and the row is
+ *  only revealed under the pointer. A ticking timer would instead keep hundreds of history messages
+ *  re-rendering to move "2 hours ago" to "3 hours ago", which nobody is reading. */
+export function renderTimeAgo(ms: number): TemplateResult {
+    return html`<span
+        class="cv-ts"
+        title=${formatAbsolute(ms)}
+        @mouseenter=${(e: Event) => {
+            (e.currentTarget as HTMLElement).textContent = formatTimeAgo(ms);
+        }}
+        >${formatTimeAgo(ms)}</span
+    >`;
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-message.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-message.ts
@@ -20,7 +20,7 @@ import { displayPathUi } from '../paths';
 import { parseIdeContextTags } from '../../core/ide';
 import { renderSlashCommand } from '../../core/slash-commands';
 import { openLightbox } from '../../core/dialog-host';
-import { formatTimeAgo, formatAbsolute } from '../../core/time';
+import { renderTimeAgo } from '../../core/time';
 import type {
     IdeContextRef,
     ForkNotification,
@@ -191,13 +191,7 @@ export class CvMessage extends LitElement {
                       </button>`
                     : nothing
             }
-            ${
-                this.timestamp > 0
-                    ? html`<span class="cv-ts" title=${formatAbsolute(this.timestamp)}
-                          >${formatTimeAgo(this.timestamp)}</span
-                      >`
-                    : nothing
-            }
+            ${this.timestamp > 0 ? renderTimeAgo(this.timestamp) : nothing}
         </div>`;
     }
 

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/helpers/actions-row.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/helpers/actions-row.ts
@@ -9,7 +9,7 @@
 import { html, nothing } from 'lit';
 import '../components/cv-copy-btn';
 import '../components/cv-speak-btn';
-import { formatTimeAgo, formatAbsolute } from '../../core/time';
+import { renderTimeAgo } from '../../core/time';
 
 /** Copy button (+ optional Read-aloud when `speak`) + "x ago" timestamp. Hover-gating is CSS:
  *  `.cv-response-actions` has base opacity 0 and a hover rule on the container reveals it — pass that
@@ -26,13 +26,7 @@ export function renderActionsRow(
         <div class="cv-response-actions ${extraClass}">
             <cv-copy-btn .text=${text} title=${title}></cv-copy-btn>
             ${speak ? html`<cv-speak-btn .text=${text}></cv-speak-btn>` : nothing}
-            ${
-                ts > 0
-                    ? html`<span class="cv-ts" title=${formatAbsolute(ts)}
-                          >${formatTimeAgo(ts)}</span
-                      >`
-                    : nothing
-            }
+            ${ts > 0 ? renderTimeAgo(ts) : nothing}
         </div>
     `;
 }


### PR DESCRIPTION
A message written at **00:41** still read *"1 second ago"* at **00:44**.

`formatTimeAgo` computes correctly — `ms - Date.now()`. Nothing was calling it again: Lit renders on property change, and elapsed time is not a property, so the stamp kept whatever it said when the message arrived.

**Hovering did not help either**, though it looks as though it should. The actions row is always in the DOM, revealed only by opacity:

```css
.cv-msg-actions          { opacity: 0; }
cv-message:hover .cv-msg-actions { opacity: 1; }
```

The pointer changes a style. Nothing re-renders.

## What it does now

`renderTimeAgo(ms)` in `core/time.ts` owns the `<span class="cv-ts">` and rewrites its text on `mouseenter`. The three places that show a timestamp — `cv-message`, and `cv-app` / `cv-tool-row` through the shared actions-row helper — all go through it, so the logic lives in one place.

It writes the text node directly rather than requesting an update, because one of those places is a plain render function with no component to update. It is also cheaper than a re-render.

**No timer.** The stamp is only legible while the row is revealed, and the row is only revealed under the pointer. A ticking timer would keep hundreds of history messages re-rendering to move "2 hours ago" to "3 hours ago", which nobody is reading. The one case hovering misses — pointer held still over a message for a full minute — is not worth the rest.

## Verification

`typecheck`, `lint`, `build`, `format` — clean. Confirmed in the IDE by the author: hovering an older message now updates the stamp.
