### PR TITLE
feat(options): a profile's Description becomes multi-line Notes

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Core/Profiles/Profile.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Profiles/Profile.cs
@@ -13,7 +13,14 @@ namespace Corsinvest.VisualStudio.Agents.Core.Profiles;
 public sealed class Profile
 {
     public string Name { get; set; } = "";
-    public string Description { get; set; } = "";
+
+    /// <summary>Free-form reminder for whoever set the profile up — which account this is, when the
+    /// token expires, why it exists. Nothing reads it: profiles are identified by Name everywhere
+    /// (the pane caption, the View menu), and a VS dynamic menu item carries no tooltip to put it
+    /// in. It earns its place in the Options page alone, which is where such a note gets written
+    /// and re-read.</summary>
+    public string Notes { get; set; } = "";
+
     public bool Enabled { get; set; } = true;
 
     // Arbitrary env vars — no special fields. The user sets ANTHROPIC_BASE_URL,
@@ -23,7 +30,7 @@ public sealed class Profile
     public Profile Clone() => new()
     {
         Name = Name,
-        Description = Description,
+        Notes = Notes,
         Enabled = Enabled,
         Env = new Dictionary<string, string>(Env),
     };

--- a/src/Corsinvest.VisualStudio.Agents/Core/Profiles/ProfileStore.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Profiles/ProfileStore.cs
@@ -78,7 +78,7 @@ internal static class ProfileStore
     /// by claude.exe from the parent.</summary>
     private static Profile NativeProfile()
     {
-        var p = new Profile { Name = "Claude", Description = "", Enabled = true };
+        var p = new Profile { Name = "Claude", Notes = "", Enabled = true };
         var sys = Environment.GetEnvironmentVariable(ClaudePaths.ConfigDirEnvVar);
         if (!string.IsNullOrEmpty(sys)) { p.Env[ClaudePaths.ConfigDirEnvVar] = sys; }
         return p;

--- a/src/Corsinvest.VisualStudio.Agents/Options/ProfilesControl.xaml
+++ b/src/Corsinvest.VisualStudio.Agents/Options/ProfilesControl.xaml
@@ -69,8 +69,15 @@
                  Margin="0,2,0,0"
                  Visibility="Collapsed" />
 
-      <TextBlock Grid.Row="3" Text="Description" Margin="0,8,0,2" />
-      <TextBox Grid.Row="4" x:Name="DescriptionBox" TextChanged="OnDescriptionChanged" />
+      <!-- Multi-line: a note is "token expires in March / client X account / not for production",
+           not a single sentence. AcceptsReturn so Enter adds a line instead of leaving the box. -->
+      <TextBlock Grid.Row="3" Text="Notes" Margin="0,8,0,2" />
+      <TextBox Grid.Row="4" x:Name="NotesBox"
+               TextChanged="OnNotesChanged"
+               AcceptsReturn="True"
+               TextWrapping="Wrap"
+               VerticalScrollBarVisibility="Auto"
+               MinHeight="56" />
 
       <Grid Grid.Row="5">
         <Grid.RowDefinitions>

--- a/src/Corsinvest.VisualStudio.Agents/Options/ProfilesControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Options/ProfilesControl.xaml.cs
@@ -62,7 +62,7 @@ public partial class ProfilesControl : UserControl
             DetailPanel.IsEnabled = profile != null;
 
             NameBox.Text = profile?.Name ?? "";
-            DescriptionBox.Text = profile?.Description ?? "";
+            NotesBox.Text = profile?.Notes ?? "";
 
             _envRows.Clear();
             if (profile != null)
@@ -169,10 +169,10 @@ public partial class ProfilesControl : UserControl
         PersistProfiles();
     }
 
-    private void OnDescriptionChanged(object sender, TextChangedEventArgs e)
+    private void OnNotesChanged(object sender, TextChangedEventArgs e)
     {
         if (_loadingDetail || _selected == null) { return; }
-        _selected.Description = DescriptionBox.Text ?? "";
+        _selected.Notes = NotesBox.Text ?? "";
         PersistProfiles();
     }
 


### PR DESCRIPTION
A profile's **Description** was written in Options, saved to `profiles.json`, and read back in Options. Nothing else touched it — grepping the sources, the only consumers were the textbox that wrote it and the one that loaded it.

Nor could it easily surface anywhere: profiles are identified by `Name` throughout (the pane caption, the View menu entries), and a VS dynamic menu item carries no tooltip — the same limitation that stopped us putting icons on those entries earlier today.

Which is fine, but then it isn't a description. It's a **note**: which account this is, when the token expires, why the profile exists at all. Renamed to match, and made multi-line, since that is the shape such a reminder actually takes:

```
token expires in March
client X account — not for production
```

## Renamed through, not just relabelled

Property, JSON field and label all become `Notes`. Relabelling the textbox alone would leave the code saying `Description` and the UI saying Notes — a small lie that costs someone ten minutes in a year's time.

**Nothing to migrate**: checked the saved `profiles.json` — one profile, empty description. A profile that did carry text would lose it silently on deserialisation; a compatibility line is a one-liner if that turns out to matter for anyone.

The property's comment records why nothing reads it, so the next person doesn't go looking for the display code that was never there.

## Verification

`msbuild /t:Build` → 0 errors. Worth opening **Tools → Options → cv4vs Agents → Profiles** to see the field takes several lines and that Enter adds one rather than leaving the box.
