### PR TITLE
fix(chat): in Bypass, Claude could not ask you anything

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ See [Options → Profiles](docs/options.md#profiles).
 
 ### Permissions
 
-- **Permission-mode selector** in the toolbar — Ask before edits / Edit automatically / Plan /
+- **Permission-mode selector** in the toolbar — Manual / Edit automatically / Plan /
   Auto / Bypass (Bypass is gated behind an option).
 - **Permission prompts & AskUserQuestion** — an inline approval banner for tool use with
   per-session/project "allow" suggestions, and interactive answering of `AskUserQuestion`. The Ask

--- a/README.md
+++ b/README.md
@@ -290,7 +290,8 @@ See [Options → Profiles](docs/options.md#profiles).
 - **Permission prompts & AskUserQuestion** — an inline approval banner for tool use with
   per-session/project "allow" suggestions, and interactive answering of `AskUserQuestion`. The Ask
   answer can be **structured** — several questions in one panel, each single- or multi-select — not
-  just a plain yes/no.
+  just a plain yes/no. Once answered, the row is compact by default (only what you picked); turn off
+  **Compact Ask answers** in Options to keep every option listed with your pick highlighted.
 
 ### Context, usage & stats
 

--- a/src/Corsinvest.VisualStudio.Agents.Contracts/ToWebViewDtos.cs
+++ b/src/Corsinvest.VisualStudio.Agents.Contracts/ToWebViewDtos.cs
@@ -87,6 +87,9 @@ public class CliStateDto
     public bool? AlwaysThinkingEnabled { get; set; }
     public bool? SwitchModelsOnFlag { get; set; }
     public bool? Ultracode { get; set; }
+    // effective.permissions.disableBypassPermissionsMode == "disable": an org policy forbids the
+    // bypass mode, so the selector must not offer it (VS Code gates on the same key).
+    public bool? BypassPermissionsDisabled { get; set; }
     // From init.fast_mode_state (off|cooldown|on). The webview derives only the on/off toggle
     // (on = state != "off"); cooldown is not currently surfaced distinctly. Replaces the
     // always-null FastMode bool from get_settings.

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.ClientEvents.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.ClientEvents.cs
@@ -160,6 +160,7 @@ public partial class ChatPaneControl
                     AlwaysThinkingEnabled = e.AlwaysThinkingEnabled,
                     SwitchModelsOnFlag = e.SwitchModelsOnFlag,
                     Ultracode = e.Ultracode,
+                    BypassPermissionsDisabled = e.BypassPermissionsDisabled,
                     FastModeState = e.FastModeState,
                     SpinnerVerbsConfig = e.SpinnerVerbs == null ? null : new Contracts.SpinnerVerbsConfigDto
                     {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated/CliStateDto.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated/CliStateDto.ts
@@ -14,6 +14,7 @@ export interface CliStateDto {
     alwaysThinkingEnabled?: boolean | null;
     switchModelsOnFlag?: boolean | null;
     ultracode?: boolean | null;
+    bypassPermissionsDisabled?: boolean;
     fastModeState: string;
     spinnerVerbsConfig: SpinnerVerbsConfigDto | null;
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/permission-modes.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/permission-modes.ts
@@ -28,7 +28,7 @@ export const PERMISSION_ITEMS: PermissionItem[] = [
     // acceptEdits only auto-approves writes inside the working directory).
     {
         value: 'default',
-        label: 'Ask before edits',
+        label: 'Manual',
         description: 'Every edit and command waits for your approval',
         icon: HandRight20Regular,
     },
@@ -41,13 +41,13 @@ export const PERMISSION_ITEMS: PermissionItem[] = [
     },
     {
         value: 'plan',
-        label: 'Plan mode',
+        label: 'Plan',
         description: 'Reads and explores freely, then proposes a plan — no file is changed',
         icon: ClipboardTask20Regular,
     },
     {
         value: 'auto',
-        label: 'Auto mode',
+        label: 'Auto',
         description: 'Decides per task when to act and when to ask, based on how risky it is',
         icon: Flash20Regular,
     },
@@ -66,7 +66,11 @@ export function permissionItems(): PermissionItem[] {
     const value = resolveModelValue(appState.currentModel);
     const m = appState.models.find((x) => x.value === value);
     const autoOk = m ? m.supportsAutoMode : true;
-    const bypassOk = appState.ui.allowDangerouslySkipPermissions;
+    // Two gates, like VS Code: our own VS option AND the CLI's effective settings — an org can
+    // forbid the mode via managed settings. Without the second one we would offer a mode the CLI
+    // then refuses. Note the different sources: `ui.*` is a VS Option, the other is CLI state.
+    const bypassOk =
+        appState.ui.allowDangerouslySkipPermissions && !appState.bypassPermissionsDisabled;
     return PERMISSION_ITEMS.filter((it) => {
         if (it.value === 'auto') {
             return autoOk;

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/state.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/state.ts
@@ -41,6 +41,8 @@ interface AppState {
     fastMode: boolean;
     /** Auto-switch model when a message is flagged (Model menu toggle). */
     switchModelsOnFlag: boolean;
+    /** An org policy (CLI settings) forbids the bypass mode → the selector must not offer it. */
+    bypassPermissionsDisabled: boolean;
 
     isBusy: boolean;
     // Raw CLI work status (system/status): "compacting" while compacting, "" otherwise. The spinner
@@ -161,6 +163,7 @@ const _impl = new StoreImpl<AppState>({
     inDev: false,
     fastMode: false,
     switchModelsOnFlag: true, // default on, like VS Code (get_settings overrides)
+    bypassPermissionsDisabled: false, // permissive until the CLI says otherwise
 
     isBusy: false,
     status: '',

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/init.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/init.ts
@@ -78,6 +78,8 @@ function wireBridgeHandlers(): void {
             if (c.switchModelsOnFlag !== null && c.switchModelsOnFlag !== undefined) {
                 state.switchModelsOnFlag = c.switchModelsOnFlag;
             }
+            // Absent → false: a missing policy means the mode is allowed.
+            state.bypassPermissionsDisabled = !!c.bypassPermissionsDisabled;
             state.fastMode = (c.fastModeState ?? 'off') !== 'off';
             // Custom spinner verbs from settings (replace/append the defaults). Migrated
             // from vsOptions into cliState — applied here rather than in applyVsOptions.

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.cs
@@ -174,9 +174,7 @@ public sealed partial class ClaudeClient : IClaudeClient
         // set it after init with a `set_model` control_request (InitializeAndPublishCatalogAsync).
         if (!string.IsNullOrEmpty(options.ResumeSessionId)) { args += " --resume " + options.ResumeSessionId; }
 
-        // --permission-prompt-tool stdio is passed ALWAYS (except bypass): the mode decides WHICH
-        // tools need confirmation, the prompt-tool is the channel to ask. Lets interactive tools
-        // (AskUserQuestion, always behavior:'ask') reach the UI even in acceptEdits/plan.
+        // The mode decides WHICH tools need confirmation, the prompt-tool is the channel to ask.
         var mode = options.InitialPermissionMode ?? Client.PermissionMode.Default;
         if (mode == Client.PermissionMode.BypassPermissions)
         {
@@ -187,8 +185,13 @@ public sealed partial class ClaudeClient : IClaudeClient
             if (mode == Client.PermissionMode.AcceptEdits) { args += " --permission-mode acceptEdits"; }
             else if (mode == Client.PermissionMode.Plan) { args += " --permission-mode plan"; }
             else if (mode == Client.PermissionMode.Auto) { args += " --permission-mode auto"; }
-            args += " --permission-prompt-tool stdio";
         }
+        // ALWAYS, bypass included. Verified on CLI 2.1.220: without this flag the CLI drops
+        // AskUserQuestion from the session entirely — the turn ends `success` and the question is
+        // never emitted, on either channel. So the flag doesn't merely carry permission prompts,
+        // it registers the interactive tool. Passing it alongside --dangerously-skip-permissions
+        // does NOT bring the confirmations back: writes and commands still run unasked.
+        args += " --permission-prompt-tool stdio";
 
         // Profile env goes FIRST, our required keys LAST — a profile (e.g. z.ai/GLM base
         // URL + token) must never be able to override what makes the IDE integration work.
@@ -344,6 +347,8 @@ public sealed partial class ClaudeClient : IClaudeClient
                 AlwaysThinkingEnabled = eff?.ValBool("alwaysThinkingEnabled"),
                 Ultracode = applied?.ValBool("ultracode"),
                 SwitchModelsOnFlag = eff?.ValBool("switchModelsOnFlag"),
+                BypassPermissionsDisabled =
+                    eff?["permissions"].Val("disableBypassPermissionsMode") == "disable",
                 SpinnerVerbs = ParseSpinnerVerbs(eff?["spinnerVerbs"] as JObject),
                 FastModeState = fastModeState,
             });

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/Events.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/Events.cs
@@ -37,6 +37,10 @@ public sealed class CliStateReceivedEventArgs
     public bool? AlwaysThinkingEnabled { get; set; }   // effective.alwaysThinkingEnabled
     public bool? Ultracode { get; set; }               // applied.ultracode
     public bool? SwitchModelsOnFlag { get; set; }      // effective.switchModelsOnFlag (absent in CLI → null → webview default)
+    // effective.permissions.disableBypassPermissionsMode == "disable": an org policy forbids the
+    // bypass mode. Absent/get_settings failed → false, i.e. allowed: only the exact "disable" may
+    // hide the mode, never a missing value.
+    public bool? BypassPermissionsDisabled { get; set; }
     // effective.spinnerVerbs, or null when the CLI configures none.
     public SpinnerVerbs SpinnerVerbs { get; set; }
     // From initialize.fast_mode_state (present only if fast is available for the account/org) or "off".

--- a/src/Corsinvest.VisualStudio.Agents/Options/AgentsChatPage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Options/AgentsChatPage.cs
@@ -16,11 +16,14 @@ namespace Corsinvest.VisualStudio.Agents.Options;
 /// initial default — matching VS Code.</summary>
 public enum InitialPermissionMode
 {
-    /// <summary>Ask before edits — approval required for each edit (prudent default).</summary>
+    /// <summary>Manual — approval required for each edit (prudent default). The name stays
+    /// `Default` because it is what goes on the wire and what VS serializes into the settings
+    /// store: renaming it would invalidate the saved preference of everyone who already chose
+    /// a mode. "Manual" is only the user-facing label.</summary>
     Default,
     /// <summary>Edit automatically — accept Edit/Write without asking.</summary>
     AcceptEdits,
-    /// <summary>Plan mode — explore and present a plan before editing.</summary>
+    /// <summary>Plan — explore and present a plan before editing.</summary>
     Plan,
 }
 
@@ -109,7 +112,7 @@ public class AgentsChatPage : AgentsOptionsPage
 
     [Category("Input")]
     [DisplayName("Initial permission mode")]
-    [Description("Permission mode every new chat session starts in. You can still change it per-session from the toolbar. \"Ask before edits\" (Default) is the most cautious.")]
+    [Description("Permission mode every new chat session starts in. You can still change it per-session from the toolbar. \"Manual\" (Default) is the most cautious.")]
     public InitialPermissionMode InitialPermissionMode { get; set; } = InitialPermissionMode.Default;
 
     [Category("Input")]


### PR DESCRIPTION
`--permission-prompt-tool stdio` was passed in every mode except `bypassPermissions`, on the assumption that a mode which never asks for approval has no use for the channel that asks.

It does — and the failure was silent.

## The bug

Measured on CLI 2.1.220 by reading the tool list in `system/init`, which is what the session actually registered:

| flags | `AskUserQuestion` | tools |
| :-- | :-- | --: |
| `--dangerously-skip-permissions` *(what we passed)* | **no** | 33 |
| the same + `--permission-prompt-tool stdio` | yes | 36 |
| `--permission-prompt-tool stdio` *(control)* | yes | 36 |

Without the flag the tool isn't merely ungated — it is **absent**. The model cannot ask, the turn ends `success`, and nothing surfaces. Anyone working in Bypass had a chat where Claude had quietly lost the ability to ask questions, with no error to notice.

So it is passed always. `--dangerously-skip-permissions` keeps doing its job: a second probe writing a file and running a command saw zero `can_use_tool` with both flags set, exactly as before.

> Note for anyone re-running this: probing a single *turn* is unreliable under bypass — the model sometimes emits `<invoke name="AskUserQuestion">` as raw text instead of calling the tool. The init tool list is the signal; the turn is not.

## Bypass now respects the CLI's policy

We gated Bypass on our VS option alone. VS Code checks that **and** `permissions.disableBypassPermissionsMode` from the effective settings, which an organisation can impose. Without the second gate we offered a mode the CLI then refuses — the user picks it, and it doesn't work.

The value already travels: `get_settings` returns `effective.permissions`, so it rides `ui_init` to the WebView and joins the existing option with an AND. Absent means allowed — only the exact `"disable"` hides the mode.

## Labels

The permission menu is the same menu VS Code has, so it now reads the same:

| before | after |
| :-- | :-- |
| Ask before edits | **Manual** |
| Plan mode | **Plan** |
| Auto mode | **Auto** |

`Manual` pairs with `Auto`, which is its exact opposite; `Ask before edits` didn't. The `mode` suffix was carried by only two of five entries, in a menu already titled "Modes".

Wire values and the `InitialPermissionMode` enum are untouched. `manual` is not a protocol value — it is VS Code's *label* for `default` (`default: { label: "Manual", … }` in their bundle). And the enum name is what VS serialises into the settings store: renaming it would invalidate every saved preference.

## Verification

Build green. Typecheck, lint, format clean.

In the experimental instance:

- Bypass + "ask me a question" → the panel appears *(before: nothing)*
- same chat, "create a file" → written, no confirmation banner *(bypass intact)*
- with `disableBypassPermissionsMode: "disable"` and the VS option **on** → Bypass gone from the selector and from the `⇧+Tab` cycle
- labels read Manual / Edit automatically / Plan / Auto

## Not in scope

`dontAsk` stays unmapped. It is the **opposite** of bypass, not a middle ground — it *denies* instead of asking (*"Permission to use Write has been denied because Claude Code is running in don't ask mode"*). VS Code doesn't expose it either, and `plan` already covers "explore without touching" in language people understand.

Descriptions are unchanged and deliberately not aligned to VS Code's: theirs for `acceptEdits` says "your selected text or the whole file", but the real boundary is the working directory.
