### PR TITLE
fix(chat): Bypass permissions could not be selected, and a failed switch lied

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Cli.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Cli.cs
@@ -71,19 +71,23 @@ internal sealed partial class WebViewMessageHandler
     private void HandleSetPermissionMode(JObject data, int? id)
     {
         var newMode = data.ToObject<Contracts.SetPermissionModeNotification>().Mode ?? "default";
-        // Hot-swap via set_permission_mode; all four modes are
-        // supported so no respawn is needed. The continuation runs off the UI
-        // thread, but bridge.Send marshals CoreWebView2 access itself.
+        // Hot-swap via set_permission_mode; every mode is supported so no respawn is
+        // needed. The continuation runs off the UI thread, but bridge.Send marshals
+        // CoreWebView2 access itself.
         _ = client.SetPermissionModeAsync(newMode).ContinueWith(t =>
         {
             if (t.IsFaulted)
             {
                 OutputWindowLogger.Warn($"!!! set_permission_mode failed: {t.Exception?.GetBaseException().Message}");
             }
-            else
-            {
-                bridge.Send(BridgeMessages.ToWebView.Cli.PermissionModeChanged, new Contracts.PermissionModeChangedNotification { Mode = newMode });
-            }
+            // Either way, tell the WebView what the mode REALLY is. The selector switched
+            // optimistically before asking, and the client only advances PermissionMode once
+            // the CLI has acked — so on failure this sends the old mode back and the UI rolls
+            // itself back. Without it the selector reads "Plan" while the CLI is still in
+            // bypass: the one lie that costs files.
+            bridge.Send(
+                BridgeMessages.ToWebView.Cli.PermissionModeChanged,
+                new Contracts.PermissionModeChangedNotification { Mode = client.PermissionMode });
         });
     }
 
@@ -96,6 +100,12 @@ internal sealed partial class WebViewMessageHandler
             {
                 OutputWindowLogger.Warn($"!!! set_model failed: {t.Exception?.GetBaseException().Message}");
             }
+            // Same rollback as the permission mode: the picker switched before asking, so echo
+            // back what the client actually holds. Null means "Default", which the WebView
+            // renders as such.
+            bridge.Send(
+                BridgeMessages.ToWebView.Cli.ModelChanged,
+                new Contracts.ModelChangedNotification { Model = client.Model });
         });
     }
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
@@ -360,7 +360,8 @@ public partial class ChatPaneControl : PaneControlBase
         // own system/init reports it (fresh pane picks the CLI default; resume re-emits the
         // session's model) and the gate ships it to the WebView. Permission mode comes from OUR
         // Options page (the CLI doesn't restore it from --resume).
-        var permMode = PermissionMode.FromInitial(AgentsOptions.Chat.InitialPermissionMode);
+        var allowBypass = AgentsOptions.Chat.AllowDangerouslySkipPermissions;
+        var permMode = PermissionMode.FromInitial(AgentsOptions.Chat.InitialPermissionMode, allowBypass);
         // Resuming (auto-resume or fork)? Read the session ONCE now so the respawn's --permission-mode
         // matches what the user last had. The transcript/title from the same read are seeded after
         // Cleared, below.
@@ -411,6 +412,7 @@ public partial class ChatPaneControl : PaneControlBase
             // "already in use".) A fresh pane passes neither.
             ResumeSessionId = _startupSessionId,
             InitialPermissionMode = permMode,
+            AllowBypassPermissions = allowBypass,
             SsePort = ssePort,
             Env = Entry.Profile.Env,
         });

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-prompt.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-prompt.ts
@@ -29,6 +29,7 @@ import type {
     PermissionMode,
 } from '../../core/types';
 import { GetSuggestionsReq } from '../../core/request-types';
+import { permissionItems } from '../../core/permission-modes';
 import type { ChatCommand, CommandHost } from '../../core/commands';
 import './cv-notice-stack';
 import type { CvNoticeStack } from './cv-notice-stack';
@@ -819,16 +820,18 @@ export class CvPrompt extends LitElement implements CommandHost {
         // like VS Code), so the textarea no longer handles it here.
     };
 
-    /** Cycle: default → acceptEdits → plan → auto → default. */
+    /** Cycle through the modes the selector actually offers — same source, so the gates hold
+     *  here too (model support for `auto`, VS option + CLI policy for `bypassPermissions`).
+     *  A hardcoded list ignored them, and stranded whoever was in a mode it left out. */
     private _cyclePermissionMode(): void {
-        const order: Array<typeof appState.permissionMode> = [
-            'default',
-            'acceptEdits',
-            'plan',
-            'auto',
-        ];
+        const order = permissionItems().map((it) => it.value);
+        if (!order.length) {
+            return;
+        }
+        // Current mode absent from the list (a policy can withdraw one mid-session):
+        // restart from the first rather than leaving it to the modulo.
         const i = order.indexOf(appState.permissionMode);
-        const next = order[(i + 1) % order.length];
+        const next = i < 0 ? order[0] : order[(i + 1) % order.length];
         appState.permissionMode = next;
         bridge.sendNotification<SetPermissionModeNotification>(
             Msg.fromWebView.cli.setPermissionMode,

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/init.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/init.ts
@@ -17,6 +17,7 @@ import type {
     ModelsNotification,
     PermissionMode,
     PermissionModeChangedNotification,
+    ModelChangedNotification,
     SetComposerNotification,
     SlashCommandsNotification,
     ThemeChangedNotification,
@@ -171,6 +172,8 @@ function wireBridgeHandlers(): void {
         document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
     });
 
+    // Both selectors switch optimistically and the host echoes back what the CLI really holds —
+    // on success the same value, on failure the previous one, which rolls the UI back.
     bridge.onNotification<PermissionModeChangedNotification>(
         Msg.toWebView.cli.permissionModeChanged,
         (data) => {
@@ -179,6 +182,14 @@ function wireBridgeHandlers(): void {
             }
         },
     );
+
+    bridge.onNotification<ModelChangedNotification>(Msg.toWebView.cli.modelChanged, (data) => {
+        // Unlike the mode, an empty model is meaningful — it is "Default" — so only a missing
+        // payload is ignored, never a null value.
+        if (data) {
+            state.currentModel = data.model || null;
+        }
+    });
 
     // Turn end: clear busy and capture the model's real context window/max output
     // (the result carries them; 0 means unknown, so keep the previous value).

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -174,23 +174,23 @@ public sealed partial class ClaudeClient : IClaudeClient
         // set it after init with a `set_model` control_request (InitializeAndPublishCatalogAsync).
         if (!string.IsNullOrEmpty(options.ResumeSessionId)) { args += " --resume " + options.ResumeSessionId; }
 
+        // Grants the capability to switch into bypassPermissions later; weakens nothing now.
+        // Must be the allow- form: --dangerously-skip-permissions disarms permissions immediately,
+        // whatever --permission-mode says. Without either, the CLI refuses the swap outright.
+        if (options.AllowBypassPermissions) { args += " --allow-dangerously-skip-permissions"; }
+
         // The mode decides WHICH tools need confirmation, the prompt-tool is the channel to ask.
         var mode = options.InitialPermissionMode ?? Client.PermissionMode.Default;
-        if (mode == Client.PermissionMode.BypassPermissions)
-        {
-            args += " --dangerously-skip-permissions";
-        }
-        else
-        {
-            if (mode == Client.PermissionMode.AcceptEdits) { args += " --permission-mode acceptEdits"; }
-            else if (mode == Client.PermissionMode.Plan) { args += " --permission-mode plan"; }
-            else if (mode == Client.PermissionMode.Auto) { args += " --permission-mode auto"; }
-        }
-        // ALWAYS, bypass included. Verified on CLI 2.1.220: without this flag the CLI drops
+        if (mode == Client.PermissionMode.AcceptEdits) { args += " --permission-mode acceptEdits"; }
+        else if (mode == Client.PermissionMode.Plan) { args += " --permission-mode plan"; }
+        else if (mode == Client.PermissionMode.Auto) { args += " --permission-mode auto"; }
+        // Needed on resume: a session left in bypass would otherwise restart in `default`.
+        else if (mode == Client.PermissionMode.BypassPermissions) { args += " --permission-mode bypassPermissions"; }
+
+        // ALWAYS, whatever the mode. Verified on CLI 2.1.220: without this flag the CLI drops
         // AskUserQuestion from the session entirely — the turn ends `success` and the question is
         // never emitted, on either channel. So the flag doesn't merely carry permission prompts,
-        // it registers the interactive tool. Passing it alongside --dangerously-skip-permissions
-        // does NOT bring the confirmations back: writes and commands still run unasked.
+        // it registers the interactive tool: a session in bypass could otherwise not ask anything.
         args += " --permission-prompt-tool stdio";
 
         // Profile env goes FIRST, our required keys LAST — a profile (e.g. z.ai/GLM base
@@ -374,6 +374,7 @@ public sealed partial class ClaudeClient : IClaudeClient
             WorkingDirectory = WorkingDirectory ?? _lastOptions.WorkingDirectory,
             ResumeSessionId = SessionId ?? _lastOptions.ResumeSessionId,
             InitialPermissionMode = PermissionMode ?? _lastOptions.InitialPermissionMode,
+            AllowBypassPermissions = _lastOptions.AllowBypassPermissions,
             SsePort = _lastOptions.SsePort,   // keep talking to the same MCP server after a restart
             // Keep the profile's provider across respawns — else the pane silently reverts to native Claude.
             Env = _env ?? _lastOptions?.Env,
@@ -399,6 +400,9 @@ public sealed partial class ClaudeClient : IClaudeClient
         {
             WorkingDirectory = WorkingDirectory,
             InitialPermissionMode = PermissionMode,
+            // Preserved across respawn like Env: losing it would make bypass unreachable
+            // for the rest of the pane's life, with nothing to explain why.
+            AllowBypassPermissions = _lastOptions?.AllowBypassPermissions ?? false,
             Env = _env,
         });
     }
@@ -417,6 +421,7 @@ public sealed partial class ClaudeClient : IClaudeClient
             WorkingDirectory = WorkingDirectory,
             ResumeSessionId = sessionId,
             InitialPermissionMode = PermissionMode,
+            AllowBypassPermissions = _lastOptions?.AllowBypassPermissions ?? false,
             Env = _env,
         });
     }

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClientOptions.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClientOptions.cs
@@ -14,6 +14,12 @@ public sealed class ClientOptions
 
     public string InitialPermissionMode { get; set; } = PermissionMode.Default;
 
+    /// <summary>Whether this pane may ENTER <c>bypassPermissions</c> later (Options → Chat).
+    /// Distinct from starting in it: the CLI refuses <c>set_permission_mode bypassPermissions</c>
+    /// unless the process was launched with the allow- flag, so the capability has to be granted
+    /// up front — see the launch args in <see cref="ClaudeClient"/>.</summary>
+    public bool AllowBypassPermissions { get; set; }
+
     /// <summary>Loopback port of the IDE's MCP server. When &gt; 0 it is passed as
     /// <c>CLAUDE_CODE_SSE_PORT</c> so the CLI connects to THIS server instead of
     /// scanning the lock dir — deterministic with multiple VS instances open.</summary>

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/PermissionMode.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/PermissionMode.cs
@@ -13,11 +13,14 @@ public static class PermissionMode
     public const string Auto = "auto";
     public const string BypassPermissions = "bypassPermissions";
 
-    /// <summary>Map the Options enum to the CLI's wire value.</summary>
-    public static string FromInitial(Options.InitialPermissionMode mode) => mode switch
+    /// <summary>Map the Options enum to the CLI's wire value. <paramref name="allowBypass"/> is
+    /// the VS option: with it off, a saved BypassPermissions falls back to Default rather than
+    /// starting the session in a mode the selector hides — it could not then be left.</summary>
+    public static string FromInitial(Options.InitialPermissionMode mode, bool allowBypass) => mode switch
     {
         Options.InitialPermissionMode.AcceptEdits => AcceptEdits,
         Options.InitialPermissionMode.Plan => Plan,
+        Options.InitialPermissionMode.BypassPermissions => allowBypass ? BypassPermissions : Default,
         _ => Default,
     };
 }

--- a/src/Corsinvest.VisualStudio.Agents/Options/AgentsChatPage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Options/AgentsChatPage.cs
@@ -9,11 +9,12 @@ using System.Runtime.InteropServices;
 
 namespace Corsinvest.VisualStudio.Agents.Options;
 
-/// <summary>Permission mode a new chat session starts in. Mirrors VS Code's
-/// `initialPermissionMode` (default/acceptEdits/plan only); maps to the CLI's
-/// <c>--permission-mode</c> (see Core/Client/PermissionMode.cs). `auto` and
-/// `bypassPermissions` are selectable per-session from the toolbar — not as an
-/// initial default — matching VS Code.</summary>
+/// <summary>Permission mode a new chat session starts in; maps to the CLI's
+/// <c>--permission-mode</c> (see Core/Client/PermissionMode.cs). VS Code's
+/// `initialPermissionMode` also lists `manual`, which their own docs call "an alias for
+/// 'default'" — one behaviour under two names, so it is deliberately not repeated here
+/// ("Manual" is already the label of Default). `auto` stays toolbar-only: it depends on the
+/// model supporting it, which isn't known until the catalogue arrives.</summary>
 public enum InitialPermissionMode
 {
     /// <summary>Manual — approval required for each edit (prudent default). The name stays
@@ -25,6 +26,11 @@ public enum InitialPermissionMode
     AcceptEdits,
     /// <summary>Plan — explore and present a plan before editing.</summary>
     Plan,
+    /// <summary>Bypass permissions — nothing is ever asked. Requires
+    /// <see cref="AgentsChatPage.AllowDangerouslySkipPermissions"/>: without it the mode is
+    /// hidden from the selector, so starting in it would leave the session in a mode the user
+    /// cannot see or leave. Falls back to Default in that case.</summary>
+    BypassPermissions,
 }
 
 [ComVisible(true)]
@@ -112,12 +118,12 @@ public class AgentsChatPage : AgentsOptionsPage
 
     [Category("Input")]
     [DisplayName("Initial permission mode")]
-    [Description("Permission mode every new chat session starts in. You can still change it per-session from the toolbar. \"Manual\" (Default) is the most cautious.")]
+    [Description("Permission mode every new chat session starts in. You can still change it per-session from the toolbar. \"Manual\" (Default) is the most cautious. \"BypassPermissions\" also requires \"Allow dangerously skip permissions\" below — without it, sessions start in Manual.")]
     public InitialPermissionMode InitialPermissionMode { get; set; } = InitialPermissionMode.Default;
 
     [Category("Input")]
     [DisplayName("Allow dangerously skip permissions")]
-    [Description("When enabled, the toolbar's permission menu offers \"Bypass permissions\", which never asks for approval — even for potentially dangerous commands. Off by default; mirrors VS Code's allowDangerouslySkipPermissions.")]
+    [Description("When enabled, the toolbar's permission menu offers \"Bypass permissions\", which never asks for approval — even for commands that can destroy data. Enabling it does not skip anything by itself: the mode still has to be selected. Takes effect on new sessions (the CLI decides at launch whether the mode can ever be entered). Off by default; mirrors VS Code's allowDangerouslySkipPermissions.")]
     public bool AllowDangerouslySkipPermissions { get; set; } = false;
 
     [Category("Diff")]


### PR DESCRIPTION
Three ways the permission selector and the CLI could disagree — one of them silent, one of them a mode that could never be entered at all.

## Bypass permissions did nothing

Picking it flashed and snapped back. The CLI was refusing the swap outright:

> `Cannot set permission mode to bypassPermissions because the session was not launched with --dangerously-skip-permissions`

That flag was only passed when bypass was already the *initial* mode — which the Options enum could not even express, offering `Default/AcceptEdits/Plan` only. Every pane therefore started without the capability, and bypass stayed unreachable for the life of the process.

**The fix is a different flag.** The CLI has two, and the distinction is the entire bug:

```
--allow-dangerously-skip-permissions   Enable bypassing all permission checks
--dangerously-skip-permissions         Bypass all permission checks.
```

*Enable bypassing*, not *bypass*. Measured on CLI 2.1.220, every run with `--permission-mode default`:

| flag | `Write` gated | hot-swap to bypass |
| :-- | :-- | :-- |
| none | yes | **refused** |
| `--allow-dangerously-skip-permissions` | **yes** | **accepted** |
| `--dangerously-skip-permissions` | **no** | (already there) |

The short form disarms permissions immediately, whatever `--permission-mode` says — passing it whenever the option is on would have left Manual gateless while still calling itself Manual. The `allow-` form grants the capability and changes nothing else. Same split VS Code makes: `if (y) push("--permission-mode", y); if (g) push("--allow-dangerously-skip-permissions")`.

`--permission-mode` is now passed for **every** mode including `bypassPermissions`, which resume needs: a session left in bypass used to fall through to `default` on restart.

The capability rides `ClientOptions` rather than being read from `AgentsOptions` inside the client, and is preserved across all three respawn paths — new session, resume, and the auto-restart replay — the way `Env` and `SsePort` already are. Losing it there would strand the pane again mid-session with nothing to explain why.

Options gains **BypassPermissions** as an initial mode, guarded: with the option off it falls back to Default, since the selector hides the mode and a session started in it could not be left. `manual` is deliberately **not** added — Anthropic's own docs call it *"an alias for 'default'"*, and Manual is already this enum's label for Default.

## Shift+Tab cycled a hand-written list

`_cyclePermissionMode` held `['default','acceptEdits','plan','auto']` while the selector, the mode list and the command palette all build from `permissionItems()` — which gates `auto` on model support and `bypassPermissions` on the VS option plus CLI policy. Being the one caller out of line, the cycle honoured none of them:

- offered `auto` to models that refuse it
- never offered Bypass, even where allowed
- **stranded anyone already in Bypass**: a mode missing from the array made `indexOf` return `-1`, and `(-1+1) % 4` landed back on `default`. Pressing Shift+Tab in the most permissive mode threw you into the most restrictive one.

It now cycles the same filtered list, with the absent-mode case handled on purpose rather than by arithmetic accident.

## A failed switch left the UI lying

Both selectors update `appState` before asking the host — good for responsiveness — and the host confirmed only on success. A failed or timed-out `set_permission_mode` wrote a warning to a log that defaults to `None` and sent nothing back: the selector kept showing the mode you picked while the CLI stayed on the old one. You believe you are in Plan, and Claude writes.

The client was never wrong (`PermissionMode` only advances after the ack) — nothing told the WebView. The host now echoes `client.PermissionMode` on both branches, so a failed switch rolls the UI back on its own. `HandleSetModel` had the same shape and is fixed the same way; `cli_model_changed` was declared but never sent or listened for, so this wires it up — with a listener that treats a null model as meaningful ("Default") rather than discarding it.

## Verification

Build green. Typecheck, lint, format clean.

In the experimental instance, with the option on:

- **Manual** → approval banner still appears *(the critical one: if it writes unasked, the wrong flag was passed)*
- **Plan** → edit blocked, plan written, approval requested via `ExitPlanMode`
- **Bypass** → stays selected, writes unasked *(was: flash and revert)*
- **Shift+Tab** → cycles only the modes the selector shows

Probes kept in the scratchpad: `probe-allow-flag.mjs` answers both questions (is `default` still gated / is the hot-swap accepted) in one pass; `probe-flag-plus-mode.mjs` demonstrates the damage the short flag does.
