### PR TITLE
fix(chat): Write is a new file, not a diff

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Helpers.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Helpers.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -26,8 +26,9 @@ namespace Corsinvest.VisualStudio.Agents.Chat.Host;
 internal sealed partial class WebViewMessageHandler
 {
     /// <summary>Project a tool's raw input JSON to the text shown when opening its IN:
-    /// the tool's main field for the verbose ones (Agent→prompt, Bash→command), else the
-    /// whole indented JSON. Mirrors the per-tool renderers on the WebView side.</summary>
+    /// the tool's main field for the verbose ones (Agent→prompt, Bash→command, Write→content),
+    /// else the whole indented JSON. Mirrors the per-tool renderers on the WebView side — a tool
+    /// missing here opens as JSON with its content escaped onto one line.</summary>
     private static string ProjectInput(string toolName, JObject input)
     {
         var field = toolName switch
@@ -35,6 +36,7 @@ internal sealed partial class WebViewMessageHandler
             "Bash" or "PowerShell" => input.Val("command"),
             "Agent" => input.Val("prompt"),
             "Skill" => input.Val("args"),
+            "Write" => input.Val("content"),
             _ => null,
         };
         return !string.IsNullOrEmpty(field) ? field : input.ToIndentedString();

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/chat.css
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/chat.css
@@ -553,6 +553,11 @@ body.sticky-user .cv-exchange > cv-message[role="user"]:first-child .cv-message.
     padding: 6px 8px;
     gap: 8px;
 }
+/* Labelless row (Write: the body IS the file, there is no in/out pair to tell apart) —
+   drop the 44px gutter instead of leaving it empty. */
+.cv-tool-body-row:not(:has(.cv-tool-body-label)) {
+    grid-template-columns: 1fr;
+}
 .cv-tool-body-row-in + .cv-tool-body-row-out {
     border-top: 1px solid var(--colorNeutralStroke1);
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/base.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/base.ts
@@ -299,7 +299,7 @@ export abstract class ToolRenderer {
     /** The standard IN/OUT body: raw input (IN) + cleaned output (OUT), each a
      *  clickable cell (opens in VS) with an inline copy button. Pass showOut=false
      *  to render IN only (e.g. Agent, whose result is just launch metadata). */
-    protected ioGrid(inText = '', showOut = true): TemplateResult {
+    protected ioGrid(inText = '', showOut = true, inLabel = 'IN'): TemplateResult {
         const outText = showOut ? cleanResult(this.host.result, this.host.status === 'error') : '';
         if (!inText && !outText) {
             return html`${nothing}`;
@@ -322,7 +322,11 @@ export abstract class ToolRenderer {
                                   style="cursor:pointer"
                                   @click=${() => this.host.openOutput('in')}
                               >
-                                  <span class="cv-tool-body-label">IN</span>
+                                  ${
+                                      inLabel
+                                          ? html`<span class="cv-tool-body-label">${inLabel}</span>`
+                                          : nothing
+                                  }
                                   <div class="cv-tool-body-cell">
                                       <pre class="cv-tool-body-pre">${preview(inText)}</pre>
                                       ${copyBtn(inText, 'in')}

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/renderers.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/renderers.ts
@@ -61,10 +61,34 @@ export class EditRenderer extends ToolRenderer {
     }
 }
 
-export class WriteRenderer extends EditRenderer {
-    override readonly name = 'Write';
+/** Write creates a file, so there is no "before" to diff against: rendered as the plain content,
+ *  not as a diff where every line is an addition. Deliberately NOT extending EditRenderer — it
+ *  would bring rowDiff() and the Accept/Reject buttons, which have nothing to act on here.
+ *  Same split VS Code makes (Edit → diff component, Write → the content). */
+export class WriteRenderer extends ToolRenderer {
+    readonly name = 'Write';
     override label(): string {
         return 'Write';
+    }
+    override header(): TemplateResult {
+        const fp = String(this.host.input.file_path ?? '');
+        const content = this.inputText();
+        // Size in the header, like Read's line range: tells a 5-line file from a 500-line one
+        // without expanding the row.
+        const lines = content ? ` (${content.split('\n').length} lines)` : '';
+        return html`${this.nameSpan('Write')}${this.detailSpan(
+            this.editFileLink(fp, html`${displayPathUi(fp)}${lines}`),
+        )}`;
+    }
+    /** The file's content, not the raw input JSON the base class would print. */
+    override inputText(): string {
+        return String(this.host.input.content ?? '');
+    }
+    /** No IN label: there is no in/out pair to tell apart, the body IS the file. And on success
+     *  the result only repeats the path already in the header ("File created successfully at: …"),
+     *  so it is dropped too — an error still gets its row, being the one thing the header can't say. */
+    override body(): TemplateResult | null {
+        return this.ioGrid(this.inputText(), this.host.status === 'error', '');
     }
 }
 


### PR DESCRIPTION
`WriteRenderer extends EditRenderer`, so a Write inherited the two-column diff with an empty `old_string`: every line marked `+` in green, the left column blank, twice the vertical space. A diff where **everything** is an addition distinguishes nothing — it only makes the content harder to read. On a several-hundred-line file it was mostly decoration.

It now extends `ToolRenderer` and shows the content as text. That also drops the Accept/Reject buttons `diffActionButtons()` brought along, which had nothing to act on: there is no prior version to reject.

VS Code makes the same split — verified in their bundle (2.1.220, `webview/index.js`): `Edit` renders a real diff component (`{original: old_string, modified: new_string}`), `Write` renders the content in a `<pre>`.

## The click opened raw JSON

Clicking the body opened the whole input payload, with the file's content escaped onto one line:

```json
{
  "file_path": "C:\\Users\\…\\commit-msg3.txt",
  "content": "fix(chat): selecting Bypass permissions did nothing\n\nPicking \"Bypass…"
}
```

The body's click doesn't go through `inputText()` — it calls `openOutput('in')`, which asks the host. And `ProjectInput` already exists for exactly this problem (`Bash`→command, `Agent`→prompt, `Skill`→args) but had no entry for `Write`, so it fell through to `input.ToIndentedString()`.

One line, in the place the codebase already solves this. Its doc comment now says what happens to a tool that isn't listed, so the next one added doesn't repeat it.

## Smaller things from the side-by-side

- **Size in the header** — `file.cs (52 lines)`, the way `Read` shows its line range. Tells a 5-line file from a 500-line one without expanding the row.
- **No `IN` label** — it earns its place when there is an in/out pair to tell apart; here the body *is* the file. The 44px gutter collapses with it, via `:has()`, so no other tool's layout changes.
- **No `OUT` row on success** — it read *"File created successfully at: `<path>`"*, repeating the header and truncating it. Failure still gets its row: that is the one case where the result says something the header cannot.

One thing deliberately **not** copied: VS Code truncates the path horizontally, we wrap it. On these paths ours is readable and theirs isn't. And our header link opens the real file in VS (`openFileAtEdit`) rather than a virtual buffer.

`MultiEditRenderer` still extends `EditRenderer`, where the diff is right — those are changes to an existing file.

## Verification

Typecheck, lint, build, format clean. Confirmed in the experimental instance: the content renders as text and clicking it opens the file content, not the payload.
