### PR TITLE
fix(chat): identify chat diffs by tool_use_id

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents.Contracts/FromWebViewDtos.cs
+++ b/src/Corsinvest.VisualStudio.Agents.Contracts/FromWebViewDtos.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -165,6 +165,7 @@ public class OpenAttachmentNotification
 /// <summary>Show the VS diff dialog for a proposed edit (open_diff_dialog).</summary>
 public class DiffDialogNotification
 {
+    public string ToolUseId { get; set; }
     public string FilePath { get; set; }
     public string OldString { get; set; }
     public string NewString { get; set; }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Cli.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Cli.cs
@@ -38,7 +38,9 @@ internal sealed partial class WebViewMessageHandler
             // sends back the chosen permission_suggestion(s) to apply.
             UpdatedPermissions = data["updatedPermissions"] as JArray,
         });
-        Ide.IdeContextService.Instance.CloseLastDiff();
+        // Close the diff opened for THIS request. It used to close "the last one", which could be
+        // a diff the user had opened themselves.
+        Ide.IdeContextService.Instance.CloseDiffFor(p.ToolUseId ?? "");
     }
 
     private void HandleSetSendSelection(JObject data, int? id)

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Cli.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Cli.cs
@@ -38,8 +38,6 @@ internal sealed partial class WebViewMessageHandler
             // sends back the chosen permission_suggestion(s) to apply.
             UpdatedPermissions = data["updatedPermissions"] as JArray,
         });
-        // Close the diff opened for THIS request. It used to close "the last one", which could be
-        // a diff the user had opened themselves.
         Ide.IdeContextService.Instance.CloseDiffFor(p.ToolUseId ?? "");
     }
 

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Open.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Open.cs
@@ -115,7 +115,8 @@ internal sealed partial class WebViewMessageHandler
     private void HandleDiffDialog(JObject data, int? id)
     {
         var p = data.ToObject<Contracts.DiffDialogNotification>();
-        _ = Ide.IdeContextService.Instance.ShowDiffAsync(p.FilePath ?? "", p.OldString ?? "", p.NewString ?? "");
+        _ = Ide.IdeContextService.Instance.ShowDiffAsync(
+            p.ToolUseId ?? "", p.FilePath ?? "", p.OldString ?? "", p.NewString ?? "");
     }
 
     private void HandleIdeOutputWindow(JObject data, int? id)

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated/DiffDialogNotification.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated/DiffDialogNotification.ts
@@ -4,6 +4,7 @@
  */
 
 export interface DiffDialogNotification {
+    toolUseId: string;
     filePath: string;
     oldString: string;
     newString: string;

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/tool-host.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/tool-host.ts
@@ -110,8 +110,6 @@ export class BridgeToolHost implements ToolHost {
         bridge.sendNotification<ExternalUrlNotification>(Msg.fromWebView.open.externalUrl, { url });
     }
 
-    // Both diff openers carry the tool_use_id: it identifies the frame, so answering this
-    // tool's permission closes THIS diff and nothing else.
     openDiffDialog(filePath: string, oldString: string, newString: string): void {
         openDiffDialog({ toolUseId: this.toolUseId, filePath, oldString, newString });
     }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/tool-host.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/tool-host.ts
@@ -110,12 +110,15 @@ export class BridgeToolHost implements ToolHost {
         bridge.sendNotification<ExternalUrlNotification>(Msg.fromWebView.open.externalUrl, { url });
     }
 
+    // Both diff openers carry the tool_use_id: it identifies the frame, so answering this
+    // tool's permission closes THIS diff and nothing else.
     openDiffDialog(filePath: string, oldString: string, newString: string): void {
-        openDiffDialog({ filePath, oldString, newString });
+        openDiffDialog({ toolUseId: this.toolUseId, filePath, oldString, newString });
     }
 
     openDiffInVs(filePath: string, oldString: string, newString: string): void {
         bridge.sendNotification<DiffDialogNotification>(Msg.fromWebView.open.diffDialog, {
+            toolUseId: this.toolUseId,
             filePath,
             oldString,
             newString,

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.Operations.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.Operations.cs
@@ -511,13 +511,14 @@ internal sealed partial class IdeContextService
     /// <summary>Show a diff between two strings (used by the WebView
     /// chat path: it has the original and proposed contents in memory).
     /// Wrapper around <see cref="OpenDiffAsync"/> with a synthetic
-    /// <c>old</c> path written to temp.</summary>
-    public Task ShowDiffAsync(string filePath, string oldContent, string newContent)
-        => IdeDiffViewer.Instance.ShowFromContentsAsync(filePath, oldContent, newContent);
+    /// <c>old</c> path written to temp. <paramref name="toolUseId"/> identifies the frame so it
+    /// can later be closed by request rather than by "whichever was last".</summary>
+    public Task ShowDiffAsync(string toolUseId, string filePath, string oldContent, string newContent)
+        => IdeDiffViewer.Instance.ShowFromContentsAsync(toolUseId, filePath, oldContent, newContent);
 
-    /// <summary>Close the last diff opened by <see cref="ShowDiffAsync"/>.
-    /// Used by the WebView chat to dismiss its preview.</summary>
-    public void CloseLastDiff() => IdeDiffViewer.Instance.CloseLast();
+    /// <summary>Close the diff opened for a given tool_use, if any. Used when its permission is
+    /// answered — a diff the user opened themselves is never touched.</summary>
+    public void CloseDiffFor(string toolUseId) => IdeDiffViewer.Instance.CloseDiffFor(toolUseId);
 
     /// <summary>Close a specific diff tab by its <paramref name="tabName"/>.
     /// Looks up the frame in <see cref="IdeDiffViewer"/>'s open-frames

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeDiffViewer.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeDiffViewer.cs
@@ -37,12 +37,6 @@ internal sealed partial class IdeDiffViewer
     public const string TabClosed = "TAB_CLOSED";
     public const string DiffRejected = "DIFF_REJECTED";
 
-    private IVsWindowFrame _lastFrame;
-    private string _lastFilePath;
-    // _openFrames key of the last ShowFromContentsAsync diff, so CloseLast
-    // can drop it from the registry (otherwise dead frames accumulate there).
-    private string _lastKey;
-
     /// <summary>Pending interactive diffs keyed by the temp "right" path.
     /// The RDT save listener and the frame-close listener look up the
     /// pending entry here and resolve its TCS. Same dictionary used by
@@ -57,6 +51,13 @@ internal sealed partial class IdeDiffViewer
     /// (or any of our own panes, whose caption used to match the old
     /// "Claude Code" substring filter).</summary>
     private readonly Dictionary<string, IVsWindowFrame> _openFrames =
+        new(StringComparer.Ordinal);
+
+    /// <summary>Diffs opened by the chat, keyed by the tool_use they preview. Separate from
+    /// <see cref="_openFrames"/>, which is keyed by tab name because close_tab addresses it that
+    /// way — the two indexes hold the same frames for different questions ("which tab?" vs
+    /// "which request?"). Answering a permission closes by request, so it needs this one.</summary>
+    private readonly Dictionary<string, IVsWindowFrame> _chatDiffs =
         new(StringComparer.Ordinal);
 
     /// <summary>Single shared RDT subscription. Created lazily on the
@@ -200,30 +201,37 @@ internal sealed partial class IdeDiffViewer
         }
     }
 
-    /// <summary>WebView-style entry point: the chat has BOTH contents in
-    /// memory. Both sides go to temp; calling twice for the same
-    /// <paramref name="filePath"/> closes the previous diff (toggle).</summary>
-    public async Task ShowFromContentsAsync(string filePath, string oldContent, string newContent)
+    /// <summary>WebView-style entry point: the chat has BOTH contents in memory. Both sides go to
+    /// temp. Clicking the same <paramref name="toolUseId"/> twice closes it (toggle); a different
+    /// one replaces it — keying this on the file path instead made two edits to the same file
+    /// indistinguishable, so the second click closed the first diff rather than showing it.</summary>
+    public async Task ShowFromContentsAsync(string toolUseId, string filePath, string oldContent, string newContent)
     {
         await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
         try
         {
-            if (_lastFrame != null && _lastFilePath == filePath) { CloseLast(); return; }
-            CloseLast();
+            if (!string.IsNullOrEmpty(toolUseId) && _chatDiffs.ContainsKey(toolUseId))
+            {
+                CloseDiffFor(toolUseId);
+                return;
+            }
+            CloseAllChatDiffs();
 
             var tempOld = WriteTemp(oldContent, Path.GetFileName(filePath) + ".old");
             var tempNew = WriteTemp(newContent, Path.GetFileName(filePath) + ".new");
             var caption = $"Claude Code — {Path.GetFileName(filePath)}";
-            _lastFrame = OpenComparison(
+            var frame = OpenComparison(
                 leftPath: tempOld, rightPath: tempNew,
                 caption: caption,
                 leftLabel: "Original", rightLabel: "Proposed",
                 rightIsTemp: true, leftIsTemp: true);
-            _lastFilePath = filePath;
-            // Track in the open-frames registry too, so closeAllDiffTabs
-            // sweeps WebView-shown diffs as well. Remember the key so
-            // CloseLast can remove it (avoids leaking dead frames).
-            if (_lastFrame != null) { _openFrames[caption] = _lastFrame; _lastKey = caption; }
+            if (frame != null)
+            {
+                // Both indexes: _openFrames so closeAllDiffTabs sweeps it, _chatDiffs so the
+                // permission answer can find it by request.
+                _openFrames[caption] = frame;
+                if (!string.IsNullOrEmpty(toolUseId)) { _chatDiffs[toolUseId] = frame; }
+            }
         }
         catch (Exception ex) { OutputWindowLogger.LogException("IdeDiffViewer.ShowFromContents", ex); }
     }
@@ -275,22 +283,40 @@ internal sealed partial class IdeDiffViewer
         }
     }
 
-    /// <summary>Close the diff opened by the last
-    /// <see cref="ShowFromContentsAsync"/>. No-op if none.</summary>
-    public void CloseLast()
+    /// <summary>Close the diff opened for a given tool_use, if any. A frame we never opened — the
+    /// user's own diff — is not in the map, so it is not found and not touched: that is the whole
+    /// point of keying by request. Finding nothing is a normal outcome, not an error: the user may
+    /// simply never have opened the diff for that edit.</summary>
+    public void CloseDiffFor(string toolUseId)
     {
         ThreadHelper.ThrowIfNotOnUIThread();
-        try
+        if (string.IsNullOrEmpty(toolUseId)) { return; }
+        if (!_chatDiffs.TryGetValue(toolUseId, out var frame)) { return; }
+        CloseChatFrame(toolUseId, frame);
+    }
+
+    /// <summary>One chat diff at a time: opening a new one closes the previous.</summary>
+    private void CloseAllChatDiffs()
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        foreach (var kv in new List<KeyValuePair<string, IVsWindowFrame>>(_chatDiffs))
         {
-            if (_lastFrame != null)
-            {
-                _lastFrame.CloseFrame((uint)__FRAMECLOSE.FRAMECLOSE_NoSave);
-                _lastFrame = null;
-                _lastFilePath = null;
-                if (_lastKey != null) { _openFrames.Remove(_lastKey); _lastKey = null; }
-            }
+            CloseChatFrame(kv.Key, kv.Value);
         }
-        catch (Exception ex) { OutputWindowLogger.LogException("IdeDiffViewer.CloseLast", ex); }
+    }
+
+    /// <summary>Close a frame and drop it from BOTH indexes — left in _openFrames it would be a
+    /// dead entry that close_all later tries to close again.</summary>
+    private void CloseChatFrame(string toolUseId, IVsWindowFrame frame)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        try { frame.CloseFrame((uint)__FRAMECLOSE.FRAMECLOSE_NoSave); }
+        catch (Exception ex) { OutputWindowLogger.LogException("IdeDiffViewer.CloseChatFrame", ex); }
+        _chatDiffs.Remove(toolUseId);
+        foreach (var kv in new List<KeyValuePair<string, IVsWindowFrame>>(_openFrames))
+        {
+            if (ReferenceEquals(kv.Value, frame)) { _openFrames.Remove(kv.Key); }
+        }
     }
 
     //  Interactive resolution plumbing

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeDiffViewer.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeDiffViewer.cs
@@ -54,9 +54,8 @@ internal sealed partial class IdeDiffViewer
         new(StringComparer.Ordinal);
 
     /// <summary>Diffs opened by the chat, keyed by the tool_use they preview. Separate from
-    /// <see cref="_openFrames"/>, which is keyed by tab name because close_tab addresses it that
-    /// way — the two indexes hold the same frames for different questions ("which tab?" vs
-    /// "which request?"). Answering a permission closes by request, so it needs this one.</summary>
+    /// <see cref="_openFrames"/> because close_tab addresses that one by tab name: the two hold
+    /// the same frames for different questions — "which tab?" vs "which request?".</summary>
     private readonly Dictionary<string, IVsWindowFrame> _chatDiffs =
         new(StringComparer.Ordinal);
 
@@ -203,8 +202,8 @@ internal sealed partial class IdeDiffViewer
 
     /// <summary>WebView-style entry point: the chat has BOTH contents in memory. Both sides go to
     /// temp. Clicking the same <paramref name="toolUseId"/> twice closes it (toggle); a different
-    /// one replaces it — keying this on the file path instead made two edits to the same file
-    /// indistinguishable, so the second click closed the first diff rather than showing it.</summary>
+    /// one replaces it — keying on the file path would make two edits to the same file the
+    /// same diff.</summary>
     public async Task ShowFromContentsAsync(string toolUseId, string filePath, string oldContent, string newContent)
     {
         await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
@@ -227,8 +226,6 @@ internal sealed partial class IdeDiffViewer
                 rightIsTemp: true, leftIsTemp: true);
             if (frame != null)
             {
-                // Both indexes: _openFrames so closeAllDiffTabs sweeps it, _chatDiffs so the
-                // permission answer can find it by request.
                 _openFrames[caption] = frame;
                 if (!string.IsNullOrEmpty(toolUseId)) { _chatDiffs[toolUseId] = frame; }
             }
@@ -283,10 +280,8 @@ internal sealed partial class IdeDiffViewer
         }
     }
 
-    /// <summary>Close the diff opened for a given tool_use, if any. A frame we never opened — the
-    /// user's own diff — is not in the map, so it is not found and not touched: that is the whole
-    /// point of keying by request. Finding nothing is a normal outcome, not an error: the user may
-    /// simply never have opened the diff for that edit.</summary>
+    /// <summary>Close the diff opened for a given tool_use. Finding none is normal, not an error:
+    /// the frame may be the user's own (never in the map) or the diff was never opened.</summary>
     public void CloseDiffFor(string toolUseId)
     {
         ThreadHelper.ThrowIfNotOnUIThread();


### PR DESCRIPTION
Two reported bugs, one cause: **the diff we open doesn't know which request it belongs to.** `IdeDiffViewer` kept `_lastFrame` / `_lastFilePath` — global state with no identity.

## Answering a permission closed someone else's diff

Open a diff of your own in VS (Git changes, a file comparison), let the chat ask for a permission, hit Accept → **your diff closes**. `HandleRespondPermission` called `CloseLastDiff()` on every answer, and `CloseLast()` closed `_lastFrame` without knowing whether it was ours or yours.

The identity was already there and simply unused. Two lines apart in the same method:

```csharp
client.RespondToToolPermission(p.ToolUseId ?? "", …);   // correlates ✓
Ide.IdeContextService.Instance.CloseLastDiff();          // correlates nothing ✗
```

…with the comment above the first one stating the principle: *"Correlate by tool_use_id so concurrent prompts each answer their own request."*

Chat diffs are now indexed by the tool_use they preview, and the permission closes that one. **A frame we never opened is not in the map, so it is not found and not touched** — the bug goes away by construction, not by a defensive check. Finding nothing is a normal outcome too: the user may never have opened the diff for that edit.

## "Open diff in VS" toggled on a *different* diff

Click the VS button on one Edit row → opens. Click it on **another** Edit row for the **same file** → closed instead of showing the new one. `ShowFromContentsAsync` decided on the file path alone, so two edits to one file were the same diff.

Same key fixes it: same id closes (the toggle people expect), a different id replaces.

## What went away

`CloseLast()`, `CloseLastDiff()`, `_lastFrame`, `_lastFilePath`, `_lastKey`. "The last one" is not an identity — it depends on order, not on what, which is the very defect being removed. It had three callers, all replaced by this work.

`_openFrames` keeps its **tab-name** key: `editor_close_tab` addresses it that way, so reindexing it would break that tool. The two maps hold the same frames for different questions — *"which tab?"* and *"which request?"* — and closing drops the frame from both, so `close_all` never meets a dead entry.

## Notes

The typecheck caught a second opener the plan had missed: `openDiffInVs` — the actual "Open diff in Visual Studio" button, i.e. the one in the bug report. Both openers now carry the id, and the generated DTO makes the field required, so a third one wouldn't compile.

The interactive diff path (`OpenAsync`, Ctrl+S to accept / close tab to reject, driven by the `editor_open_diff` MCP tool) is untouched: it resolves itself and never needed the permission to close it.

## Verification

Build green, same 164 warnings as master. Typecheck, lint, format clean.

Confirmed in the experimental instance:

- two different Edits on one file → the second VS button **shows the new diff** *(was: closed it)*
- in Manual, with a Git diff of your own open → Accept **leaves it open** *(was: closed it)*
- clicking the same row twice still toggles open/closed
