### PR TITLE
chore: drop comments that restate the code

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/bridge.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/bridge.ts
@@ -31,7 +31,6 @@ declare global {
     }
 }
 
-// Streamed channels — emit too often for a useful trace, skip them.
 // High-frequency channels excluded from bridge trace. Sourced from the generated message
 // names (same constants the host's IsNoisyChannel uses) so the two lists can't drift.
 const NOISY = new Set<string>([

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/markdown.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/markdown.ts
@@ -62,7 +62,6 @@ renderer.link = function (token: Tokens.Link): string {
         const line = ref.lines[0] ?? 0;
         return `<a class="cv-file-link" data-file="${escapeHtml(ref.path)}" data-line="${line}" title="Open in editor">${escapeHtml(text)}</a>`;
     }
-    // Other local paths render as plain text.
     return escapeHtml(text);
 };
 

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/request-types.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/request-types.ts
@@ -39,8 +39,8 @@ export class RequestType<TParams, TResult> {
     ) {}
 }
 
-// The 5 request/response pairs. requestChannel = FromWebView (TS→C#),
-// responseChannel = ToWebView (C#→TS, carries the same id back).
+// requestChannel = FromWebView (TS→C#), responseChannel = ToWebView (C#→TS, carries the same
+// id back).
 export const GetImageReq = new RequestType<GetImageRequest, GetImageResponse>(
     Msg.fromWebView.chat.getImage,
     Msg.toWebView.chat.imageData,

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/types.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/types.ts
@@ -251,7 +251,7 @@ export interface SubagentTask {
     taskId: string;
     description: string;
     toolUseId?: string;
-    recentTools: string[]; // last 3 tool names (cosa fa ora = at(-1))
+    recentTools: string[]; // last 3 tool names — at(-1) is what it is doing now
     summary?: string;
     usage: SubagentUsageDto;
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
@@ -347,12 +347,6 @@ export class CvApp extends LitElement {
             ),
         );
 
-        // subagent_loaded: full sub-agent transcript arrives (expand "show all").
-        // Replace the kept ≤3 with all children; hasMore clears (nothing hidden).
-        // Collapse re-slices to 3 — no separate cache is kept (lazy: re-fetch on re-expand).
-        // (The former subagent_loaded listener moved into the fetchSubagent().then in
-        // _toggleSubagentExpand — the correlated response drives the upsert now.)
-
         this._offs.push(
             bridge.onNotification(Msg.toWebView.chat.cleared, () => {
                 // Abort in-flight requests for the old session so their Promises reject
@@ -654,10 +648,6 @@ export class CvApp extends LitElement {
         appState.isBusy = false;
     };
 
-    /**
-     * Convert a Chat.History `messages[]` array into the backing UiEntry
-     * list. Shared by the initial load and lazy-loaded older pages.
-     */
     /** Build UiEntry[] from a replayed page of typed events (chat_history / subagent_loaded).
      *  Uses the SAME build* as the live handlers; only the placement differs (accumulate here,
      *  append/prepend in the caller). Parent-bucket + post-pass = order-independent nesting. */
@@ -1027,7 +1017,7 @@ export class CvApp extends LitElement {
         return ('uuid' in e ? e.uuid : undefined) ?? `t${e.id}`;
     }
 
-    // ---- Pure DTO → UiEntry builders, shared by the live handlers (then append)
+    // Pure DTO → UiEntry builders, shared by the live handlers (then append)
     // and the history replay (then batch/prepend). Zero side effects: no _entries,
     // no _appendEntry, no scroll, no gauge. The one construction path for both.
 
@@ -1207,17 +1197,6 @@ export class CvApp extends LitElement {
         return el.scrollHeight - el.scrollTop - el.clientHeight <= threshold;
     }
 
-    /**
-     * Prepend a page of older history while keeping the user's reading row
-     * fixed. We anchor on the DISTANCE FROM THE BOTTOM (`scrollHeight -
-     * scrollTop`), which is invariant to content growing both above (the
-     * prepended page) and below (async-rendered markdown / diff2html / lazy
-     * images) the viewport — unlike a one-shot `scrollTop += delta`, which
-     * slides as async children settle. A ResizeObserver keeps re-applying the
-     * anchor until the list height stops changing, so there are no magic frame
-     * counts. `scroll-behavior` is forced to `auto` during the operation so the
-     * imperative `scrollTop` writes aren't swallowed by the smooth animation.
-     */
     /** Shared history-page processing for both the unprompted load (chat_history_loaded) and
      *  the scroll-up response (getHistory): replay the events to UiEntry and update the paging
      *  state (currentSessionId / oldestLoadedOffset / hasMoreHistory). Returns the replayed list;
@@ -1237,6 +1216,17 @@ export class CvApp extends LitElement {
         return out;
     }
 
+    /**
+     * Prepend a page of older history while keeping the user's reading row
+     * fixed. We anchor on the DISTANCE FROM THE BOTTOM (`scrollHeight -
+     * scrollTop`), which is invariant to content growing both above (the
+     * prepended page) and below (async-rendered markdown / diff2html / lazy
+     * images) the viewport — unlike a one-shot `scrollTop += delta`, which
+     * slides as async children settle. A ResizeObserver keeps re-applying the
+     * anchor until the list height stops changing, so there are no magic frame
+     * counts. `scroll-behavior` is forced to `auto` during the operation so the
+     * imperative `scrollTop` writes aren't swallowed by the smooth animation.
+     */
     private _prependWithAnchor(older: UiEntry[]): void {
         const el = this._messagesEl;
         if (!el) {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-popover-list.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-popover-list.ts
@@ -117,8 +117,8 @@ export class CvPopoverList extends LitElement {
                 color: var(--colorNeutralForeground2);
             }
 
-            /* --- Row-content classes shared by the callers' renderRow markup (they render into
-             *     this component's shadow, so their styles must live here). --- */
+            /* Row-content classes shared by the callers' renderRow markup (they render into
+             * this component's shadow, so their styles must live here). */
             .row-icon {
                 flex-shrink: 0;
                 width: 20px;

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-prompt.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-prompt.ts
@@ -1188,7 +1188,6 @@ export class CvPrompt extends LitElement implements CommandHost {
         bridge.sendNotification(Msg.fromWebView.open.chatPane, {});
     }
 
-    /** Open the Manage Plugins dialog. */
     openPluginManager(): void {
         openPluginManagerDialog();
     }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-stats-dialog.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-stats-dialog.ts
@@ -25,7 +25,6 @@ const SCOPES: ReadonlyArray<{ value: StatsScopeDto; label: string; title: string
     { value: 'project', label: 'Project', title: 'This project' },
     { value: 'session', label: 'Current', title: 'Current chat' },
 ];
-// Short labels for the segmented control; `title` carries the full wording as a tooltip.
 const RANGES: ReadonlyArray<{ value: StatsRangeDto; label: string; title: string }> = [
     { value: 'all', label: 'All', title: 'All time' },
     { value: 'days30', label: '30d', title: 'Last 30 days' },
@@ -575,8 +574,6 @@ export class CvStatsDialog extends CvDialogBase {
         `;
     }
 
-    /** GitHub-style activity heatmap under the overview cards, via the generic cv-heatmap.
-     *  Passes each day's semantic intensity (0–4); cv-heatmap owns the color scale. */
     /** The rich per-day hover card, identical for the heatmap and the chart (mirrors the WPF
      *  StatsTooltip): full date, an activity line (messages · sessions · tools), then one coloured
      *  row per model (dot · name · tokens · share-of-day), largest first.
@@ -646,6 +643,8 @@ export class CvStatsDialog extends CvDialogBase {
         return infos;
     }
 
+    /** GitHub-style activity heatmap under the overview cards, via the generic cv-heatmap.
+     *  Passes each day's semantic intensity (0–4); cv-heatmap owns the color scale. */
     private _renderHeatmap(d: StatsResponse): TemplateResult {
         const cols = buildHeatmap(d.dailyActivity);
         if (cols.length === 0) {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/base.css
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/base.css
@@ -88,9 +88,6 @@ fluent-button[icon-only] svg {
 }
 
 
-/* cv-attach-menu is Shadow DOM: its fluent-menu-list/item styling (sizing, icon
- * centering) lives in its own static styles now. */
-
 #app {
     display: flex;
     flex-direction: column;

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/chat.css
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/chat.css
@@ -31,11 +31,6 @@
     }
 }
 
-/* Empty chat placeholder: logo + title + subtitle, gentle fade-in (no pulse —
- * a perpetual animation on an idle view distracts). Hidden once a message
- * arrives. */
-/* cv-welcome (empty-chat screen) styling now lives in its static styles (Shadow DOM). */
-
 .cv-message.user {
     display: block;
     align-self: stretch;
@@ -577,7 +572,6 @@ body.sticky-user .cv-exchange > cv-message[role="user"]:first-child .cv-message.
     padding-top: 2px;
 }
 
-/* Actions overlay on user messages */
 .cv-message.user:hover {
     background: var(--colorNeutralBackground4);
 }
@@ -773,10 +767,7 @@ cv-message:focus-within .cv-msg-actions {
     white-space: nowrap;
 }
 
-/* cv-spinner styling now lives in its static styles (Shadow DOM). */
-
-/* cv-subagent-chip styling now lives in its static styles (Shadow DOM). The
- * .cv-children / -collapsed / -more classes above belong to cv-tool-row. */
+/* The .cv-children / -collapsed / -more classes above belong to cv-tool-row. */
 
 /* Elapsed time on a running Agent row (the dot handles the spinner). */
 .cv-agent-time { margin-left: 4px; font-size: 11px; opacity: 0.7; }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/markdown.css
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/markdown.css
@@ -116,9 +116,6 @@
     background-color: rgba(150, 70, 70, 0.25);
     color: inherit;
 }
-/* cv-copy-btn: display:contents host + copied-state tint now live in its
- * static styles (Shadow DOM). Position its button via ::part(button) below. */
-
 /* Markdown code-block wrapper: <pre> + copy button as siblings. The
  * wrapper provides the relative positioning context for the copy button,
  * which sits absolute over the top-right corner of the <pre>. */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.Protocol.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.Protocol.cs
@@ -22,8 +22,6 @@ namespace Corsinvest.VisualStudio.Agents.Core.Client;
 /// </summary>
 public sealed partial class ClaudeClient
 {
-    // ----- Control protocol internals -----
-
     private static readonly TimeSpan DefaultRequestTimeout = TimeSpan.FromSeconds(10);
     private static readonly TimeSpan InitializeTimeout = TimeSpan.FromSeconds(30);
     private static readonly TimeSpan LongRunningTimeout = TimeSpan.FromMinutes(5);
@@ -105,8 +103,6 @@ public sealed partial class ClaudeClient
         // GUID suffix (first 8 hex chars) for uniqueness — just a correlation id, no crypto needed.
         return $"req_{n}_{Guid.NewGuid():N}".Substring(0, $"req_{n}_".Length + 8);
     }
-
-    // ----- Incoming dispatcher -----
 
     private void HandleLine(JObject obj)
     {

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.cs
@@ -389,8 +389,6 @@ public sealed partial class ClaudeClient : IClaudeClient
         return Task.CompletedTask;
     }
 
-    // ----- High-level session operations (encapsulate respawn vs hot-swap) -----
-
     /// <summary>Starts a new empty session in the same working directory. Kills the current process and spawns a fresh one.</summary>
     public Task NewSessionAsync()
     {
@@ -428,8 +426,7 @@ public sealed partial class ClaudeClient : IClaudeClient
 
     private void KillForRespawn() => _transport.DisposeIntentional();
 
-    // ----- Hot-swap operations -----
-
+    // Hot-swap operations — these must never respawn the process.
     public async Task SetModelAsync(string model)
     {
         await SendControlRequestAsync(ClientMessages.ControlSubtype.SetModel, new { model });
@@ -654,8 +651,6 @@ public sealed partial class ClaudeClient : IClaudeClient
 
     public Task McpToggleAsync(string serverName, bool enabled)
         => SendControlRequestAsync(ClientMessages.ControlSubtype.McpToggle, new { serverName, enabled });
-
-    // ----- Dialogue -----
 
     public void SendSelectionChanged(string text, string filePath, string fileUrl,
                                       int startLine, int startChar, int endLine, int endChar,

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClientMessages.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClientMessages.cs
@@ -8,7 +8,7 @@ namespace Corsinvest.VisualStudio.Agents.Core.Client;
 /// <summary>Wire-level type and subtype names for stream-json messages exchanged with claude.exe.</summary>
 internal static class ClientMessages
 {
-    // ----- Top-level type field on every line of stdin/stdout -----
+    // Top-level type field on every line of stdin/stdout.
     public static class Type
     {
         public const string User = "user";
@@ -29,7 +29,7 @@ internal static class ClientMessages
         public const string ConversationReset = "conversation_reset";
     }
 
-    // ----- subtype on system messages -----
+    // subtype on system messages.
     public static class SystemSubtype
     {
         public const string Init = "init";
@@ -56,7 +56,7 @@ internal static class ClientMessages
         public const string Informational = "informational";
     }
 
-    // ----- subtype on control_request messages -----
+    // subtype on control_request messages.
     public static class ControlSubtype
     {
         // Outbound (we send these to the CLI)
@@ -93,7 +93,7 @@ internal static class ClientMessages
         public const string Error = "error";
     }
 
-    // ----- JSON field names on entries written to the JSONL session files -----
+    // JSON field names on entries written to the JSONL session files.
     public static class JsonlEntryType
     {
         public const string CustomTitle = "custom-title";

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/IClaudeClient.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/IClaudeClient.cs
@@ -17,7 +17,6 @@ namespace Corsinvest.VisualStudio.Agents.Core.Client;
 /// </summary>
 public interface IClaudeClient : IDisposable
 {
-    // ----- State -----
     string WorkingDirectory { get; }
     string SessionId { get; }
     string Model { get; }
@@ -27,7 +26,6 @@ public interface IClaudeClient : IDisposable
     /// subscriptionType, apiProvider). Null until init / for 3P sessions.</summary>
     AccountInfo Account { get; }
 
-    // ----- In-process SDK MCP server (chat IDE tools) -----
     /// <summary>Serves an inbound MCP JSON-RPC message (CLI `mcp_message`) and returns
     /// the JSON-RPC response string. Host wires this to the MCP dispatcher.</summary>
     Func<string, Task<string>> McpMessageHandler { get; set; }
@@ -35,7 +33,6 @@ public interface IClaudeClient : IDisposable
     /// mcp__&lt;name&gt;__*). Null = don't register (e.g. the CLI pane uses WS instead).</summary>
     string SdkMcpServerName { get; set; }
 
-    // ----- Lifecycle -----
     /// <summary>
     /// Configures the client without launching the process. The process will be started
     /// lazily on the first <see cref="SendPrompt"/>. If a process is already running and
@@ -49,11 +46,11 @@ public interface IClaudeClient : IDisposable
     /// <summary>Gracefully stops the process.</summary>
     Task StopAsync();
 
-    // ----- Session operations (encapsulate respawn vs hot-swap) -----
+    // Session operations: these encapsulate respawn vs hot-swap.
     Task NewSessionAsync();
     Task ResumeSessionAsync(string sessionId, string permissionMode = null);
 
-    // ----- Hot-swap operations (no respawn) -----
+    // Hot-swap operations — these must never respawn the process.
     Task SetModelAsync(string model);
     Task SetPermissionModeAsync(string mode);
     Task InterruptAsync();
@@ -78,12 +75,10 @@ public interface IClaudeClient : IDisposable
     /// on demand. Empty when the CLI predates `list_models` or answers without models.</summary>
     Task<IReadOnlyList<ModelInfo>> ListModelsAsync();
 
-    // ----- MCP -----
     Task<McpStatus> GetMcpStatusAsync();
     Task McpReconnectAsync(string serverName);
     Task McpToggleAsync(string serverName, bool enabled);
 
-    // ----- Dialogue -----
     void SendSelectionChanged(string text, string filePath, string fileUrl,
                               int startLine, int startChar, int endLine, int endChar,
                               bool isEmpty);
@@ -99,7 +94,6 @@ public interface IClaudeClient : IDisposable
     /// <summary>Responds to a HookCallback event (raw payload, since hook response shape depends on event).</summary>
     void RespondToHookCallback(string requestId, object response);
 
-    // ----- Events -----
     event EventHandler<InitializedEventArgs> Initialized;
     /// <summary>The CLI startup state (model + toggles from initialize+get_settings), gathered without
     /// a user turn so the UI can seed on open. Fired once per StartProcess (open + respawn).</summary>

--- a/src/Corsinvest.VisualStudio.Agents/Core/Context/ContextUsageControl.Render.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Context/ContextUsageControl.Render.cs
@@ -112,7 +112,6 @@ public partial class ContextUsageControl
             Grid.SetColumn(seg, col++);
             bar.Children.Add(seg);
         }
-        // Rounded corners on the whole bar.
         bar.SetValue(FrameworkElement.MinHeightProperty, 8.0);
         return new Border { CornerRadius = new CornerRadius(3), ClipToBounds = true, Child = bar, Margin = new Thickness(0, 0, 0, 12) };
     }

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneControlBase.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneControlBase.cs
@@ -22,7 +22,6 @@ namespace Corsinvest.VisualStudio.Agents.Core.Panes;
 /// </summary>
 public abstract class PaneControlBase : UserControl, IPaneControl
 {
-    // --- readiness (identical in both) ---
     public bool IsReady { get; private set; }
     public event EventHandler ReadyChanged;
     protected void SetReady(bool value)
@@ -32,7 +31,6 @@ public abstract class PaneControlBase : UserControl, IPaneControl
         ReadyChanged?.Invoke(this, EventArgs.Empty);
     }
 
-    // --- multi-instance plumbing ---
     /// <summary>The pane window this control lives in (set on attach); used to close the
     /// pane and push the caption.</summary>
     protected PaneWindowBase Pane { get; private set; }
@@ -62,7 +60,6 @@ public abstract class PaneControlBase : UserControl, IPaneControl
     /// silently no-op.</summary>
     protected void RepushCaption() => Pane?.SetSessionCaption(Entry);
 
-    // --- teardown template ---
     protected bool _disposed;
 
     /// <summary>Real teardown (IPaneControl), called once by PaneWindowBase.Dispose on frame
@@ -89,7 +86,6 @@ public abstract class PaneControlBase : UserControl, IPaneControl
     /// teardown is DisposePane on frame close, so this is a deliberate no-op.</summary>
     protected static void OnUnloaded(object sender, RoutedEventArgs e) { }
 
-    // --- session title (mechanism identical to SetReady; the base owns it) ---
     /// <summary>Whether this pane exposes an editable title in the toolbar. Chat: true;
     /// CLI: false (the raw terminal doesn't surface its live session id). Default false.</summary>
     public virtual bool SupportsTitleEditing => false;
@@ -141,7 +137,6 @@ public abstract class PaneControlBase : UserControl, IPaneControl
         catch (Exception ex) { OutputWindowLogger.LogException("Pane.ShowSessionInfo", ex); }
     }
 
-    // --- IPaneControl kind-specific (implemented by the concrete controls) ---
     public abstract void NewSession();
     public abstract void LoadSession(string sessionId);
     public abstract void FocusInput();

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneToolbar.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneToolbar.xaml.cs
@@ -45,8 +45,8 @@ public partial class PaneToolbar : UserControl
         UpdateTitle();
     }
 
-    // ----- Session title (always an editable TextBox; border shows on hover/focus).
-    //       Enter or focus-loss saves a rename, Esc reverts. -----
+    // Session title: always an editable TextBox (border shows on hover/focus). Enter or
+    // focus-loss saves a rename, Esc reverts.
 
     // True while the title box has keyboard focus → don't let a background title
     // refresh (turn-end re-read) overwrite what the user is typing.
@@ -167,9 +167,6 @@ public partial class PaneToolbar : UserControl
         OpenContextMenu(BtnPanes);
     }
 
-
-    // ----- History (this pane) -----
-
     private void OnHistory_Click(object sender, RoutedEventArgs e) => ShowSessionHistory();
 
     /// <summary>Open the session picker for this pane. Public because the chat's
@@ -251,16 +248,12 @@ public partial class PaneToolbar : UserControl
     [System.Runtime.InteropServices.DllImport("user32.dll")]
     private static extern IntPtr SetFocus(IntPtr hWnd);
 
-    // ----- New session (this pane) -----
-
     // Fresh conversation in THIS pane (vs. BtnNew, which opens a new pane).
     private void OnNewSession_Click(object sender, RoutedEventArgs e)
     {
         _pane.NewSession();
         _pane.FocusInput();
     }
-
-    // ----- More (⋯): static items in XAML; pane extras inserted at top -----
 
     private void OnMore_Click(object sender, RoutedEventArgs e)
     {

--- a/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.cs
@@ -158,14 +158,6 @@ public sealed partial class SessionManager
         => line.IndexOf("\"" + key + "\":true", StringComparison.Ordinal) >= 0
         || line.IndexOf("\"" + key + "\": true", StringComparison.Ordinal) >= 0;
 
-    // Extracts text from a user message line — used as LastPrompt fallback when no last-prompt entry exists.
-    /// <summary>True only for a genuine user PROMPT (opens an exchange), not a synthetic
-    /// role:user line. The CLI writes tool_results as role:user with a content ARRAY, and
-    /// meta-injections (task-notification/system-reminder/local-command…) as role:user with
-    /// text starting '&lt;'. History paging scrolls past those to the real prompt so the oldest
-    /// exchange isn't orphaned — but bounded (see the page loop) so a long tool-only stretch
-    /// doesn't load the whole session in one page.</summary>
-    // CLI-injected entries that ride in a role:user line but aren't the user's own turn.
     /// <summary>True only for a genuine user PROMPT that OPENS an exchange — not a tool_result
     /// (content is an array) nor a CLI meta-injection (Chat.MetaInjection, the same filter used
     /// to drop them from the transcript). History paging stops on one of these so the oldest

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/CvDonut.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/CvDonut.cs
@@ -81,7 +81,6 @@ internal sealed class CvDonut : Grid
         Children.Add(row);
     }
 
-    // A legend entry: colour dot + label + share-of-total %.
     // A legend entry: colour dot + label + tokens + share-of-total %.
     private static UIElement LegendRow(Brush fill, string label, long tokens, double pct)
     {

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsChart.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsChart.cs
@@ -161,7 +161,6 @@ internal static class StatsChart
         if (days.Length == 0) { return new List<DayBar>(); }
 
         var infos = BuildDayInfos(r);
-        // One bar per day that has token data, in chronological order.
         return [.. days
             .Where(d => d.Date != null && infos.ContainsKey(d.Date))
             .OrderBy(d => d.Date, StringComparer.Ordinal)

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsService.cs
@@ -797,7 +797,6 @@ internal static class StatsService
         return info;
     }
 
-    // Fold every project of one profile.
     private static StatsTotals AggregateProfile(ClaudePaths paths, string fromDate, string toDate)
     {
         var totals = new StatsTotals();

--- a/src/Corsinvest.VisualStudio.Agents/Core/Usage/UsageProbe.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Usage/UsageProbe.cs
@@ -20,7 +20,6 @@ namespace Corsinvest.VisualStudio.Agents.Core.Usage;
 /// as the transport is up — so we send it directly without spending a turn.</summary>
 internal static class UsageProbe
 {
-    // How long to wait for the transport to come up before giving up.
     private static readonly TimeSpan StartTimeout = TimeSpan.FromSeconds(15);
 
     /// <summary>Start a CLI for <paramref name="profile"/>, read its usage, kill it. Throws on


### PR DESCRIPTION
Section banners (`// ----- Events -----`), JSDoc that repeats the method name below it, narration of the following line. The repo's own convention forbids the box-drawing separators; the rest is noise that makes the comments that *do* matter harder to spot.

## Most of it wasn't obvious — it was stale

The interesting finds weren't harmless boilerplate. They were comments that had drifted away from the code:

- **`SessionManager.cs`** — a duplicate `<summary>` describing a *different* method, plus two orphaned `//` fragments left by a refactor
- **`core/request-types.ts`** — *"the 5 request/response pairs"*. There are ten
- **`ui/styles/chat.css`** — comments describing rules that moved to Shadow DOM `static styles` and are no longer in the file. One was a full paragraph about the empty-chat screen, stranded above an unrelated `.cv-message.user` rule
- **`cv-app.ts`** — stale JSDoc documenting a `messages[]` parameter the method no longer takes

## Rewritten, not deleted

Where a banner carried real information it became prose without the dashes: the hot-swap invariant (*must never respawn the process*), which wire field each `ClientMessages` group maps to, Enter-saves/Esc-reverts on the pane title.

Two comments were **moved** onto the method they actually describe — the scroll-anchoring one in `cv-app` documents `_prependWithAnchor`, not `_applyHistoryPage`, and the heatmap one in `cv-stats-dialog`. One Italian comment in `types.ts` is now English, per CLAUDE.md.

## Scope

`Core/`, `Contracts/` and the WebView only. `Ide/` and `Mcp/` are 87 more files and get their own pass — splitting them off kept this diff reviewable.

Worth noting what *didn't* change: of 89 WebView files surveyed, 79 were left untouched. The comments in this codebase are largely load-bearing — they record traps found in the field (COM threading, CLI protocol quirks, WebView2 workarounds), and those were the explicit keep-list.

## Verification

- Mechanical check: the diff contains **zero non-comment lines**, in either direction
- Build green — `Errori: 0`, 164 warnings, same as master
- `typecheck`, `lint` (0 errors, the 7 pre-existing `no-explicit-any` warnings), `build`, `format` all clean
- SPDX headers verified intact on every touched file
