### PR TITLE
fix(chat): expanding a nested sub-agent opened its parent

### DIFF
--- a/.claude/skills/cv4vs-ci-log/SKILL.md
+++ b/.claude/skills/cv4vs-ci-log/SKILL.md
@@ -15,7 +15,7 @@ through a `success` build:
 - `tgconfig.json` was shipped inside the VSIX (23 entries instead of 22).
 
 None of them was an error in the log. They were **absences** — a line that should have been printed
-and wasn't, or an `MSB3073` buried under 147 known warnings. Reading the log by hand took five
+and wasn't, or an `MSB3073` buried under 164 known warnings. Reading the log by hand took five
 attempts and two wrong filters, because CodeQL query *names* contain the word "error".
 
 This skill reads a finished run and answers one question: did every check actually run, and did
@@ -61,7 +61,7 @@ Everything below is background and must not reach the report — except as a cou
 | CodeQL banners | `CODEQL_ACTION_CLI_VERSION_INFO`, `CODEQL_DIST`, any `CODEQL_*` |
 | CodeQL query names | `Loaded C:`, `Starting evaluation`, `Evaluation done`, `.qlx`, `.bqrs` |
 | Script echo | lines containing `^[[36;1m` |
-| Known warnings | `VSTHRD*`, `VSSDK*` (147 of them), `no-explicit-any` (7) |
+| Known warnings | `VSTHRD*`, `VSSDK*` (164 of them), `no-explicit-any` (7) |
 | Infrastructure deprecations | Node 20→24, CodeQL Action v3, `DEP0169`, `npm warn deprecated` |
 | CodeQL informational | `overlay database`, `TRAP caching` |
 
@@ -108,7 +108,7 @@ Expected checks
 Anomalies
   <job> / <step>: <line>
 
-Noise skipped: 147 VSTHRD/VSSDK, 7 ESLint, Node 20 + CodeQL v3 deprecations
+Noise skipped: 164 VSTHRD/VSSDK, 7 ESLint, Node 20 + CodeQL v3 deprecations
 ```
 
 Lead with anything `MISSING` or any anomaly — at the bottom of a report they get skimmed past, and

--- a/src/Corsinvest.VisualStudio.Agents/Chat/ContentBlockTranslator.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/ContentBlockTranslator.cs
@@ -127,7 +127,17 @@ internal static class ContentBlockTranslator
                     string text;
                     if (resultContent is JArray arr)
                     {
-                        text = string.Join("\n", arr.Where(c => c.Val("type", "") == "text").Select(c => c.Val("text", "")));
+                        var texts = arr.Where(c => c.Val("type", "") == "text").Select(c => c.Val("text", "")).ToList();
+                        // The Agent tool's result is padded with blocks addressed to the model, not
+                        // the user: a trailing handle ("agentId: … use SendMessage to continue this
+                        // agent" + counters the UI already gets structured from task_progress), and
+                        // sometimes a leading harness warning about instruction-shaped output. Both
+                        // belong to the hand-off, not to the sub-agent — the transcript the history
+                        // path reads has neither. Its report is the last block before the handle;
+                        // keeping just that one makes live and history show the same thing.
+                        text = agentId != null && texts.Count > 1
+                            ? texts[texts.Count - 2]
+                            : string.Join("\n", texts);
                     }
                     else
                     {
@@ -137,7 +147,10 @@ internal static class ContentBlockTranslator
                     send(BridgeMessages.ToWebView.Chat.ToolResult, new Contracts.ToolResultNotification
                     {
                         ToolUseId = item.Val("tool_use_id", ""),
-                        Result = TruncateLines(text, previewLines),
+                        // The sub-agent's report is a message to read whole, not a tool output to
+                        // preview — the history path shows it in full, from the transcript. Every
+                        // other tool stays capped and opens in full on demand.
+                        Result = agentId == null ? TruncateLines(text, previewLines) : text,
                         IsError = item.Val("is_error", false),
                         ParentToolUseId = parentToolUseId,
                         AgentId = agentId,

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/types.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/types.ts
@@ -254,6 +254,10 @@ export interface SubagentTask {
     recentTools: string[]; // last 3 tool names — at(-1) is what it is doing now
     summary?: string;
     usage: SubagentUsageDto;
+    /** The task that launched this one, undefined at top level. The wire carries no parent link,
+     *  so it is derived from where the launching row sits in the entry tree; it settles once that
+     *  row has arrived (the task can beat it by a few ms). */
+    parentTaskId?: string;
 }
 
 /** Status of a tool call: pending (spinner) | done (green) | error (red). */

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
@@ -200,7 +200,7 @@ export class CvApp extends LitElement {
                         // The final assistant notification carries the message time; live fallback = now.
                         streaming.timestamp = data?.timestamp ?? Date.now();
                         this._streamingMsgs.delete(parentId);
-                        this._entries = [...this._entries];
+                        this._commit(streaming);
                     } else {
                         const entry = CvApp.buildAssistantEntry(data);
                         entry.timestamp = data?.timestamp ?? Date.now();
@@ -228,7 +228,7 @@ export class CvApp extends LitElement {
                         // Auto-follow only if already near the bottom.
                         const atBottom = this._isNearBottom();
                         streaming.text += delta;
-                        this._entries = [...this._entries];
+                        this._commit(streaming);
                         if (atBottom) {
                             queueMicrotask(() => this._scrollToBottom('instant'));
                         }
@@ -269,7 +269,7 @@ export class CvApp extends LitElement {
                             entry.tokens = (entry.tokens ?? 0) + data.estimatedTokens;
                         }
                     }
-                    this._entries = [...this._entries];
+                    this._commit(entry);
                 },
             ),
         );
@@ -294,7 +294,7 @@ export class CvApp extends LitElement {
                     entry.streaming = false;
                     entry.durationMs = entry.startedAt ? Date.now() - entry.startedAt : 0;
                     this._thinkingMsgs.delete(parentId);
-                    this._entries = [...this._entries];
+                    this._commit(entry);
                 },
             ),
         );
@@ -432,13 +432,10 @@ export class CvApp extends LitElement {
                             name: data.name,
                             input: (data.input ?? {}) as Record<string, unknown>,
                         };
-                        this._entries = [...this._entries];
+                        this._commit(existing);
                         return;
                     }
-                    this._appendEntry(
-                        CvApp.buildToolEntry(data),
-                        data.parentToolUseId ?? undefined,
-                    );
+                    this._appendEntry(this.buildToolEntry(data), data.parentToolUseId ?? undefined);
                     queueMicrotask(() => this._scrollToBottom());
                 },
             ),
@@ -455,7 +452,7 @@ export class CvApp extends LitElement {
                 }
                 const atBottom = this._isNearBottom();
                 CvApp.applyToolResult(tool, data);
-                this._entries = [...this._entries];
+                this._commit(tool);
                 // The result grows the tool row (e.g. an answered ask); follow it down so the
                 // view doesn't stay stuck on the tool until the next message arrives.
                 if (atBottom) {
@@ -478,7 +475,7 @@ export class CvApp extends LitElement {
                     // Wire field is elapsedSeconds (from the host); the entry keeps it as
                     // elapsedSec (internal UI state).
                     tool.elapsedSec = data.elapsedSeconds ?? 0;
-                    this._entries = [...this._entries];
+                    this._commit(tool);
                 },
             ),
         );
@@ -554,7 +551,14 @@ export class CvApp extends LitElement {
                         usage: { totalTokens: 0, toolUses: 0, durationMs: 0 },
                     });
                     this._subagentTasks = m;
-                    appState.subagentTasks = [...m.values()];
+                    this._publishSubagentTasks(m);
+                    // The Agent row usually arrives after this, and picks the id up in
+                    // buildToolEntry; tag it here too in case it got in first.
+                    const row = d.toolUseId ? this._findTool(d.toolUseId) : null;
+                    if (row && !row.agentId) {
+                        row.agentId = d.taskId;
+                        this._commit(row);
+                    }
                 },
             ),
         );
@@ -584,7 +588,7 @@ export class CvApp extends LitElement {
                         usage: d.usage ?? prev.usage,
                     });
                     this._subagentTasks = m;
-                    appState.subagentTasks = [...m.values()];
+                    this._publishSubagentTasks(m);
                 },
             ),
         );
@@ -598,7 +602,7 @@ export class CvApp extends LitElement {
                     const m = new Map(this._subagentTasks);
                     m.delete(d.taskId);
                     this._subagentTasks = m;
-                    appState.subagentTasks = [...m.values()];
+                    this._publishSubagentTasks(m);
                 },
             ),
         );
@@ -699,7 +703,7 @@ export class CvApp extends LitElement {
                 case Msg.toWebView.chat.toolPermission: {
                     const d = ev.data as ToolPermissionNotification;
                     if (d.id && d.name) {
-                        place(CvApp.buildToolEntry(d), d.parentToolUseId);
+                        place(this.buildToolEntry(d), d.parentToolUseId);
                     }
                     break;
                 }
@@ -772,15 +776,6 @@ export class CvApp extends LitElement {
                                     c.text?.trim() === prompt
                                 ),
                         );
-                    }
-                    // Child tool rows inherit the Agent's agentId so the open-output path
-                    // routes to the sub-agent transcript file (agent-<agentId>.jsonl).
-                    if (e.agentId) {
-                        for (const c of children) {
-                            if (c.kind === 'tool') {
-                                c.agentId = e.agentId;
-                            }
-                        }
                     }
                     e.children = {
                         items: children.slice(-3),
@@ -871,11 +866,6 @@ export class CvApp extends LitElement {
                 ) {
                     return;
                 }
-                // Inherit agentId from the parent Agent entry to child tool rows,
-                // so the open-output path can route to the sub-agent transcript.
-                if (parent.agentId && entry.kind === 'tool') {
-                    (entry as UiToolEntry).agentId = parent.agentId;
-                }
                 // First child under this parent creates the children block.
                 const kids = (parent.children ??= { items: [], hasMore: false, showAll: false });
                 if (kids.showAll) {
@@ -889,7 +879,7 @@ export class CvApp extends LitElement {
                     }
                     kids.items = [...kids.items, entry].slice(-3);
                 }
-                this._entries = [...this._entries];
+                this._commit(parent);
                 return;
             }
         }
@@ -914,6 +904,8 @@ export class CvApp extends LitElement {
             //    already streamed them in → no fetch.
             //  - Show all (preview=false): mark showAll; fetch the whole transcript only if there's
             //    more than we hold (hasMore = a history preview). Live/already-full → just show all.
+            // The CLI writes the transcript as the agent runs, so a fetch mid-run returns
+            // everything that has happened so far — no need to special-case a running agent.
             const showAll = !preview;
             // Show all sets the flag; preview (chevron open) leaves it false → renderChildren shows ≤3.
             // Row open/closed is the component's own `_expanded`, not tracked here.
@@ -923,12 +915,8 @@ export class CvApp extends LitElement {
                 ? kids.items.length === 0 // history preview
                 : kids.hasMore; // Show all with more on disk than we hold
             if (!needFetch) {
-                this._entries = [...this._entries];
+                this._commit(parent);
                 return;
-            }
-            // Show all replaces with the whole transcript, so clear first (it re-adds in order).
-            if (showAll) {
-                kids.items = [];
             }
             fetchSubagent(agentId, { preview: !!preview })
                 .then((data) => {
@@ -938,19 +926,26 @@ export class CvApp extends LitElement {
                     }
                     const pk = (p.children ??= { items: [], hasMore: false, showAll: false });
                     const full = this._replayEvents(data.events ?? []);
-                    // The transcript's first user message echoes the launch prompt (already shown as
-                    // the Agent row's IN). Its events carry no parentToolUseId, so the _replayEvents
-                    // post-pass filter doesn't reach them — drop the echo here.
+                    // The transcript opens and closes with what the Agent row already shows in its
+                    // own cells: the launch prompt (IN) and the closing report (OUT, from the
+                    // tool_result the parent recorded). Both would read as duplicates among the
+                    // sub-agent's steps. Their events carry no parentToolUseId, so the
+                    // _replayEvents post-pass filter doesn't reach them — drop them here.
                     const prompt = String(p.data?.input?.prompt ?? '').trim();
-                    let list = pk.items;
+                    const report = (p.result ?? '').trim();
+                    // Show all replaces the kept ≤3 with the whole transcript, in file order.
+                    // Cleared HERE, not before the fetch: an empty list hides the Show all button
+                    // (componentHeaderActions), so the row would lose its control mid-flight.
+                    let list = showAll ? [] : pk.items;
                     for (const child of full) {
-                        if (
-                            prompt &&
-                            child.kind === 'text' &&
-                            child.role === 'user' &&
-                            child.text?.trim() === prompt
-                        ) {
-                            continue;
+                        if (child.kind === 'text') {
+                            const t = child.text?.trim();
+                            if (prompt && child.role === 'user' && t === prompt) {
+                                continue;
+                            }
+                            if (report && child.role === 'assistant' && t === report) {
+                                continue;
+                            }
                         }
                         list = this._upsertChild(list, child);
                     }
@@ -959,7 +954,7 @@ export class CvApp extends LitElement {
                     pk.items = preview ? list.slice(-3) : list;
                     pk.hasMore = preview ? list.length > 3 : false;
                     pk.showAll = !preview;
-                    this._entries = [...this._entries];
+                    this._commit(p);
                 })
                 .catch(() => {
                     /* timeout / not found — leave the kept children as-is */
@@ -971,7 +966,7 @@ export class CvApp extends LitElement {
             kids.showAll = false;
             kids.hasMore = kids.items.length > 3;
         }
-        this._entries = [...this._entries];
+        this._commit(parent);
     };
 
     /** A compact separator's <details> opened for the first time: fetch the summary lazily
@@ -1082,9 +1077,13 @@ export class CvApp extends LitElement {
         };
     }
 
-    /** ToolPermissionNotification → a pending tool row. */
-    private static buildToolEntry(d: ToolPermissionNotification): UiToolEntry {
+    /** ToolPermissionNotification → a pending tool row. An Agent row takes the id of the
+     *  sub-agent it launched: task_started names both ids and lands just before this, whereas
+     *  the result only carries agentId in history — live it is null, and without it the row has
+     *  no transcript to open. */
+    private buildToolEntry(d: ToolPermissionNotification): UiToolEntry {
         const input = (d.input ?? {}) as Record<string, unknown>;
+        const spawned = [...this._subagentTasks.values()].find((t) => t.toolUseId === d.id);
         return {
             kind: 'tool',
             id: ++_entryIdSeq,
@@ -1094,6 +1093,7 @@ export class CvApp extends LitElement {
             result: '',
             fullLineCount: 0,
             elapsedSec: 0,
+            agentId: spawned?.taskId,
         };
     }
 
@@ -1120,6 +1120,93 @@ export class CvApp extends LitElement {
         return next;
     }
 
+    /** Publish the running sub-agents, each linked to the task that launched it and ordered so a
+     *  child follows its parent. The wire has no parent link — task_started only names the Agent
+     *  row — so it is read off the tree, where nesting is the row's position. Recomputed on every
+     *  update: a task can beat its own row by a few ms and would otherwise stay flat. */
+    private _publishSubagentTasks(tasks: Map<string, SubagentTask>): void {
+        // The Agent row enclosing the one that launched this task. Descends carrying the current
+        // container, so finding the row IS finding its parent.
+        const enclosingToolOf = (toolUseId?: string): string | undefined => {
+            if (!toolUseId) {
+                return undefined;
+            }
+            const walk = (list: UiEntry[], container?: string): string | undefined | false => {
+                for (const e of list) {
+                    if (e.kind !== 'tool') {
+                        continue;
+                    }
+                    if (e.toolUseId === toolUseId) {
+                        return container;
+                    }
+                    if (e.children?.items.length) {
+                        const hit = walk(e.children.items, e.toolUseId);
+                        if (hit !== false) {
+                            return hit;
+                        }
+                    }
+                }
+                return false; // not in this branch — distinct from "found, no container"
+            };
+            const hit = walk(this._entries);
+            return hit === false ? undefined : hit;
+        };
+
+        const byToolUse = new Map<string, string>();
+        for (const t of tasks.values()) {
+            if (t.toolUseId) {
+                byToolUse.set(t.toolUseId, t.taskId);
+            }
+        }
+        const linked = [...tasks.values()].map((t) => {
+            const parentTool = enclosingToolOf(t.toolUseId);
+            return { ...t, parentTaskId: parentTool ? byToolUse.get(parentTool) : undefined };
+        });
+        // Depth-first: every task is emitted right after its parent, so the indent in the popover
+        // lines up with who launched whom.
+        const childrenOf = (parentTaskId?: string) =>
+            linked.filter((t) => t.parentTaskId === parentTaskId);
+        const flatten = (parentTaskId?: string): SubagentTask[] =>
+            childrenOf(parentTaskId).flatMap((t) => [t, ...flatten(t.taskId)]);
+        const ordered = flatten(undefined);
+        // A task whose parent is gone (ended while the child runs) would vanish from the walk —
+        // keep it, at top level.
+        const seen = new Set(ordered.map((t) => t.taskId));
+        appState.subagentTasks = [...ordered, ...linked.filter((t) => !seen.has(t.taskId))];
+    }
+
+    /** Commit an in-place change to `target` so it reaches the DOM. Lit diffs properties by
+     *  identity and requestUpdate() only refreshes the component it's called on, so mutating a
+     *  row nested inside an Agent leaves every array ABOVE it untouched: the ancestors skip their
+     *  update and their renderChildren never re-reads the new list. Re-identifying just the
+     *  arrays on the path is Lit's prescribed top-down immutable flow, and leaves rows that
+     *  didn't change alone. Pass the row itself, or the Agent holding it for a text child. */
+    private _commit(target?: UiEntry | null): void {
+        if (target) {
+            // Walk down re-identifying each children array that leads to the target; returns
+            // true for the branch that holds it, so the copy happens on the way back up.
+            const refresh = (list: UiEntry[]): boolean => {
+                let found = false;
+                for (const e of list) {
+                    if (e.kind !== 'tool' || !e.children?.items.length) {
+                        continue;
+                    }
+                    if (e.children.items.includes(target) || refresh(e.children.items)) {
+                        e.children = { ...e.children, items: [...e.children.items] };
+                        found = true;
+                    }
+                }
+                return found;
+            };
+            // render() maps _exchanges, not _entries: the entry objects are shared between the
+            // two, so only the group array holding the path needs a new identity.
+            this._exchanges = this._exchanges.map((g) =>
+                g.includes(target) || refresh(g) ? [...g] : g,
+            );
+        }
+        this._entries = [...this._entries];
+    }
+
     /** Find a tool entry by toolUseId, walking nested children. */
     private _findTool(toolUseId: string): UiToolEntry | null {
         const visit = (list: UiEntry[]): UiToolEntry | null => {
@@ -1142,7 +1229,8 @@ export class CvApp extends LitElement {
         return visit(this._entries);
     }
 
-    /** Locate an Agent tool entry by its sub-agent id (set on the Agent record). */
+    /** Locate an Agent tool entry by the sub-agent it spawned. Unique: only an Agent row carries
+     *  an agentId, and it names the transcript that row alone opened. */
     private _findToolByAgentId(agentId: string): UiToolEntry | null {
         const visit = (list: UiEntry[]): UiToolEntry | null => {
             for (const e of list) {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
@@ -340,8 +340,11 @@ export class CvApp extends LitElement {
                         for (const m of this._streamingMsgs.values()) {
                             m.streaming = false;
                         }
+                        // Keyed by parentToolUseId, so a sub-agent's message is nested and needs
+                        // its path refreshed like any other nested change. Before the clear —
+                        // after it there is nothing left to pass.
+                        this._commit(...this._streamingMsgs.values());
                         this._streamingMsgs.clear();
-                        this._entries = [...this._entries];
                     }
                 },
             ),
@@ -987,7 +990,7 @@ export class CvApp extends LitElement {
             .then((res) => {
                 entry.summary = res.summary;
                 entry.loaded = true;
-                this._entries = [...this._entries];
+                this._commit(entry);
             })
             .catch(() => {
                 /* timeout / not found — leave "Loading…" as-is */
@@ -1181,17 +1184,21 @@ export class CvApp extends LitElement {
      *  update and their renderChildren never re-reads the new list. Re-identifying just the
      *  arrays on the path is Lit's prescribed top-down immutable flow, and leaves rows that
      *  didn't change alone. Pass the row itself, or the Agent holding it for a text child. */
-    private _commit(target?: UiEntry | null): void {
-        if (target) {
-            // Walk down re-identifying each children array that leads to the target; returns
-            // true for the branch that holds it, so the copy happens on the way back up.
+    private _commit(...targets: Array<UiEntry | null | undefined>): void {
+        const wanted = targets.filter(Boolean) as UiEntry[];
+        if (wanted.length > 0) {
+            // Walk down re-identifying each children array that leads to a target; returns
+            // true for the branch that holds one, so the copy happens on the way back up.
             const refresh = (list: UiEntry[]): boolean => {
                 let found = false;
                 for (const e of list) {
                     if (e.kind !== 'tool' || !e.children?.items.length) {
                         continue;
                     }
-                    if (e.children.items.includes(target) || refresh(e.children.items)) {
+                    if (
+                        e.children.items.some((c) => wanted.includes(c)) ||
+                        refresh(e.children.items)
+                    ) {
                         e.children = { ...e.children, items: [...e.children.items] };
                         found = true;
                     }
@@ -1201,7 +1208,7 @@ export class CvApp extends LitElement {
             // render() maps _exchanges, not _entries: the entry objects are shared between the
             // two, so only the group array holding the path needs a new identity.
             this._exchanges = this._exchanges.map((g) =>
-                g.includes(target) || refresh(g) ? [...g] : g,
+                g.some((e) => wanted.includes(e)) || refresh(g) ? [...g] : g,
             );
         }
         this._entries = [...this._entries];

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
@@ -552,12 +552,12 @@ export class CvApp extends LitElement {
                     });
                     this._subagentTasks = m;
                     this._publishSubagentTasks(m);
-                    // The Agent row usually arrives after this, and picks the id up in
-                    // buildToolEntry; tag it here too in case it got in first.
+                    // The Agent row is usually created after this and reads the id in
+                    // buildToolEntry; when it got in first, tag it here. No _commit — the row
+                    // was just appended, so its render is still pending and will read the id.
                     const row = d.toolUseId ? this._findTool(d.toolUseId) : null;
                     if (row && !row.agentId) {
                         row.agentId = d.taskId;
-                        this._commit(row);
                     }
                 },
             ),

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-subagent-chip.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-subagent-chip.ts
@@ -169,6 +169,26 @@ export class CvSubagentChip extends LitElement {
         }
     };
 
+    /** Left padding in px per task, walking up parentTaskId. The list arrives ordered depth-first,
+     *  so a child always sits under its parent and the indent reads as the tree. */
+    private _indents(): Map<string, number> {
+        const byId = new Map(this.tasks.map((t) => [t.taskId, t]));
+        const out = new Map<string, number>();
+        for (const t of this.tasks) {
+            let depth = 0;
+            let cur: SubagentTask | undefined = t;
+            // The cap is a cycle guard: parentTaskId is derived, not guaranteed acyclic.
+            while (cur?.parentTaskId && depth < 8) {
+                cur = byId.get(cur.parentTaskId);
+                if (cur) {
+                    depth++;
+                }
+            }
+            out.set(t.taskId, depth * 16);
+        }
+        return out;
+    }
+
     /** The CLI prefixes the description with its own status verb ("Running Run build…"), which
      *  the live dot already conveys — strip it so the row reads as the task itself. */
     private _desc(t: SubagentTask): string {
@@ -203,6 +223,7 @@ export class CvSubagentChip extends LitElement {
         if (n === 0) {
             return nothing;
         }
+        const indents = this._indents();
         return html`<fluent-button
                 id="cv-subagent-chip-btn"
                 class="chip"
@@ -236,10 +257,17 @@ export class CvSubagentChip extends LitElement {
                 </div>
                 ${this.tasks.map(
                     (t) =>
-                        html`<div class="row">
+                        html`<div
+                            class="row"
+                            style=${
+                                indents.get(t.taskId)
+                                    ? `padding-left:${indents.get(t.taskId)}px`
+                                    : ''
+                            }
+                        >
                             <span class="cv-dot active"></span>
                             <div class="main">
-                                <div class="desc">${this._desc(t)}</div>
+                                <div class="desc" title=${this._desc(t)}>${this._desc(t)}</div>
                                 <div class="meta">
                                     <span class="now"
                                         >${t.recentTools[t.recentTools.length - 1] ?? '—'}</span

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-tool-row.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-tool-row.ts
@@ -37,8 +37,11 @@ export class CvToolRow extends LitElement implements ToolRowState {
     @property({ attribute: false }) childItems: UiEntry[] = [];
     /** More children exist on disk beyond the (≤3) kept in `childItems`. */
     @property({ type: Boolean }) hasMore = false;
-    /** Sub-agent id (Agent tool), used to fetch the full transcript on expand. */
+    /** The sub-agent this row SPAWNED (Agent tool only) — the transcript to fetch on expand. */
     @property() agentId = '';
+    /** The transcript this row LIVES in, i.e. which agent-<id>.jsonl holds its untruncated
+     *  text. Empty in the main session. A nested Agent row has both, and they differ. */
+    @property() containerAgentId = '';
     /** Show-all — owned by cv-app (UiToolEntry.showAll), read here. True shows the full
      *  list; false shows the last 3. NOT the row open/closed state (that's `_expanded`). */
     @property({ type: Boolean }) showAll = false;
@@ -154,7 +157,10 @@ export class CvToolRow extends LitElement implements ToolRowState {
     }
 
     /** Nested child rows/messages (Agent tool today; generic). Lit-owned, so it stays in the
-     *  component; the host exposes it to the renderer via renderChildren(). */
+     *  component; the host exposes it to the renderer via renderChildren().
+     *  Children live in the transcript we opened (or, for a plain tool, in ours) — that is what
+     *  routes their open-output. Their own agentId stays untouched: a nested Agent row must keep
+     *  the transcript IT opens, or expanding it would reopen us. */
     renderChildren() {
         if (this.childItems.length === 0) {
             return nothing;
@@ -199,7 +205,8 @@ export class CvToolRow extends LitElement implements ToolRowState {
                                     .elapsedSec=${c.elapsedSec}
                                     .childItems=${c.children?.items ?? []}
                                     .fullLineCount=${c.fullLineCount}
-                                    .agentId=${this.agentId}
+                                    .agentId=${c.agentId ?? ''}
+                                    .containerAgentId=${this.agentId || this.containerAgentId}
                                     .hasMore=${c.children?.hasMore ?? false}
                                     .showAll=${c.children?.showAll ?? false}
                                 ></cv-tool-row>`,

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/chat.css
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/chat.css
@@ -378,6 +378,18 @@ body.sticky-user .cv-exchange > cv-message[role="user"]:first-child .cv-message.
     margin: 0;
     padding: 0;
 }
+/* Prose cell (Agent IN/OUT): .md brings the typography, this only caps the height so a long
+   report scrolls inside the row instead of pushing the nested rows off screen. The caps differ
+   because the two cells are read differently: IN is the prompt the user just wrote, OUT is the
+   answer they opened the row for. */
+.cv-tool-body-md {
+    font-size: 12px;
+    max-height: 220px;
+    overflow-y: auto;
+}
+.cv-tool-body-row-in .cv-tool-body-md {
+    max-height: 110px;
+}
 .cv-tool-body-error {
     margin-top: 4px;
     padding: 6px 8px;

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/base.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/base.ts
@@ -25,6 +25,7 @@ import '../components/cv-copy-btn';
 import '../components/cv-diff-preview';
 import { cleanResult, previewText, formatElapsed } from './tool-host';
 import { state as appState } from '../../core/state';
+import { renderMarkdown } from '../../core/markdown';
 import type { ToolHost } from './types';
 
 export abstract class ToolRenderer {
@@ -296,16 +297,42 @@ export abstract class ToolRenderer {
         >`;
     }
 
-    /** The standard IN/OUT body: raw input (IN) + cleaned output (OUT), each a
-     *  clickable cell (opens in VS) with an inline copy button. Pass showOut=false
-     *  to render IN only (e.g. Agent, whose result is just launch metadata). */
-    protected ioGrid(inText = '', showOut = true, inLabel = 'IN'): TemplateResult {
+    /** A path:line reference inside a markdown cell opens that file, not the cell's own temp doc —
+     *  the enclosing row listens for clicks too, so this has to stop the event from reaching it. */
+    protected onMarkdownClick = (e: Event): void => {
+        const a = (e.target as HTMLElement | null)?.closest('a.cv-file-link');
+        const file = a?.getAttribute('data-file');
+        if (!file) {
+            return;
+        }
+        e.preventDefault();
+        e.stopPropagation();
+        const line = Number(a?.getAttribute('data-line') ?? 0) || 0;
+        this.host.openFile(file, line, Number(a?.getAttribute('data-line-end') ?? 0) || line);
+    };
+
+    /** The standard IN/OUT body: raw input (IN) + cleaned output (OUT), each a clickable cell
+     *  (opens in VS) with an inline copy button. `showOut: false` renders IN only; `inLabel: ''`
+     *  drops the IN label; `markdown: true` is for cells holding prose instead of tool output. */
+    protected ioGrid(
+        inText = '',
+        opts: { showOut?: boolean; inLabel?: string; markdown?: boolean } = {},
+    ): TemplateResult {
+        const { showOut = true, inLabel = 'IN', markdown = false } = opts;
         const outText = showOut ? cleanResult(this.host.result, this.host.status === 'error') : '';
         if (!inText && !outText) {
             return html`${nothing}`;
         }
-        const preview = (t: string) =>
-            previewText(t, appState.ui.previewLines, this.host.expanded, this.host.clipsOutput);
+        // Markdown cells hold prose (an Agent's prompt and its report), so they render as rich
+        // text and in full: clipping a paragraph mid-sentence hides the answer, and the preview
+        // cap exists for tool output — logs, file dumps — where the first lines are enough.
+        const cell = (t: string, extra = '') =>
+            markdown
+                ? html`<div class="cv-tool-body-md md" @click=${this.onMarkdownClick}>
+                      ${unsafeHTML(renderMarkdown(t))}
+                  </div>`
+                : html`<pre class="cv-tool-body-pre ${extra}">
+${previewText(t, appState.ui.previewLines, this.host.expanded, this.host.clipsOutput)}</pre>`;
         const copyBtn = (text: string, slot: 'in' | 'out') =>
             html`<cv-copy-btn
                 class="cv-tool-body-copy-btn cv-tool-body-copy-${slot}"
@@ -328,8 +355,7 @@ export abstract class ToolRenderer {
                                           : nothing
                                   }
                                   <div class="cv-tool-body-cell">
-                                      <pre class="cv-tool-body-pre">${preview(inText)}</pre>
-                                      ${copyBtn(inText, 'in')}
+                                      ${cell(inText)}${copyBtn(inText, 'in')}
                                   </div>
                               </div>`
                             : nothing
@@ -345,9 +371,7 @@ export abstract class ToolRenderer {
                                       >${this.host.status === 'error' ? 'ERR' : 'OUT'}</span
                                   >
                                   <div class="cv-tool-body-cell">
-                                      <pre class="cv-tool-body-pre cv-tool-body-result">
-${preview(outText)}</pre>
-                                      ${copyBtn(outText, 'out')}
+                                      ${cell(outText, 'cv-tool-body-result')}${copyBtn(outText, 'out')}
                                   </div>
                               </div>`
                             : nothing

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/renderers.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/renderers.ts
@@ -88,7 +88,10 @@ export class WriteRenderer extends ToolRenderer {
      *  the result only repeats the path already in the header ("File created successfully at: …"),
      *  so it is dropped too — an error still gets its row, being the one thing the header can't say. */
     override body(): TemplateResult | null {
-        return this.ioGrid(this.inputText(), this.host.status === 'error', '');
+        return this.ioGrid(this.inputText(), {
+            showOut: this.host.status === 'error',
+            inLabel: '',
+        });
     }
 }
 
@@ -222,17 +225,18 @@ export class AgentRenderer extends ToolRenderer {
             : nothing;
         return html`${this.nameSpan('Agent')}${this.detailSpan(desc)}${badge}`;
     }
-    // IN = the sub-agent prompt (like the VS Code extension). The tool's own
-    // result is just launch metadata ("Async agent launched… do not mention"),
-    // so there is no OUT — the real work shows as the nested sub-agent rows below.
+    // IN = the sub-agent prompt (like the VS Code extension).
     override inputText(): string {
         return String(
             this.host.input.prompt ?? this.host.input.message ?? this.host.input.description ?? '',
         );
     }
+    // IN is the prompt we handed the sub-agent, OUT the report it handed back — prose on both
+    // sides, so they render as markdown and in full. Keeping the pair on the row itself puts the
+    // answer next to the question, where it is readable without scrolling past the nested rows.
     override body(): TemplateResult | null {
         const inText = this.inputText();
-        return inText ? this.ioGrid(inText, false) : null;
+        return inText ? this.ioGrid(inText, { markdown: true }) : null;
     }
     // A sub-agent's whole transcript (prompt IN + nested rows) is a lot of content, so the
     // row starts collapsed even when previews are on — dot + description until expanded — and

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/tool-host.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/tool-host.ts
@@ -55,6 +55,9 @@ export class BridgeToolHost implements ToolHost {
     get agentId(): string {
         return this.row.agentId ?? '';
     }
+    get containerAgentId(): string {
+        return this.row.containerAgentId ?? '';
+    }
     get expanded(): boolean {
         return this.row.expanded;
     }
@@ -140,7 +143,7 @@ export class BridgeToolHost implements ToolHost {
             toolUseId: this.toolUseId,
             title: `[${this.name || 'Tool'}] ${detail.slice(0, 60)}`,
             which,
-            agentId: this.agentId,
+            agentId: this.containerAgentId,
             // Lets the host project the IN to the tool's main field (Agent→prompt,
             // Bash→command) instead of dumping the whole input JSON.
             toolName: this.name,
@@ -152,7 +155,7 @@ export class BridgeToolHost implements ToolHost {
             toolUseId: this.toolUseId,
             title: `[${this.name || 'Tool'}] error`,
             which: 'out',
-            agentId: this.agentId,
+            agentId: this.containerAgentId,
         });
     }
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/types.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/types.ts
@@ -20,9 +20,11 @@ export interface ToolRowState {
     readonly fullLineCount: number;
     readonly elapsedSec: number;
     readonly expanded: boolean;
-    /** Sub-agent id when this row is a child of an Agent — routes open-output to the
-     *  sub-agent transcript. Empty for top-level tools. */
+    /** The sub-agent this row SPAWNED (Agent tool only) — the transcript to fetch on expand. */
     readonly agentId: string;
+    /** The transcript this row LIVES in — routes open-output to that agent-<id>.jsonl.
+     *  Empty in the main session. */
+    readonly containerAgentId: string;
     /** How many nested children this row holds (Agent tool today). 0 for a normal tool. */
     readonly childCount: number;
     clipsOutput: boolean;

--- a/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.History.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.History.cs
@@ -290,7 +290,8 @@ public sealed partial class SessionManager
         ref string lastUserText,
         List<JToken> messagesNewestFirst,
         ref int parsedLines,
-        ref int skippedLines)
+        ref int skippedLines,
+        SubagentContext subagent = null)
     {
         JObject obj;
         try { obj = JObject.Parse(line); }
@@ -325,10 +326,15 @@ public sealed partial class SessionManager
                     // lift it too so HistoryReplay's ValTimestampMs finds it (the "x ago" on replay).
                     var ts = obj.Val("timestamp");
                     if (!string.IsNullOrEmpty(ts)) { msg["timestamp"] = ts; }
-                    // The Agent tool's result carries the sub-agent id at the line's
-                    // top-level toolUseResult.agentId (camelCase on disk). Lift it onto
-                    // the message so HistoryReplay can nest the sub-agent's tools.
-                    var agentId = ToolUseResultField(obj, "agentId");
+                    // The sub-agent this line SPAWNED, so the WebView knows which transcript to
+                    // open when the row is expanded. The main JSONL carries it inline on
+                    // toolUseResult.agentId (camelCase on disk); a transcript has no
+                    // toolUseResult at all, so there the link survives only in the sidecars.
+                    // Not to be confused with the line's own top-level agentId, which names the
+                    // file the line sits in — a different question, answered WebView-side.
+                    var agentId = subagent != null
+                        ? subagent.SpawnedAgentIdFor(msg)
+                        : ToolUseResultField(obj, "agentId");
                     if (!string.IsNullOrEmpty(agentId)) { msg["agentId"] = agentId; }
                     messagesNewestFirst.Add(msg);
                 }
@@ -489,7 +495,7 @@ public sealed partial class SessionManager
     /// <summary>Build a HistoryPage from a flat array of JSONL lines (chronological order).
     /// Used by ReadSubagentHistory (forward pass). ReadHistoryRaw keeps its own reverse-scan
     /// paginated reader — its algorithm can't share this simple forward builder.</summary>
-    private static HistoryPage BuildHistoryPageFromLines(string[] lines)
+    private static HistoryPage BuildHistoryPageFromLines(string[] lines, SubagentContext subagent = null)
     {
         var messages = new List<JToken>();
         string lastUserText = null;
@@ -497,9 +503,59 @@ public sealed partial class SessionManager
         foreach (var line in lines)
         {
             if (string.IsNullOrWhiteSpace(line)) { continue; }
-            TryProcessHistoryLine(line, null, ref lastUserText, messages, ref parsed, ref skipped);
+            TryProcessHistoryLine(line, null, ref lastUserText, messages, ref parsed, ref skipped, subagent);
         }
         return new HistoryPage { Messages = new JArray(messages) };
+    }
+
+    /// <summary>Which Agent row spawned which sub-agent, keyed by tool_use_id. A transcript can't
+    /// say it: toolUseResult — where the main JSONL carries the id inline — never appears in one,
+    /// so the link survives only in the subagents/*.meta.json sidecars the CLI writes beside it.
+    /// ~150 bytes each, read once per page.</summary>
+    private sealed class SubagentContext
+    {
+        private readonly Dictionary<string, string> _spawnedByToolUse =
+            new Dictionary<string, string>(StringComparer.Ordinal);
+
+        /// <summary>A session with no sidecars yields an empty map, which leaves every row exactly
+        /// as it was before this existed.</summary>
+        public static SubagentContext Read(string dir)
+        {
+            var ctx = new SubagentContext();
+            if (!Directory.Exists(dir)) { return ctx; }
+            try
+            {
+                foreach (var file in Directory.EnumerateFiles(dir, "agent-*.meta.json"))
+                {
+                    try
+                    {
+                        var toolUseId = JObject.Parse(File.ReadAllText(file, Encoding.UTF8)).Val("toolUseId");
+                        if (string.IsNullOrEmpty(toolUseId)) { continue; }
+                        // The agentId IS the file name (agent-<id>.meta.json) — the same convention
+                        // the transcript uses, so it can be opened straight away.
+                        var name = Path.GetFileNameWithoutExtension(file);   // agent-<id>.meta
+                        ctx._spawnedByToolUse[toolUseId] =
+                            name.Substring("agent-".Length, name.Length - "agent-".Length - ".meta".Length);
+                    }
+                    catch { /* a malformed sidecar only costs that one link */ }
+                }
+            }
+            catch (Exception ex) { OutputWindowLogger.LogException("SessionManager.SubagentContext.Read", ex); }
+            return ctx;
+        }
+
+        /// <summary>The sub-agent a message spawned, or null when it isn't an Agent tool_result.
+        /// Keyed by the tool_use_id it answers.</summary>
+        public string SpawnedAgentIdFor(JToken msg)
+        {
+            if (_spawnedByToolUse.Count == 0 || msg?["content"] is not JArray blocks) { return null; }
+            foreach (var b in blocks)
+            {
+                if (b.Val("type", "") != "tool_result") { continue; }
+                return _spawnedByToolUse.TryGetValue(b.Val("tool_use_id", ""), out var spawned) ? spawned : null;
+            }
+            return null;
+        }
     }
 
     /// <summary>Read a sub-agent transcript (subagents/agent-<agentId>.jsonl) into a HistoryPage,
@@ -507,11 +563,13 @@ public sealed partial class SessionManager
     /// tools); true reads the whole file. Missing file or empty agentId → empty page (no throw).</summary>
     public HistoryPage ReadSubagentHistory(string sessionId, string agentId, bool fullFile)
     {
+        using var _ = OutputWindowLogger.PerfSpan($"ReadSubagentHistory({agentId}, full={fullFile})");
         // agentId/sessionId reach here from the WebView; reject anything that isn't a
         // plain id token so they can't traverse out of the session dir into the path.
         if (!IsSafePathToken(sessionId) || !IsSafePathToken(agentId)) { return new HistoryPage { Messages = [] }; }
         var folder = FolderFor();
-        var path = Path.Combine(folder, sessionId, "subagents", $"agent-{agentId}.jsonl");
+        var dir = Path.Combine(folder, sessionId, "subagents");
+        var path = Path.Combine(dir, $"agent-{agentId}.jsonl");
         if (!File.Exists(path)) { return new HistoryPage { Messages = [] }; }
         try
         {
@@ -529,7 +587,7 @@ public sealed partial class SessionManager
                 var size = fs.Length;
                 lines = ReadWindow(fs, Math.Max(0, size - LiteReadWindowBytes), dropPartialFirstLine: size > LiteReadWindowBytes);
             }
-            return BuildHistoryPageFromLines(lines);
+            return BuildHistoryPageFromLines(lines, SubagentContext.Read(dir));
         }
         catch (Exception ex) { OutputWindowLogger.LogException("SessionManager.ReadSubagentHistory", ex); return new HistoryPage { Messages = [] }; }
     }


### PR DESCRIPTION
Expanding a sub-agent nested inside another one reopened the parent's transcript instead of its own. Fixing it surfaced three more defects on the same path.

## The reported bug

`cv-tool-row` passed its own `agentId` down to every child, overwriting a nested Agent row's. The toggle then asked for the parent — already in memory, so nothing was fetched and nothing changed on screen.

## What it uncovered

**Live never had an `agentId` at all.** C# read it from `toolUseResult.agentId`, a field the CLI only writes to the `.jsonl`; on the wire it is null. The first level worked by accident — its children stream in with `parentToolUseId`, so it had content without needing a fetch. A nested agent's tools are not streamed at all, so its row stayed empty with no way to load it. The id *is* on the wire, just elsewhere: `task_started` carries both `task_id` (the agentId) and `tool_use_id`, so the Agent row takes it at creation.

**History could not find it either.** Transcripts carry no `toolUseResult.agentId`; only the `agent-<id>.meta.json` sidecars map `toolUseId` to `agentId`. Read once per request and applied while replaying.

**Nested changes never reached the DOM.** `render()` maps `_exchanges`, while every update replaced `_entries`. The defect predates this branch and was masked by `_rebuildExchanges` firing on each top-level append — invisible until a nested row updated on its own. `_commit` now re-identifies the path down to the changed entry. The same fix applies to a compact separator's summary, which showed "Loading…" forever, and to clearing `streaming` at end of turn.

**The sub-agents popover ordered tasks by arrival**, so with two agents running in parallel a child could render under the wrong parent. Each task now links to the one that launched it, read off the entry tree, and the list is emitted depth-first so the indent matches who launched whom.

## Also here

The Agent tool's result is a report to read, not a tool output to preview: rendered as markdown, untruncated, with its file links opening in VS. The CLI pads that result with blocks addressed to the model — a trailing handle, sometimes a leading harness warning — which are dropped.

## Verification

Manual, in the experimental instance: chains three levels deep, two agents in parallel each with a nested child, expansion at every level, live and history. No test project exists; the gate is a green MSBuild plus typecheck / lint / format.

Known limit: a third-level agent whose containing row has never been expanded appears in the popover without indentation. The CLI does not send the parent chain — `task_started` has no parent field, verified on the full untruncated wire line — and live does not read from disk. Expanding the row settles it.
