### PR TITLE
fix(panes): clicking into a pane left its OS toast on screen

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneAttentionService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneAttentionService.cs
@@ -5,6 +5,7 @@
 
 using Corsinvest.VisualStudio.Agents.Helpers;
 using Microsoft.VisualStudio.Shell;
+using System;
 using System.Collections.Generic;
 
 namespace Corsinvest.VisualStudio.Agents.Core.Panes;
@@ -18,6 +19,10 @@ internal static class PaneAttentionService
 {
     // One live InfoBar per pane (by SeqNo) so repeated events replace instead of stacking.
     private static readonly Dictionary<int, PaneAttentionInfoBar> _bars = [];
+
+    // The toast raised alongside it, same key. To the user the two are one notification, so they
+    // are taken down together — the balloon outlives its InfoBar otherwise, until it expires.
+    private static readonly Dictionary<int, IDisposable> _toasts = [];
 
     /// <summary>A pane is asking for input (blocking). Always notifies (unless the pane is active):
     /// the model is waiting on the user.</summary>
@@ -53,18 +58,49 @@ internal static class PaneAttentionService
         // the user regardless of layout; clicking it brings VS to the front and activates the pane.
         if (!vsForeground)
         {
-            Win32Focus.ShowToast("Claude Code", message, onClick: () => entry.ActivateAction?.Invoke());
+            DismissToast(seq);
+            IDisposable toast = null;
+            toast = Win32Focus.ShowToast(
+                "Claude Code",
+                message,
+                onClick: () => entry.ActivateAction?.Invoke(),
+                // Only drop our own handle: a replacement toast may already hold the slot.
+                onClosed: () =>
+                {
+                    if (_toasts.TryGetValue(seq, out var held) && ReferenceEquals(held, toast))
+                    {
+                        _toasts.Remove(seq);
+                    }
+                });
+            if (toast != null) { _toasts[seq] = toast; }
         }
     }
 
-    /// <summary>Dismiss any attention InfoBar for this pane (e.g. the user answered / navigated to it).</summary>
+    /// <summary>Dismiss this pane's attention notification — InfoBar and toast alike (e.g. the user
+    /// answered / navigated to it).</summary>
     public static void Clear(PaneEntry entry)
     {
         ThreadHelper.ThrowIfNotOnUIThread();
-        if (entry != null && _bars.TryGetValue(entry.SeqNo, out var bar))
+        if (entry == null) { return; }
+        if (_bars.TryGetValue(entry.SeqNo, out var bar))
         {
             bar.Close();
             _bars.Remove(entry.SeqNo);
+        }
+        DismissToast(entry.SeqNo);
+    }
+
+    private static void DismissToast(int seq)
+    {
+        if (!_toasts.TryGetValue(seq, out var toast)) { return; }
+        _toasts.Remove(seq);
+        try
+        {
+            toast.Dispose();
+        }
+        catch (Exception ex)
+        {
+            OutputWindowLogger.Warn($"[panes] toast dismiss failed for #{seq}: {ex.Message}");
         }
     }
 }

--- a/src/Corsinvest.VisualStudio.Agents/Helpers/Win32Focus.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Helpers/Win32Focus.cs
@@ -6,6 +6,7 @@
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
 
@@ -48,8 +49,13 @@ internal static class Win32Focus
     /// <summary>Raise an OS balloon toast. A short-lived tray NotifyIcon shows the balloon then
     /// disposes itself — no persistent tray icon. Appears above everything regardless of window
     /// layout, so it reaches the user in another app / tile / monitor. Clicking it brings VS to the
-    /// front and runs <paramref name="onClick"/> (e.g. activate the owning pane).</summary>
-    public static void ShowToast(string title, string message, Action onClick = null)
+    /// front and runs <paramref name="onClick"/> (e.g. activate the owning pane).
+    /// Returns a handle that takes the balloon down early (the user dealt with the pane before it
+    /// expired), or null when the toast could not be shown. Disposing it twice is harmless.
+    /// <paramref name="onClosed"/> runs when the balloon goes away on its own, so the caller can
+    /// drop the handle it is holding.</summary>
+    public static IDisposable ShowToast(string title, string message, Action onClick = null,
+                                        Action onClosed = null)
     {
         ThreadHelper.ThrowIfNotOnUIThread();
         try
@@ -61,22 +67,107 @@ internal static class Win32Focus
                 BalloonTipTitle = title,
                 BalloonTipText = message,
             };
-            // Dispose the tray icon once the balloon has run its course (or the user closes it).
-            void cleanup(object s, EventArgs e) => icon.Dispose();
-            icon.BalloonTipClosed += cleanup;
+            var handle = new ToastHandle(icon);
+            // Drop the tray icon once the balloon has run its course (or the user closes it).
+            icon.BalloonTipClosed += (s, e) =>
+            {
+                handle.Dispose();
+                onClosed?.Invoke();
+            };
             icon.BalloonTipClicked += (s, e) =>
             {
                 // Bring VS to the front, then let the caller go to the right pane.
                 var main = MainWindowHandle();
                 if (main != IntPtr.Zero) { SetForegroundWindow(main); }
                 onClick?.Invoke();
-                icon.Dispose();
+                handle.Dispose();
+                onClosed?.Invoke();
             };
             icon.ShowBalloonTip(5000);
+            return handle;
         }
         catch (Exception ex)
         {
             OutputWindowLogger.LogException("Win32Focus.ShowToast", ex);
+            return null;
+        }
+    }
+
+    private const int NIM_MODIFY = 0x00000001;
+    private const int NIF_INFO = 0x00000010;
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct NOTIFYICONDATA
+    {
+        public int cbSize;
+        public IntPtr hWnd;
+        public int uID;
+        public int uFlags;
+        public int uCallbackMessage;
+        public IntPtr hIcon;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)] public string szTip;
+        public int dwState;
+        public int dwStateMask;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 256)] public string szInfo;
+        public int uTimeoutOrVersion;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 64)] public string szInfoTitle;
+        public int dwInfoFlags;
+    }
+
+    [DllImport("shell32.dll", CharSet = CharSet.Unicode)]
+    private static extern bool Shell_NotifyIcon(int dwMessage, ref NOTIFYICONDATA data);
+
+    /// <summary>Takes a balloon that is still on screen down. Neither deleting the icon nor the
+    /// Visible off/on round-trip retracts one already showing (both verified on Windows 11 — it
+    /// stays until it times out). What does is the documented call: NIM_MODIFY carrying NIF_INFO
+    /// with an empty szInfo, which the shell reads as "no balloon for this icon". WinForms keeps
+    /// the hWnd/uID that call needs private, hence the reflection — field names are the .NET
+    /// Framework ones (`window`, `id`), which differ from .NET Core's.</summary>
+    private sealed class ToastHandle(NotifyIcon icon) : IDisposable
+    {
+        private bool _done;
+
+        public void Dispose()
+        {
+            if (_done) { return; }
+            _done = true;
+            RetractBalloon();
+            icon.Dispose();
+        }
+
+        private void RetractBalloon()
+        {
+            try
+            {
+                const BindingFlags flags = BindingFlags.NonPublic | BindingFlags.Instance;
+                var type = typeof(NotifyIcon);
+                var window = type.GetField("window", flags)?.GetValue(icon) as NativeWindow;
+                var id = type.GetField("id", flags)?.GetValue(icon);
+                if (window == null || window.Handle == IntPtr.Zero || id == null)
+                {
+                    OutputWindowLogger.Warn("[panes] balloon retract skipped: NotifyIcon internals not found");
+                    return;
+                }
+
+                var data = new NOTIFYICONDATA
+                {
+                    cbSize = Marshal.SizeOf(typeof(NOTIFYICONDATA)),
+                    hWnd = window.Handle,
+                    uID = (int)id,
+                    uFlags = NIF_INFO,
+                    szInfo = string.Empty,
+                    szInfoTitle = string.Empty,
+                    szTip = string.Empty,
+                };
+                if (!Shell_NotifyIcon(NIM_MODIFY, ref data))
+                {
+                    OutputWindowLogger.Warn("[panes] balloon retract refused by the shell");
+                }
+            }
+            catch (Exception ex)
+            {
+                OutputWindowLogger.Warn($"[panes] balloon retract failed: {ex.Message}");
+            }
         }
     }
 }


### PR DESCRIPTION
A pane asking for attention raises two things: an InfoBar in VS, and — when VS hasn't got the OS focus — a balloon toast, which is layout-proof and reaches the user in another app or on another monitor.

Clicking into the pane cleared only the InfoBar. The balloon stayed until it timed out, so the notification the user had just dealt with was still on screen, half of it gone and half of it not.

## The fix

`ShowToast` returns a handle now, and `PaneAttentionService` keeps it per `SeqNo` next to the InfoBar. `Clear` takes both down; a replacement toast revokes the one it replaces; the handle is dropped when the balloon closes on its own, comparing references so a newer toast is not evicted by an older one's callback.

## Retracting the balloon

Disposing the `NotifyIcon` does not retract a balloon that is already showing, and neither does toggling `Visible` off and on — the trick usually quoted for this. Both were tried on Windows 11 and the balloon outlived them.

What works is the call Microsoft documents for it: `Shell_NotifyIcon(NIM_MODIFY)` with `NIF_INFO` and an empty `szInfo`, which the shell reads as "no balloon for this icon". WinForms keeps the `hWnd` and `uID` that call needs private, so they are read by reflection.

The field names matter: on .NET Framework they are `window` and `id`, where .NET Core has `_window` and `_id`. This project targets 4.8, so the Framework names are the right ones — checked against the GAC assembly rather than assumed, along with `NotifyIconNativeWindow` deriving from `NativeWindow` and `id` being an `Int32`. A `Warn` fires if the fields ever stop resolving, so the retraction cannot quietly stop working after a runtime update.

## Verification

Manual, in the experimental instance: prompt sent, focus moved to another app, turn finished → toast appears; clicking into the pane takes the balloon down together with the InfoBar. Before this change the balloon stayed. MSBuild green.
