### PR TITLE
style(chat): reclaim width in the tool body, and highlight written files

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/lang.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/lang.ts
@@ -2,9 +2,11 @@
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
-// Language alias maps for highlight.js. Used by both the markdown code
-// block renderer (fence label → language) and the diff renderer (file
-// extension → language for the patch header).
+import hljs from 'highlight.js';
+
+// Language alias maps for highlight.js. Used by the markdown code block renderer (fence label →
+// language), the diff renderer (file extension → language for the patch header) and Write's body
+// (the file's own extension).
 //
 // Only entries that hljs does NOT recognise natively. hljs already covers:
 // bash/sh/zsh, json/jsonc/json5, xml/html/xhtml/plist/svg, dockerfile,
@@ -33,6 +35,7 @@ export const ALIASES: Record<string, string> = {
     manifest: 'xml',
     appxmanifest: 'xml',
     slnx: 'xml',
+    vsct: 'xml',
 
     // Razor / WPF / Xamarin / WinUI / Avalonia / Android markup (XML).
     // cshtml/razor would need highlightjs-cshtml-razor (separate package);
@@ -59,7 +62,10 @@ export const ALIASES: Record<string, string> = {
     containerfile: 'dockerfile',
     compose: 'yaml',
 
-    // Shell variants not covered by hljs (bash already covers sh/zsh)
+    // Shell variants not covered by hljs (bash already covers sh/zsh; ps1 is native,
+    // the module/manifest extensions are not)
+    psm1: 'powershell',
+    psd1: 'powershell',
     ksh: 'bash',
     fish: 'bash',
     bashrc: 'bash',
@@ -102,4 +108,21 @@ export const FILE_NAME_LANGS: Record<string, string> = {
 export function resolveLang(label: string | undefined | null): string {
     const lc = (label ?? '').toLowerCase();
     return ALIASES[lc] || lc;
+}
+
+/**
+ * Highlight `code` as `label` (a fence label or a file extension), returning HTML.
+ * Null when the language is unknown or hljs throws — the caller then renders the text
+ * plain, which is what an unhighlighted file should look like anyway.
+ */
+export function highlightCode(code: string, label: string | undefined | null): string | null {
+    const language = resolveLang(label);
+    if (!language || !hljs.getLanguage(language)) {
+        return null;
+    }
+    try {
+        return hljs.highlight(code, { language, ignoreIllegals: true }).value;
+    } catch {
+        return null;
+    }
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/markdown.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/markdown.ts
@@ -7,8 +7,7 @@
 
 import { marked, type Renderer, type Tokens } from 'marked';
 import DOMPurify from 'dompurify';
-import hljs from 'highlight.js';
-import { resolveLang } from './lang';
+import { resolveLang, highlightCode } from './lang';
 import { escapeHtml } from './html';
 import { findFileRefs, firstRefHint, parseFileRef } from './file-links';
 
@@ -26,19 +25,13 @@ const renderer = new marked.Renderer() as Renderer & {
 renderer.code = function (token: Tokens.Code): string {
     const code = token.text ?? '';
     const lang = resolveLang(token.lang ?? '');
-    const language = hljs.getLanguage(lang) ? lang : 'plaintext';
-    let highlighted: string;
-    try {
-        highlighted =
-            language !== 'plaintext' ? hljs.highlight(code, { language }).value : escapeHtml(code);
-    } catch {
-        highlighted = escapeHtml(code);
-    }
+    const hl = highlightCode(code, lang);
+    const language = hl !== null ? lang : 'plaintext';
     // <cv-copy-btn> is upgraded on innerHTML parse; it reads its text from
     // the sibling <pre> at click time (`frompre` attribute).
     return (
         `<div class="cv-md-code-wrap">` +
-        `<pre><code class="hljs language-${language}">${highlighted}</code></pre>` +
+        `<pre><code class="hljs language-${language}">${hl ?? escapeHtml(code)}</code></pre>` +
         `<cv-copy-btn class="cv-md-copy-btn" frompre="1" title="Copy"></cv-copy-btn>` +
         `</div>`
     );

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/permission-modes.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/permission-modes.ts
@@ -7,7 +7,9 @@
 
 import HandRight20Regular from '@fluentui/svg-icons/icons/hand_right_20_regular.svg';
 import Code20Regular from '@fluentui/svg-icons/icons/code_20_regular.svg';
-import ClipboardTask20Regular from '@fluentui/svg-icons/icons/clipboard_task_20_regular.svg';
+// A bullet list, not the task clipboard: that one carries a tick, and at 16px next to the
+// menu's own selection check it reads as a second checkbox saying the opposite.
+import ClipboardBulletListLtr20Regular from '@fluentui/svg-icons/icons/clipboard_bullet_list_ltr_20_regular.svg';
 import Flash20Regular from '@fluentui/svg-icons/icons/flash_20_regular.svg';
 import ShieldDismiss20Regular from '@fluentui/svg-icons/icons/shield_dismiss_20_regular.svg';
 import { state as appState } from './state';
@@ -43,7 +45,7 @@ export const PERMISSION_ITEMS: PermissionItem[] = [
         value: 'plan',
         label: 'Plan',
         description: 'Reads and explores freely, then proposes a plan — no file is changed',
-        icon: ClipboardTask20Regular,
+        icon: ClipboardBulletListLtr20Regular,
     },
     {
         value: 'auto',

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/chat.css
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/chat.css
@@ -553,17 +553,15 @@ body.sticky-user .cv-exchange > cv-message[role="user"]:first-child .cv-message.
     overflow: hidden;
     background: var(--colorNeutralBackground1);
 }
+/* IN/OUT label above its block, not beside it: a 44px gutter plus its gap cost every row 52px
+   of width for two three-letter words, and width is what a docked tool window hasn't got —
+   height scrolls. A labelless row (Write: the body IS the file) needs no special case now. */
 .cv-tool-body-row {
     display: grid;
-    grid-template-columns: 44px 1fr;
+    grid-template-columns: 1fr;
     align-items: start;
     padding: 6px 8px;
-    gap: 8px;
-}
-/* Labelless row (Write: the body IS the file, there is no in/out pair to tell apart) —
-   drop the 44px gutter instead of leaving it empty. */
-.cv-tool-body-row:not(:has(.cv-tool-body-label)) {
-    grid-template-columns: 1fr;
+    gap: 2px;
 }
 .cv-tool-body-row-in + .cv-tool-body-row-out {
     border-top: 1px solid var(--colorNeutralStroke1);
@@ -581,7 +579,7 @@ body.sticky-user .cv-exchange > cv-message[role="user"]:first-child .cv-message.
     font-weight: 600;
     color: var(--colorNeutralForeground3);
     letter-spacing: 0.05em;
-    padding-top: 2px;
+    opacity: 0.75;
 }
 
 .cv-message.user:hover {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/chat.css
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/chat.css
@@ -277,10 +277,10 @@ body.sticky-user .cv-exchange > cv-message[role="user"]:first-child .cv-message.
 }
 /* A tool row's nested children (Agent / Skill transcript today) — indented and
  * separated by a left border to show the parent/child relationship. */
+/* No rule down the side: the indent already says "these belong to the row above". */
 .cv-children {
     margin-left: 16px;
     padding-left: 8px;
-    border-left: 2px solid var(--colorNeutralStroke1);
     margin-top: 2px;
 }
 /* Only the scrolling area is capped — the actions footer is a sibling below it (outside this box)
@@ -360,9 +360,10 @@ body.sticky-user .cv-exchange > cv-message[role="user"]:first-child .cv-message.
     position: relative;
 }
 
+/* The content already sits in .cv-tool-body-box, which is bordered on all four sides —
+   a rule down the left of it only doubles up. */
 .cv-tool-body {
     margin: 2px 0 4px 0;
-    border-left: 2px solid var(--colorNeutralStroke1);
     padding-left: 8px;
     overflow-x: hidden;
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/base.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/base.ts
@@ -26,6 +26,7 @@ import '../components/cv-diff-preview';
 import { cleanResult, previewText, formatElapsed } from './tool-host';
 import { state as appState } from '../../core/state';
 import { renderMarkdown } from '../../core/markdown';
+import { highlightCode } from '../../core/lang';
 import type { ToolHost } from './types';
 
 export abstract class ToolRenderer {
@@ -316,9 +317,14 @@ export abstract class ToolRenderer {
      *  drops the IN label; `markdown: true` is for cells holding prose instead of tool output. */
     protected ioGrid(
         inText = '',
-        opts: { showOut?: boolean; inLabel?: string; markdown?: boolean } = {},
+        opts: {
+            showOut?: boolean;
+            inLabel?: string;
+            markdown?: boolean;
+            highlightAs?: string;
+        } = {},
     ): TemplateResult {
-        const { showOut = true, inLabel = 'IN', markdown = false } = opts;
+        const { showOut = true, inLabel = 'IN', markdown = false, highlightAs = '' } = opts;
         const outText = showOut ? cleanResult(this.host.result, this.host.status === 'error') : '';
         if (!inText && !outText) {
             return html`${nothing}`;
@@ -326,13 +332,27 @@ export abstract class ToolRenderer {
         // Markdown cells hold prose (an Agent's prompt and its report), so they render as rich
         // text and in full: clipping a paragraph mid-sentence hides the answer, and the preview
         // cap exists for tool output — logs, file dumps — where the first lines are enough.
-        const cell = (t: string, extra = '') =>
-            markdown
-                ? html`<div class="cv-tool-body-md md" @click=${this.onMarkdownClick}>
-                      ${unsafeHTML(renderMarkdown(t))}
-                  </div>`
-                : html`<pre class="cv-tool-body-pre ${extra}">
-${previewText(t, appState.ui.previewLines, this.host.expanded, this.host.clipsOutput)}</pre>`;
+        const cell = (t: string, extra = '') => {
+            if (markdown) {
+                return html`<div class="cv-tool-body-md md" @click=${this.onMarkdownClick}>
+                    ${unsafeHTML(renderMarkdown(t))}
+                </div>`;
+            }
+            const shown = previewText(
+                t,
+                appState.ui.previewLines,
+                this.host.expanded,
+                this.host.clipsOutput,
+            );
+            // Highlight only what a caller asked to (Write's file content): tool OUTPUT is logs
+            // and dumps, where colouring guesses at structure that isn't there.
+            const code = highlightAs ? highlightCode(shown, highlightAs) : null;
+            return code
+                ? html`<pre
+                      class="cv-tool-body-pre hljs ${extra}"
+                  ><code>${unsafeHTML(code)}</code></pre>`
+                : html`<pre class="cv-tool-body-pre ${extra}">${shown}</pre>`;
+        };
         const copyBtn = (text: string, slot: 'in' | 'out') =>
             html`<cv-copy-btn
                 class="cv-tool-body-copy-btn cv-tool-body-copy-${slot}"

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/renderers.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/renderers.ts
@@ -86,11 +86,19 @@ export class WriteRenderer extends ToolRenderer {
     }
     /** No IN label: there is no in/out pair to tell apart, the body IS the file. And on success
      *  the result only repeats the path already in the header ("File created successfully at: …"),
-     *  so it is dropped too — an error still gets its row, being the one thing the header can't say. */
+     *  so it is dropped too — an error still gets its row, being the one thing the header can't say.
+     *  The body is a file, so it is highlighted as one, by its own extension. */
     override body(): TemplateResult | null {
+        const name =
+            String(this.host.input.file_path ?? '')
+                .split(/[\\/]/)
+                .pop() ?? '';
+        const dot = name.lastIndexOf('.');
         return this.ioGrid(this.inputText(), {
             showOut: this.host.status === 'error',
             inLabel: '',
+            // Extension only when there is one: an extensionless name is not its own language.
+            highlightAs: dot > 0 ? name.slice(dot + 1) : '',
         });
     }
 }


### PR DESCRIPTION
Four independent tweaks to the chat WebView, each addressing something that
read wrong in a docked tool window.

### Stack the IN/OUT label above its block
The 44px gutter plus its gap cost every tool body row 52px of width for two
three-letter words. Width is what a docked tool window hasn't got — height
scrolls. Nested under an Agent the row is indented already. The labelless-row
rule goes with it: with a single column there is no empty gutter to special-case.

### Plan's icon
`clipboard_task` carries a tick. At 16px, across from the menu's own selection
check, it read as a second checkbox saying the opposite of the real one.
`clipboard_bullet_list_ltr` says the same thing without the contradiction.

### Highlight a written file by its extension
Write's body is a file but rendered as a plain `<pre>`. hljs is already bundled
and `lang.ts` already maps the extensions the .NET world uses — the logic was
just buried inside the markdown renderer. It moves to `lang.ts` as
`highlightCode`, so the fence renderer and Write share it, and `ioGrid` takes a
`highlightAs` option.

Opt-in per caller: tool OUTPUT stays plain, since colouring logs and dumps
invents a structure that isn't there. `vsct`, `psm1` and `psd1` join the alias
map — extensions this repo uses that hljs did not resolve on its own.

### Drop the vertical rules
A tool body sits inside `.cv-tool-body-box`, bordered on all four sides — a rule
down its left doubled up. An Agent's children are indented 24px, which already
reads as belonging to the row above. The slash-result rule stays: that output
has neither box nor indent, so the rule is the only thing setting it apart.

## Verification
`npm run typecheck` clean, `format:check` clean, `lint` 0 errors (7 pre-existing
`no-explicit-any` warnings in files this branch doesn't touch).

WebView-only change — no C# touched. Not yet exercised in the Exp instance;
the visual result wants a look there before merge.
