### PR TITLE
fix(chat): a sub-agent that failed left its Agent row green

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
@@ -602,6 +602,18 @@ export class CvApp extends LitElement {
                     if (!d?.taskId || !this._subagentTasks.has(d.taskId)) {
                         return;
                     }
+                    // The Agent row's own tool_result is launch metadata — it arrives at once and is
+                    // never is_error, so the row would settle green however the sub-agent ended. This
+                    // notification carries the real outcome; 'stopped' is a cancellation the user
+                    // asked for, so only 'failed' turns the row red.
+                    const toolUseId = this._subagentTasks.get(d.taskId)?.toolUseId;
+                    if (d.status === 'failed' && toolUseId) {
+                        const row = this._findTool(toolUseId);
+                        if (row) {
+                            row.status = 'error';
+                            this._commit(row);
+                        }
+                    }
                     const m = new Map(this._subagentTasks);
                     m.delete(d.taskId);
                     this._subagentTasks = m;


### PR DESCRIPTION
A sub-agent that died on an API error (a 529, say) looked exactly like one
that succeeded: green dot, then the chip quietly left the list.

## Why the row was green

The Agent row settles from its own `tool_result`, and for the Agent tool that
result is launch metadata — it arrives the moment the sub-agent starts and is
never `is_error`. `renderers.ts` already notes this and keeps the dot spinning
off `subagentTasks` instead. But when the task left that map the row fell back
to its own status, which said "done" regardless of how the agent ended.

## What carries the truth

`task_notification`. The CLI emits it from AgentTool's `finally` block for
every foreground agent:

```ts
status: syncAgentError ? 'failed' : wasAborted ? 'stopped' : 'completed'
```

The SDK types it as a required field (`sdk.d.ts`: `'completed' | 'failed' |
'stopped'`), the Zod schema validates the same three values, and the emitter's
own comment names the intended consumers — "VS Code subagent panel". We already
received it and dropped it on the floor, as the VS Code extension does.

## The change

Twelve lines in the `subagentEnded` handler, before the task is removed from
the map (the ordering matters — that's where `toolUseId` comes from, so no DTO
or host change is needed):

- `failed` → find the Agent row (`_findTool` walks nested children) and set its
  status to `error`. The dot turns red and the "Show error details" button
  appears; both already existed for every other failing tool.
- `stopped` → nothing. That's a cancellation the user asked for, and the
  transcript already says so — same reasoning as `isUserAbort` for a stopped
  turn.

## Scope

Only the row's outcome. The error text still lives in the sub-agent's report
inside the collapsed box; no notice is added at the top, since unlike a failed
turn there is a row here to colour.

Applies to foreground agents — a backgrounded agent settles through a different
path that this doesn't touch. If `failed` never arrives the branch simply never
runs, so there is no regression either way.

## Verification

`typecheck`, `format:check` and `lint` clean (7 pre-existing `no-explicit-any`
warnings in files this branch doesn't touch).

Not yet exercised against a real failing sub-agent in the Exp instance — the
red dot wants a look there before this is trusted.
