### PR TITLE
style(chat): an error notice drew its red rail twice

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/chat.css
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/chat.css
@@ -697,8 +697,11 @@ cv-message:focus-within .cv-msg-actions {
 .cv-message.slash-result.error {
     color: var(--colorPaletteRedForeground1);
 }
+/* .cv-message.error below already gives the box its own red rail; the rail on the pre
+ * would sit just inside it, two red lines saying the same thing. */
 .cv-message.slash-result.error pre {
-    border-left-color: var(--colorPaletteRedForeground1);
+    border-left: none;
+    padding-left: 0;
 }
 
 .cv-message.error {


### PR DESCRIPTION
A failed turn drew two red vertical rails a few pixels apart.

## Why

The notice renders as `role: 'slash-result'` with `isError`, so the div carries
both classes and both rules apply:

- `.cv-message.error` — a 3px red rail, plus the tinted background and the
  8px/12px padding that make it read as an error box.
- `.cv-message.slash-result pre` — a 2px rail on the block inside, red via
  `.slash-result.error pre`.

Confirmed in the WebView's own devtools: the div computed `2.66667px solid
rgb(227,125,128)` (3px scaled for DPI) and the `pre` inside it another `2px
solid rgb(227,125,128)`. Neither rule knows about the other — one was written
for error bubbles, the other for slash-command output, and this entry is both.

## The change

The `pre`'s rail goes, along with its `padding-left`. The box rail is the one
that stays: it comes with the background and padding that carry the meaning,
while the `pre`'s exists for a plain slash-result, which has neither box nor
tint. The text now aligns with the box instead of being indented twice.

A non-error slash-result is untouched — it keeps its single grey rail, which is
the only thing setting that output apart.

## Verification

Built and checked in the Exp instance against a real 529: the second rail is
gone. `npm run build` clean.
