### PR TITLE
fix(chat): a file link VS won't open now says so

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Helpers.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Helpers.cs
@@ -188,12 +188,42 @@ internal sealed partial class WebViewMessageHandler
         Contracts.StatsRangeDto.Days7 => Core.Stats.StatsRange.Last7d,
         _ => Core.Stats.StatsRange.All,
     };
+    /// <summary>Open <paramref name="filePath"/> in the text editor, or null when VS won't.
+    /// A file the solution itself owns — the .csproj of a loaded project — is not the shell's to
+    /// hand out: it throws "already open as a project or solution", and asking for the primary
+    /// view instead throws the same. There is no view kind that opens it, so that case is reported
+    /// rather than retried; unloading the project to satisfy a chat link would be worse than the
+    /// link not working.</summary>
+    private static Window OpenWindow(DTE2 dte, string filePath)
+    {
+        try
+        {
+            return dte?.ItemOperations?.OpenFile(filePath, Constants.vsViewKindTextView);
+        }
+        catch (ArgumentException ex)
+        {
+            // What VS throws for a project/solution file; the caller's Warn already names the file.
+            OutputWindowLogger.Debug(() => $"[chat] OpenFile refused: {ex.Message}");
+            return null;
+        }
+        catch (Exception ex)
+        {
+            OutputWindowLogger.LogException("OpenFileInEditor", ex);
+            return null;
+        }
+    }
+
     private static async Task OpenFileInEditorAsync(string filePath, int startLine, int endLine)
     {
         await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
         var dte = Package.GetGlobalService(typeof(DTE)) as DTE2;
-        var window = dte?.ItemOperations?.OpenFile(filePath, Constants.vsViewKindTextView);
-        if (window == null) { return; }
+        var window = OpenWindow(dte, filePath);
+        if (window == null)
+        {
+            // A click on a file link that does nothing at all reads as a broken link, so say why.
+            OutputWindowLogger.Warn($"[chat] Visual Studio would not open '{filePath}' — it refuses a file already open as a project or solution (its own .csproj, say)");
+            return;
+        }
         window.Activate();
         if (startLine <= 0) { return; }
         await Task.Yield();


### PR DESCRIPTION
Clicking a `.csproj` link in the chat did nothing at all — no editor, no
error, nothing in the log. Finding out why took a TRACE log showing the
request arrive and no reply, then reading three files.

## What was happening

`DTE.ItemOperations.OpenFile` throws `ArgumentException` for a file the
solution already owns:

> Impossibile aprire il documento '…\Corsinvest.VisualStudio.Agents.csproj' in
> un editor. Il documento è già aperto come progetto o soluzione.

The call was unguarded, so the exception unwound into the fire-and-forget
task, and the `if (window == null) return;` below it was silent anyway. Two
ways to say nothing, stacked.

## The change

Guard the call, and warn on the way out with the file and the reason. The
known `ArgumentException` goes to Debug so it doesn't read as a crash;
anything else still gets `LogException`.

Retrying with `vsViewKindPrimary` was tried first and throws the same — there
is no view kind that opens a loaded project's own file — so that path was
dropped rather than left in as a second failing call. Unloading the project to
satisfy a chat link would be a worse answer than the link not working.

## Verification

Built, and exercised in the Exp instance against the link that started this.
Before:

```
TRACE [bridge ← web] open_ide_file {...Corsinvest.VisualStudio.Agents.csproj...}
TRACE [bridge → web] ui_blur_input
```

After:

```
DEBUG [chat] OpenFile refused: Impossibile aprire il documento '…' …
WARN  [chat] Visual Studio would not open '…' — it refuses a file already
      open as a project or solution (its own .csproj, say)
```

The click still opens nothing, because nothing can. It is no longer a mystery.
