### PR TITLE
refactor(chat): the composer on one row, in Fluent's own controls

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.cs
@@ -208,7 +208,10 @@ internal sealed partial class WebViewBridge(Microsoft.Web.WebView2.Wpf.WebView2 
         {
             _ = RegisterBootThemeScriptAsync(isDark);
         }
-        if (_ready) { SendDirect(BridgeMessages.ToWebView.Ui.ThemeChanged, new Contracts.ThemeChangedNotification { Dark = isDark }); }
+        // Send, not SendDirect: a pane sends its theme once while opening, before the WebView is
+        // ready, and dropping that one left every new pane on the dark default no matter what VS
+        // was set to. Send queues it instead, and the queue drains on ready.
+        Send(BridgeMessages.ToWebView.Ui.ThemeChanged, new Contracts.ThemeChangedNotification { Dark = isDark });
     }
 
     /// <summary>

--- a/src/Corsinvest.VisualStudio.Agents/Chat/IconCacheService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/IconCacheService.cs
@@ -41,14 +41,22 @@ internal static class IconCacheService
     {
         ThreadHelper.ThrowIfNotOnUIThread();
         var key = string.IsNullOrEmpty(iconKey) ? "file" : iconKey.ToLowerInvariant();
-        Directory.CreateDirectory(AppPaths.IconCacheFolder);
-        var pngPath = Path.Combine(AppPaths.IconCacheFolder, key + ".png");
+        // Keyed by the background the PNG is rendered against (see RenderMonikerToPng), not by the
+        // theme's name: that colour is what decides the glyph, so two themes sharing a background
+        // can share the cache, and one that only LOOKS dark still gets its own. Before this the
+        // cache was flat, so a dark-theme run left pale icons that stayed pale on white.
+        // The light-/dark- prefix is for whoever opens the folder; the hex is what makes it correct.
+        var themeBg = VSColorTheme.GetThemedColor(EnvironmentColors.ToolWindowBackgroundColorKey);
+        var bucket = $"{(VsThemeReader.IsDark() ? "dark" : "light")}-{themeBg.R:x2}{themeBg.G:x2}{themeBg.B:x2}";
+        var folder = Path.Combine(AppPaths.IconCacheFolder, bucket);
+        Directory.CreateDirectory(folder);
+        var pngPath = Path.Combine(folder, key + ".png");
         if (File.Exists(pngPath)) { return pngPath; }
 
         try
         {
             var moniker = ResolveMoniker(key);
-            var bytes = RenderMonikerToPng(moniker);
+            var bytes = RenderMonikerToPng(moniker, themeBg);
             if (bytes != null) { File.WriteAllBytes(pngPath, bytes); }
         }
         catch (Exception ex)
@@ -75,15 +83,16 @@ internal static class IconCacheService
         return m.Guid != Guid.Empty || m.Id != 0 ? m : KnownMonikers.Document;
     }
 
-    private static byte[] RenderMonikerToPng(ImageMoniker moniker)
+    /// <summary>Render at the given background — the same colour the caller keyed the cache folder
+    /// on, so what is drawn and where it is filed can't drift apart.</summary>
+    private static byte[] RenderMonikerToPng(ImageMoniker moniker, System.Drawing.Color themeBg)
     {
         ThreadHelper.ThrowIfNotOnUIThread();
 
         if (Package.GetGlobalService(typeof(SVsImageService)) is not IVsImageService2 imageService) { return null; }
 
-        // Pass the tool-window background as theming hint so the icon matches
-        // Solution Explorer (light icons on dark theme, dark on light).
-        var themeBg = VSColorTheme.GetThemedColor(EnvironmentColors.ToolWindowBackgroundColorKey);
+        // The background is a theming hint: it makes the icon match Solution Explorer
+        // (light glyphs on a dark theme, dark on light).
         uint bgUint = ((uint)themeBg.A << 24)
                     | ((uint)themeBg.R << 16)
                     | ((uint)themeBg.G << 8)

--- a/src/Corsinvest.VisualStudio.Agents/Chat/IconCacheService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/IconCacheService.cs
@@ -55,8 +55,15 @@ internal static class IconCacheService
 
         try
         {
-            var moniker = ResolveMoniker(key);
-            var bytes = RenderMonikerToPng(moniker, themeBg);
+            var bytes = RenderMonikerToPng(ResolveMoniker(key), themeBg);
+            // A moniker VS knows but won't rasterise (".sh" is one) renders to nothing, and the
+            // path returned below would then 404 into a broken-image glyph. Fall back to the
+            // generic document rather than serve a file that isn't there.
+            if (bytes == null && key != "file")
+            {
+                OutputWindowLogger.Debug(() => $"[icons] no bitmap for '{key}' — using the generic document");
+                bytes = RenderMonikerToPng(KnownMonikers.Document, themeBg);
+            }
             if (bytes != null) { File.WriteAllBytes(pngPath, bytes); }
         }
         catch (Exception ex)

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/permission-modes.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/permission-modes.ts
@@ -19,6 +19,9 @@ import type { PermissionMode } from './types';
 export interface PermissionItem {
     value: PermissionMode;
     label: string;
+    /** What the composer button shows: the menu has room to explain, a docked pane hasn't. Set on
+     *  every mode, equal to `label` where that is already short enough. */
+    short: string;
     description: string;
     icon: string;
 }
@@ -31,12 +34,14 @@ export const PERMISSION_ITEMS: PermissionItem[] = [
     {
         value: 'default',
         label: 'Manual',
+        short: 'Manual',
         description: 'Every edit and command waits for your approval',
         icon: HandRight20Regular,
     },
     {
         value: 'acceptEdits',
         label: 'Edit automatically',
+        short: 'Auto-edit',
         description:
             'Files in the working directory are edited without asking — anything outside it, and commands, still ask',
         icon: Code20Regular,
@@ -44,18 +49,21 @@ export const PERMISSION_ITEMS: PermissionItem[] = [
     {
         value: 'plan',
         label: 'Plan',
+        short: 'Plan',
         description: 'Reads and explores freely, then proposes a plan — no file is changed',
         icon: ClipboardBulletListLtr20Regular,
     },
     {
         value: 'auto',
         label: 'Auto',
+        short: 'Auto',
         description: 'Decides per task when to act and when to ask, based on how risky it is',
         icon: Flash20Regular,
     },
     {
         value: 'bypassPermissions',
         label: 'Bypass permissions',
+        short: 'Bypass',
         description: 'Nothing is ever asked, including commands that can destroy data',
         icon: ShieldDismiss20Regular,
     },

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-attach-menu.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-attach-menu.ts
@@ -10,7 +10,7 @@ import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import Add16Regular from '@fluentui/svg-icons/icons/add_16_regular.svg';
 import ArrowUpload16Regular from '@fluentui/svg-icons/icons/arrow_upload_16_regular.svg';
 import DocumentText16Regular from '@fluentui/svg-icons/icons/document_text_16_regular.svg';
-import { iconStyles, iconButtonStyles, tooltipStyles } from '../styles/shared';
+import { iconStyles, tooltipStyles } from '../styles/shared';
 
 /**
  * Attach-actions button in the input toolbar, built on `<fluent-menu>`.
@@ -21,7 +21,6 @@ import { iconStyles, iconButtonStyles, tooltipStyles } from '../styles/shared';
 export class CvAttachMenu extends LitElement {
     static override styles = [
         iconStyles,
-        iconButtonStyles,
         tooltipStyles,
         css`
             :host {
@@ -50,9 +49,18 @@ export class CvAttachMenu extends LitElement {
                 align-items: center;
                 justify-content: center;
             }
-            /* Attach trigger: green, at the shared 14px. */
-            .icon-btn {
-                color: var(--colorPaletteGreenForeground1);
+            /* Fluent's own button, cut to the row's density: even size="small" is padded for a
+               control standing alone. No accent colour — in this row colour means state (the
+               gauge's bands, the mic while recording, send when there is something to send), and
+               a permanently green plus says nothing while competing with the ones that do. */
+            .trigger {
+                padding: 3px;
+                min-width: 0;
+            }
+            /* Wraps the glyph so it can be the tooltip's anchor while the button stays the menu's.
+               A real box (not display:contents) — an anchor has to be laid out to be anchored to. */
+            .tip-anchor {
+                display: inline-flex;
             }
         `,
     ];
@@ -69,9 +77,25 @@ export class CvAttachMenu extends LitElement {
     override render() {
         return html`
             <fluent-menu>
-                <button id="attach-trigger" slot="trigger" class="icon-btn" type="button">
-                    ${unsafeHTML(Add16Regular)}
-                </button>
+                <!-- A fluent-button, not the fluent-menu-button the docs show in this slot: that
+                     one always draws a chevron beside the glyph, which on a toolbar icon is a
+                     second symbol for what the plus already says. The id is load-bearing —
+                     fluent-menu-list anchors itself to --menu-trigger, and the trigger's
+                     anchor-name comes from its id, so any other id opens the list at 0,0. -->
+                <fluent-button
+                    id="menu-trigger"
+                    slot="trigger"
+                    class="trigger"
+                    appearance="subtle"
+                    shape="rounded"
+                    size="small"
+                    icon-only
+                >
+                    <!-- The tooltip anchors to this span, not to the button: fluent-tooltip writes
+                         anchor-name onto whatever it points at, and on the button that overwrote
+                         the name fluent-menu-list needs — the list then opened at 0,0. -->
+                    <span id="attach-tip" class="tip-anchor">${unsafeHTML(Add16Regular)}</span>
+                </fluent-button>
                 <fluent-menu-list>
                     <fluent-menu-item @click=${this._onUpload}>
                         <span slot="start">${unsafeHTML(ArrowUpload16Regular)}</span>
@@ -83,11 +107,13 @@ export class CvAttachMenu extends LitElement {
                     </fluent-menu-item>
                 </fluent-menu-list>
             </fluent-menu>
-            <!-- Outside the menu: inside it the tooltip would be a menu child, and fluent-menu
-                 lays out only its trigger and its list. -->
-            <fluent-tooltip anchor="attach-trigger" positioning="above-start"
-                >Add files or content</fluent-tooltip
-            >
+            <!-- Outside the menu: inside it the tooltip would be a menu child, and fluent-menu lays
+                 out only its trigger and its list. Anchored to the same id the list uses — one
+                 names the anchor, the other looks the element up, and they don't collide. -->
+            <fluent-tooltip anchor="attach-tip" positioning="above-start">
+                <span class="tip-name">Add</span>
+                <span class="tip-action">A file from disk, or a path from the workspace</span>
+            </fluent-tooltip>
         `;
     }
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-attach-menu.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-attach-menu.ts
@@ -10,7 +10,7 @@ import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import Add16Regular from '@fluentui/svg-icons/icons/add_16_regular.svg';
 import ArrowUpload16Regular from '@fluentui/svg-icons/icons/arrow_upload_16_regular.svg';
 import DocumentText16Regular from '@fluentui/svg-icons/icons/document_text_16_regular.svg';
-import { iconStyles } from '../styles/shared';
+import { iconStyles, iconButtonStyles, tooltipStyles } from '../styles/shared';
 
 /**
  * Attach-actions button in the input toolbar, built on `<fluent-menu>`.
@@ -21,6 +21,8 @@ import { iconStyles } from '../styles/shared';
 export class CvAttachMenu extends LitElement {
     static override styles = [
         iconStyles,
+        iconButtonStyles,
+        tooltipStyles,
         css`
             :host {
                 display: inline-flex;
@@ -48,10 +50,8 @@ export class CvAttachMenu extends LitElement {
                 align-items: center;
                 justify-content: center;
             }
-            /* Attach trigger icon: 16px green. */
-            fluent-button[slot='trigger'] svg {
-                width: 16px;
-                height: 16px;
+            /* Attach trigger: green, at the shared 14px. */
+            .icon-btn {
                 color: var(--colorPaletteGreenForeground1);
             }
         `,
@@ -69,15 +69,9 @@ export class CvAttachMenu extends LitElement {
     override render() {
         return html`
             <fluent-menu>
-                <fluent-button
-                    slot="trigger"
-                    appearance="subtle"
-                    size="small"
-                    icon-only
-                    title="Add files or content"
-                >
+                <button id="attach-trigger" slot="trigger" class="icon-btn" type="button">
                     ${unsafeHTML(Add16Regular)}
-                </fluent-button>
+                </button>
                 <fluent-menu-list>
                     <fluent-menu-item @click=${this._onUpload}>
                         <span slot="start">${unsafeHTML(ArrowUpload16Regular)}</span>
@@ -89,6 +83,11 @@ export class CvAttachMenu extends LitElement {
                     </fluent-menu-item>
                 </fluent-menu-list>
             </fluent-menu>
+            <!-- Outside the menu: inside it the tooltip would be a menu child, and fluent-menu
+                 lays out only its trigger and its list. -->
+            <fluent-tooltip anchor="attach-trigger" positioning="above-start"
+                >Add files or content</fluent-tooltip
+            >
         `;
     }
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-command-menu.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-command-menu.ts
@@ -34,6 +34,11 @@ export class CvCommandMenu extends LitElement {
     @property({ attribute: false }) query = '';
     /** True when opened from the lightning button: show the search box in the list. */
     @property({ type: Boolean }) searchable = false;
+    /** Show only these commands, by id, in the order given — the toolbar's Effort trigger opens
+     *  the menu on that one row. Takes precedence over `query`: a trigger that means "this exact
+     *  setting" can't go through Fuse, whose matches depend on what else happens to be installed.
+     *  Ids, not labels: the id is the stable name, the label is what the user reads. */
+    @property({ attribute: false }) only: string[] | null = null;
     /** The command host (cv-prompt), needed by inline controls (slider/toggle). */
     @property({ attribute: false }) host!: CommandHost;
 
@@ -110,8 +115,12 @@ export class CvCommandMenu extends LitElement {
 
     /** Commands matching the current query (Fuse), or all commands unchanged when empty. */
     private _filtered(): ChatCommand[] {
-        const q = this.query.trim();
         const all = allCommands();
+        if (this.only) {
+            const wanted = this.only;
+            return all.filter((c) => wanted.includes(c.id));
+        }
+        const q = this.query.trim();
         return q ? this._fuseSearch(all, q) : all;
     }
 
@@ -160,7 +169,11 @@ export class CvCommandMenu extends LitElement {
             ></fluent-switch>`;
         }
         if (ctrl?.kind === 'slider') {
+            // Value before the slider, so the slider's own edge is the row's: with the label after
+            // it, changing level re-measured the text and shifted the slider under the pointer
+            // mid-drag.
             return html`<span class="dots-wrap" @click=${(e: Event) => e.stopPropagation()}>
+                <span class="dots-val">${ctrl.label}</span>
                 <cv-segmented-slider
                     .stops=${ctrl.stops}
                     .activeValue=${ctrl.value}
@@ -169,7 +182,6 @@ export class CvCommandMenu extends LitElement {
                         this.requestUpdate();
                     }}
                 ></cv-segmented-slider>
-                <span class="dots-val">${ctrl.label}</span>
             </span>`;
         }
         if (ctrl?.kind === 'value') {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-context-dialog.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-context-dialog.ts
@@ -142,7 +142,7 @@ export class CvContextDialog extends CvDialogBase {
                 border-radius: var(--borderRadiusSmall);
             }
             .row-toggle:hover {
-                background: var(--colorSubtleBackgroundHover, rgba(127, 127, 127, 0.1));
+                background: color-mix(in srgb, var(--colorNeutralForeground1) 10%, transparent);
             }
             .dot {
                 width: 10px;

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-context-gauge.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-context-gauge.ts
@@ -74,11 +74,17 @@ export class CvContextGauge extends LitElement {
                 padding: 0;
                 cursor: pointer;
             }
+            /* Same tint as the icon buttons beside it (iconButtonStyles): the Subtle* tokens are
+               near-white in the light theme, so an hover drawn with them never showed. */
             .gauge:hover {
-                background: var(--colorSubtleBackgroundHover, rgba(127, 127, 127, 0.15));
+                background: color-mix(in srgb, var(--colorNeutralForeground1) 10%, transparent);
             }
             .gauge:active {
-                background: var(--colorSubtleBackgroundPressed, rgba(127, 127, 127, 0.25));
+                background: color-mix(in srgb, var(--colorNeutralForeground1) 16%, transparent);
+            }
+            .gauge:focus-visible {
+                outline: 1px solid var(--colorStrokeFocus2, currentColor);
+                outline-offset: 1px;
             }
             .gauge svg {
                 flex: 0 0 auto;
@@ -90,11 +96,13 @@ export class CvContextGauge extends LitElement {
                 white-space: nowrap;
             }
 
-            /* Click panel: info + actions, absolutely positioned above the ring, left-aligned to it. */
+            /* Click panel: info + actions, absolutely positioned above the ring. Right-aligned:
+               the ring sits at the right end of the toolbar, so a 340px panel anchored left would
+               run off the composer's right edge. */
             .popover {
                 position: absolute;
                 bottom: calc(100% + 4px);
-                left: 0;
+                right: 0;
                 z-index: 1000;
                 padding: 8px 10px;
                 width: 340px;

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-context-gauge.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-context-gauge.ts
@@ -4,6 +4,13 @@
  */
 import { LitElement, html, css, svg } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+// The same two the VS menu's Analytics group uses (AgentsPackage.vsct): Statistics is a
+// bar chart there, Context usage a doughnut. Usage keeps the gauge, which command-icons
+// already maps to the same glyph.
+import DataBarVertical16Regular from '@fluentui/svg-icons/icons/data_bar_vertical_16_regular.svg';
+import DataPie16Regular from '@fluentui/svg-icons/icons/data_pie_16_regular.svg';
+import { iconForCommandName } from '../../core/commands/command-icons';
 import { iconStyles, tooltipStyles } from '../styles/shared';
 import { state as appState } from '../../core/state';
 import { bridge } from '../../core/bridge';
@@ -55,71 +62,41 @@ export class CvContextGauge extends LitElement {
         iconStyles,
         tooltipStyles,
         css`
-            /* Relative host so the click panel can be absolutely positioned above the ring — plain
-           position:absolute, not CSS anchor-positioning (position-area is unreliable in the VS
-           WebView2's Chromium: the top-layer popover jumps to the viewport corner). */
             :host {
-                position: relative;
                 display: inline-flex;
             }
-            /* Ring hit-area, sized to hug the small ring exactly. Clickable (opens the panel). */
+            /* Fluent's own button, cut to the row's density: even size="small" is padded for a
+               control standing alone. The ring is 14px like every other glyph here. */
             .gauge {
+                padding: 3px;
+                min-width: 0;
+            }
+            /* Wraps the ring so it can be the tooltip's anchor while the button stays the menu's
+               — see cv-attach-menu for what happens when they share one. */
+            .tip-anchor {
                 display: inline-flex;
-                align-items: center;
-                justify-content: center;
-                width: 22px;
-                height: 22px;
-                border-radius: 4px;
-                border: none;
-                background: none;
-                padding: 0;
-                cursor: pointer;
-            }
-            /* Same tint as the icon buttons beside it (iconButtonStyles): the Subtle* tokens are
-               near-white in the light theme, so an hover drawn with them never showed. */
-            .gauge:hover {
-                background: color-mix(in srgb, var(--colorNeutralForeground1) 10%, transparent);
-            }
-            .gauge:active {
-                background: color-mix(in srgb, var(--colorNeutralForeground1) 16%, transparent);
-            }
-            .gauge:focus-visible {
-                outline: 1px solid var(--colorStrokeFocus2, currentColor);
-                outline-offset: 1px;
             }
             .gauge svg {
-                flex: 0 0 auto;
                 display: block;
             }
-            /* Small hover tooltip: just the % (one line). The detail + actions live in the click panel. */
-
-            /* Click panel: info + actions, absolutely positioned above the ring. Right-aligned:
-               the ring sits at the right end of the toolbar, so a 340px panel anchored left would
-               run off the composer's right edge. */
-            .popover {
-                position: absolute;
-                bottom: calc(100% + 4px);
-                right: 0;
-                z-index: 1000;
-                padding: 8px 10px;
-                width: 340px;
-                max-width: 90vw;
-                font-size: var(--fontSizeBase300);
+            /* The reading at the top of the menu: not an action, so a plain div rather than a
+               menu-item — the focusgroup skips what has no menuitem role, and arrow keys land on
+               the four actions below. */
+            /* Colour set here, not inherited: the div is slotted into fluent-menu-list, whose own
+               foreground doesn't reach a plain child — it would fall back to the UA black. */
+            .reading {
+                padding: 6px 10px 8px;
+                min-width: 280px;
+                font-size: var(--fontSizeBase200);
                 line-height: var(--lineHeightBase200);
-                background: var(--colorNeutralBackground1);
                 color: var(--colorNeutralForeground1);
-                border: 1px solid var(--colorNeutralStroke1);
-                border-radius: var(--borderRadiusMedium);
-                box-shadow: var(--shadow16);
+                border-bottom: 1px solid var(--colorNeutralStroke2);
             }
-            .popover[hidden] {
-                display: none;
-            }
-            .tip-head {
+            .reading-head {
                 font-weight: var(--fontWeightSemibold);
             }
-            /* fluent-progress-bar stays pure — only vertical spacing (colour comes from validation-state,
-           matching the donut's green/amber/red bands). */
+            /* fluent-progress-bar stays pure — only vertical spacing (colour comes from
+               validation-state, matching the donut's green/amber/red bands). */
             .bar {
                 margin: 8px 0 2px;
             }
@@ -129,25 +106,34 @@ export class CvContextGauge extends LitElement {
                 font-size: 0.82em;
                 color: var(--colorNeutralForeground3);
                 font-variant-numeric: tabular-nums;
-                margin-bottom: 4px;
             }
-            .tip-actions {
-                display: flex;
-                flex-wrap: nowrap;
-                gap: 14px;
-                margin-top: 6px;
-                padding-top: 6px;
-                border-top: 1px solid var(--colorNeutralStroke2);
+            /* Hung from the ring's right edge, not its left: Fluent aligns the list's start to the
+               trigger's, which on the last control in the row throws 280px of menu out to the left
+               and leaves the pointer crossing open air to reach it. */
+            fluent-menu-list {
+                inset-inline-start: unset;
+                /* Negative, so the right edge lands past the ring rather than flush with it: the
+                   composer's own padding is to the right of the trigger, and hanging into it keeps
+                   the menu from crowding the row it belongs to. */
+                inset-inline-end: calc(anchor(self-end) - 24px);
             }
-            .tip-actions fluent-link {
-                white-space: nowrap;
+            .sep {
+                height: 1px;
+                margin: 4px 0;
+                background: var(--colorNeutralStroke2);
+            }
+            /* Centre the glyph in the item's start cell — Fluent's default hugs the cell edge,
+               too tight at this density. Same rule as cv-attach-menu. */
+            fluent-menu-item [slot='start'] {
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
             }
         `,
     ];
 
     @state() private _usage: ContextUsageDto | null = appState.contextUsage;
     @state() private _window = appState.contextWindow;
-    @state() private _open = false;
 
     private _offUsage?: () => void;
     private _offWindow?: () => void;
@@ -160,26 +146,13 @@ export class CvContextGauge extends LitElement {
         this._offWindow = appState.on('contextWindow', (v) => {
             this._window = v;
         });
-        // Light dismiss: a click anywhere outside the gauge closes the panel.
-        document.addEventListener('pointerdown', this._onDocPointerDown, true);
     }
 
     override disconnectedCallback(): void {
         super.disconnectedCallback();
         this._offUsage?.();
         this._offWindow?.();
-        document.removeEventListener('pointerdown', this._onDocPointerDown, true);
     }
-
-    private _onDocPointerDown = (e: PointerEvent): void => {
-        if (!this._open) {
-            return;
-        }
-        // composedPath crosses the shadow boundary; if the click isn't on us, close.
-        if (!e.composedPath().includes(this)) {
-            this._open = false;
-        }
-    };
 
     /** Compact the conversation via the CLI's `/compact` command (mirrors cv-prompt._dispatch). */
     private _onCompact = (): void => {
@@ -193,16 +166,6 @@ export class CvContextGauge extends LitElement {
             uuid: crypto.randomUUID(),
         });
     };
-
-    private _toggle = (): void => {
-        this._open = !this._open;
-    };
-
-    // Run an action, then close the panel (like a menu item).
-    private _act(fn: () => void): void {
-        fn();
-        this._open = false;
-    }
 
     // Open each panel directly via dialog-host (no parent host needed).
     private _onViewUsage = (): void => openUsageDialog();
@@ -228,18 +191,27 @@ export class CvContextGauge extends LitElement {
         const remainingPct = known ? remainingPercent(u) : 100;
         const window = autoCompactWindow();
 
-        // Clickable ring (<button>) → opens a light-dismiss popover with the usage detail + actions
-        // (like cv-subagent-chip). Click, not hover: the panel is interactive (Compact/dialogs) and
-        // a hover panel above the ring overlaps the composer / vanishes as the mouse moves to it.
+        // The ring opens a menu: the reading at the top, then what you can do about it. Click, not
+        // hover — the items are actions, and a hover panel above the ring would vanish as the
+        // mouse travelled to them.
         return html`
-            <button
-                id="cv-context-gauge-btn"
-                class="gauge"
-                type="button"
-                aria-label="Context usage"
-                @click=${this._toggle}
-            >
-                ${svg`
+            <fluent-menu>
+                <!-- id="menu-trigger" is load-bearing: fluent-menu-list anchors itself to
+                     --menu-trigger, and the trigger's anchor-name comes from its id. The tooltip
+                     hangs off the span inside instead — anchoring it here would overwrite that
+                     name and drop the list at 0,0 (see cv-attach-menu). -->
+                <fluent-button
+                    id="menu-trigger"
+                    slot="trigger"
+                    class="gauge"
+                    appearance="subtle"
+                    shape="rounded"
+                    size="small"
+                    icon-only
+                    aria-label="Context usage"
+                >
+                    <span id="gauge-tip" class="tip-anchor">
+                        ${svg`
                     <svg width=${SIZE} height=${SIZE} viewBox="0 0 ${SIZE} ${SIZE}">
                         <circle
                             cx=${SIZE / 2}
@@ -263,55 +235,60 @@ export class CvContextGauge extends LitElement {
                         />
                     </svg>
                 `}
-            </button>
-            <div id="cv-gauge-popover" class="popover" ?hidden=${!this._open}>
-                <div class="tip-head">
-                    ${
-                        known
-                            ? `${remainingPct.toFixed(0)}% of context remaining until auto-compact`
-                            : 'Context usage is reported after the first reply'
-                    }
-                </div>
-                <fluent-progress-bar
-                    class="bar"
-                    min="0"
-                    max="100"
-                    value=${limit > 0 ? Math.min(100, (used / limit) * 100) : 0}
-                    validation-state=${gaugeValidationState(percent)}
-                ></fluent-progress-bar>
-                <div class="bar-legend">
-                    <span>${formatTokens(used)} used</span>
-                    <span>${formatTokens(window)} before compact</span>
-                    <span>${formatTokens(limit)} total</span>
-                </div>
-                <div class="tip-actions">
-                    <fluent-button
-                        appearance="transparent"
-                        size="small"
-                        @click=${(): void => this._act(this._onCompact)}
-                        >Compact</fluent-button
-                    >
-                    <fluent-button
-                        appearance="transparent"
-                        size="small"
-                        @click=${(): void => this._act(this._onViewUsage)}
-                        >Usage…</fluent-button
-                    >
-                    <fluent-button
-                        appearance="transparent"
-                        size="small"
-                        @click=${(): void => this._act(this._onViewContext)}
-                        >Context…</fluent-button
-                    >
-                    <fluent-button
-                        appearance="transparent"
-                        size="small"
-                        @click=${(): void => this._act(this._onViewStats)}
-                        >Statistics…</fluent-button
-                    >
-                </div>
-            </div>
-            <fluent-tooltip anchor="cv-context-gauge-btn" positioning="above-end">
+                    </span>
+                </fluent-button>
+                <fluent-menu-list>
+                    <!-- A plain div, not a menu-item: the reading is what the menu is for, but it
+                         is not an action. Without role=menuitem the focusgroup skips it, so arrow
+                         keys go straight to the four below. -->
+                    <div class="reading">
+                        <div class="reading-head">
+                            ${
+                                known
+                                    ? `${remainingPct.toFixed(0)}% of context remaining until auto-compact`
+                                    : 'Context usage is reported after the first reply'
+                            }
+                        </div>
+                        <fluent-progress-bar
+                            class="bar"
+                            min="0"
+                            max="100"
+                            value=${limit > 0 ? Math.min(100, (used / limit) * 100) : 0}
+                            validation-state=${gaugeValidationState(percent)}
+                        ></fluent-progress-bar>
+                        <div class="bar-legend">
+                            <span>${formatTokens(used)} used</span>
+                            <span>${formatTokens(window)} before compact</span>
+                            <span>${formatTokens(limit)} total</span>
+                        </div>
+                    </div>
+                    <fluent-menu-item @click=${this._onCompact}>
+                        <span slot="start">${unsafeHTML(iconForCommandName('compact'))}</span>
+                        Compact
+                    </fluent-menu-item>
+                    <!-- Compact acts on the conversation; the three below open a window to look at
+                         it. A plain div, not fluent-divider: that one ships no package entry point
+                         (only dist/esm), and a rule is a rule. -->
+                    <div class="sep" role="separator"></div>
+                    <!-- Statistics, Usage, Context usage — the order and the icons of the VS
+                         menu's own Analytics group, so the two ways in read the same. No trailing
+                         ellipsis, for the same reason: these open a window, they don't ask for
+                         anything first. -->
+                    <fluent-menu-item @click=${this._onViewStats}>
+                        <span slot="start">${unsafeHTML(DataBarVertical16Regular)}</span>
+                        Statistics
+                    </fluent-menu-item>
+                    <fluent-menu-item @click=${this._onViewUsage}>
+                        <span slot="start">${unsafeHTML(iconForCommandName('usage'))}</span>
+                        Usage
+                    </fluent-menu-item>
+                    <fluent-menu-item @click=${this._onViewContext}>
+                        <span slot="start">${unsafeHTML(DataPie16Regular)}</span>
+                        Context usage
+                    </fluent-menu-item>
+                </fluent-menu-list>
+            </fluent-menu>
+            <fluent-tooltip anchor="gauge-tip" positioning="above-end">
                 <span class="tip-name"
                     >${known ? `${remainingPct.toFixed(0)}% of context left` : 'Context'}</span
                 >

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-context-gauge.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-context-gauge.ts
@@ -4,7 +4,7 @@
  */
 import { LitElement, html, css, svg } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { iconStyles } from '../styles/shared';
+import { iconStyles, tooltipStyles } from '../styles/shared';
 import { state as appState } from '../../core/state';
 import { bridge } from '../../core/bridge';
 import { Msg } from '../../core/bridge-messages';
@@ -53,6 +53,7 @@ const CIRC = 2 * Math.PI * RADIUS;
 export class CvContextGauge extends LitElement {
     static override styles = [
         iconStyles,
+        tooltipStyles,
         css`
             /* Relative host so the click panel can be absolutely positioned above the ring — plain
            position:absolute, not CSS anchor-positioning (position-area is unreliable in the VS
@@ -91,10 +92,6 @@ export class CvContextGauge extends LitElement {
                 display: block;
             }
             /* Small hover tooltip: just the % (one line). The detail + actions live in the click panel. */
-            fluent-tooltip {
-                padding: 4px 8px;
-                white-space: nowrap;
-            }
 
             /* Click panel: info + actions, absolutely positioned above the ring. Right-aligned:
                the ring sits at the right end of the toolbar, so a 340px panel anchored left would
@@ -315,7 +312,12 @@ export class CvContextGauge extends LitElement {
                 </div>
             </div>
             <fluent-tooltip anchor="cv-context-gauge-btn" positioning="above-end">
-                ${known ? `${remainingPct.toFixed(0)}% of context remaining` : 'Context usage'}
+                <span class="tip-name"
+                    >${known ? `${remainingPct.toFixed(0)}% of context left` : 'Context'}</span
+                >
+                <span class="tip-action"
+                    >${known ? 'Click for the breakdown' : 'Known once the first turn lands'}</span
+                >
             </fluent-tooltip>
         `;
     }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-copy-btn.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-copy-btn.ts
@@ -44,7 +44,7 @@ export class CvCopyBtn extends LitElement {
                 opacity: 0.75;
             }
             .icon-btn:hover {
-                background: var(--colorSubtleBackgroundHover, rgba(127, 127, 127, 0.12));
+                background: color-mix(in srgb, var(--colorNeutralForeground1) 10%, transparent);
                 opacity: 1;
             }
             .icon-btn:focus-visible {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-effort-selector.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-effort-selector.ts
@@ -3,103 +3,37 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 import { LitElement, html, css, nothing } from 'lit';
-import { customElement, property, state } from 'lit/decorators.js';
-import { unsafeHTML } from 'lit/directives/unsafe-html.js';
-// The menu's own Effort glyph, shown in the panel header.
-import Dumbbell16Regular from '@fluentui/svg-icons/icons/dumbbell_16_regular.svg';
+import { customElement, state } from 'lit/decorators.js';
 import { state as appState } from '../../core/state';
-import { iconStyles, iconButtonStyles, tooltipStyles } from '../styles/shared';
+import { tooltipStyles } from '../styles/shared';
 import { currentEffortLevels, EffortCommand } from '../../core/commands/model-controls';
-import type { CommandHost } from '../../core/commands/base';
 import { effortLabel } from '../../core/types';
-import './cv-segmented-slider';
-import type { SliderStop } from './cv-segmented-slider';
 
 /**
  * Effort trigger in the input toolbar, beside the model selector: shows the active reasoning effort
- * and opens a small popover holding the same `cv-segmented-slider` the menu's Effort row uses.
- *
- * A popover rather than "open the command palette on that row": the palette is forty rows deep for
- * one setting, and it would have to scroll to and highlight the right one. The neighbouring model
- * and permission triggers open their own list too, so this keeps the toolbar consistent.
- *
- * The stops and the set logic come from EffortCommand — ultracode is a special case in three places
- * (a synthetic stop, effort=xhigh plus a flag, cleared by any other stop) and must not be written
- * twice. This component is presentation only.
+ * and asks cv-prompt to open the command palette on its Effort row — the same row, with the same
+ * slider, that the palette shows when opened in full. The list, not this button, owns the control:
+ * the same split as the model and permission triggers.
  *
  * Hidden when the model has no effort levels (Haiku), on the same condition that hides the menu row.
  */
 @customElement('cv-effort-selector')
 export class CvEffortSelector extends LitElement {
     static override styles = [
-        iconStyles,
-        iconButtonStyles,
         tooltipStyles,
         css`
-            /* Relative host so the popover can sit above the chip — plain absolute positioning,
-               like cv-context-gauge (CSS anchor-positioning misplaces top-layer popovers in the
-               VS WebView2's Chromium). */
             :host {
-                position: relative;
-                display: inline-flex;
+                display: contents;
             }
-            .popover {
-                position: absolute;
-                bottom: calc(100% + 4px);
-                /* Anchored right: the chip sits in the row's right-hand group, so a panel growing
-                   leftwards stays inside the composer. Anchored left it would run off the right
-                   edge, and the chip's own width changes with the level's name. */
-                right: 0;
-                z-index: 1000;
-                padding: 8px 10px;
-                display: flex;
-                flex-direction: column;
-                gap: 6px;
-                white-space: nowrap;
-                background: var(--colorNeutralBackground1);
-                color: var(--colorNeutralForeground1);
-                border: 1px solid var(--colorNeutralStroke1);
-                border-radius: var(--borderRadiusMedium);
-                box-shadow: var(--shadow16);
-            }
-            .popover[hidden] {
-                display: none;
-            }
-            /* Header: says what the slider regulates — on its own the control is unlabelled. */
-            .head {
-                display: flex;
-                align-items: baseline;
-                justify-content: space-between;
-                gap: 12px;
+            /* See cv-model-selector: Fluent's own pill, ours only the metrics. */
+            .trigger {
                 font-size: var(--fontSizeBase200);
-            }
-            .head-title {
-                display: inline-flex;
-                align-items: center;
-                gap: 5px;
-                font-weight: var(--fontWeightSemibold);
-                color: var(--colorNeutralForeground1);
-            }
-            .head-title svg {
-                width: 14px;
-                height: 14px;
-            }
-            /* The active stop's name. Right-aligned in a fixed box so stepping through the levels
-               doesn't resize the popover under the pointer. */
-            .value {
-                color: var(--colorNeutralForeground2);
-                min-width: 10ch;
-                text-align: right;
+                padding-inline: 8px;
+                min-width: 0;
             }
         `,
     ];
 
-    /** The command host (cv-prompt), which owns applyFlagSettings. Passed as a property because
-     *  cv-prompt renders into a shadow root: `closest()` would stop at our own boundary. Same way
-     *  cv-command-menu receives it. */
-    @property({ attribute: false }) host!: CommandHost;
-
-    @state() private _open = false;
     @state() private _effort = appState.effortLevel;
     @state() private _ultracode = appState.ultracodeEnabled;
     // The catalogue decides whether this model has effort at all.
@@ -107,6 +41,8 @@ export class CvEffortSelector extends LitElement {
     @state() private _current = appState.currentModel;
 
     private _offs: Array<() => void> = [];
+    // The menu row for the same thing: its label and description are the one place that says what
+    // effort is, so the tooltip borrows them instead of wording it a second time.
     private readonly _command = new EffortCommand();
 
     override connectedCallback(): void {
@@ -125,26 +61,16 @@ export class CvEffortSelector extends LitElement {
                 this._current = v;
             }),
         ];
-        document.addEventListener('pointerdown', this._onDocPointerDown, true);
     }
 
     override disconnectedCallback(): void {
         super.disconnectedCallback();
         this._offs.forEach((off) => off());
         this._offs = [];
-        document.removeEventListener('pointerdown', this._onDocPointerDown, true);
     }
 
-    /** Light dismiss. composedPath crosses the shadow boundary, so a click on our own
-     *  trigger is "inside" and leaves the toggle to handle it. */
-    private _onDocPointerDown = (e: PointerEvent): void => {
-        if (this._open && !e.composedPath().includes(this)) {
-            this._open = false;
-        }
-    };
-
-    private _toggle = (): void => {
-        this._open = !this._open;
+    private _onClick = (): void => {
+        this.dispatchEvent(new CustomEvent('open-effort', { bubbles: true, composed: true }));
     };
 
     override render() {
@@ -155,32 +81,20 @@ export class CvEffortSelector extends LitElement {
             return nothing;
         }
         const label = effortLabel(this._effort, this._ultracode);
-        const ctrl = this._command.trailingControl;
         return html`
-            <button id="effort-trigger" class="icon-btn" type="button" @click=${this._toggle}>
+            <fluent-button
+                id="effort-trigger"
+                class="trigger"
+                shape="circular"
+                size="small"
+                @click=${this._onClick}
+            >
                 <span>${label}</span>
-            </button>
+            </fluent-button>
             <fluent-tooltip anchor="effort-trigger" positioning="above-end">
                 <span class="tip-name">${this._command.label}: ${label}</span>
                 <span class="tip-action">${this._command.description}</span>
             </fluent-tooltip>
-            <div class="popover" ?hidden=${!this._open}>
-                <div class="head">
-                    <!-- The glyph lives here now that the trigger is a word-only pill: the panel
-                         has the room the toolbar row hasn't, and it's the menu's own Effort icon. -->
-                    <span class="head-title">${unsafeHTML(Dumbbell16Regular)} Effort</span>
-                    <span class="value">${label}</span>
-                </div>
-                <cv-segmented-slider
-                    .stops=${ctrl.kind === 'slider' ? ctrl.stops : []}
-                    .activeValue=${ctrl.kind === 'slider' ? ctrl.value : 0}
-                    @change=${(e: CustomEvent<SliderStop<number>>) => {
-                        if (this.host && ctrl.kind === 'slider') {
-                            ctrl.onSet(this.host, e.detail.value);
-                        }
-                    }}
-                ></cv-segmented-slider>
-            </div>
         `;
     }
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-effort-selector.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-effort-selector.ts
@@ -5,10 +5,10 @@
 import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
-// Same icon the menu's "Effort" row uses — one glyph for one concept.
+// The menu's own Effort glyph, shown in the panel header.
 import Dumbbell16Regular from '@fluentui/svg-icons/icons/dumbbell_16_regular.svg';
 import { state as appState } from '../../core/state';
-import { iconStyles } from '../styles/shared';
+import { iconStyles, iconButtonStyles, tooltipStyles } from '../styles/shared';
 import { currentEffortLevels, EffortCommand } from '../../core/commands/model-controls';
 import type { CommandHost } from '../../core/commands/base';
 import { effortLabel } from '../../core/types';
@@ -33,6 +33,8 @@ import type { SliderStop } from './cv-segmented-slider';
 export class CvEffortSelector extends LitElement {
     static override styles = [
         iconStyles,
+        iconButtonStyles,
+        tooltipStyles,
         css`
             /* Relative host so the popover can sit above the chip — plain absolute positioning,
                like cv-context-gauge (CSS anchor-positioning misplaces top-layer popovers in the
@@ -41,24 +43,13 @@ export class CvEffortSelector extends LitElement {
                 position: relative;
                 display: inline-flex;
             }
-            /* Trigger is a <fluent-button> — keep it pure (layout only). */
-            .trigger svg {
-                width: 16px;
-                height: 16px;
-                margin-right: 4px;
-            }
-            /* "Extra high" is the only two-word level, and it must not wrap the button onto a
-               second row. */
-            .trigger {
-                white-space: nowrap;
-            }
             .popover {
                 position: absolute;
                 bottom: calc(100% + 4px);
-                /* Anchored left: the chip leads the settings row, so its left edge is the one
-                   against the composer's. Anchoring right would grow the panel outwards from a
-                   chip whose width changes with the level's name, off the left of the box. */
-                left: 0;
+                /* Anchored right: the chip sits in the row's right-hand group, so a panel growing
+                   leftwards stays inside the composer. Anchored left it would run off the right
+                   edge, and the chip's own width changes with the level's name. */
+                right: 0;
                 z-index: 1000;
                 padding: 8px 10px;
                 display: flex;
@@ -83,8 +74,15 @@ export class CvEffortSelector extends LitElement {
                 font-size: var(--fontSizeBase200);
             }
             .head-title {
+                display: inline-flex;
+                align-items: center;
+                gap: 5px;
                 font-weight: var(--fontWeightSemibold);
                 color: var(--colorNeutralForeground1);
+            }
+            .head-title svg {
+                width: 14px;
+                height: 14px;
             }
             /* The active stop's name. Right-aligned in a fixed box so stepping through the levels
                doesn't resize the popover under the pointer. */
@@ -159,19 +157,18 @@ export class CvEffortSelector extends LitElement {
         const label = effortLabel(this._effort, this._ultracode);
         const ctrl = this._command.trailingControl;
         return html`
-            <fluent-button
-                class="trigger"
-                appearance="subtle"
-                size="small"
-                title=${`${this._command.label}: ${label}\n${this._command.description}`}
-                @click=${this._toggle}
-            >
-                ${unsafeHTML(Dumbbell16Regular)}
+            <button id="effort-trigger" class="icon-btn" type="button" @click=${this._toggle}>
                 <span>${label}</span>
-            </fluent-button>
+            </button>
+            <fluent-tooltip anchor="effort-trigger" positioning="above-end">
+                <span class="tip-name">${this._command.label}: ${label}</span>
+                <span class="tip-action">${this._command.description}</span>
+            </fluent-tooltip>
             <div class="popover" ?hidden=${!this._open}>
                 <div class="head">
-                    <span class="head-title">Effort</span>
+                    <!-- The glyph lives here now that the trigger is a word-only pill: the panel
+                         has the room the toolbar row hasn't, and it's the menu's own Effort icon. -->
+                    <span class="head-title">${unsafeHTML(Dumbbell16Regular)} Effort</span>
                     <span class="value">${label}</span>
                 </div>
                 <cv-segmented-slider

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-ide-context-badge.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-ide-context-badge.ts
@@ -26,34 +26,32 @@ export class CvIdeContextBadge extends LitElement {
         css`
             /* inline-flex, not the default inline: an inline host sits on the text baseline, which
                left the chip a pixel low against the icon buttons beside it. */
+            /* The one thing in the row that gives way: min-width:0 lets a flex item go below its
+               content width, which is what makes the name truncate instead of pushing the row
+               wider than the composer. */
             :host {
                 display: inline-flex;
                 align-items: center;
-            }
-            /* Single clickable chip = the share toggle (the file is already open in VS). */
-            .badge {
-                display: inline-flex;
-                align-items: center;
-                gap: 4px;
                 min-width: 0;
+                flex-shrink: 1;
+            }
+            /* Single clickable chip = the share toggle (the file is already open in VS). Fluent's
+               own button so its hover and focus come with it; ours are the metrics and the cap. */
+            .badge {
                 /* The ceiling belongs to the whole chip, not to the name: capping the name alone
                    let the icon and the :24-27 range add to it, so selecting lines made the chip
                    wider than a chip without one. The name is the part that gives way. */
                 max-width: 160px;
+                min-width: 0;
                 font-size: var(--fontSizeBase100);
-                color: var(--colorNeutralForeground3);
-                background: none;
-                border: none;
-                padding: 2px 4px;
-                cursor: pointer;
-                border-radius: var(--borderRadiusSmall);
-                font-family: inherit;
+                padding-inline: 6px;
             }
-            .badge:hover {
-                background: color-mix(in srgb, var(--colorNeutralForeground1) 8%, transparent);
-            }
-            .badge:hover .name {
-                color: var(--colorNeutralForeground1);
+            .badge::part(content) {
+                display: inline-flex;
+                align-items: center;
+                gap: 4px;
+                min-width: 0;
+                overflow: hidden;
             }
             .badge.is-disabled {
                 opacity: 0.55;
@@ -149,7 +147,14 @@ export class CvIdeContextBadge extends LitElement {
         const lineInfo = ctx.hasSelection ? `:${ctx.startLine}-${ctx.endLine}` : '';
 
         return html`
-            <button id="ide-badge" class=${cls} type="button" @click=${this._onToggleEye}>
+            <fluent-button
+                id="ide-badge"
+                class=${cls}
+                appearance="subtle"
+                shape="circular"
+                size="small"
+                @click=${this._onToggleEye}
+            >
                 <!-- Only when paused. Sharing is the normal state and the file icon and name
                      already say which file is in play; a second glyph beside them adds nothing.
                      Not being sent is the exception, and the one worth marking — otherwise the
@@ -162,7 +167,7 @@ export class CvIdeContextBadge extends LitElement {
                 <img class="file-icon" src=${iconUrl(ctx.fileName)} width="16" height="16" alt="" />
                 <span class="name"><bdi>${ctx.fileName}</bdi></span>
                 ${lineInfo ? html`<span class="info">${lineInfo}</span>` : nothing}
-            </button>
+            </fluent-button>
             <!-- The chip truncates the name, so the tooltip is where it can be read in full. -->
             <fluent-tooltip anchor="ide-badge" positioning="above-start">
                 <span class="tip-name">${ctx.fileName}${lineInfo}</span>

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-ide-context-badge.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-ide-context-badge.ts
@@ -11,7 +11,7 @@ import type { IdeContextNotification, SetSendSelectionNotification } from '../..
 import { bridge } from '../../core/bridge';
 import { Msg } from '../../core/bridge-messages';
 import { iconUrl } from '../../core/icon-url';
-import { iconStyles } from '../styles/shared';
+import { iconStyles, tooltipStyles } from '../styles/shared';
 
 /**
  * Compact "context chip" above the chat textarea, showing the file that rides along with each
@@ -22,13 +22,24 @@ import { iconStyles } from '../styles/shared';
 export class CvIdeContextBadge extends LitElement {
     static override styles = [
         iconStyles,
+        tooltipStyles,
         css`
+            /* inline-flex, not the default inline: an inline host sits on the text baseline, which
+               left the chip a pixel low against the icon buttons beside it. */
+            :host {
+                display: inline-flex;
+                align-items: center;
+            }
             /* Single clickable chip = the share toggle (the file is already open in VS). */
             .badge {
                 display: inline-flex;
                 align-items: center;
                 gap: 4px;
                 min-width: 0;
+                /* The ceiling belongs to the whole chip, not to the name: capping the name alone
+                   let the icon and the :24-27 range add to it, so selecting lines made the chip
+                   wider than a chip without one. The name is the part that gives way. */
+                max-width: 160px;
                 font-size: var(--fontSizeBase100);
                 color: var(--colorNeutralForeground3);
                 background: none;
@@ -59,12 +70,22 @@ export class CvIdeContextBadge extends LitElement {
                 height: 14px;
                 display: block;
             }
+            /* A ceiling, not a width: a short name takes the room it needs and a long one stops
+               here. The ellipsis goes at the START — a truncated name keeps its extension and last
+               words, which is what tells one file from another, while the head is usually a shared
+               prefix. rtl flips which end is cut; bdi keeps the text itself in reading order
+               (without it "Chat.cs" would render as "sc.tahC"). */
             .name {
                 font-family: var(--fontFamilyMonospace);
                 overflow: hidden;
                 text-overflow: ellipsis;
                 white-space: nowrap;
-                max-width: 140px;
+                /* No max of its own — it shrinks to whatever the chip's ceiling leaves once the
+                   icon and the range have taken theirs. min-width:0 is what allows a flex item
+                   to go below its content width at all. */
+                min-width: 0;
+                direction: rtl;
+                text-align: left;
             }
             .file-icon {
                 flex-shrink: 0;
@@ -126,12 +147,9 @@ export class CvIdeContextBadge extends LitElement {
         // Editor-style `:start-end` range, shown only for a real selection
         // (a bare open file carries no lines). Matches the in-bubble chip.
         const lineInfo = ctx.hasSelection ? `:${ctx.startLine}-${ctx.endLine}` : '';
-        const title = this._enabled
-            ? `${ctx.fileName} goes with every message — click to stop`
-            : `${ctx.fileName} is not sent — click to include it`;
 
         return html`
-            <button class=${cls} type="button" title=${title} @click=${this._onToggleEye}>
+            <button id="ide-badge" class=${cls} type="button" @click=${this._onToggleEye}>
                 <!-- Only when paused. Sharing is the normal state and the file icon and name
                      already say which file is in play; a second glyph beside them adds nothing.
                      Not being sent is the exception, and the one worth marking — otherwise the
@@ -142,9 +160,20 @@ export class CvIdeContextBadge extends LitElement {
                         : html`<span class="eye">${unsafeHTML(EyeOff16Regular)}</span>`
                 }
                 <img class="file-icon" src=${iconUrl(ctx.fileName)} width="16" height="16" alt="" />
-                <span class="name">${ctx.fileName}</span>
+                <span class="name"><bdi>${ctx.fileName}</bdi></span>
                 ${lineInfo ? html`<span class="info">${lineInfo}</span>` : nothing}
             </button>
+            <!-- The chip truncates the name, so the tooltip is where it can be read in full. -->
+            <fluent-tooltip anchor="ide-badge" positioning="above-start">
+                <span class="tip-name">${ctx.fileName}${lineInfo}</span>
+                <span class="tip-action">
+                    ${
+                        this._enabled
+                            ? 'Goes with every message — click to stop'
+                            : 'Is not sent — click to include it'
+                    }
+                </span>
+            </fluent-tooltip>
         `;
     }
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-mic-button.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-mic-button.ts
@@ -6,7 +6,7 @@ import { LitElement, html, css, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import Mic16Regular from '@fluentui/svg-icons/icons/mic_16_regular.svg';
-import { iconStyles, iconButtonStyles, tooltipStyles } from '../styles/shared';
+import { iconStyles, tooltipStyles } from '../styles/shared';
 
 /**
  * Mic button using Web Speech API. Fires a `transcript` CustomEvent with
@@ -18,16 +18,21 @@ import { iconStyles, iconButtonStyles, tooltipStyles } from '../styles/shared';
 export class CvMicButton extends LitElement {
     static override styles = [
         iconStyles,
-        iconButtonStyles,
         tooltipStyles,
         css`
-            /* While recording: red button that pulses, reads as "stop". Full opacity so it holds
-               its own colour rather than the resting 0.75 of the shared style. */
-            .icon-btn.is-recording,
-            .icon-btn.is-recording:hover {
+            /* Fluent's own button, cut to the row's density: even size="small" is padded for a
+               control standing alone. */
+            .trigger {
+                padding: 3px;
+                min-width: 0;
+            }
+            /* While recording: red button that pulses, reads as "stop". The colour is set on the
+               host, over the subtle appearance — this state is the one thing Fluent has no
+               variant for. */
+            .trigger.is-recording,
+            .trigger.is-recording:hover {
                 background: var(--colorPaletteRedBackground3);
                 color: var(--colorNeutralForegroundOnBrand);
-                opacity: 1;
                 animation: mic-pulse 1.8s ease-in-out infinite;
             }
             @keyframes mic-pulse {
@@ -107,17 +112,27 @@ export class CvMicButton extends LitElement {
         if (!this._hasSpeech) {
             return nothing;
         }
-        return html`<button
+        return html`<fluent-button
                 id="btn-mic"
-                type="button"
-                class=${`icon-btn${this._recording ? ' is-recording' : ''}`}
+                class=${`trigger${this._recording ? ' is-recording' : ''}`}
+                appearance="subtle"
+                shape="rounded"
+                size="small"
+                icon-only
                 @click=${this._onClick}
             >
                 ${unsafeHTML(Mic16Regular)}
-            </button>
-            <fluent-tooltip anchor="btn-mic" positioning="above-end"
-                >${this._recording ? 'Stop recording' : 'Voice dictation'}</fluent-tooltip
-            >`;
+            </fluent-button>
+            <fluent-tooltip anchor="btn-mic" positioning="above-end">
+                <span class="tip-name">${this._recording ? 'Recording' : 'Dictate'}</span>
+                <span class="tip-action"
+                    >${
+                        this._recording
+                            ? 'Click to stop — what was heard stays in the message'
+                            : 'Speak instead of typing'
+                    }</span
+                >
+            </fluent-tooltip>`;
     }
 }
 

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-mic-button.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-mic-button.ts
@@ -6,7 +6,7 @@ import { LitElement, html, css, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import Mic16Regular from '@fluentui/svg-icons/icons/mic_16_regular.svg';
-import { iconStyles } from '../styles/shared';
+import { iconStyles, iconButtonStyles, tooltipStyles } from '../styles/shared';
 
 /**
  * Mic button using Web Speech API. Fires a `transcript` CustomEvent with
@@ -18,17 +18,16 @@ import { iconStyles } from '../styles/shared';
 export class CvMicButton extends LitElement {
     static override styles = [
         iconStyles,
+        iconButtonStyles,
+        tooltipStyles,
         css`
-            /* Shrink the inline icon to 16px (Fluent defaults to 20px, too big here). */
-            svg {
-                width: 16px;
-                height: 16px;
-            }
-            /* While recording: red button that pulses, reads as "stop". */
-            fluent-button.is-recording {
+            /* While recording: red button that pulses, reads as "stop". Full opacity so it holds
+               its own colour rather than the resting 0.75 of the shared style. */
+            .icon-btn.is-recording,
+            .icon-btn.is-recording:hover {
                 background: var(--colorPaletteRedBackground3);
-                border-color: var(--colorPaletteRedBackground3);
                 color: var(--colorNeutralForegroundOnBrand);
+                opacity: 1;
                 animation: mic-pulse 1.8s ease-in-out infinite;
             }
             @keyframes mic-pulse {
@@ -108,16 +107,17 @@ export class CvMicButton extends LitElement {
         if (!this._hasSpeech) {
             return nothing;
         }
-        return html`<fluent-button
-            id="btn-mic"
-            appearance="subtle"
-            icon-only
-            size="small"
-            title=${this._recording ? 'Stop recording' : 'Voice dictation'}
-            class=${this._recording ? 'is-recording' : ''}
-            @click=${this._onClick}
-            >${unsafeHTML(Mic16Regular)}</fluent-button
-        >`;
+        return html`<button
+                id="btn-mic"
+                type="button"
+                class=${`icon-btn${this._recording ? ' is-recording' : ''}`}
+                @click=${this._onClick}
+            >
+                ${unsafeHTML(Mic16Regular)}
+            </button>
+            <fluent-tooltip anchor="btn-mic" positioning="above-end"
+                >${this._recording ? 'Stop recording' : 'Voice dictation'}</fluent-tooltip
+            >`;
     }
 }
 

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-model-selector.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-model-selector.ts
@@ -2,13 +2,10 @@
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
-import { LitElement, html, css } from 'lit';
+import { LitElement, html, css, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { unsafeHTML } from 'lit/directives/unsafe-html.js';
-// Same icon the menu's "Switch model…" row uses — one glyph for one concept.
-import Brain16Regular from '@fluentui/svg-icons/icons/brain_16_regular.svg';
 import { state as appState } from '../../core/state';
-import { iconStyles } from '../styles/shared';
+import { iconStyles, iconButtonStyles, tooltipStyles } from '../styles/shared';
 import { modelLabel, modelLabelShort, resolveModelValue } from '../../core/ai-models';
 import { SwitchModelCommand } from '../../core/commands/builtin-commands';
 
@@ -25,23 +22,18 @@ import { SwitchModelCommand } from '../../core/commands/builtin-commands';
 export class CvModelSelector extends LitElement {
     static override styles = [
         iconStyles,
+        iconButtonStyles,
+        tooltipStyles,
         css`
             :host {
                 display: contents;
             }
-            /* Trigger is a <fluent-button> — keep it pure (layout only). */
-            .trigger svg {
-                width: 16px;
-                height: 16px;
-                margin-right: 4px;
-            }
             /* A provider can return a long id as the display name; cap it rather than
                letting the toolbar reflow. */
-            .trigger span {
+            .icon-btn span {
                 max-width: 14ch;
                 overflow: hidden;
                 text-overflow: ellipsis;
-                white-space: nowrap;
             }
         `,
     ];
@@ -85,18 +77,17 @@ export class CvModelSelector extends LitElement {
         // everyday, complex tasks"), then the command's line for what clicking does. The button has
         // no room for any of it; the tooltip has plenty.
         const info = this._models.find((m) => m.value === resolveModelValue(this._current));
-        const tip = [full, info?.description, this._command.description].filter(Boolean).join('\n');
+        // fluent-tooltip, not a title attribute: the native one is drawn by the OS, so it keeps the
+        // system's light/dark regardless of the theme VS is in. Same reason the gauge uses one.
         return html`
-            <fluent-button
-                class="trigger"
-                appearance="subtle"
-                size="small"
-                title=${tip}
-                @click=${this._onClick}
-            >
-                ${unsafeHTML(Brain16Regular)}
+            <button id="model-trigger" class="icon-btn" type="button" @click=${this._onClick}>
                 <span>${modelLabelShort(this._current)}</span>
-            </fluent-button>
+            </button>
+            <fluent-tooltip anchor="model-trigger" positioning="above-end">
+                <span class="tip-name">${full}</span>
+                ${info?.description ? html`<span class="tip-desc">${info.description}</span>` : nothing}
+                <span class="tip-action">${this._command.description}</span>
+            </fluent-tooltip>
         `;
     }
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-model-selector.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-model-selector.ts
@@ -5,7 +5,7 @@
 import { LitElement, html, css, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { state as appState } from '../../core/state';
-import { iconStyles, iconButtonStyles, tooltipStyles } from '../styles/shared';
+import { iconStyles, tooltipStyles } from '../styles/shared';
 import { modelLabel, modelLabelShort, resolveModelValue } from '../../core/ai-models';
 import { SwitchModelCommand } from '../../core/commands/builtin-commands';
 
@@ -22,7 +22,6 @@ import { SwitchModelCommand } from '../../core/commands/builtin-commands';
 export class CvModelSelector extends LitElement {
     static override styles = [
         iconStyles,
-        iconButtonStyles,
         tooltipStyles,
         css`
             :host {
@@ -30,7 +29,17 @@ export class CvModelSelector extends LitElement {
             }
             /* A provider can return a long id as the display name; cap it rather than
                letting the toolbar reflow. */
-            .icon-btn span {
+            /* The pill is Fluent's own — shape="circular" and the default appearance, so its
+               hover, pressed and focus come with it in either theme rather than being written out
+               here. Only the metrics are ours: even size="small" is padded for a control standing
+               alone, and min-width holds a floor a word like "Opus" never reaches. Both live on
+               the host (the template is a single content span), so no ::part is involved. */
+            .trigger {
+                font-size: var(--fontSizeBase200);
+                padding-inline: 8px;
+                min-width: 0;
+            }
+            .trigger span {
                 max-width: 14ch;
                 overflow: hidden;
                 text-overflow: ellipsis;
@@ -80,9 +89,15 @@ export class CvModelSelector extends LitElement {
         // fluent-tooltip, not a title attribute: the native one is drawn by the OS, so it keeps the
         // system's light/dark regardless of the theme VS is in. Same reason the gauge uses one.
         return html`
-            <button id="model-trigger" class="icon-btn" type="button" @click=${this._onClick}>
+            <fluent-button
+                id="model-trigger"
+                class="trigger"
+                shape="circular"
+                size="small"
+                @click=${this._onClick}
+            >
                 <span>${modelLabelShort(this._current)}</span>
-            </button>
+            </fluent-button>
             <fluent-tooltip anchor="model-trigger" positioning="above-end">
                 <span class="tip-name">${full}</span>
                 ${info?.description ? html`<span class="tip-desc">${info.description}</span>` : nothing}

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-permission-selector.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-permission-selector.ts
@@ -5,7 +5,7 @@
 import { LitElement, html, css } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { state as appState } from '../../core/state';
-import { iconStyles, iconButtonStyles, tooltipStyles } from '../styles/shared';
+import { tooltipStyles } from '../styles/shared';
 import type { PermissionMode } from '../../core/types';
 import { permissionItems } from '../../core/permission-modes';
 import { SwitchPermissionModeCommand } from '../../core/commands/builtin-commands';
@@ -21,12 +21,16 @@ import { SwitchPermissionModeCommand } from '../../core/commands/builtin-command
 @customElement('cv-permission-selector')
 export class CvPermissionSelector extends LitElement {
     static override styles = [
-        iconStyles,
-        iconButtonStyles,
         tooltipStyles,
         css`
             :host {
                 display: contents;
+            }
+            /* See cv-model-selector: Fluent's own pill, ours only the metrics. */
+            .trigger {
+                font-size: var(--fontSizeBase200);
+                padding-inline: 8px;
+                min-width: 0;
             }
         `,
     ];
@@ -69,9 +73,15 @@ export class CvPermissionSelector extends LitElement {
         const items = permissionItems();
         const item = items.find((it) => it.value === this._current) ?? items[0];
         return html`
-            <button id="perm-trigger" class="icon-btn" type="button" @click=${this._onClick}>
+            <fluent-button
+                id="perm-trigger"
+                class="trigger"
+                shape="circular"
+                size="small"
+                @click=${this._onClick}
+            >
                 <span>${item.short}</span>
-            </button>
+            </fluent-button>
             <fluent-tooltip anchor="perm-trigger" positioning="above-end">
                 <span class="tip-name">${item.label}</span>
                 <span class="tip-desc">${item.description}</span>

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-permission-selector.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-permission-selector.ts
@@ -4,9 +4,8 @@
  */
 import { LitElement, html, css } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { state as appState } from '../../core/state';
-import { iconStyles } from '../styles/shared';
+import { iconStyles, iconButtonStyles, tooltipStyles } from '../styles/shared';
 import type { PermissionMode } from '../../core/types';
 import { permissionItems } from '../../core/permission-modes';
 import { SwitchPermissionModeCommand } from '../../core/commands/builtin-commands';
@@ -23,22 +22,11 @@ import { SwitchPermissionModeCommand } from '../../core/commands/builtin-command
 export class CvPermissionSelector extends LitElement {
     static override styles = [
         iconStyles,
+        iconButtonStyles,
+        tooltipStyles,
         css`
             :host {
                 display: contents;
-            }
-            /* Trigger is a <fluent-button> — keep it pure (layout only). */
-            .trigger svg {
-                width: 16px;
-                height: 16px;
-                margin-right: 4px;
-            }
-            /* Two-word labels ("Edit automatically") otherwise wrap inside the button and make the
-               whole toolbar two rows tall. On the span too: the label is our own light-DOM node,
-               so it takes the rule even where the Fluent shadow wouldn't inherit it. */
-            .trigger,
-            .trigger span {
-                white-space: nowrap;
             }
         `,
     ];
@@ -81,16 +69,14 @@ export class CvPermissionSelector extends LitElement {
         const items = permissionItems();
         const item = items.find((it) => it.value === this._current) ?? items[0];
         return html`
-            <fluent-button
-                class="trigger"
-                appearance="subtle"
-                size="small"
-                title=${`${item.label}\n${item.description}\n${this._command.description} — Shift+Tab to switch`}
-                @click=${this._onClick}
-            >
-                ${unsafeHTML(item.icon)}
+            <button id="perm-trigger" class="icon-btn" type="button" @click=${this._onClick}>
                 <span>${item.short}</span>
-            </fluent-button>
+            </button>
+            <fluent-tooltip anchor="perm-trigger" positioning="above-end">
+                <span class="tip-name">${item.label}</span>
+                <span class="tip-desc">${item.description}</span>
+                <span class="tip-action">${this._command.description} — Shift+Tab to switch</span>
+            </fluent-tooltip>
         `;
     }
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-permission-selector.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-permission-selector.ts
@@ -89,7 +89,7 @@ export class CvPermissionSelector extends LitElement {
                 @click=${this._onClick}
             >
                 ${unsafeHTML(item.icon)}
-                <span>${item.label}</span>
+                <span>${item.short}</span>
             </fluent-button>
         `;
     }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-popover-list.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-popover-list.ts
@@ -224,8 +224,10 @@ export class CvPopoverList extends LitElement {
                 align-items: center;
                 gap: 8px;
             }
+            /* Wide enough for the longest level ("Extra high"): the value sits after the slider, so
+               a box that grows with the word drags the slider sideways while you are dragging it. */
             .dots-val {
-                min-width: 3.5em;
+                min-width: 6em;
                 text-align: right;
                 font-size: var(--fontSizeBase200);
                 color: var(--colorNeutralForeground3);

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-prompt.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-prompt.ts
@@ -5,7 +5,7 @@
 import { LitElement, html, css, nothing } from 'lit';
 import { customElement, query, state } from 'lit/decorators.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
-import { iconStyles } from '../styles/shared';
+import { iconStyles, iconButtonStyles, tooltipStyles } from '../styles/shared';
 import Send16Filled from '@fluentui/svg-icons/icons/send_16_filled.svg';
 import Stop16Filled from '@fluentui/svg-icons/icons/stop_16_filled.svg';
 import { iconUrl } from '../../core/icon-url';
@@ -150,6 +150,8 @@ function readAsAttachment(file: File): Promise<Attachment> {
 export class CvPrompt extends LitElement implements CommandHost {
     static override styles = [
         iconStyles,
+        iconButtonStyles,
+        tooltipStyles,
         css`
             :host {
                 display: contents;
@@ -233,36 +235,45 @@ export class CvPrompt extends LitElement implements CommandHost {
             #toolbar-right {
                 display: flex;
                 align-items: center;
-                gap: 6px;
+                gap: 4px;
             }
-            /* Turn settings on their own row: effort, model and permission mode answer "how should
-               this turn run", while the row above is about the message itself (attach, commands,
-               context, send). Splitting them means the labels always fit, at any pane width — no
-               truncation and no width-dependent hiding. */
-            #toolbar-settings {
-                display: flex;
-                align-items: center;
-                gap: 6px;
-                padding: 4px;
-                border-top: 1px solid var(--colorNeutralStroke2);
+            /* One row for everything, so the left side has to be able to shrink: min-width:0 lets
+               it go below its content width, and the file chip — the only elastic thing in it —
+               is what gives way. The right side keeps its buttons at full size. */
+            #toolbar-left {
+                min-width: 0;
+            }
+            #toolbar-right {
+                flex: 0 0 auto;
             }
             /* Send button: shrink the inline icon to 16px (Fluent default 20px dominates
              * a small button); turn it red when the CLI is busy so it reads as "stop". */
-            #send svg {
-                width: 16px;
-                height: 16px;
+            /* The one filled button in the composer: it carries the turn, and everything around it
+               is a subtle icon. Its own colours rather than .icon-btn's transparent resting state
+               — but the same element, so the row shares one set of metrics. */
+            #send {
+                background: var(--colorBrandBackground);
+                color: var(--colorNeutralForegroundOnBrand);
+                opacity: 1;
+            }
+            #send:hover {
+                background: var(--colorBrandBackgroundHover);
+                color: var(--colorNeutralForegroundOnBrand);
+            }
+            #send:disabled {
+                background: var(--colorNeutralBackgroundDisabled);
+                color: var(--colorNeutralForegroundDisabled);
+                cursor: default;
             }
             /* Busy = "Stop": red like the mic's recording state (same "click to stop the live
-               action" pattern). Set on the element (not ::part) so it beats the neutral appearance,
-               matching how cv-mic-button colours its recording button. */
-            #send.is-busy {
+               action" pattern). */
+            #send.is-busy,
+            #send.is-busy:hover {
                 background: var(--colorPaletteRedBackground3);
-                border-color: var(--colorPaletteRedBackground3);
                 color: var(--colorNeutralForegroundOnBrand);
             }
             #send.is-busy:hover {
                 background: var(--colorPaletteRedForeground1);
-                border-color: var(--colorPaletteRedForeground1);
             }
             #attachments {
                 display: flex;
@@ -1459,39 +1470,43 @@ export class CvPrompt extends LitElement implements CommandHost {
                     >
                         <cv-attach-menu></cv-attach-menu>
                         <cv-slash-menu></cv-slash-menu>
-                        <cv-context-gauge></cv-context-gauge>
                         <cv-subagent-chip .tasks=${this._subagentTasks}></cv-subagent-chip>
                         <cv-ide-context-badge></cv-ide-context-badge>
                     </div>
-                    <div id="toolbar-right">
+                    <div
+                        id="toolbar-right"
+                        @open-models=${this._onOpenModels}
+                        @open-permissions=${this._onOpenPermissions}
+                    >
+                        <!-- Turn settings with send, not with attach/commands: the left of the row
+                             is what goes into the message, the right is how and when it leaves.
+                             The gap between the two groups is the separation. -->
+                        <cv-thinking-toggle .host=${this}></cv-thinking-toggle>
+                        <cv-effort-selector .host=${this}></cv-effort-selector>
+                        <cv-model-selector></cv-model-selector>
+                        <cv-permission-selector></cv-permission-selector>
+                        <!-- The gauge sits with send, not with attach/commands: those act on the
+                             message you are writing, while how much context is left is about the
+                             conversation you are about to add to. -->
+                        <cv-context-gauge></cv-context-gauge>
                         <cv-mic-button
                             @transcript=${this._onMicTranscript}
                             @recording-start=${this._onMicStart}
                             @recording-end=${this._onMicEnd}
                         ></cv-mic-button>
-                        <fluent-button
+                        <button
                             id="send"
-                            class=${this._isBusy ? 'is-busy' : ''}
-                            appearance=${this._isBusy ? 'neutral' : 'primary'}
-                            icon-only
-                            size="small"
-                            title=${this._isBusy ? 'Stop' : 'Send'}
+                            type="button"
+                            class=${`icon-btn${this._isBusy ? ' is-busy' : ''}`}
                             ?disabled=${!this._isBusy && !this._hasText && this._attachments.length === 0}
                             @click=${this._onSendClick}
                         >
                             ${unsafeHTML(this._isBusy ? Stop16Filled : Send16Filled)}
-                        </fluent-button>
+                        </button>
+                        <fluent-tooltip anchor="send" positioning="above-end"
+                            >${this._isBusy ? 'Stop' : 'Send'}</fluent-tooltip
+                        >
                     </div>
-                </div>
-                <div
-                    id="toolbar-settings"
-                    @open-models=${this._onOpenModels}
-                    @open-permissions=${this._onOpenPermissions}
-                >
-                    <cv-thinking-toggle .host=${this}></cv-thinking-toggle>
-                    <cv-effort-selector .host=${this}></cv-effort-selector>
-                    <cv-model-selector></cv-model-selector>
-                    <cv-permission-selector></cv-permission-selector>
                 </div>
                 <input
                     data-cv-file-picker

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-prompt.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-prompt.ts
@@ -5,7 +5,7 @@
 import { LitElement, html, css, nothing } from 'lit';
 import { customElement, query, state } from 'lit/decorators.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
-import { iconStyles, iconButtonStyles, tooltipStyles } from '../styles/shared';
+import { iconStyles, tooltipStyles } from '../styles/shared';
 import Send16Filled from '@fluentui/svg-icons/icons/send_16_filled.svg';
 import Stop16Filled from '@fluentui/svg-icons/icons/stop_16_filled.svg';
 import { iconUrl } from '../../core/icon-url';
@@ -150,7 +150,6 @@ function readAsAttachment(file: File): Promise<Attachment> {
 export class CvPrompt extends LitElement implements CommandHost {
     static override styles = [
         iconStyles,
-        iconButtonStyles,
         tooltipStyles,
         css`
             :host {
@@ -243,37 +242,31 @@ export class CvPrompt extends LitElement implements CommandHost {
             #toolbar-left {
                 min-width: 0;
             }
+            /* Everything on the left keeps its size except the file chip — it is the one carrying
+               text that can be shortened, so it absorbs whatever the row runs out of. */
+            #toolbar-left > *:not(cv-ide-context-badge) {
+                flex-shrink: 0;
+            }
             #toolbar-right {
                 flex: 0 0 auto;
             }
             /* Send button: shrink the inline icon to 16px (Fluent default 20px dominates
              * a small button); turn it red when the CLI is busy so it reads as "stop". */
-            /* The one filled button in the composer: it carries the turn, and everything around it
-               is a subtle icon. Its own colours rather than .icon-btn's transparent resting state
-               — but the same element, so the row shares one set of metrics. */
+            /* The one filled button in the composer: appearance="primary" brings the brand fill,
+               its hover and its disabled state, so only the metrics are ours. */
             #send {
-                background: var(--colorBrandBackground);
-                color: var(--colorNeutralForegroundOnBrand);
-                opacity: 1;
-            }
-            #send:hover {
-                background: var(--colorBrandBackgroundHover);
-                color: var(--colorNeutralForegroundOnBrand);
-            }
-            #send:disabled {
-                background: var(--colorNeutralBackgroundDisabled);
-                color: var(--colorNeutralForegroundDisabled);
-                cursor: default;
+                padding: 3px;
+                min-width: 0;
             }
             /* Busy = "Stop": red like the mic's recording state (same "click to stop the live
-               action" pattern). */
-            #send.is-busy,
-            #send.is-busy:hover {
+               action" pattern) — the one state Fluent has no appearance for. */
+            #send.is-busy {
                 background: var(--colorPaletteRedBackground3);
-                color: var(--colorNeutralForegroundOnBrand);
+                border-color: var(--colorPaletteRedBackground3);
             }
             #send.is-busy:hover {
                 background: var(--colorPaletteRedForeground1);
+                border-color: var(--colorPaletteRedForeground1);
             }
             #attachments {
                 display: flex;
@@ -302,6 +295,9 @@ export class CvPrompt extends LitElement implements CommandHost {
     // True when the palette was opened from the lightning button (owns its own
     // search box + focus); false when opened by typing `/` (textarea drives it).
     @state() private _cmdSearchable = false;
+    // Non-null when the palette was opened on one specific row (the Effort trigger): the ids to
+    // show, instead of the whole list.
+    @state() private _cmdOnly: string[] | null = null;
     @state() private _modelListOpen = false;
     @state() private _permissionListOpen = false;
     @state() private _permissionMode = appState.permissionMode;
@@ -515,16 +511,20 @@ export class CvPrompt extends LitElement implements CommandHost {
                 this._permissionListOpen = false;
             }
         }
-        if (!this._cmdOpen || !this._cmdSearchable) {
+        // Only the palettes a click opened: the `/` one is driven by the textarea and closes when
+        // the token goes away, so an outside click must not touch it.
+        if (!this._cmdOpen || !(this._cmdSearchable || this._cmdOnly)) {
             return;
         }
         const path = e.composedPath();
         if (!path.some((n) => n instanceof Element && n.tagName === 'CV-COMMAND-MENU')) {
-            // Let the lightning button's own click do the toggle; don't double-close.
-            const onLightning = path.some(
-                (n) => n instanceof Element && n.tagName === 'CV-SLASH-MENU',
+            // Both triggers toggle themselves; closing here too would reopen-then-close.
+            const onTrigger = path.some(
+                (n) =>
+                    n instanceof Element &&
+                    (n.tagName === 'CV-SLASH-MENU' || n.tagName === 'CV-EFFORT-SELECTOR'),
             );
-            if (!onLightning) {
+            if (!onTrigger) {
                 this._closeCommandMenu();
             }
         }
@@ -596,6 +596,7 @@ export class CvPrompt extends LitElement implements CommandHost {
             this._cmdOpen = true;
             this._cmdSearchable = false; // textarea drives the filter
             this._cmdQuery = slashQuery;
+            this._cmdOnly = null; // typing `/` searches everything, whatever opened it last
             this._atOpen = false;
             return;
         }
@@ -1275,15 +1276,34 @@ export class CvPrompt extends LitElement implements CommandHost {
     /** Lightning button: toggle the full palette with its own search box focused
      *  (all sections, the menu owns filtering + keyboard nav). */
     private _onOpenCommands = (): void => {
-        // Re-clicking the lightning while it's open closes it (toggle).
-        if (this._cmdOpen && this._cmdSearchable) {
+        // Re-clicking the lightning while its own list is open closes it (toggle). Not when the
+        // palette is open on a single row: that came from another trigger, so this click means
+        // "show me all of them", not "close".
+        if (this._cmdOpen && this._cmdSearchable && !this._cmdOnly) {
             this._closeCommandMenu();
             return;
         }
         this._cmdQuery = '';
         this._cmdSearchable = true;
+        this._cmdOnly = null; // the full list, even if the Effort trigger narrowed it last
         this._cmdOpen = true;
         this._atOpen = false;
+    };
+
+    /** The Effort trigger: the same palette, opened on its Effort row alone. The row already
+     *  carries the slider, so there is nothing here the menu doesn't already do. */
+    private _onOpenEffort = (): void => {
+        if (this._cmdOpen && this._cmdOnly) {
+            this._closeCommandMenu();
+            return;
+        }
+        this._modelListOpen = false;
+        this._permissionListOpen = false;
+        this._atOpen = false;
+        this._cmdQuery = '';
+        this._cmdSearchable = false;
+        this._cmdOnly = ['effort'];
+        this._cmdOpen = true;
     };
 
     private _closeCommandMenu = (): void => {
@@ -1291,6 +1311,7 @@ export class CvPrompt extends LitElement implements CommandHost {
             this._cmdOpen = false;
             this._cmdQuery = '';
             this._cmdSearchable = false;
+            this._cmdOnly = null;
         }
     };
 
@@ -1449,6 +1470,7 @@ export class CvPrompt extends LitElement implements CommandHost {
                     .query=${this._cmdQuery}
                     ?open=${this._cmdOpen}
                     .searchable=${this._cmdSearchable}
+                    .only=${this._cmdOnly}
                     .host=${this}
                     @select-command=${this._onSelectCommand}
                     @close-commands=${this._closeCommandMenu}
@@ -1477,12 +1499,13 @@ export class CvPrompt extends LitElement implements CommandHost {
                         id="toolbar-right"
                         @open-models=${this._onOpenModels}
                         @open-permissions=${this._onOpenPermissions}
+                        @open-effort=${this._onOpenEffort}
                     >
                         <!-- Turn settings with send, not with attach/commands: the left of the row
                              is what goes into the message, the right is how and when it leaves.
                              The gap between the two groups is the separation. -->
                         <cv-thinking-toggle .host=${this}></cv-thinking-toggle>
-                        <cv-effort-selector .host=${this}></cv-effort-selector>
+                        <cv-effort-selector></cv-effort-selector>
                         <cv-model-selector></cv-model-selector>
                         <cv-permission-selector></cv-permission-selector>
                         <!-- The gauge sits with send, not with attach/commands: those act on the
@@ -1494,18 +1517,24 @@ export class CvPrompt extends LitElement implements CommandHost {
                             @recording-start=${this._onMicStart}
                             @recording-end=${this._onMicEnd}
                         ></cv-mic-button>
-                        <button
+                        <fluent-button
                             id="send"
-                            type="button"
-                            class=${`icon-btn${this._isBusy ? ' is-busy' : ''}`}
+                            class=${this._isBusy ? 'is-busy' : ''}
+                            appearance="primary"
+                            shape="rounded"
+                            size="small"
+                            icon-only
                             ?disabled=${!this._isBusy && !this._hasText && this._attachments.length === 0}
                             @click=${this._onSendClick}
                         >
                             ${unsafeHTML(this._isBusy ? Stop16Filled : Send16Filled)}
-                        </button>
-                        <fluent-tooltip anchor="send" positioning="above-end"
-                            >${this._isBusy ? 'Stop' : 'Send'}</fluent-tooltip
-                        >
+                        </fluent-button>
+                        <fluent-tooltip anchor="send" positioning="above-end">
+                            <span class="tip-name">${this._isBusy ? 'Stop' : 'Send'}</span>
+                            <span class="tip-action"
+                                >${this._isBusy ? 'Interrupt the turn — Esc' : 'Enter'}</span
+                            >
+                        </fluent-tooltip>
                     </div>
                 </div>
                 <input

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-segmented-slider.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-segmented-slider.ts
@@ -44,20 +44,24 @@ export class CvSegmentedSlider<V = unknown> extends LitElement {
             gap: 8px;
             font: inherit;
             user-select: none;
-            /* Themable parts — the host row overrides these (e.g. on a brand
-             * background) so the slider stays legible. Defaults track VS Code. */
-            --cv-slider-track: var(--vscode-input-background, #3c3c3c);
-            --cv-slider-fill: var(--vscode-button-background, #0e639c);
-            --cv-slider-knob: var(--vscode-button-foreground, #fff);
-            --cv-slider-dot: var(--vscode-descriptionForeground, #888);
-            --cv-slider-border: transparent;
+            /* The tokens fluent-switch itself uses (switch.styles.js), so this reads as one of the
+             * family in either theme: a transparent track outlined in StrokeAccessible, filled with
+             * CompoundBrand, and a thumb that is Foreground3 over the track and ForegroundInverted
+             * over the fill. Previously --vscode-* names, which exist in VS Code's webview and
+             * nowhere here — every one fell through to a hard-coded dark default, so the track
+             * stayed charcoal on a light theme. The host row can still override them. */
+            --cv-slider-track: var(--colorTransparentBackground);
+            --cv-slider-fill: var(--colorCompoundBrandBackground);
+            --cv-slider-knob: var(--colorNeutralForegroundInverted);
+            --cv-slider-dot: var(--colorNeutralForeground3);
+            --cv-slider-border: var(--colorNeutralStrokeAccessible);
         }
         .lead {
-            color: var(--vscode-descriptionForeground, #999);
+            color: var(--colorNeutralForeground3);
             white-space: nowrap;
         }
         .lead strong {
-            color: var(--vscode-foreground, #ccc);
+            color: var(--colorNeutralForeground1);
             font-weight: 600;
         }
         .track {
@@ -75,7 +79,7 @@ export class CvSegmentedSlider<V = unknown> extends LitElement {
             outline: none;
         }
         .track:focus-visible {
-            box-shadow: 0 0 0 2px var(--vscode-focusBorder, #007fd4);
+            box-shadow: 0 0 0 2px var(--colorStrokeFocus2, currentColor);
         }
         /* Accent stop (ultracode): purple fill/knob past the max. */
         .track.accent {
@@ -119,7 +123,7 @@ export class CvSegmentedSlider<V = unknown> extends LitElement {
             height: 16px;
             border-radius: 50%;
             background: var(--cv-slider-knob);
-            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
+            box-shadow: var(--shadow4);
             transform: translate(-50%, -50%);
             transition: left 120ms ease;
             z-index: 2;
@@ -201,7 +205,11 @@ export class CvSegmentedSlider<V = unknown> extends LitElement {
         const active = this.stops[idx];
         // knob/fill position as a percentage of the padded track span
         const pos = n > 1 ? (idx / (n - 1)) * 100 : 0;
-        const fillPx = `calc(11px + (100% - 22px) * ${pos / 100})`;
+        const knobPx = `calc(11px + (100% - 22px) * ${pos / 100})`;
+        // The knob is centred on that point (translate(-50%)), so a fill of the same width stops
+        // at its middle and leaves a gap of half a knob before it. Run the fill to the knob's far
+        // edge instead — 8px is half of the 16px knob.
+        const fillPx = `calc(${knobPx} + 8px)`;
 
         return html`
             ${
@@ -236,7 +244,7 @@ export class CvSegmentedSlider<V = unknown> extends LitElement {
                             ></span>`,
                     )}
                 </div>
-                <div class="knob" style=${`left:${fillPx}`}></div>
+                <div class="knob" style=${`left:${knobPx}`}></div>
             </div>
         `;
     }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-segmented-slider.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-segmented-slider.ts
@@ -206,10 +206,11 @@ export class CvSegmentedSlider<V = unknown> extends LitElement {
         // knob/fill position as a percentage of the padded track span
         const pos = n > 1 ? (idx / (n - 1)) * 100 : 0;
         const knobPx = `calc(11px + (100% - 22px) * ${pos / 100})`;
-        // The knob is centred on that point (translate(-50%)), so a fill of the same width stops
-        // at its middle and leaves a gap of half a knob before it. Run the fill to the knob's far
-        // edge instead — 8px is half of the 16px knob.
-        const fillPx = `calc(${knobPx} + 8px)`;
+        // The fill runs past the knob, like fluent-switch — but it is measured from the track's own
+        // edges, not from the knob: derived from knobPx it inherited the 11px padding the knob is
+        // inset by, so at the last stop it stopped short of the right edge and left a sliver of
+        // bare track. 19px is that inset plus the knob's 8px half.
+        const fillPx = `calc(19px + (100% - 19px) * ${pos / 100})`;
 
         return html`
             ${

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-slash-menu.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-slash-menu.ts
@@ -6,7 +6,7 @@ import { LitElement, html, css } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import SlashForward16Regular from '@fluentui/svg-icons/icons/slash_forward_16_regular.svg';
-import { iconStyles, iconButtonStyles, tooltipStyles } from '../styles/shared';
+import { iconStyles, tooltipStyles } from '../styles/shared';
 
 /**
  * Slash button in the input toolbar. Opens the unified command palette
@@ -18,12 +18,14 @@ import { iconStyles, iconButtonStyles, tooltipStyles } from '../styles/shared';
 export class CvSlashMenu extends LitElement {
     static override styles = [
         iconStyles,
-        iconButtonStyles,
         tooltipStyles,
         css`
-            /* Marigold "system" accent (like the model/permission triggers), at the shared 14px. */
-            .icon-btn {
-                color: var(--colorPaletteMarigoldForeground1);
+            /* Fluent's own button, cut to the row's density: even size="small" is padded for a
+               control standing alone. No accent colour — see cv-attach-menu: in this row colour
+               means state, and this button has none. */
+            .trigger {
+                padding: 3px;
+                min-width: 0;
             }
         `,
     ];
@@ -34,12 +36,21 @@ export class CvSlashMenu extends LitElement {
 
     override render() {
         return html`
-            <button id="slash-trigger" class="icon-btn" type="button" @click=${this._onClick}>
-                ${unsafeHTML(SlashForward16Regular)}
-            </button>
-            <fluent-tooltip anchor="slash-trigger" positioning="above-start"
-                >Commands</fluent-tooltip
+            <fluent-button
+                id="slash-trigger"
+                class="trigger"
+                appearance="subtle"
+                shape="rounded"
+                size="small"
+                icon-only
+                @click=${this._onClick}
             >
+                ${unsafeHTML(SlashForward16Regular)}
+            </fluent-button>
+            <fluent-tooltip anchor="slash-trigger" positioning="above-start">
+                <span class="tip-name">Commands</span>
+                <span class="tip-action">Every slash command, in one list</span>
+            </fluent-tooltip>
         `;
     }
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-slash-menu.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-slash-menu.ts
@@ -6,7 +6,7 @@ import { LitElement, html, css } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import SlashForward16Regular from '@fluentui/svg-icons/icons/slash_forward_16_regular.svg';
-import { iconStyles } from '../styles/shared';
+import { iconStyles, iconButtonStyles, tooltipStyles } from '../styles/shared';
 
 /**
  * Slash button in the input toolbar. Opens the unified command palette
@@ -18,11 +18,11 @@ import { iconStyles } from '../styles/shared';
 export class CvSlashMenu extends LitElement {
     static override styles = [
         iconStyles,
+        iconButtonStyles,
+        tooltipStyles,
         css`
-            /* 16px slash glyph, marigold "system" accent (like the model/permission triggers). */
-            svg {
-                width: 16px;
-                height: 16px;
+            /* Marigold "system" accent (like the model/permission triggers), at the shared 14px. */
+            .icon-btn {
                 color: var(--colorPaletteMarigoldForeground1);
             }
         `,
@@ -34,15 +34,12 @@ export class CvSlashMenu extends LitElement {
 
     override render() {
         return html`
-            <fluent-button
-                appearance="subtle"
-                size="small"
-                icon-only
-                title="Commands"
-                @click=${this._onClick}
-            >
+            <button id="slash-trigger" class="icon-btn" type="button" @click=${this._onClick}>
                 ${unsafeHTML(SlashForward16Regular)}
-            </fluent-button>
+            </button>
+            <fluent-tooltip anchor="slash-trigger" positioning="above-start"
+                >Commands</fluent-tooltip
+            >
         `;
     }
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-speak-btn.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-speak-btn.ts
@@ -64,7 +64,7 @@ export class CvSpeakBtn extends LitElement {
                 opacity: 0.75;
             }
             .icon-btn:hover {
-                background: var(--colorSubtleBackgroundHover, rgba(127, 127, 127, 0.12));
+                background: color-mix(in srgb, var(--colorNeutralForeground1) 10%, transparent);
                 opacity: 1;
             }
             .icon-btn:focus-visible {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-thinking-toggle.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-thinking-toggle.ts
@@ -10,7 +10,7 @@ import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import Lightbulb16Filled from '@fluentui/svg-icons/icons/lightbulb_16_filled.svg';
 import Lightbulb16Regular from '@fluentui/svg-icons/icons/lightbulb_16_regular.svg';
 import { state as appState } from '../../core/state';
-import { iconStyles } from '../styles/shared';
+import { iconStyles, iconButtonStyles, tooltipStyles } from '../styles/shared';
 import { ThinkingCommand } from '../../core/commands/model-controls';
 import type { CommandHost } from '../../core/commands/base';
 
@@ -28,14 +28,11 @@ import type { CommandHost } from '../../core/commands/base';
 export class CvThinkingToggle extends LitElement {
     static override styles = [
         iconStyles,
+        iconButtonStyles,
+        tooltipStyles,
         css`
             :host {
                 display: contents;
-            }
-            /* Trigger is a <fluent-button> — keep it pure (layout only). */
-            .trigger svg {
-                width: 16px;
-                height: 16px;
             }
         `,
     ];
@@ -89,17 +86,19 @@ export class CvThinkingToggle extends LitElement {
         }
         const on = this._enabled;
         return html`
-            <fluent-button
-                class="trigger"
-                appearance="subtle"
-                size="small"
-                icon-only
+            <button
+                id="thinking-trigger"
+                class="icon-btn"
+                type="button"
                 aria-pressed=${on ? 'true' : 'false'}
-                title=${`${this._command.label}: ${on ? 'on' : 'off'}\n${this._command.description}`}
                 @click=${this._onClick}
             >
                 ${unsafeHTML(on ? Lightbulb16Filled : Lightbulb16Regular)}
-            </fluent-button>
+            </button>
+            <fluent-tooltip anchor="thinking-trigger" positioning="above-end">
+                <span class="tip-name">${this._command.label}: ${on ? 'on' : 'off'}</span>
+                <span class="tip-action">${this._command.description}</span>
+            </fluent-tooltip>
         `;
     }
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-thinking-toggle.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-thinking-toggle.ts
@@ -10,7 +10,7 @@ import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import Lightbulb16Filled from '@fluentui/svg-icons/icons/lightbulb_16_filled.svg';
 import Lightbulb16Regular from '@fluentui/svg-icons/icons/lightbulb_16_regular.svg';
 import { state as appState } from '../../core/state';
-import { iconStyles, iconButtonStyles, tooltipStyles } from '../styles/shared';
+import { iconStyles, tooltipStyles } from '../styles/shared';
 import { ThinkingCommand } from '../../core/commands/model-controls';
 import type { CommandHost } from '../../core/commands/base';
 
@@ -28,11 +28,16 @@ import type { CommandHost } from '../../core/commands/base';
 export class CvThinkingToggle extends LitElement {
     static override styles = [
         iconStyles,
-        iconButtonStyles,
         tooltipStyles,
         css`
             :host {
                 display: contents;
+            }
+            /* Fluent's own button, cut to the row's density: even size="small" is padded for a
+               control standing alone. */
+            .trigger {
+                padding: 3px;
+                min-width: 0;
             }
         `,
     ];
@@ -86,15 +91,18 @@ export class CvThinkingToggle extends LitElement {
         }
         const on = this._enabled;
         return html`
-            <button
+            <fluent-button
                 id="thinking-trigger"
-                class="icon-btn"
-                type="button"
+                class="trigger"
+                appearance="subtle"
+                shape="rounded"
+                size="small"
+                icon-only
                 aria-pressed=${on ? 'true' : 'false'}
                 @click=${this._onClick}
             >
                 ${unsafeHTML(on ? Lightbulb16Filled : Lightbulb16Regular)}
-            </button>
+            </fluent-button>
             <fluent-tooltip anchor="thinking-trigger" positioning="above-end">
                 <span class="tip-name">${this._command.label}: ${on ? 'on' : 'off'}</span>
                 <span class="tip-action">${this._command.description}</span>

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/chat.css
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/chat.css
@@ -618,9 +618,15 @@ cv-message:focus-within .cv-msg-actions {
     cursor: pointer;
     opacity: 0.75;
 }
+/* NOT --colorSubtleBackgroundHover: in the light theme that token is #f5f5f5, three points of
+ * luminance off the #ffffff behind it — the hover is there and invisible. Mixing the foreground
+ * inverts with the theme by construction. Kept in step with iconButtonStyles (shared.ts). */
 .icon-btn:hover {
-    background: var(--colorSubtleBackgroundHover, rgba(127, 127, 127, 0.12));
+    background: color-mix(in srgb, var(--colorNeutralForeground1) 10%, transparent);
     opacity: 1;
+}
+.icon-btn:active {
+    background: color-mix(in srgb, var(--colorNeutralForeground1) 16%, transparent);
 }
 .icon-btn:focus-visible {
     outline: 1px solid var(--colorStrokeFocus2, currentColor);

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/shared.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/shared.ts
@@ -28,6 +28,121 @@ export const iconStyles = css`
 `;
 
 /**
+ * Shared icon-action button — the Shadow-DOM twin of `.icon-btn` in chat.css, which the light DOM
+ * uses for the same thing. A bare `<button>`, not a fluent-button: Fluent sizes a standalone
+ * control, and cutting it down to an icon's own size means overriding its tokens, which the
+ * fluent-pure rule forbids. Owning the element instead keeps that rule intact.
+ *
+ * Glyph size comes from `--cv-icon-btn-size` (default 14px, the density of an action inside the
+ * transcript). A composer control sets 16px: it is permanent chrome, sits beside a text label, and
+ * has to be worth aiming at.
+ */
+export const iconButtonStyles = css`
+    .icon-btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 3px;
+        border: 0;
+        border-radius: var(--borderRadiusSmall);
+        background: transparent;
+        /* Foreground2, not the inherited Foreground1: these sit beside the message they act on and
+           should not compete with it. Full strength on hover, below. */
+        color: var(--colorNeutralForeground2);
+        cursor: pointer;
+        opacity: 0.75;
+    }
+    .icon-btn:hover,
+    .icon-btn:focus-visible {
+        color: var(--colorNeutralForeground1);
+    }
+    /* NOT --colorSubtleBackgroundHover: in the light theme that token is #f5f5f5, three points of
+       luminance off the #ffffff behind it — the hover is there and invisible. Mixing the foreground
+       inverts with the theme by construction, so the tint reads on either. Same as the IDE-context
+       chip beside these buttons. */
+    .icon-btn:hover {
+        background: color-mix(in srgb, var(--colorNeutralForeground1) 10%, transparent);
+        opacity: 1;
+    }
+    .icon-btn:active {
+        background: color-mix(in srgb, var(--colorNeutralForeground1) 16%, transparent);
+    }
+    .icon-btn:focus-visible {
+        outline: 1px solid var(--colorStrokeFocus2, currentColor);
+        outline-offset: 1px;
+    }
+    .icon-btn svg {
+        width: var(--cv-icon-btn-size, 14px);
+        height: var(--cv-icon-btn-size, 14px);
+        display: block;
+        fill: currentColor;
+    }
+    /* The label of a button that carries one (the composer's model/effort/permission triggers).
+       Base200: below the body text, since these name a setting rather than say anything, but above
+       the Base100 of the IDE-context chip — on those three the word is the whole control, with no
+       glyph to carry it. nowrap so the button never wraps onto a second row. */
+    .icon-btn span {
+        font-size: var(--fontSizeBase200);
+        white-space: nowrap;
+    }
+    /* A labelled button reads as a pill: a word on its own needs more room than a glyph (3px is
+       right for a 14px icon, cramped for text), and a faint fill with a full radius says "this is
+       one control" where three bare words in a row would read as one phrase. Enough on its own
+       that no separator is needed between them. */
+    .icon-btn:has(span) {
+        padding: 2px 8px;
+        border-radius: 999px;
+        border: 1px solid var(--colorNeutralStroke2);
+        background: var(--colorNeutralBackground1);
+        opacity: 1;
+    }
+    .icon-btn:has(span):hover {
+        border-color: var(--colorNeutralStroke1);
+        background: color-mix(
+            in srgb,
+            var(--colorNeutralForeground1) 8%,
+            var(--colorNeutralBackground1)
+        );
+    }
+    .icon-btn svg + span {
+        margin-left: 4px;
+    }
+`;
+
+/**
+ * Shared tooltip for the composer's triggers. A `title` attribute is drawn by the OS, so it keeps
+ * the system's light/dark whatever theme VS is in — `fluent-tooltip` is themed like the rest.
+ *
+ * Three optional lines, in the order the reader needs them: what the setting is on (`.tip-name`),
+ * what that means (`.tip-desc`), and what clicking does (`.tip-action`).
+ */
+export const tooltipStyles = css`
+    /* :popover-open, not the bare tag: fluent-tooltip is a popover, and a closed popover is hidden
+       by a UA display:none that a plain display:flex here would override — which left the tooltip
+       on screen permanently. Layout only applies once it opens. */
+    fluent-tooltip:popover-open {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+    }
+    fluent-tooltip {
+        padding: 6px 8px;
+        max-width: 320px;
+    }
+    .tip-name {
+        font-weight: var(--fontWeightSemibold);
+    }
+    .tip-desc {
+        color: var(--colorNeutralForeground2);
+    }
+    /* The verb, set apart from the description of what is currently in force. */
+    .tip-action {
+        color: var(--colorNeutralForeground3);
+        font-size: var(--fontSizeBase100);
+    }
+`;
+
+/**
  * Shared shell for the info dialogs (Account & Usage, Context usage, Statistics), all built
  * on fluent-dialog + fluent-dialog-body. Tall content overflows Fluent's default
  * max-height:100vh; cap the box at 85vh and let the body content part scroll inside it (the

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/shared.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/shared.ts
@@ -18,12 +18,12 @@ export const iconStyles = css`
     svg[fill='none'] {
         fill: none;
     }
-    /* Fluent's small icon-only button scales its glyph to 20px; pin it to the nominal
-     * 16px so the action icons (copy, chevron, toggles) read as one size in the dense
-     * chat and don't look oversized. Only icon-only buttons — labelled ones keep theirs. */
+    /* Fluent's small icon-only button scales its glyph to 20px; pin it to 14, the size every
+     * action icon in the chat is drawn at (see iconButtonStyles), so the two kinds of button
+     * read as one set. Only icon-only buttons — labelled ones keep theirs. */
     fluent-button[icon-only] svg {
-        width: 16px;
-        height: 16px;
+        width: 14px;
+        height: 14px;
     }
 `;
 
@@ -34,8 +34,11 @@ export const iconStyles = css`
  * fluent-pure rule forbids. Owning the element instead keeps that rule intact.
  *
  * Glyph size comes from `--cv-icon-btn-size` (default 14px, the density of an action inside the
- * transcript). A composer control sets 16px: it is permanent chrome, sits beside a text label, and
- * has to be worth aiming at.
+ * transcript); a component can raise it where the icon has to carry more.
+ *
+ * Icon-only buttons. A control with a word instead of a glyph is a `fluent-button` with
+ * `shape="circular"` — Fluent's own pill, so its hover and focus come with it (see
+ * cv-model-selector).
  */
 export const iconButtonStyles = css`
     .icon-btn {
@@ -77,36 +80,6 @@ export const iconButtonStyles = css`
         display: block;
         fill: currentColor;
     }
-    /* The label of a button that carries one (the composer's model/effort/permission triggers).
-       Base200: below the body text, since these name a setting rather than say anything, but above
-       the Base100 of the IDE-context chip — on those three the word is the whole control, with no
-       glyph to carry it. nowrap so the button never wraps onto a second row. */
-    .icon-btn span {
-        font-size: var(--fontSizeBase200);
-        white-space: nowrap;
-    }
-    /* A labelled button reads as a pill: a word on its own needs more room than a glyph (3px is
-       right for a 14px icon, cramped for text), and a faint fill with a full radius says "this is
-       one control" where three bare words in a row would read as one phrase. Enough on its own
-       that no separator is needed between them. */
-    .icon-btn:has(span) {
-        padding: 2px 8px;
-        border-radius: 999px;
-        border: 1px solid var(--colorNeutralStroke2);
-        background: var(--colorNeutralBackground1);
-        opacity: 1;
-    }
-    .icon-btn:has(span):hover {
-        border-color: var(--colorNeutralStroke1);
-        background: color-mix(
-            in srgb,
-            var(--colorNeutralForeground1) 8%,
-            var(--colorNeutralBackground1)
-        );
-    }
-    .icon-btn svg + span {
-        margin-left: 4px;
-    }
 `;
 
 /**
@@ -128,6 +101,9 @@ export const tooltipStyles = css`
     fluent-tooltip {
         padding: 6px 8px;
         max-width: 320px;
+        /* Lets a plain string with newlines break where it says to, so a tooltip with two or three
+           lines doesn't need an element per line. */
+        white-space: pre-line;
     }
     .tip-name {
         font-weight: var(--fontWeightSemibold);

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.Protocol.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.Protocol.cs
@@ -30,6 +30,11 @@ public sealed partial class ClaudeClient
         => subtype switch
         {
             "initialize" => InitializeTimeout,
+            // The gauge asks for this as the pane opens, which is exactly when the CLI is busiest:
+            // resuming a large session it answers nothing for tens of seconds, then drains its
+            // queue at once. Ten seconds lost the answer to a request the CLI did go on to serve.
+            // Safe to wait on — it reads, changes nothing, and an empty gauge is the only cost.
+            "get_context_usage" => InitializeTimeout,
             "generate_session_title" => LongRunningTimeout,
             "rewind_files" => LongRunningTimeout,
             _ => DefaultRequestTimeout,


### PR DESCRIPTION
A day on the composer. It started with two long permission labels setting the
width of a docked pane, and ended with the row on one line, its controls all
Fluent, and seven theme bugs found along the way.

## The row

Settings had a row of their own because the labels would not otherwise fit at
any pane width. Shortening them changed that arithmetic — `Edit automatically`
and `Bypass permissions` are eighteen characters next to three that fit in
four — so the row is gone. The left of the line is what goes into the message
(attach, commands, the file in context), the right is how and when it leaves
(the settings, the gauge, mic, send). The gap between the two is the
separation; the file chip is the only elastic thing and gives way first.

The three settings lost their icons. "Opus" and "High" say it better than a
brain and a dumbbell do, and the effort panel keeps its glyph in the header.

## Fluent, twice

The controls went to bare `<button>`s first, on the reasoning already written
in cv-copy-btn: a fluent-button is sized for a standalone control, and cutting
it to an icon's size means overriding its tokens, which the fluent-pure rule
forbids.

Then the theme bugs came in, and every one of them was hand-written theming:
`--colorSubtleBackgroundHover` is `#f5f5f5` in the light theme, three points
of luminance off the white behind it, so the hover on **seven** buttons was
being drawn and could not be seen. The effort slider was still asking for
`--vscode-*` names, which exist in VS Code's webview and nowhere here — every
colour fell through to a hard-coded dark default. And a stray parenthesis of
mine left three rules inert.

Fluent had none of them. And `shape` gives the pill look through the
component's API rather than over its tokens, so what is left to write is two
lines of metric. The second refactor puts them back — the commit says so
rather than pretending the first didn't happen.

## Menus

Effort's popover is gone: the palette can now open on named rows (`only`,
by command id — not a query string, since that goes through Fuse and would
depend on what else is installed), and Effort is one of them. The gauge's
340px panel is gone the same way: it is a fluent-menu now, with the reading at
the top as a plain div the focusgroup steps over, then Compact, a rule, and
Statistics / Usage / Context usage in the order and icons of the VS menu's own
Analytics group.

Tooltips are fluent-tooltip throughout. A `title` is drawn by the OS, so it
kept the system's light/dark whatever theme VS was in.

## Things that fought back

`fluent-menu` anchors its list to the trigger's `anchor-name`, which the
trigger derives from its **id** — so the attach button's id is load-bearing,
and a tooltip anchored to the same element overwrote it and dropped the list
at 0,0. The tooltip hangs off a span inside the button instead. Both menus
now hang from their trigger's right edge; anchored Fluent's way the gauge's
list flew out to the left with the pointer crossing open air to reach it.

## Elsewhere

Four fixes that surfaced while working here and stand on their own: a new pane
opened dark whatever theme VS was in (the theme message was sent before the
WebView was ready and dropped); file icons kept the theme they were first
drawn under (the cache was keyed on the extension alone); a file type VS
declines to rasterise showed a broken image; and the context gauge gave up
after ten seconds on a CLI that was resuming a 5.7 MB session and answered
after fifty.

## Verification

`typecheck`, `format:check` and `lint` clean throughout; each step was
exercised in the Exp instance in both themes as it was made. The C# — theme,
timeout, icon cache — was built in the debug session but has not had a
standalone msbuild since the last edit.
