### PR TITLE
feat(chat): a button back to the latest message

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
@@ -4,6 +4,8 @@
  */
 import { LitElement, html, nothing } from 'lit';
 import { customElement, query, state } from 'lit/decorators.js';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import ChevronDown16Regular from '@fluentui/svg-icons/icons/chevron_down_16_regular.svg';
 import { bridge } from '../../core/bridge';
 import { Msg } from '../../core/bridge-messages';
 import { fetchSubagent, fetchContextUsage, fetchCompactSummary } from '../../core/lazy';
@@ -87,6 +89,9 @@ export class CvApp extends LitElement {
     @state() private _awaitingUser = appState.pendingPermission != null;
 
     @query('#messages') private _messagesEl!: HTMLDivElement;
+    /** Whether the "jump to the latest" button is showing — see _updateJump for the hysteresis. */
+    @state() private _showJump = false;
+    private _jumpRaf = 0;
     @query('#system-notices') private _systemNotices!: CvNoticeStack | null;
 
     private _offs: Array<() => void> = [];
@@ -640,6 +645,10 @@ export class CvApp extends LitElement {
     override disconnectedCallback(): void {
         super.disconnectedCallback();
         this._messagesEl?.removeEventListener('scroll', this._onMessagesScroll);
+        if (this._jumpRaf !== 0) {
+            cancelAnimationFrame(this._jumpRaf);
+            this._jumpRaf = 0;
+        }
         window.removeEventListener('keydown', this._onGlobalEsc);
         this.removeEventListener('subagent-toggle', this._onChildrenToggle as EventListener);
         this.removeEventListener('compact-expand', this._onCompactExpand as EventListener);
@@ -811,6 +820,10 @@ export class CvApp extends LitElement {
         if (!el) {
             return;
         }
+        // Before the lazy-load guards below: those return early on most scrolls, and the jump
+        // button has to follow every one of them. This listener is already passive — a second one
+        // for the same event is what we are avoiding.
+        this._queueJumpUpdate();
         if (!appState.hasMoreHistory || appState.loadingOlder) {
             return;
         }
@@ -1300,6 +1313,37 @@ export class CvApp extends LitElement {
 
     /** True when scrolled at/near the bottom. Gates stream auto-follow so
      *  the user isn't yanked down while reading scrolled-up content. */
+    /** Coalesce to one measurement per frame: a scroll fires far more often than it repaints, and
+     *  reading scrollHeight on each event is a forced layout for a value that can't have changed
+     *  twice in a frame. */
+    private _queueJumpUpdate(): void {
+        if (this._jumpRaf !== 0) {
+            return;
+        }
+        this._jumpRaf = requestAnimationFrame(() => {
+            this._jumpRaf = 0;
+            this._updateJump();
+        });
+    }
+
+    /** Two thresholds, not one: during streaming the distance to the bottom oscillates as content
+     *  lands, and a single line would flicker the button in and out on every delta. It takes a
+     *  real scroll of 300px to show it, and coming back within 120px to hide it again. */
+    private _updateJump(): void {
+        const el = this._messagesEl;
+        // clientHeight reads 0 while WebView2 is suspended in the background; a distance measured
+        // then is meaningless, so leave the button as it is rather than acting on a false.
+        if (!el || el.clientHeight === 0) {
+            return;
+        }
+        const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
+        if (!this._showJump && distance > 300) {
+            this._showJump = true;
+        } else if (this._showJump && distance < 120) {
+            this._showJump = false;
+        }
+    }
+
     private _isNearBottom(threshold = 80): boolean {
         const el = this._messagesEl;
         if (!el) {
@@ -1508,16 +1552,32 @@ export class CvApp extends LitElement {
 
             <div id="messages" aria-live="polite">
                 ${
-                    this._entries.length === 0 && !this._isBusy
-                        ? html`<cv-welcome></cv-welcome>`
-                        : nothing
-                }
+                        this._entries.length === 0 && !this._isBusy
+                            ? html`<cv-welcome></cv-welcome>`
+                            : nothing
+                    }
                 ${this._exchanges.map((group) => this.renderExchange(group))}
                 ${
-                    this._isBusy && this._streamingMsgs.size === 0 && !this._awaitingUser
-                        ? html`<cv-spinner .status=${this._status}></cv-spinner>`
-                        : nothing
-                }
+                        this._isBusy && this._streamingMsgs.size === 0 && !this._awaitingUser
+                            ? html`<cv-spinner .status=${this._status}></cv-spinner>`
+                            : nothing
+                    }
+                <!-- Last child of the scroller, stuck to its bottom edge: position:sticky keeps it
+                     in view without a wrapper. A wrapper would have been cleaner, but cv-app
+                     renders into the light DOM, and re-parenting #messages moves nodes Lit holds
+                     markers into — the next update then writes a property onto a node that is
+                     gone. -->
+                <fluent-button
+                    id="jump-to-bottom"
+                    shape="circular"
+                    size="small"
+                    icon-only
+                    title="Jump to the latest"
+                    ?hidden=${!this._showJump}
+                    @click=${(): void => this._scrollToBottom()}
+                >
+                    ${unsafeHTML(ChevronDown16Regular)}
+                </fluent-button>
             </div>
 
             <div id="composer-area">

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/chat.css
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/chat.css
@@ -13,6 +13,25 @@
     overflow-anchor: auto;
 }
 
+/* Sticky, not absolute: it is the scroller's own last child, so sticking it to the bottom edge
+ * keeps it in view as the content moves under it — no wrapper, which cv-app's light DOM can't
+ * take. float:right pulls it out of the flow so it adds no height of its own.
+ * Fluent's default appearance, not outline: this floats over the transcript, and an outline
+ * button is near-transparent — the text underneath showed straight through it. */
+#jump-to-bottom {
+    position: sticky;
+    float: right;
+    bottom: 12px;
+    right: 6px;
+    z-index: 3;
+    padding: 4px;
+    min-width: 0;
+    box-shadow: var(--shadow16);
+}
+#jump-to-bottom[hidden] {
+    display: none;
+}
+
 .cv-message {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
Scrolling up during a turn switches auto-follow off — deliberately, so you
aren't yanked down mid-read — but the only way back was the wheel, and on a
long turn with many tool rows that is a lot of it. The mechanism was already
there: `_scrollToBottom` is what the button calls. What was missing was the
affordance.

## Not flickering

Two thresholds, not one: 300px out to appear, back within 120px to go away.
During streaming the distance to the bottom oscillates as content lands, and a
single line would flip the button in and out on every delta.

A reading taken while WebView2 is suspended is discarded — `clientHeight` is 0
in the background, and the distance computed from it is a lie. This is the same
measurement the streaming scroll bug feeds on, so the button declines to act on
it rather than inheriting the fault.

## Not costing anything

It rides on the scroll listener the lazy-load already installs, before that
handler's early returns (which fire on most scrolls), coalesced to one
measurement per frame. A scroll fires far more often than a repaint, and
`scrollHeight` is a forced layout — a second listener doing `setState` per tick
is what the TODO explicitly warned against.

## Not disturbing the layout

Sticky rather than absolute, as the scroller's own last child, with
`float: right` so it stays out of the flow and adds no height. That matters
here specifically: `scrollHeight` is what every scroll decision is measured
against, and an element in the flow would change it while we are trying to
anchor to the bottom.

The tidier structure would have been a wrapper around `#messages` with the
button as its sibling. That is what I wrote first, and it threw
`Cannot set properties of null` on the next render: `cv-app` renders into the
**light DOM**, so re-parenting `#messages` moved nodes Lit holds part markers
into, and the following update wrote `.data` onto a node that no longer
existed. Worth knowing before anyone reaches for a wrapper in this component
again.

## Appearance

`fluent-button shape="circular"`, default appearance — `outline` is
near-transparent and the transcript showed straight through it. No accent
colour: in this pane colour means state (the gauge's bands, the mic recording,
send having something to send), and this is navigation.

## Not included

The TODO's follow-on idea — a badge counting new messages that arrived while
scrolled up — isn't here. It wants its own thinking about what counts as new.

## Verification

`typecheck`, `format:check`, `lint` clean; exercised in the Exp instance.
The TODO recommends doing this after the streaming-scroll fix, since the
predicate shares that bug's unreliable measurements; the `clientHeight === 0`
guard is what stands in for that until it lands.
