### PR TITLE
fix(chat): a closed pane left its WebView renderer running

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.cs
@@ -21,8 +21,10 @@ namespace Corsinvest.VisualStudio.Agents.Chat.Host;
 /// and dispatching messages received from JS to the host via <see cref="MessageReceived"/>.
 /// </summary>
 internal sealed partial class WebViewBridge(Microsoft.Web.WebView2.Wpf.WebView2 webView, Dispatcher dispatcher)
+    : IDisposable
 {
     private bool _ready;
+    private bool _disposed;
     private readonly ConcurrentQueue<(string type, object data)> _pending = new();
     private bool? _pendingTheme;
     private string _docCreatedScriptId;
@@ -80,6 +82,9 @@ internal sealed partial class WebViewBridge(Microsoft.Web.WebView2.Wpf.WebView2 
             var isFirstLoad = true;
             webView.CoreWebView2.NavigationCompleted += (s, args) =>
             {
+                // A navigation landing during teardown would re-arm _ready and drain the queue
+                // into a WebView being disposed.
+                if (_disposed) { return; }
                 _ready = true;
                 if (isFirstLoad)
                 {
@@ -169,6 +174,29 @@ internal sealed partial class WebViewBridge(Microsoft.Web.WebView2.Wpf.WebView2 
     }
 
     public void OpenDevTools() => webView.CoreWebView2?.OpenDevToolsWindow();
+
+    /// <summary>Release the WebView2 control, and with it the CoreWebView2Controller and the
+    /// renderer process behind this pane. VS keeps the closed tool window's control alive, so
+    /// without this the renderer outlives the pane and the browser accumulates one per pane ever
+    /// opened. Handlers are unhooked first: they run on the controller being torn down.</summary>
+    public void Dispose()
+    {
+        if (_disposed) { return; }
+        _disposed = true;
+        _ready = false;
+        try
+        {
+            var core = webView.CoreWebView2;
+            if (core != null)
+            {
+                core.WebMessageReceived -= OnRawMessage;
+                core.ContextMenuRequested -= OnContextMenuRequested;
+                core.WebResourceRequested -= OnIconRequested;
+            }
+            webView.Dispose();
+        }
+        catch (Exception ex) { OutputWindowLogger.LogException("WebViewBridge.Dispose", ex); }
+    }
 
     /// <summary>Give the WebView2 control the native (WPF) focus, so the keyboard
     /// actually reaches the page. Without this a JS `element.focus()` only shows a

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
@@ -290,7 +290,7 @@ public partial class ChatPaneControl : PaneControlBase
 
     /// <summary>Kind-specific release (the base handles _disposed guard, solution-events
     /// unadvise, and the registry drop). Unhook the theme + static Options subscriptions and
-    /// dispose the client. The IdeContextService singleton is owned by the package
+    /// dispose the client and the WebView. The IdeContextService singleton is owned by the package
     /// (McpServerHost lifetime) — only unhook our handler, don't dispose it.</summary>
     protected override void DisposeCore()
     {
@@ -306,6 +306,9 @@ public partial class ChatPaneControl : PaneControlBase
         // stdout line as the process closes) would otherwise reach this disposed control.
         if (_client != null) { DetachClientEvents(_client); }
         _client?.Dispose();
+        // Last: the bridge tears down the WebView2, and anything above may still post to it.
+        _bridge?.Dispose();
+        _bridge = null;
     }
 
     private void OnEditorContextChanged(EditorContext ctx)

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
@@ -1552,16 +1552,16 @@ export class CvApp extends LitElement {
 
             <div id="messages" aria-live="polite">
                 ${
-                        this._entries.length === 0 && !this._isBusy
-                            ? html`<cv-welcome></cv-welcome>`
-                            : nothing
-                    }
+                    this._entries.length === 0 && !this._isBusy
+                        ? html`<cv-welcome></cv-welcome>`
+                        : nothing
+                }
                 ${this._exchanges.map((group) => this.renderExchange(group))}
                 ${
-                        this._isBusy && this._streamingMsgs.size === 0 && !this._awaitingUser
-                            ? html`<cv-spinner .status=${this._status}></cv-spinner>`
-                            : nothing
-                    }
+                    this._isBusy && this._streamingMsgs.size === 0 && !this._awaitingUser
+                        ? html`<cv-spinner .status=${this._status}></cv-spinner>`
+                        : nothing
+                }
                 <!-- Last child of the scroller, stuck to its bottom edge: position:sticky keeps it
                      in view without a wrapper. A wrapper would have been cleaner, but cv-app
                      renders into the light DOM, and re-parenting #messages moves nodes Lit holds

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneControlBase.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneControlBase.cs
@@ -78,7 +78,7 @@ public abstract class PaneControlBase : UserControl, IPaneControl
     }
 
     /// <summary>Kind-specific release: chat unsubs Options.Applied + editor context + disposes
-    /// the client; cli disposes the ConPTY process. Theme unsub lives here too (handler name
+    /// the client and the WebView; cli disposes the ConPTY process. Theme unsub lives here too (handler name
     /// differs per kind). Runs before the base drops the registry entry.</summary>
     protected abstract void DisposeCore();
 


### PR DESCRIPTION
Closing a chat pane released the CLI client but never the WebView2 control, so the `CoreWebView2Controller` — and the renderer process behind it — outlived the pane. VS keeps a closed tool window's control alive, so nothing else collected it either: the browser accumulated one renderer per pane ever opened, for the lifetime of the IDE.

The CLI pane already disposed its ConPTY child; the chat pane disposed `claude.exe` but not the renderer. The asymmetry wasn't deliberate.

## What changed

- `WebViewBridge` implements `IDisposable`: unhooks its three named handlers, then disposes the control. Idempotent, and logs rather than swallowing.
- `ChatPaneControl.DisposeCore` disposes the bridge **last**, after the client — anything torn down above it may still post to the WebView.
- `NavigationCompleted` stays subscribed (it's a lambda on the `CoreWebView2`, which dies with the controller), so it now bails out when `_disposed` is set instead of re-arming `_ready` and draining the pending queue into a WebView on its way out.

The three inline lambdas are deliberately left subscribed: the event source is the `CoreWebView2` being disposed, so it holds them, not the reverse.

## Verification

Build green (`msbuild /t:Build /p:Configuration=Debug`), VSIX produced.

Checked in the experimental instance by watching the browser's renderer processes across a pane close/reopen:

- **Before**: renderers born at 19:27–19:38 were still alive an hour later, with only 3 panes open.
- **After**: the renderer hosting the pane (PID 73576) exited on close; reopening spawned a fresh one (83348). Count stayed flat instead of growing.

Worth knowing for anyone reading the process list: WebView2 keys the browser process on the user-data folder, not on the host, so a second VS instance running the extension shares the same browser — its renderers show up in the same list.
