### PR TITLE
feat(panes): say which processes are behind the pane you are looking at

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -23,6 +23,7 @@ go to `%LOCALAPPDATA%` — see [Settings and data](settings-and-data.md).
 | Show relative paths in tool rows | bool | `true` | File paths relative to the working directory (full path if outside it). |
 | Preview lines | int | `3` | Lines shown in preview areas (tool output, user messages). `0` = no preview. |
 | Chat font size | int (px) | `13` | Font size of the chat message text. |
+| Show WebView developer entries | bool | `false` | Add "WebView DevTools" and "WebView task manager" to the chat toolbar's "More" (…) menu — the browser console/DOM/network on the chat itself, and the browser's processes with their memory and CPU. Pre-release builds always offer both. |
 | Autosave before Claude reads/writes | bool | `true` | Save a dirty file before Claude reads/writes it, so it sees your in-editor edits, not the stale on-disk version. |
 | Send post-edit diagnostics to Claude (experimental) | bool | `false` | Feed back the new errors/warnings an edit introduced. Experimental — unreliable because VS only analyses files open in an editor (see IDE integration). |
 | Allowed upload file extensions | string[] | ~120 defaults | Extensions accepted on upload/drop. Images → images, `.pdf` → document, rest → text; anything else rejected. Editable list. |

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.cs
@@ -11,6 +11,7 @@ using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Concurrent;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Threading;
 
@@ -174,6 +175,42 @@ internal sealed partial class WebViewBridge(Microsoft.Web.WebView2.Wpf.WebView2 
     }
 
     public void OpenDevTools() => webView.CoreWebView2?.OpenDevToolsWindow();
+
+    /// <summary>PID of the WebView2 browser process, or null before the WebView is up. WebView2
+    /// keys the browser on the user-data folder, not on the host: every pane shares this one, and
+    /// so does a second VS instance running the extension. It identifies the group, not the pane —
+    /// <see cref="RendererProcessIdAsync"/> is the per-pane process.</summary>
+    public uint? BrowserProcessId => webView.CoreWebView2?.BrowserProcessId;
+
+    /// <summary>PID of the renderer hosting THIS pane, or null if it can't be resolved. Matched on
+    /// the main frame's id: the browser's process list alone can't say which renderer is ours, and
+    /// with panes from another VS instance in there too, listing them all answers nobody's
+    /// question. Async because the frame→process map is only exposed that way.</summary>
+    public async Task<int?> RendererProcessIdAsync()
+    {
+        try
+        {
+            var core = webView.CoreWebView2;
+            if (core == null) { return null; }
+
+            var frameId = core.FrameId;
+            var infos = await core.Environment.GetProcessExtendedInfosAsync();
+            return infos.FirstOrDefault(
+                p => p.ProcessInfo.Kind == CoreWebView2ProcessKind.Renderer
+                     && p.AssociatedFrameInfos.Any(f => f.FrameId == frameId))?.ProcessInfo.ProcessId;
+        }
+        catch (Exception ex)
+        {
+            OutputWindowLogger.LogException("WebViewBridge.RendererProcessId", ex);
+            return null;
+        }
+    }
+
+    /// <summary>The browser's own task manager — the Edge one, with live memory/CPU per process.
+    /// It covers every pane on the user-data folder, panes in another VS instance included, which
+    /// is what makes it worth having: a stray renderer or a process count that doesn't add up is a
+    /// question about the whole browser, not about this pane.</summary>
+    public void OpenTaskManager() => webView.CoreWebView2?.OpenTaskManagerWindow();
 
     /// <summary>Release the WebView2 control, and with it the CoreWebView2Controller and the
     /// renderer process behind this pane. VS keeps the closed tool window's control alive, so

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
@@ -14,6 +14,7 @@ using Microsoft.VisualStudio.Shell;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
 
@@ -196,12 +197,36 @@ public partial class ChatPaneControl : PaneControlBase
         return true;
     }
 
+    /// <summary>Only while the transport is up: a dead client keeps the exited process's id, which
+    /// would show as a live PID pointing at nothing (or at whatever reused the number).</summary>
+    protected override int CliProcessId => _client is { IsRunning: true } c ? c.Pid : 0;
+
+    /// <summary>The WebView processes behind this pane, for the info dialog (the CLI's own PID is
+    /// the base's shared row). What a frozen or misbehaving chat comes down to is "which process is
+    /// mine" — with several panes open that is otherwise a command-line hunt in Task Manager, so
+    /// the renderer is the pane's own, resolved by frame, not the browser's whole list.</summary>
+    protected override IEnumerable<(string Label, string Value)> ExtraSessionInfo
+    {
+        get
+        {
+            yield return ("WebView PID", _bridge?.BrowserProcessId?.ToString() ?? "(not started)");
+            // Blocking on the UI thread: the dialog is modal and about to show anyway, and the
+            // call is a single in-process round-trip to the browser.
+            var renderer = _bridge == null
+                ? null
+                : ThreadHelper.JoinableTaskFactory.Run(_bridge.RendererProcessIdAsync);
+            yield return ("WebView renderer", renderer?.ToString() ?? "(unknown)");
+        }
+    }
+
     /// <summary>Chat-only extra for the toolbar's "More" menu: the WebView DevTools, on preview and
     /// Debug builds. Testers on a release candidate are exactly who needs to inspect the WebView to
     /// report a bug, and so is anyone building the extension — the DEBUG arm is what keeps it around
     /// once a version drops its -rc suffix, which is when it silently disappeared. A stable
-    /// Marketplace build, which is neither, should not expose it. (Info is shared, so it lives on
-    /// the base; the CLI returns none.)</summary>
+    /// Marketplace build, which is neither, hides it unless the user opts in from Options: a chat
+    /// that renders wrongly or stops taking input can only be diagnosed from the browser console,
+    /// and that happens on stable builds too. (Info is shared, so it lives on the base; the CLI
+    /// returns none.)</summary>
     public override IEnumerable<ButtonAction> MoreMenuActions
     {
         get
@@ -211,9 +236,10 @@ public partial class ChatPaneControl : PaneControlBase
 #else
             const bool devBuild = false;
 #endif
-            if (BuildInfo.IsPreRelease || devBuild)
+            if (BuildInfo.IsPreRelease || devBuild || AgentsOptions.Chat.ShowDevToolsButton)
             {
                 yield return new ButtonAction("WebView DevTools", () => _bridge?.OpenDevTools(), "DevTools");
+                yield return new ButtonAction("WebView task manager", () => _bridge?.OpenTaskManager(), "DevTools");
             }
         }
     }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
@@ -219,14 +219,14 @@ public partial class ChatPaneControl : PaneControlBase
         }
     }
 
-    /// <summary>Chat-only extra for the toolbar's "More" menu: the WebView DevTools, on preview and
-    /// Debug builds. Testers on a release candidate are exactly who needs to inspect the WebView to
-    /// report a bug, and so is anyone building the extension — the DEBUG arm is what keeps it around
-    /// once a version drops its -rc suffix, which is when it silently disappeared. A stable
-    /// Marketplace build, which is neither, hides it unless the user opts in from Options: a chat
-    /// that renders wrongly or stops taking input can only be diagnosed from the browser console,
-    /// and that happens on stable builds too. (Info is shared, so it lives on the base; the CLI
-    /// returns none.)</summary>
+    /// <summary>Chat-only extras for the toolbar's "More" menu — the WebView DevTools and the
+    /// browser's task manager — on preview and Debug builds. Testers on a release candidate are
+    /// exactly who needs to inspect the WebView to report a bug, and so is anyone building the
+    /// extension — the DEBUG arm is what keeps them around once a version drops its -rc suffix,
+    /// which is when they silently disappeared. A stable Marketplace build, which is neither, hides
+    /// them unless the user opts in from Options: a chat that renders wrongly or stops taking input
+    /// can only be diagnosed from the browser console, and that happens on stable builds too.
+    /// (Info is shared, so it lives on the base; the CLI returns none.)</summary>
     public override IEnumerable<ButtonAction> MoreMenuActions
     {
         get
@@ -236,7 +236,7 @@ public partial class ChatPaneControl : PaneControlBase
 #else
             const bool devBuild = false;
 #endif
-            if (BuildInfo.IsPreRelease || devBuild || AgentsOptions.Chat.ShowDevToolsButton)
+            if (BuildInfo.IsPreRelease || devBuild || AgentsOptions.Chat.ShowWebViewDevEntries)
             {
                 yield return new ButtonAction("WebView DevTools", () => _bridge?.OpenDevTools(), "DevTools");
                 yield return new ButtonAction("WebView task manager", () => _bridge?.OpenTaskManager(), "TaskManager");

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
@@ -239,7 +239,7 @@ public partial class ChatPaneControl : PaneControlBase
             if (BuildInfo.IsPreRelease || devBuild || AgentsOptions.Chat.ShowDevToolsButton)
             {
                 yield return new ButtonAction("WebView DevTools", () => _bridge?.OpenDevTools(), "DevTools");
-                yield return new ButtonAction("WebView task manager", () => _bridge?.OpenTaskManager(), "DevTools");
+                yield return new ButtonAction("WebView task manager", () => _bridge?.OpenTaskManager(), "TaskManager");
             }
         }
     }

--- a/src/Corsinvest.VisualStudio.Agents/Cli/Pane/CliPaneControl.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Cli/Pane/CliPaneControl.cs
@@ -53,6 +53,10 @@ internal class CliPaneControl : PaneControlBase, ITerminalConnection, IDisposabl
     /// <summary>No kind-specific "More" actions for the terminal pane.</summary>
     public override IEnumerable<ButtonAction> MoreMenuActions => [];
 
+    /// <summary>The ConPTY child. 0 both before Start and after Dispose, which is what the base
+    /// renders as "not running".</summary>
+    protected override int CliProcessId => _process?.ProcessId ?? 0;
+
     /// <summary>ITerminalConnection requires IDisposable; route the terminal-driven
     /// dispose through the shared pane teardown (guarded by _disposed in the base).</summary>
     public void Dispose() => DisposePane();

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.cs
@@ -42,6 +42,11 @@ public sealed partial class ClaudeClient : IClaudeClient
     public AccountInfo Account { get; private set; }
     public bool IsRunning => _transport.IsRunning;
 
+    /// <summary>PID of the claude.exe this client drives, or -1 when no process is running. For the
+    /// info dialog and bug reports: with several panes open, "which claude.exe is this one" is
+    /// otherwise only answerable by matching command lines.</summary>
+    public int Pid => _transport.Pid;
+
     public event EventHandler<InitializedEventArgs> Initialized;
     /// <summary>The CLI startup state (model + toggles from initialize+get_settings), gathered
     /// without a user turn so the UI can seed on open. Fired once per StartProcess (open + respawn).</summary>

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneControlBase.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneControlBase.cs
@@ -7,6 +7,7 @@ using Corsinvest.VisualStudio.Agents.Core.Client;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 
@@ -107,9 +108,22 @@ public abstract class PaneControlBase : UserControl, IPaneControl
     /// custom-title JSONL; CLI keeps the no-op (no editable title).</summary>
     public virtual void RenameSession(string newTitle) { }
 
+    /// <summary>OS process id of the claude CLI behind this pane, or 0 when it isn't running.
+    /// Both kinds have one — chat drives it over stdio, cli through the ConPTY — so the info
+    /// dialog's row is built once here rather than duplicated per kind.</summary>
+    protected abstract int CliProcessId { get; }
+
+    /// <summary>Extra info rows for <see cref="ShowSessionInfo"/>, appended after the shared ones
+    /// and after the CLI PID. Chat adds the WebView2 processes; the CLI pane adds none — its
+    /// process is the shared row. Kept as label/value pairs rather than formatted lines so the
+    /// base owns the column alignment — a longer label added here must not leave the whole dialog
+    /// ragged.</summary>
+    protected virtual IEnumerable<(string Label, string Value)> ExtraSessionInfo => [];
+
     /// <summary>Read-only session info (id, session file, workdir, CLI) for debug and bug reports.
-    /// Built entirely from <see cref="Entry"/>, which both pane kinds keep current — so the terminal
-    /// gets the same dialog as the chat, with no duplicated code.</summary>
+    /// Built from <see cref="Entry"/>, which both pane kinds keep current — so the terminal gets the
+    /// same dialog as the chat, with no duplicated code — plus whatever
+    /// <see cref="ExtraSessionInfo"/> adds for the kind.</summary>
     public void ShowSessionInfo()
     {
         try
@@ -123,14 +137,22 @@ public abstract class PaneControlBase : UserControl, IPaneControl
                 ? Path.Combine(paths.SessionFolder(wd), sid + ".jsonl")
                 : "(none)";
 
-            var info = string.Join("\n",
-                $"Session title:  {(string.IsNullOrEmpty(SessionTitle) ? "(untitled)" : SessionTitle)}",
-                $"Session ID:     {sid ?? "(none)"}",
-                $"Session file:   {sessionFile}",
-                $"Workdir:        {wd ?? "(none)"}",
-                $"Profile:        {Entry.Profile?.Name ?? "(native)"}",
-                $"CLI path:       {ClaudeInstall.ResolveExecutable() ?? "(not found)"}",
-                $"CLI version:    {ClaudeInstall.Version() ?? "(unknown)"}");
+            List<(string Label, string Value)> rows =
+            [
+                ("Session title", string.IsNullOrEmpty(SessionTitle) ? "(untitled)" : SessionTitle),
+                ("Session ID", sid ?? "(none)"),
+                ("Session file", sessionFile),
+                ("Workdir", wd ?? "(none)"),
+                ("Profile", Entry.Profile?.Name ?? "(native)"),
+                ("CLI path", ClaudeInstall.ResolveExecutable() ?? "(not found)"),
+                ("CLI version", ClaudeInstall.Version() ?? "(unknown)"),
+                ("CLI PID", CliProcessId > 0 ? CliProcessId.ToString() : "(not running)"),
+                .. ExtraSessionInfo,
+            ];
+
+            // Widest label decides the column, so an added row can't misalign the others.
+            var width = rows.Max(r => r.Label.Length) + 2;
+            var info = string.Join("\n", rows.Select(r => (r.Label + ":").PadRight(width) + r.Value));
 
             new DevInfoDialog(info).ShowDialog();
         }

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneToolbar.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneToolbar.xaml.cs
@@ -306,6 +306,7 @@ public partial class PaneToolbar : UserControl
             Moniker = iconId switch
             {
                 "DevTools" => KnownMonikers.JSConsole,
+                "TaskManager" => KnownMonikers.ActivityMonitor,
                 "Refresh" => KnownMonikers.Refresh,
                 "Info" => KnownMonikers.StatusInformation,
                 _ => KnownMonikers.Code,

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneToolbar.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneToolbar.xaml.cs
@@ -306,7 +306,7 @@ public partial class PaneToolbar : UserControl
             Moniker = iconId switch
             {
                 "DevTools" => KnownMonikers.JSConsole,
-                "TaskManager" => KnownMonikers.ActivityMonitor,
+                "TaskManager" => KnownMonikers.Checklist,
                 "Refresh" => KnownMonikers.Refresh,
                 "Info" => KnownMonikers.StatusInformation,
                 _ => KnownMonikers.Code,

--- a/src/Corsinvest.VisualStudio.Agents/Options/AgentsChatPage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Options/AgentsChatPage.cs
@@ -67,6 +67,11 @@ public class AgentsChatPage : AgentsOptionsPage
     [Description("Font size (px) of the chat message text. Default: 13.")]
     public int ChatFontSize { get; set; } = 13;
 
+    [Category("Display")]
+    [DisplayName("Show WebView DevTools button")]
+    [Description("Add \"WebView DevTools\" to the chat toolbar's \"More\" (…) menu. It opens the WebView2 developer tools (browser console, DOM, network) on the chat itself — how you diagnose a chat that renders wrongly or stops responding. Pre-release builds always offer it.")]
+    public bool ShowDevToolsButton { get; set; } = false;
+
     [Category("Files")]
     [DisplayName("Autosave before Claude reads/writes")]
     [Description("Automatically save a file with unsaved changes before Claude reads or writes it, so Claude sees your in-editor edits (not the stale on-disk version).")]

--- a/src/Corsinvest.VisualStudio.Agents/Options/AgentsChatPage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Options/AgentsChatPage.cs
@@ -68,9 +68,9 @@ public class AgentsChatPage : AgentsOptionsPage
     public int ChatFontSize { get; set; } = 13;
 
     [Category("Display")]
-    [DisplayName("Show WebView DevTools button")]
-    [Description("Add \"WebView DevTools\" to the chat toolbar's \"More\" (…) menu. It opens the WebView2 developer tools (browser console, DOM, network) on the chat itself — how you diagnose a chat that renders wrongly or stops responding. Pre-release builds always offer it.")]
-    public bool ShowDevToolsButton { get; set; } = false;
+    [DisplayName("Show WebView developer entries")]
+    [Description("Add \"WebView DevTools\" and \"WebView task manager\" to the chat toolbar's \"More\" (…) menu. DevTools opens the WebView2 developer tools (browser console, DOM, network) on the chat itself — how you diagnose a chat that renders wrongly or stops responding. The task manager lists the browser's processes with their memory and CPU. Pre-release builds always offer both.")]
+    public bool ShowWebViewDevEntries { get; set; } = false;
 
     [Category("Files")]
     [DisplayName("Autosave before Claude reads/writes")]


### PR DESCRIPTION
Follow-up to #56, which fixed the renderer leak. This is the diagnostics that made the leak visible in the first place.

The session info dialog named the CLI's process for the chat pane only, and the terminal pane — which also drives a `claude.exe` — offered nothing. With several panes open, "which of these is mine" was a command-line hunt in Task Manager.

## What changed

**`CliProcessId` moves to `PaneControlBase`** as an abstract member, so the row is built once for both pane kinds rather than duplicated per kind:
- chat reports it only while the transport is up — a dead client keeps the exited pid, which would show as a live PID pointing at nothing, or at whatever reused the number
- cli reports its ConPTY child

**The chat pane names its WebView processes.** The renderer is resolved by matching the main frame's id through `GetProcessExtendedInfosAsync`, not by listing the browser's whole set. WebView2 keys the browser process on the user-data folder and not on the host, so that set spans every pane on the profile — including panes in a second VS instance running the extension. Seven indistinct PIDs answer nobody's question; one resolved PID does.

**More menu gains the browser's own task manager** (`OpenTaskManagerWindow`) — the Edge one, with live memory and CPU per process, and tabs named. For when the whole set *is* the question. Same gate as the DevTools entry.

**That gate now includes an Options toggle** (`Show WebView DevTools button`): a chat that renders wrongly or stops taking input can only be diagnosed from the browser console, and that happens on stable builds too.

## Notes

- `RendererProcessIdAsync` is awaited via `JoinableTaskFactory.Run` from the sync `ExtraSessionInfo`: the dialog is modal and about to block anyway, and the call is a single in-process round-trip. On failure the row reads `(unknown)` rather than falling back to the full list, which would reintroduce the noise.
- The frame→process map is only exposed asynchronously — there is no sync equivalent.

## Verification

Build green (`msbuild /t:Build /p:Configuration=Debug`), VSIX produced. TypeScript untouched; `format`, `typecheck` and `lint` all clean.

The dialog was exercised in the experimental instance while chasing the leak in #56: it reported the CLI pid and the WebView pid correctly across a pane close/reopen, and the browser pid it showed (79604) is what revealed that a second VS instance shares the same browser process.
