### PR TITLE
fix(panes): a solution reload no longer takes the chat down with it

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/AgentsPackage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/AgentsPackage.cs
@@ -372,6 +372,16 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
         try { kept = Core.Panes.PaneRegistry.Instance.CloseWhereWorkdirDiffers(CurrentSolutionFolder); }
         catch (Exception ex) { OutputWindowLogger.LogException("Pkg.OnAfterOpenSolution", ex); }
         OutputWindowLogger.Info($"[reload] solution open on {CurrentSolutionFolder ?? "(none)"} — kept {kept} of {had} pane(s)");
+        // Bring back what the close hid. StartOnIdle for the same reason the restore defers: showing
+        // a frame from inside this COM event freezes the shell, which is still mid-transition.
+        if (kept > 0)
+        {
+            _ = JoinableTaskFactory.StartOnIdle(() =>
+            {
+                try { Core.Panes.PaneLauncher.ShowExisting(); }
+                catch (Exception ex) { OutputWindowLogger.LogException("Pkg.ShowPanesOnReload", ex); }
+            });
+        }
         // Reopen the panes saved for THIS solution — minus the ones a reload just kept alive (see
         // RestorePanesForCurrentSolution). Deferred to shell-idle (see RestorePanesDeferred):
         // spawning panes inside this COM event reenters solution state.
@@ -415,6 +425,10 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
     {
         OutputWindowLogger.Debug(() => $"[reload] solution closed — panes={Core.Panes.PaneRegistry.Instance.Entries.Count}");
         CurrentSolutionFolder = null;
+        // Out of sight straight away, so closing a solution looks like it always did — but alive, so
+        // a reload can hand them back with the session intact.
+        try { Core.Panes.PaneLauncher.HideExisting(); }
+        catch (Exception ex) { OutputWindowLogger.LogException("Pkg.HidePanesOnClose", ex); }
         // Armed here, not on the Before: unloading the projects happens in between and would eat the
         // window on a large solution.
         ArmReloadWatch(ReloadWatchCloseMs);

--- a/src/Corsinvest.VisualStudio.Agents/AgentsPackage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/AgentsPackage.cs
@@ -64,6 +64,19 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
     private uint _debuggerEventsCookie;
     private IVsDebugger _debugger;
 
+    // Solution reload watch. VS models a reload as close-then-open and no event tells the two apart
+    // from a plain close, so the close is deferred and the panes are kept until we know which it was.
+    private System.Threading.Timer _reloadWatch;
+    private string _closingSolutionFolder;
+
+    // Close→open gap, measured at ~850 ms on a small solution. Timed from OnAfterCloseSolution, so it
+    // excludes unloading the projects and does not grow with the solution.
+    private const int ReloadWatchCloseMs = 10_000;
+    // Once a solution is loading, the wait covers the load itself, which does grow with the solution.
+    // Long on purpose: a load that never completes must still trip the timer rather than leave panes
+    // pinned to a solution that never came back.
+    private const int ReloadWatchOpenMs = 120_000;
+
     static AgentsPackage() =>
         // Microsoft.Terminal.Wpf ships with VS but isn't on any VSIX probing
         // path, so resolve it from VS's own Terminal folder.
@@ -137,6 +150,39 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
         if (string.IsNullOrEmpty(folder)) { return; }
         Core.Workspace.WorkspaceStore.Save(folder, DateTime.Now.ToString("o"));
     }
+
+    /// <summary>(Re)start the reload watch. Fires once; rearmed with a longer window when a solution
+    /// starts loading. The callback lands on a pool thread and closing panes touches VS frames, hence
+    /// the hop back to the UI thread.</summary>
+    private void ArmReloadWatch(int dueMs)
+    {
+        if (_reloadWatch == null)
+        {
+            _reloadWatch = new System.Threading.Timer(_ => OnReloadWatchElapsed(), null,
+                                                      dueMs, System.Threading.Timeout.Infinite);
+        }
+        else
+        {
+            _reloadWatch.Change(dueMs, System.Threading.Timeout.Infinite);
+        }
+        OutputWindowLogger.Info($"[reload] watch armed for {dueMs} ms (folder={_closingSolutionFolder ?? "(none)"})");
+    }
+
+    /// <summary>Stop the watch — a solution finished opening, or the package is going away.</summary>
+    private void DisarmReloadWatch()
+        => _reloadWatch?.Change(System.Threading.Timeout.Infinite, System.Threading.Timeout.Infinite);
+
+    /// <summary>No solution came back in time: the close was a real one. Close every pane, which is
+    /// what OnBeforeCloseSolution used to do inline.</summary>
+    private void OnReloadWatchElapsed()
+        => JoinableTaskFactory.RunAsync(async () =>
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync();
+            _closingSolutionFolder = null;
+            OutputWindowLogger.Info($"[reload] watch elapsed — closing {Core.Panes.PaneRegistry.Instance.Entries.Count} pane(s)");
+            try { Core.Panes.PaneRegistry.Instance.CloseAll(); }
+            catch (Exception ex) { OutputWindowLogger.LogException("Pkg.ReloadWatchElapsed", ex); }
+        }).FileAndForget(nameof(AgentsPackage));
 
     /// <summary>Reopen the panes saved for the current solution's workspace.json. Each saved pane is
     /// validated: an unknown profile falls back to native; a missing session .jsonl opens fresh.</summary>
@@ -305,15 +351,18 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
         // Redundant with OnBeforeOpenSolution, but covers the rare load path
         // that skips IVsSolutionLoadEvents.
         RefreshCurrentSolutionFolder();
-        // Close any panes born WITHOUT a solution (home-dir workdir): a pane belongs to the
-        // context it was born in, and their workdir can't follow a solution change. On normal
-        // startup the solution is already open before the user opens a pane, so the registry is
-        // empty here and this is a no-op — it only fires for pre-existing home-born panes.
-        try { Core.Panes.PaneRegistry.Instance.CloseAll(); }
+        DisarmReloadWatch();
+        _closingSolutionFolder = null;
+        // Panes belong to the folder they were born in: their CLI runs there and can't follow a move.
+        // Same folder → the session is still valid, so the pane (and its live process) stays. This is
+        // what makes a reload survivable. Everything else closes, home-born panes included.
+        var kept = 0;
+        try { kept = Core.Panes.PaneRegistry.Instance.CloseWhereWorkdirDiffers(CurrentSolutionFolder); }
         catch (Exception ex) { OutputWindowLogger.LogException("Pkg.OnAfterOpenSolution", ex); }
-        // Reopen the panes saved for THIS solution. After CloseAll, so we start from a clean registry
-        // and don't stack restored panes on top of home-born leftovers. Deferred to shell-idle (see
-        // RestorePanesDeferred): spawning panes inside this COM event reenters solution state.
+        OutputWindowLogger.Info($"[reload] OnAfterOpenSolution kept={kept} pane(s) on {CurrentSolutionFolder ?? "(none)"}");
+        // Reopen the panes saved for THIS solution — minus the ones a reload just kept alive (see
+        // RestorePanesForCurrentSolution). Deferred to shell-idle (see RestorePanesDeferred):
+        // spawning panes inside this COM event reenters solution state.
         RestorePanesDeferred();
         _ = Mcp.McpServerHost.Instance.RewriteLockFileAsync();
         // VS may restore editor tabs without firing a DTE event we listen to;
@@ -329,6 +378,10 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
     int IVsSolutionLoadEvents.OnBeforeOpenSolution(string pszSolutionFilename)
     {
         OutputWindowLogger.Info($"[reload] OnBeforeOpenSolution file={pszSolutionFilename ?? "(none)"} panes={Core.Panes.PaneRegistry.Instance.Entries.Count}");
+        // Rearm rather than disarm: if this load fails or is cancelled, OnAfterOpenSolution never
+        // comes and no close event follows either — the solution was already closed — so the panes
+        // would stay pinned forever.
+        if (_closingSolutionFolder != null) { ArmReloadWatch(ReloadWatchOpenMs); }
         // Cache the folder eagerly from the .sln path so consumers don't hit
         // IVsSolution before it's populated (projects may still be loading).
         if (!string.IsNullOrEmpty(pszSolutionFilename))
@@ -348,8 +401,11 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
 
     int IVsSolutionEvents.OnAfterCloseSolution(object pUnkReserved)
     {
-        OutputWindowLogger.Info($"[reload] OnAfterCloseSolution folder={CurrentSolutionFolder ?? "(none)"} panes={Core.Panes.PaneRegistry.Instance.Entries.Count}");
+        OutputWindowLogger.Info($"[reload] OnAfterCloseSolution panes={Core.Panes.PaneRegistry.Instance.Entries.Count}");
         CurrentSolutionFolder = null;
+        // Armed here, not on the Before: unloading the projects happens in between and would eat the
+        // window on a large solution.
+        ArmReloadWatch(ReloadWatchCloseMs);
         _ = Mcp.McpServerHost.Instance.RewriteLockFileAsync();
         return VSConstants.S_OK;
     }
@@ -413,15 +469,12 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
     }
     int IVsSolutionEvents.OnBeforeCloseSolution(object pUnkReserved)
     {
-        OutputWindowLogger.Info($"[reload] OnBeforeCloseSolution folder={CurrentSolutionFolder ?? "(none)"} panes={Core.Panes.PaneRegistry.Instance.Entries.Count} — CLOSING ALL");
-        // Snapshot before CloseAll drains the registry, so the closing solution's
-        // workspace.json reflects the panes it actually had open.
+        OutputWindowLogger.Info($"[reload] OnBeforeCloseSolution folder={CurrentSolutionFolder ?? "(none)"} panes={Core.Panes.PaneRegistry.Instance.Entries.Count}");
+        // Snapshot while the frames are still valid and the pane list is complete.
         SaveWorkspace();
-        // Panes are bound to the solution's workdir and can't follow a change,
-        // so close them all here (frames still valid) to avoid orphan sessions
-        // against a dead workdir. Draining the registry also stops MCP.
-        try { Core.Panes.PaneRegistry.Instance.CloseAll(); }
-        catch (Exception ex) { OutputWindowLogger.LogException("Pkg.OnBeforeCloseSolution", ex); }
+        // Last point where the folder is still known — OnAfterCloseSolution clears it. The panes are
+        // NOT closed here: a reload would take the live CLI down with them, losing the turn in flight.
+        _closingSolutionFolder = CurrentSolutionFolder;
         return VSConstants.S_OK;
     }
 }

--- a/src/Corsinvest.VisualStudio.Agents/AgentsPackage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/AgentsPackage.cs
@@ -168,7 +168,6 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
         OutputWindowLogger.Debug(() => $"[reload] watch armed for {dueMs} ms (folder={_closingSolutionFolder ?? "(none)"})");
     }
 
-    /// <summary>Stop the watch — a solution finished opening, or the package is going away.</summary>
     private void DisarmReloadWatch()
         => _reloadWatch?.Change(System.Threading.Timeout.Infinite, System.Threading.Timeout.Infinite);
 
@@ -201,7 +200,6 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
         foreach (var p in ws.Panes)
         {
             // A reload leaves its panes alive: restoring them again would double every chat.
-            // Matched on session id, the only field that survives on both sides.
             if (!string.IsNullOrEmpty(p.SessionId)
                 && Core.Panes.PaneRegistry.Instance.Entries.Any(e =>
                        string.Equals(e.ActiveSessionId, p.SessionId, StringComparison.OrdinalIgnoreCase)))
@@ -343,7 +341,6 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
                 _debugger?.UnadviseDebuggerEvents(_debuggerEventsCookie);
                 _debuggerEventsCookie = 0;
             }
-            // A watch still armed here would fire into a package that is going away.
             _reloadWatch?.Dispose();
             _reloadWatch = null;
             Mcp.McpServerHost.Instance.Stop();
@@ -451,7 +448,6 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
     int IVsSolutionEvents.OnBeforeCloseSolution(object pUnkReserved)
     {
         OutputWindowLogger.Debug(() => $"[reload] solution closing: {CurrentSolutionFolder ?? "(none)"} — panes={Core.Panes.PaneRegistry.Instance.Entries.Count}");
-        // Snapshot while the frames are still valid and the pane list is complete.
         SaveWorkspace();
         // Last point where the folder is still known — OnAfterCloseSolution clears it. The panes are
         // NOT closed here: a reload would take the live CLI down with them, losing the turn in flight.

--- a/src/Corsinvest.VisualStudio.Agents/AgentsPackage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/AgentsPackage.cs
@@ -165,7 +165,7 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
         {
             _reloadWatch.Change(dueMs, System.Threading.Timeout.Infinite);
         }
-        OutputWindowLogger.Info($"[reload] watch armed for {dueMs} ms (folder={_closingSolutionFolder ?? "(none)"})");
+        OutputWindowLogger.Debug(() => $"[reload] watch armed for {dueMs} ms (folder={_closingSolutionFolder ?? "(none)"})");
     }
 
     /// <summary>Stop the watch — a solution finished opening, or the package is going away.</summary>
@@ -359,7 +359,7 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
 
     int IVsSolutionEvents.OnAfterOpenSolution(object pUnkReserved, int fNewSolution)
     {
-        OutputWindowLogger.Info($"[reload] OnAfterOpenSolution fNew={fNewSolution} panes={Core.Panes.PaneRegistry.Instance.Entries.Count}");
+        OutputWindowLogger.Debug(() => $"[reload] OnAfterOpenSolution fNew={fNewSolution} panes={Core.Panes.PaneRegistry.Instance.Entries.Count}");
         // Redundant with OnBeforeOpenSolution, but covers the rare load path
         // that skips IVsSolutionLoadEvents.
         RefreshCurrentSolutionFolder();
@@ -389,7 +389,7 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
 
     int IVsSolutionLoadEvents.OnBeforeOpenSolution(string pszSolutionFilename)
     {
-        OutputWindowLogger.Info($"[reload] OnBeforeOpenSolution file={pszSolutionFilename ?? "(none)"} panes={Core.Panes.PaneRegistry.Instance.Entries.Count}");
+        OutputWindowLogger.Debug(() => $"[reload] OnBeforeOpenSolution file={pszSolutionFilename ?? "(none)"} panes={Core.Panes.PaneRegistry.Instance.Entries.Count}");
         // Rearm rather than disarm: if this load fails or is cancelled, OnAfterOpenSolution never
         // comes and no close event follows either — the solution was already closed — so the panes
         // would stay pinned forever.
@@ -413,7 +413,7 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
 
     int IVsSolutionEvents.OnAfterCloseSolution(object pUnkReserved)
     {
-        OutputWindowLogger.Info($"[reload] OnAfterCloseSolution panes={Core.Panes.PaneRegistry.Instance.Entries.Count}");
+        OutputWindowLogger.Debug(() => $"[reload] OnAfterCloseSolution panes={Core.Panes.PaneRegistry.Instance.Entries.Count}");
         CurrentSolutionFolder = null;
         // Armed here, not on the Before: unloading the projects happens in between and would eat the
         // window on a large solution.
@@ -422,66 +422,21 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
         return VSConstants.S_OK;
     }
 
-    int IVsSolutionEvents.OnQueryCloseSolution(object pUnkReserved, ref int pfCancel)
-    {
-        OutputWindowLogger.Info($"[reload] OnQueryCloseSolution cancelIn={pfCancel} panes={Core.Panes.PaneRegistry.Instance.Entries.Count}");
-        return VSConstants.S_OK;
-    }
+    int IVsSolutionEvents.OnQueryCloseSolution(object pUnkReserved, ref int pfCancel) => VSConstants.S_OK;
 
-    /// <summary>Project name off a hierarchy, for the trace below — the events carry the project
-    /// only as an IVsHierarchy, and "which project" is half of what the sequence has to tell us.</summary>
-    private static string HierName(IVsHierarchy hier)
-    {
-        if (hier == null) { return "(null)"; }
-        try
-        {
-            hier.GetProperty(VSConstants.VSITEMID_ROOT, (int)__VSHPROPID.VSHPROPID_Name, out var name);
-            return name as string ?? "(unnamed)";
-        }
-        catch { return "(error)"; }
-    }
+    // Project-level events stay no-ops. A project reload is an unload followed by a load (the SDK
+    // has no reload event of its own), but SDK-style projects absorb an edited .csproj in place and
+    // never take that path — traced once and confirmed silent, so there is nothing to hook here.
+    int IVsSolutionEvents.OnAfterOpenProject(IVsHierarchy pHierarchy, int fAdded) => VSConstants.S_OK;
+    int IVsSolutionEvents.OnQueryCloseProject(IVsHierarchy pHierarchy, int fRemoving, ref int pfCancel) => VSConstants.S_OK;
+    int IVsSolutionEvents.OnBeforeCloseProject(IVsHierarchy pHierarchy, int fRemoved) => VSConstants.S_OK;
+    int IVsSolutionEvents.OnAfterLoadProject(IVsHierarchy pStubHierarchy, IVsHierarchy pRealHierarchy) => VSConstants.S_OK;
+    int IVsSolutionEvents.OnQueryUnloadProject(IVsHierarchy pRealHierarchy, ref int pfCancel) => VSConstants.S_OK;
+    int IVsSolutionEvents.OnBeforeUnloadProject(IVsHierarchy pRealHierarchy, IVsHierarchy pStubHierarchy) => VSConstants.S_OK;
 
-    // Project-level events: no-ops we only trace. A project reload (the "modified outside the
-    // environment" prompt) is an unload followed by a load — the SDK has no reload event of its
-    // own — and the open question is whether it takes the chat panes down with it.
-    int IVsSolutionEvents.OnAfterOpenProject(IVsHierarchy pHierarchy, int fAdded)
-    {
-        OutputWindowLogger.Info($"[reload] OnAfterOpenProject proj={HierName(pHierarchy)} fAdded={fAdded} panes={Core.Panes.PaneRegistry.Instance.Entries.Count}");
-        return VSConstants.S_OK;
-    }
-
-    int IVsSolutionEvents.OnQueryCloseProject(IVsHierarchy pHierarchy, int fRemoving, ref int pfCancel)
-    {
-        OutputWindowLogger.Info($"[reload] OnQueryCloseProject proj={HierName(pHierarchy)} fRemoving={fRemoving} cancelIn={pfCancel} panes={Core.Panes.PaneRegistry.Instance.Entries.Count}");
-        return VSConstants.S_OK;
-    }
-
-    int IVsSolutionEvents.OnBeforeCloseProject(IVsHierarchy pHierarchy, int fRemoved)
-    {
-        OutputWindowLogger.Info($"[reload] OnBeforeCloseProject proj={HierName(pHierarchy)} fRemoved={fRemoved} panes={Core.Panes.PaneRegistry.Instance.Entries.Count}");
-        return VSConstants.S_OK;
-    }
-
-    int IVsSolutionEvents.OnAfterLoadProject(IVsHierarchy pStubHierarchy, IVsHierarchy pRealHierarchy)
-    {
-        OutputWindowLogger.Info($"[reload] OnAfterLoadProject stub={HierName(pStubHierarchy)} real={HierName(pRealHierarchy)} panes={Core.Panes.PaneRegistry.Instance.Entries.Count}");
-        return VSConstants.S_OK;
-    }
-
-    int IVsSolutionEvents.OnQueryUnloadProject(IVsHierarchy pRealHierarchy, ref int pfCancel)
-    {
-        OutputWindowLogger.Info($"[reload] OnQueryUnloadProject proj={HierName(pRealHierarchy)} cancelIn={pfCancel} panes={Core.Panes.PaneRegistry.Instance.Entries.Count}");
-        return VSConstants.S_OK;
-    }
-
-    int IVsSolutionEvents.OnBeforeUnloadProject(IVsHierarchy pRealHierarchy, IVsHierarchy pStubHierarchy)
-    {
-        OutputWindowLogger.Info($"[reload] OnBeforeUnloadProject real={HierName(pRealHierarchy)} stub={HierName(pStubHierarchy)} panes={Core.Panes.PaneRegistry.Instance.Entries.Count}");
-        return VSConstants.S_OK;
-    }
     int IVsSolutionEvents.OnBeforeCloseSolution(object pUnkReserved)
     {
-        OutputWindowLogger.Info($"[reload] OnBeforeCloseSolution folder={CurrentSolutionFolder ?? "(none)"} panes={Core.Panes.PaneRegistry.Instance.Entries.Count}");
+        OutputWindowLogger.Debug(() => $"[reload] OnBeforeCloseSolution folder={CurrentSolutionFolder ?? "(none)"} panes={Core.Panes.PaneRegistry.Instance.Entries.Count}");
         // Snapshot while the frames are still valid and the pane list is complete.
         SaveWorkspace();
         // Last point where the folder is still known — OnAfterCloseSolution clears it. The panes are

--- a/src/Corsinvest.VisualStudio.Agents/AgentsPackage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/AgentsPackage.cs
@@ -192,7 +192,7 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
         var ws = Core.Workspace.WorkspaceStore.Load(folder);
         if (ws?.Panes == null)
         {
-            OutputWindowLogger.Debug(() => $"[restore] no workspace/panes for {folder ?? "<null>"}");
+            OutputWindowLogger.Debug(() => $"[restore] no workspace/panes for {folder ?? "(none)"}");
             return;
         }
         // Load(forEdit:false) normally includes the native "Claude" profile → profiles[0] is the fallback.
@@ -359,7 +359,6 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
 
     int IVsSolutionEvents.OnAfterOpenSolution(object pUnkReserved, int fNewSolution)
     {
-        OutputWindowLogger.Debug(() => $"[reload] OnAfterOpenSolution fNew={fNewSolution} panes={Core.Panes.PaneRegistry.Instance.Entries.Count}");
         // Redundant with OnBeforeOpenSolution, but covers the rare load path
         // that skips IVsSolutionLoadEvents.
         RefreshCurrentSolutionFolder();
@@ -368,10 +367,11 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
         // Panes belong to the folder they were born in: their CLI runs there and can't follow a move.
         // Same folder → the session is still valid, so the pane (and its live process) stays. This is
         // what makes a reload survivable. Everything else closes, home-born panes included.
+        var had = Core.Panes.PaneRegistry.Instance.Entries.Count;
         var kept = 0;
         try { kept = Core.Panes.PaneRegistry.Instance.CloseWhereWorkdirDiffers(CurrentSolutionFolder); }
         catch (Exception ex) { OutputWindowLogger.LogException("Pkg.OnAfterOpenSolution", ex); }
-        OutputWindowLogger.Info($"[reload] OnAfterOpenSolution kept={kept} pane(s) on {CurrentSolutionFolder ?? "(none)"}");
+        OutputWindowLogger.Info($"[reload] solution open on {CurrentSolutionFolder ?? "(none)"} — kept {kept} of {had} pane(s)");
         // Reopen the panes saved for THIS solution — minus the ones a reload just kept alive (see
         // RestorePanesForCurrentSolution). Deferred to shell-idle (see RestorePanesDeferred):
         // spawning panes inside this COM event reenters solution state.
@@ -389,7 +389,7 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
 
     int IVsSolutionLoadEvents.OnBeforeOpenSolution(string pszSolutionFilename)
     {
-        OutputWindowLogger.Debug(() => $"[reload] OnBeforeOpenSolution file={pszSolutionFilename ?? "(none)"} panes={Core.Panes.PaneRegistry.Instance.Entries.Count}");
+        OutputWindowLogger.Debug(() => $"[reload] solution opening: {pszSolutionFilename ?? "(none)"} — panes={Core.Panes.PaneRegistry.Instance.Entries.Count}");
         // Rearm rather than disarm: if this load fails or is cancelled, OnAfterOpenSolution never
         // comes and no close event follows either — the solution was already closed — so the panes
         // would stay pinned forever.
@@ -413,7 +413,7 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
 
     int IVsSolutionEvents.OnAfterCloseSolution(object pUnkReserved)
     {
-        OutputWindowLogger.Debug(() => $"[reload] OnAfterCloseSolution panes={Core.Panes.PaneRegistry.Instance.Entries.Count}");
+        OutputWindowLogger.Debug(() => $"[reload] solution closed — panes={Core.Panes.PaneRegistry.Instance.Entries.Count}");
         CurrentSolutionFolder = null;
         // Armed here, not on the Before: unloading the projects happens in between and would eat the
         // window on a large solution.
@@ -436,7 +436,7 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
 
     int IVsSolutionEvents.OnBeforeCloseSolution(object pUnkReserved)
     {
-        OutputWindowLogger.Debug(() => $"[reload] OnBeforeCloseSolution folder={CurrentSolutionFolder ?? "(none)"} panes={Core.Panes.PaneRegistry.Instance.Entries.Count}");
+        OutputWindowLogger.Debug(() => $"[reload] solution closing: {CurrentSolutionFolder ?? "(none)"} — panes={Core.Panes.PaneRegistry.Instance.Entries.Count}");
         // Snapshot while the frames are still valid and the pane list is complete.
         SaveWorkspace();
         // Last point where the folder is still known — OnAfterCloseSolution clears it. The panes are

--- a/src/Corsinvest.VisualStudio.Agents/AgentsPackage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/AgentsPackage.cs
@@ -200,6 +200,15 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
         if (profiles.Count == 0) { return; }   // defensive: nothing enabled → nothing to restore onto
         foreach (var p in ws.Panes)
         {
+            // A reload leaves its panes alive: restoring them again would double every chat.
+            // Matched on session id, the only field that survives on both sides.
+            if (!string.IsNullOrEmpty(p.SessionId)
+                && Core.Panes.PaneRegistry.Instance.Entries.Any(e =>
+                       string.Equals(e.ActiveSessionId, p.SessionId, StringComparison.OrdinalIgnoreCase)))
+            {
+                OutputWindowLogger.Debug(() => $"[restore] session {p.SessionId} still open → skip");
+                continue;
+            }
             var kind = string.Equals(p.Kind, "Cli", StringComparison.OrdinalIgnoreCase)
                 ? Core.Panes.PaneKind.Cli : Core.Panes.PaneKind.Chat;
             var profile = profiles.FirstOrDefault(x =>
@@ -334,6 +343,9 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
                 _debugger?.UnadviseDebuggerEvents(_debuggerEventsCookie);
                 _debuggerEventsCookie = 0;
             }
+            // A watch still armed here would fire into a package that is going away.
+            _reloadWatch?.Dispose();
+            _reloadWatch = null;
             Mcp.McpServerHost.Instance.Stop();
             AgentsOptions.Applied -= ProfilesMenuCommand.InvalidateCache;
             // Unadvise the selection sink (MS pattern: at package dispose). Dispose was never

--- a/src/Corsinvest.VisualStudio.Agents/AgentsPackage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/AgentsPackage.cs
@@ -301,6 +301,7 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
 
     int IVsSolutionEvents.OnAfterOpenSolution(object pUnkReserved, int fNewSolution)
     {
+        OutputWindowLogger.Info($"[reload] OnAfterOpenSolution fNew={fNewSolution} panes={Core.Panes.PaneRegistry.Instance.Entries.Count}");
         // Redundant with OnBeforeOpenSolution, but covers the rare load path
         // that skips IVsSolutionLoadEvents.
         RefreshCurrentSolutionFolder();
@@ -327,6 +328,7 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
 
     int IVsSolutionLoadEvents.OnBeforeOpenSolution(string pszSolutionFilename)
     {
+        OutputWindowLogger.Info($"[reload] OnBeforeOpenSolution file={pszSolutionFilename ?? "(none)"} panes={Core.Panes.PaneRegistry.Instance.Entries.Count}");
         // Cache the folder eagerly from the .sln path so consumers don't hit
         // IVsSolution before it's populated (projects may still be loading).
         if (!string.IsNullOrEmpty(pszSolutionFilename))
@@ -346,21 +348,72 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
 
     int IVsSolutionEvents.OnAfterCloseSolution(object pUnkReserved)
     {
+        OutputWindowLogger.Info($"[reload] OnAfterCloseSolution folder={CurrentSolutionFolder ?? "(none)"} panes={Core.Panes.PaneRegistry.Instance.Entries.Count}");
         CurrentSolutionFolder = null;
         _ = Mcp.McpServerHost.Instance.RewriteLockFileAsync();
         return VSConstants.S_OK;
     }
 
-    int IVsSolutionEvents.OnQueryCloseSolution(object pUnkReserved, ref int pfCancel) => VSConstants.S_OK;
+    int IVsSolutionEvents.OnQueryCloseSolution(object pUnkReserved, ref int pfCancel)
+    {
+        OutputWindowLogger.Info($"[reload] OnQueryCloseSolution cancelIn={pfCancel} panes={Core.Panes.PaneRegistry.Instance.Entries.Count}");
+        return VSConstants.S_OK;
+    }
 
-    int IVsSolutionEvents.OnAfterOpenProject(IVsHierarchy pHierarchy, int fAdded) => VSConstants.S_OK;
-    int IVsSolutionEvents.OnQueryCloseProject(IVsHierarchy pHierarchy, int fRemoving, ref int pfCancel) => VSConstants.S_OK;
-    int IVsSolutionEvents.OnBeforeCloseProject(IVsHierarchy pHierarchy, int fRemoved) => VSConstants.S_OK;
-    int IVsSolutionEvents.OnAfterLoadProject(IVsHierarchy pStubHierarchy, IVsHierarchy pRealHierarchy) => VSConstants.S_OK;
-    int IVsSolutionEvents.OnQueryUnloadProject(IVsHierarchy pRealHierarchy, ref int pfCancel) => VSConstants.S_OK;
-    int IVsSolutionEvents.OnBeforeUnloadProject(IVsHierarchy pRealHierarchy, IVsHierarchy pStubHierarchy) => VSConstants.S_OK;
+    /// <summary>Project name off a hierarchy, for the trace below — the events carry the project
+    /// only as an IVsHierarchy, and "which project" is half of what the sequence has to tell us.</summary>
+    private static string HierName(IVsHierarchy hier)
+    {
+        if (hier == null) { return "(null)"; }
+        try
+        {
+            hier.GetProperty(VSConstants.VSITEMID_ROOT, (int)__VSHPROPID.VSHPROPID_Name, out var name);
+            return name as string ?? "(unnamed)";
+        }
+        catch { return "(error)"; }
+    }
+
+    // Project-level events: no-ops we only trace. A project reload (the "modified outside the
+    // environment" prompt) is an unload followed by a load — the SDK has no reload event of its
+    // own — and the open question is whether it takes the chat panes down with it.
+    int IVsSolutionEvents.OnAfterOpenProject(IVsHierarchy pHierarchy, int fAdded)
+    {
+        OutputWindowLogger.Info($"[reload] OnAfterOpenProject proj={HierName(pHierarchy)} fAdded={fAdded} panes={Core.Panes.PaneRegistry.Instance.Entries.Count}");
+        return VSConstants.S_OK;
+    }
+
+    int IVsSolutionEvents.OnQueryCloseProject(IVsHierarchy pHierarchy, int fRemoving, ref int pfCancel)
+    {
+        OutputWindowLogger.Info($"[reload] OnQueryCloseProject proj={HierName(pHierarchy)} fRemoving={fRemoving} cancelIn={pfCancel} panes={Core.Panes.PaneRegistry.Instance.Entries.Count}");
+        return VSConstants.S_OK;
+    }
+
+    int IVsSolutionEvents.OnBeforeCloseProject(IVsHierarchy pHierarchy, int fRemoved)
+    {
+        OutputWindowLogger.Info($"[reload] OnBeforeCloseProject proj={HierName(pHierarchy)} fRemoved={fRemoved} panes={Core.Panes.PaneRegistry.Instance.Entries.Count}");
+        return VSConstants.S_OK;
+    }
+
+    int IVsSolutionEvents.OnAfterLoadProject(IVsHierarchy pStubHierarchy, IVsHierarchy pRealHierarchy)
+    {
+        OutputWindowLogger.Info($"[reload] OnAfterLoadProject stub={HierName(pStubHierarchy)} real={HierName(pRealHierarchy)} panes={Core.Panes.PaneRegistry.Instance.Entries.Count}");
+        return VSConstants.S_OK;
+    }
+
+    int IVsSolutionEvents.OnQueryUnloadProject(IVsHierarchy pRealHierarchy, ref int pfCancel)
+    {
+        OutputWindowLogger.Info($"[reload] OnQueryUnloadProject proj={HierName(pRealHierarchy)} cancelIn={pfCancel} panes={Core.Panes.PaneRegistry.Instance.Entries.Count}");
+        return VSConstants.S_OK;
+    }
+
+    int IVsSolutionEvents.OnBeforeUnloadProject(IVsHierarchy pRealHierarchy, IVsHierarchy pStubHierarchy)
+    {
+        OutputWindowLogger.Info($"[reload] OnBeforeUnloadProject real={HierName(pRealHierarchy)} stub={HierName(pStubHierarchy)} panes={Core.Panes.PaneRegistry.Instance.Entries.Count}");
+        return VSConstants.S_OK;
+    }
     int IVsSolutionEvents.OnBeforeCloseSolution(object pUnkReserved)
     {
+        OutputWindowLogger.Info($"[reload] OnBeforeCloseSolution folder={CurrentSolutionFolder ?? "(none)"} panes={Core.Panes.PaneRegistry.Instance.Entries.Count} — CLOSING ALL");
         // Snapshot before CloseAll drains the registry, so the closing solution's
         // workspace.json reflects the panes it actually had open.
         SaveWorkspace();

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneLauncher.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneLauncher.cs
@@ -26,10 +26,39 @@ internal static class PaneLauncher
     private static Type WindowType(PaneKind kind)
         => kind == PaneKind.Cli ? typeof(CliPaneWindow) : typeof(ChatPaneWindow);
 
+    /// <summary>Hide every pane the registry knows about, keeping the frames (and the CLI processes
+    /// behind them) alive. Used while a closing solution might still be a reload coming back: the
+    /// panes have to look gone straight away, but closing them would kill the session for good.
+    /// Hide leaves the dock position untouched, so <see cref="ShowExisting"/> brings them back where
+    /// they were. Main thread only — IVsWindowFrame is not free-threaded.</summary>
+    public static void HideExisting()
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        var pkg = AgentsPackage.Instance;
+        if (pkg == null) { return; }
+
+        foreach (var entry in PaneRegistry.Instance.Entries.ToList())
+        {
+            try
+            {
+                if (Frame(pkg, entry) is IVsWindowFrame frame && frame.IsVisible() == VSConstants.S_OK)
+                {
+                    frame.Hide();
+                }
+            }
+            catch (Exception ex)
+            {
+                // One pane failing to hide must not stop the others.
+                OutputWindowLogger.LogException($"PaneLauncher.HideExisting({entry.Title})", ex);
+            }
+        }
+    }
+
     /// <summary>Re-show the panes the registry already knows about, without creating any. VS holds a
     /// separate window layout for design time and run time, so panes opened while writing code are
     /// missing from the run-time one and look closed when the debugger starts — the frames are alive,
-    /// they are simply not in that layout. Called on debugger mode changes.
+    /// they are simply not in that layout. Called on debugger mode changes, and after a solution
+    /// reload to bring back what <see cref="HideExisting"/> put away.
     ///
     /// create: false throughout: a pane the user closed is gone from the registry and must stay
     /// closed, and a frame we cannot find is not one to conjure up.

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneLauncher.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneLauncher.cs
@@ -48,7 +48,6 @@ internal static class PaneLauncher
             }
             catch (Exception ex)
             {
-                // One pane failing to hide must not stop the others.
                 OutputWindowLogger.LogException($"PaneLauncher.HideExisting({entry.Title})", ex);
             }
         }

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneRegistry.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneRegistry.cs
@@ -64,8 +64,8 @@ public sealed class PaneRegistry
     }
 
     /// <summary>Close every live pane via its CloseAction (which disposes the pane and
-    /// removes the entry). Used on solution close, since panes are bound to its workdir.
-    /// Snapshot first — CloseAction mutates Entries.</summary>
+    /// removes the entry). Used when no solution came back after a close, and on package
+    /// teardown. Snapshot first — CloseAction mutates Entries.</summary>
     public void CloseAll()
     {
         foreach (var entry in Entries.ToArray())
@@ -74,6 +74,29 @@ public sealed class PaneRegistry
             catch (Exception ex) { OutputWindowLogger.LogException("PaneRegistry.CloseAll", ex); }
         }
     }
+
+    /// <summary>Close every pane whose working directory differs from <paramref name="workingDirectory"/>,
+    /// and return how many were left alive. A solution reload reopens the same folder, so the panes on
+    /// it keep their live CLI process instead of being torn down and resumed from disk. A null or empty
+    /// folder means "no solution" — nothing can match, so everything closes.
+    /// Snapshot first: CloseAction mutates Entries.</summary>
+    public int CloseWhereWorkdirDiffers(string workingDirectory)
+    {
+        var kept = 0;
+        foreach (var entry in Entries.ToArray())
+        {
+            if (SameFolder(entry.WorkingDirectory, workingDirectory)) { kept++; continue; }
+            try { entry.CloseAction?.Invoke(); }
+            catch (Exception ex) { OutputWindowLogger.LogException("PaneRegistry.CloseWhereWorkdirDiffers", ex); }
+        }
+        return kept;
+    }
+
+    /// <summary>Folder comparison for the reload check: case-insensitive (Windows) and blind to a
+    /// trailing separator, which IVsSolution and Path.GetDirectoryName disagree about.</summary>
+    private static bool SameFolder(string a, string b)
+        => !string.IsNullOrEmpty(a) && !string.IsNullOrEmpty(b)
+           && string.Equals(a.TrimEnd('\\', '/'), b.TrimEnd('\\', '/'), StringComparison.OrdinalIgnoreCase);
 
     /// <summary>Live entries of one kind — what the toolbar open-panes list binds to.</summary>
     public IEnumerable<PaneEntry> OfKind(PaneKind kind) => Entries.Where(e => e.Kind == kind);

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneWindowBase.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneWindowBase.cs
@@ -252,6 +252,7 @@ public abstract class PaneWindowBase : ToolWindowPane
         if (disposing)
         {
             Ide.IdeContextService.ActiveFrameChanged -= OnActiveFrameChanged;
+            OutputWindowLogger.Info($"[reload] pane frame disposed: {GetType().Name} #{PaneId}");
             try { PaneControl.DisposePane(); }
             catch (System.Exception ex) { OutputWindowLogger.LogException($"{GetType().Name}.Dispose", ex); }
         }

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneWindowBase.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneWindowBase.cs
@@ -252,7 +252,7 @@ public abstract class PaneWindowBase : ToolWindowPane
         if (disposing)
         {
             Ide.IdeContextService.ActiveFrameChanged -= OnActiveFrameChanged;
-            OutputWindowLogger.Info($"[reload] pane frame disposed: {GetType().Name} #{PaneId}");
+            OutputWindowLogger.Debug(() => $"[pane] frame disposed: {GetType().Name} #{PaneId}");
             try { PaneControl.DisposePane(); }
             catch (System.Exception ex) { OutputWindowLogger.LogException($"{GetType().Name}.Dispose", ex); }
         }


### PR DESCRIPTION
Adding a project to the solution used to cost you the conversation. VS reloads the solution when the `.sln`/`.slnx` changes on disk, and `OnBeforeCloseSolution` closed every pane — killing the `claude.exe` and the turn in flight with it.

## Why it wasn't a one-liner

There is no reload event in the SDK: a reload is a close followed by an open, and **nothing at close time tells the two apart**. Traced in the experimental instance, the two sequences are identical — same events, same `fRemoving`/`fRemoved`/`fNew` values. The only difference is what happens next: the solution comes back, or it doesn't.

So the close is deferred instead of decided:

| Event | Action |
|---|---|
| `OnBeforeCloseSolution` | remember the folder, save the workspace — **don't close** |
| `OnAfterCloseSolution` | hide the panes, arm a 10 s watch |
| `OnBeforeOpenSolution` | rearm at 120 s — something is loading |
| `OnAfterOpenSolution` | disarm; keep the panes whose workdir matches, close the rest |
| watch elapsed | it was a real close — close everything |

**Timed from `OnAfterCloseSolution`**, not the Before: unloading the projects happens in between and would eat the window on a large solution. The measured close→open gap is 88–850 ms, so 10 s has room to spare and doesn't grow with the solution.

**Rearming rather than disarming** on `OnBeforeOpenSolution` covers the load that fails or gets cancelled: `OnAfterOpenSolution` never arrives, and no close event follows either — the solution was already closed — so the panes would otherwise stay pinned forever.

**Matching on the working directory**, not the solution path: the workdir is what ties a pane to its CLI, since the process runs there and can't follow a move. That also handles two solutions sharing a folder, and lets home-born panes be closed by the same rule instead of a special case.

## Panes hide rather than linger

Keeping them on screen for ten seconds after Close Solution read as a bug — the solution is gone but the chats are still there. `PaneLauncher.HideExisting()` takes the frames out of sight straight away while the control and its CLI stay alive; `Hide` leaves the dock position alone, so a reload hands them back where they were rather than rebuilding them at the default spot. It's the same mechanism `ShowExisting` already used for the debugger's layout switches.

## Also

- The restore skips sessions a reload left open — it assumed a drained registry, and would have doubled every chat.
- The reload trace was thirteen `Info` lines for one solution open. The lifecycle traces drop to `Debug`; only the outcome (`kept N of M`, `watch elapsed`) stays `Info`.
- The project-level handlers go back to bare no-ops. A project reload is also unload-then-load, but SDK-style projects absorb an edited `.csproj` in place and never take that path — traced once, confirmed silent.

## Verification

Build green, VSIX produced.

Exercised in the experimental instance across two consecutive reloads (add a project to the `.slnx`, then remove it), with a chat mid-answer:

```
[reload] solution closing: K:\...\ConsoleApp3 — panes=1
[reload] solution closed — panes=1
[reload] watch armed for 10000 ms
[reload] solution opening: K:\...\ConsoleApp3.slnx
[reload] watch armed for 120000 ms
[reload] solution open on K:\...\ConsoleApp3 — kept 1 of 1 pane(s)
[restore] session 6ba8bf29-... still open → skip
```

No `frame disposed`, no `transport exit`, same session id throughout, and the panes came back where they were. The answer carried on across the reload.

Close, solution switch and normal open were confirmed by hand rather than from a log.
