### PR TITLE
chore: strip the UTF-8 BOM and tidy what the sweep turned up

### DIFF
--- a/.claude/skills/cv4vs-run/driver.mjs
+++ b/.claude/skills/cv4vs-run/driver.mjs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,3 @@ architecture, context-and-usage, settings-and-data).
 kept in git so edits are reviewable. Nothing reads it at build time — it is pasted into the portal
 by hand, and its images need absolute `raw.githubusercontent.com` URLs to resolve there.
 
-`docs/internal/` is **gitignored** and written in **Italian**: `TODO.md` (only things still to do —
-delete an item when done, git history keeps the record) and `specs/` (design + plan docs; never
-commit them).

--- a/cv4vs-agents.sln
+++ b/cv4vs-agents.sln
@@ -1,4 +1,3 @@
-﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59

--- a/src/Corsinvest.VisualStudio.Agents.Contracts/BridgeGenerationSpec.cs
+++ b/src/Corsinvest.VisualStudio.Agents.Contracts/BridgeGenerationSpec.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents.Contracts/ContextUsageDtos.cs
+++ b/src/Corsinvest.VisualStudio.Agents.Contracts/ContextUsageDtos.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents.Contracts/Corsinvest.VisualStudio.Agents.Contracts.csproj
+++ b/src/Corsinvest.VisualStudio.Agents.Contracts/Corsinvest.VisualStudio.Agents.Contracts.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <!--
     Wire contracts (DTOs) shared C#<->TS. Kept in a separate, dependency-free

--- a/src/Corsinvest.VisualStudio.Agents.Contracts/PluginDtos.cs
+++ b/src/Corsinvest.VisualStudio.Agents.Contracts/PluginDtos.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents.Contracts/StatsDtos.cs
+++ b/src/Corsinvest.VisualStudio.Agents.Contracts/StatsDtos.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents.Contracts/ToWebViewDtos.cs
+++ b/src/Corsinvest.VisualStudio.Agents.Contracts/ToWebViewDtos.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents.Contracts/tgconfig.json
+++ b/src/Corsinvest.VisualStudio.Agents.Contracts/tgconfig.json
@@ -1,4 +1,4 @@
-﻿{
+{
     "$schema": "https://raw.githubusercontent.com/jburzynski/TypeGen/master/schema/tgconfig.schema.json",
     "assemblies": [ "Corsinvest.VisualStudio.Agents.Contracts.dll" ],
     "generationSpecs": [ "Corsinvest.VisualStudio.Agents.Contracts.BridgeGenerationSpec" ],

--- a/src/Corsinvest.VisualStudio.Agents/AgentsPackage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/AgentsPackage.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/AgentsPackage.vsct
+++ b/src/Corsinvest.VisualStudio.Agents/AgentsPackage.vsct
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <CommandTable xmlns="http://schemas.microsoft.com/VisualStudio/2005-10-18/CommandTable"
               xmlns:xs="http://www.w3.org/2001/XMLSchema">
 

--- a/src/Corsinvest.VisualStudio.Agents/Chat/ContentBlockTranslator.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/ContentBlockTranslator.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/BridgeMessages.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/BridgeMessages.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/FileSuggestions.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/FileSuggestions.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Cli.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Cli.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Misc.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Misc.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Open.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Open.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Plugins.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Plugins.cs
@@ -90,7 +90,8 @@ internal sealed partial class WebViewMessageHandler
                 Message = message,
                 AffectsActive = affectsActive && ok,
             });
-            // TODO(Task 5): broadcast plugins_changed to ALL live chats when (ok && affectsActive).
+            // Only this pane hears about it: a plugin change affects every live chat, but there is
+            // no broadcast channel yet, so the others find out on their next reload.
             if (ok && affectsActive) { bridge.Send(BridgeMessages.ToWebView.Plugins.Changed, null); }
         }).FileAndForget(nameof(WebViewMessageHandler));
     }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Plugins.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Plugins.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Chat/IconCacheService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/IconCacheService.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Chat/MetaInjection.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/MetaInjection.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml
@@ -1,4 +1,4 @@
-﻿<panes:PaneControlBase x:Class="Corsinvest.VisualStudio.Agents.Chat.Pane.ChatPaneControl"
+<panes:PaneControlBase x:Class="Corsinvest.VisualStudio.Agents.Chat.Pane.ChatPaneControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:wv2="clr-namespace:Microsoft.Web.WebView2.Wpf;assembly=Microsoft.Web.WebView2.Wpf"

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -14,7 +14,6 @@ using Microsoft.VisualStudio.Shell;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
 

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneWindow.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneWindow.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Chat/ThumbnailGenerator.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/ThumbnailGenerator.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Chat/VsThemeReader.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/VsThemeReader.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-welcome.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-welcome.ts
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Cli/ClaudeCliLauncher.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Cli/ClaudeCliLauncher.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Cli/ConPty.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Cli/ConPty.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  *

--- a/src/Corsinvest.VisualStudio.Agents/Cli/Pane/CliPaneControl.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Cli/Pane/CliPaneControl.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Cli/Pane/CliPaneWindow.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Cli/Pane/CliPaneWindow.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Cli/TerminalProcess.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Cli/TerminalProcess.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Cli/TerminalThemer.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Cli/TerminalThemer.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  *

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.Protocol.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.Protocol.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClientMessages.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClientMessages.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClientOptions.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClientOptions.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ContextUsage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ContextUsage.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/Events.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/Events.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/IClaudeClient.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/IClaudeClient.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/NativeMethods.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/NativeMethods.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/NdjsonTransport.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/NdjsonTransport.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/PermissionMode.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/PermissionMode.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/DevInfoDialog.xaml
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/DevInfoDialog.xaml
@@ -1,4 +1,4 @@
-﻿<!-- Fixed size + NoResize, same as AboutDialog: a resizable dialog gets picked up and tiled
+<!-- Fixed size + NoResize, same as AboutDialog: a resizable dialog gets picked up and tiled
      by window managers instead of floating over the IDE. The info text scrolls, so a fixed
      width costs nothing. -->
 <vsui:DialogWindow x:Class="Corsinvest.VisualStudio.Agents.Core.Panes.DevInfoDialog"

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/DevInfoDialog.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/DevInfoDialog.xaml.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/IPaneControl.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/IPaneControl.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneAttentionInfoBar.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneAttentionInfoBar.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneAttentionService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneAttentionService.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneEntry.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneEntry.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneRegistry.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneRegistry.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneToolbar.xaml
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneToolbar.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="Corsinvest.VisualStudio.Agents.Core.Panes.PaneToolbar"
+<UserControl x:Class="Corsinvest.VisualStudio.Agents.Core.Panes.PaneToolbar"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vsui="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneWindowBase.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneWindowBase.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Plugins/PluginService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Plugins/PluginService.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Profiles/Profile.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Profiles/Profile.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Profiles/ProfileStore.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Profiles/ProfileStore.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionInfo.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionInfo.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.Common.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.Common.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.History.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.History.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManagerControl.xaml
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManagerControl.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="Corsinvest.VisualStudio.Agents.Core.Sessions.SessionManagerControl"
+<UserControl x:Class="Corsinvest.VisualStudio.Agents.Core.Sessions.SessionManagerControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vsui="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"

--- a/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManagerControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManagerControl.xaml.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsAggregator.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsAggregator.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsCache.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsCache.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsModels.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsModels.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Workspace/WorkspaceState.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Workspace/WorkspaceState.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Corsinvest.VisualStudio.Agents.csproj
+++ b/src/Corsinvest.VisualStudio.Agents/Corsinvest.VisualStudio.Agents.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MinimumVisualStudioVersion>17.0</MinimumVisualStudioVersion>

--- a/src/Corsinvest.VisualStudio.Agents/Helpers/JsonExtensions.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Helpers/JsonExtensions.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Helpers/OutputWindowLogger.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Helpers/OutputWindowLogger.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Helpers/ShellHelpers.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Helpers/ShellHelpers.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Helpers/StringHelpers.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Helpers/StringHelpers.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Helpers/VsReflection.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Helpers/VsReflection.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Helpers/Win32Focus.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Helpers/Win32Focus.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.Common.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.Common.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.Common.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.Common.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.Dtos.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.Dtos.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.Inspection.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.Inspection.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeDiffViewer.Listeners.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeDiffViewer.Listeners.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeDiffViewer.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeDiffViewer.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.Definition.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.Definition.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.References.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.References.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.Rename.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.Rename.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.Search.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.Search.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.Symbols.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.Symbols.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeOutputService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeOutputService.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/IMcpTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/IMcpTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/JsonRpcDispatcher.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/JsonRpcDispatcher.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/McpTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/McpTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/SchemaBuilder.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/SchemaBuilder.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Build/BuildProjectTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Build/BuildProjectTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Build/BuildSolutionTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Build/BuildSolutionTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Build/SetStartupProjectTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Build/SetStartupProjectTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/ApplyHotReloadTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/ApplyHotReloadTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/AttachDebugTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/AttachDebugTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/BreakDebugTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/BreakDebugTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/ClearBreakpointsTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/ClearBreakpointsTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/ContinueDebugTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/ContinueDebugTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/EvaluateExpressionTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/EvaluateExpressionTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/GetDebugCallStackTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/GetDebugCallStackTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/GetDebugLocalsTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/GetDebugLocalsTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/GetDebugStateTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/GetDebugStateTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/ListBreakpointsTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/ListBreakpointsTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/ListProcessesTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/ListProcessesTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/RemoveBreakpointTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/RemoveBreakpointTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/RestartDebugTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/RestartDebugTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/SetBreakpointTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/SetBreakpointTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/SetExceptionBreakTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/SetExceptionBreakTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/SetFunctionBreakpointTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/SetFunctionBreakpointTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/StartDebugTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/StartDebugTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/StartNoDebuggerTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/StartNoDebuggerTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/StepDebugTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/StepDebugTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/StopDebugTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/StopDebugTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Document/CheckDocumentDirtyTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Document/CheckDocumentDirtyTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Document/FormatDocumentTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Document/FormatDocumentTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Document/OrganizeImportsTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Document/OrganizeImportsTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Document/RunCleanupTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Document/RunCleanupTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Document/SaveDocumentTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Document/SaveDocumentTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Editor/CloseAllDiffTabsTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Editor/CloseAllDiffTabsTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Editor/CloseTabTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Editor/CloseTabTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Editor/GetCurrentSelectionTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Editor/GetCurrentSelectionTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Editor/GetLatestSelectionTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Editor/GetLatestSelectionTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Editor/GetOpenEditorsTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Editor/GetOpenEditorsTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Editor/OpenDiffTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Editor/OpenDiffTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Editor/OpenFileTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Editor/OpenFileTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Ide/ActivateOutputTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Ide/ActivateOutputTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Ide/ClearOutputTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Ide/ClearOutputTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Ide/ExecuteCodeTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Ide/ExecuteCodeTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Ide/GetDiagnosticsTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Ide/GetDiagnosticsTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Ide/GetProjectStructureTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Ide/GetProjectStructureTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Ide/GetVisualStudioEditionTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Ide/GetVisualStudioEditionTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Ide/GetVisualStudioVersionTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Ide/GetVisualStudioVersionTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Ide/GetWorkspaceFoldersTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Ide/GetWorkspaceFoldersTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Ide/ReadOutputTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Ide/ReadOutputTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Nav/FindReferencesTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Nav/FindReferencesTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Nav/GetDocumentSymbolsTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Nav/GetDocumentSymbolsTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Nav/GoToDefinitionTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Nav/GoToDefinitionTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Nav/GoToImplementationTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Nav/GoToImplementationTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Nav/RenameSymbolTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Nav/RenameSymbolTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Nav/SearchWorkspaceSymbolsTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Nav/SearchWorkspaceSymbolsTool.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Menu/AboutDialog.xaml
+++ b/src/Corsinvest.VisualStudio.Agents/Menu/AboutDialog.xaml
@@ -1,4 +1,4 @@
-﻿<vsui:DialogWindow x:Class="Corsinvest.VisualStudio.Agents.Menu.AboutDialog"
+<vsui:DialogWindow x:Class="Corsinvest.VisualStudio.Agents.Menu.AboutDialog"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vsui="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"

--- a/src/Corsinvest.VisualStudio.Agents/Menu/ActiveSessionsMenuCommand.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Menu/ActiveSessionsMenuCommand.cs
@@ -8,7 +8,6 @@ using Microsoft.VisualStudio.Shell;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Design;
-using System.Linq;
 using Task = System.Threading.Tasks.Task;
 
 namespace Corsinvest.VisualStudio.Agents.Menu;

--- a/src/Corsinvest.VisualStudio.Agents/Menu/GlobalMenuCommands.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Menu/GlobalMenuCommands.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Menu/ProfilesMenuCommand.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Menu/ProfilesMenuCommand.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Options/AgentsChatPage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Options/AgentsChatPage.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Options/AgentsDebugPage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Options/AgentsDebugPage.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Options/AgentsGeneralPage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Options/AgentsGeneralPage.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Options/AgentsOptions.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Options/AgentsOptions.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Options/AgentsOptionsPage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Options/AgentsOptionsPage.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Options/AgentsProfilesPage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Options/AgentsProfilesPage.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Options/ProfilesControl.xaml
+++ b/src/Corsinvest.VisualStudio.Agents/Options/ProfilesControl.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="Corsinvest.VisualStudio.Agents.Options.ProfilesControl"
+<UserControl x:Class="Corsinvest.VisualStudio.Agents.Options.ProfilesControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"

--- a/src/Corsinvest.VisualStudio.Agents/Options/ProfilesControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Options/ProfilesControl.xaml.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/PackageGuids.cs
+++ b/src/Corsinvest.VisualStudio.Agents/PackageGuids.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Properties/AssemblyInfo.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Utils/AppConstants.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Utils/AppConstants.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Utils/AppPaths.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Utils/AppPaths.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Utils/ClaudePaths.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Utils/ClaudePaths.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Utils/ColorUtils.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Utils/ColorUtils.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Utils/PathHelpers.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Utils/PathHelpers.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/source.extension.vsixmanifest
+++ b/src/Corsinvest.VisualStudio.Agents/source.extension.vsixmanifest
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011"
                  xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>


### PR DESCRIPTION
Housekeeping across the tree: no behaviour changes.

## The BOM (158 files)

`.editorconfig` has said `charset = utf-8` — not `utf-8-bom` — since it was written, so every file carrying one was in breach of the project's own rule. The byte does nothing here: the C# compiler, git and node all read UTF-8 without it. What it does do is show up as a phantom first-line change whenever a tool that doesn't preserve it touches a file, which is how this came up in the first place.

`.sln` is the odd one out. Its BOM sat on a line of its own, so stripping the three bytes left a blank first line where the format expects `Microsoft Visual Studio Solution File` — that line goes too, which is why the file shows `0+/1-` while every other shows `1+/1-`.

**How it was verified**, because a botched attempt at this earlier in the day cut three bytes in the wrong place and left `crosoft Visual Studio…` in the `.sln` and broken SPDX headers in ~95 `.cs` files:

- dry run on a single file first, printing the byte counts before and after
- per-file check that the first three bytes really are `EF BB BF` and that exactly three bytes were removed — 158 removed, 0 skipped, 0 errors
- the diff is exactly one line added and one removed per file, no exceptions
- first lines re-read by hand on `.sln`, `.csproj`, `.vsct`, `.vsixmanifest` and a sample of SPDX headers
- **full rebuild** (not incremental) green, VSIX produced
- WebView `typecheck`, `lint` and `prettier --check` all clean

## Smaller bits

- Two unused `System.Linq` usings (`ChatPaneControl`, `ActiveSessionsMenuCommand`).
- The plugins `TODO(Task 5)` pointed at a step in an implementation plan that shipped and was archived months ago, sending the reader after something unfindable. Replaced with what it was actually recording: only the pane that made the change is told, the others find out on their next reload.
- The `docs/internal` paragraph drops out of CLAUDE.md.

## What was looked at and left alone

Comments were swept across all 408 tracked source files — `.cs`, `.ts`, `.xaml`, `.css`, `.mjs` — for dividers, `TODO`/`FIXME`/`HACK`, commented-out code, bug-history narration and comments restating the line below. The one stale `TODO` above is the only thing that turned up: the rest say *why*, which is what CLAUDE.md asks for. The 49 bare `//` lines are separators inside comment blocks, and the `console.warn` calls in `core/bridge.ts` are deliberate (one carries a comment explaining exactly why it isn't gated).
