### PR TITLE
chore(tools): only close the Visual Studio on the hive being installed to

### DIFF
--- a/tools/extension.ps1
+++ b/tools/extension.ps1
@@ -11,7 +11,8 @@
     instead of a double-click, a dialog and a manual cleanup.
 
     Experimental hives by default: that is where an extension under test belongs, and it keeps the
-    IDE you actually work in untouched.
+    IDE you actually work in untouched — including while this runs, since only instances on the hive
+    being written to have to be closed.
 
     Why this exists rather than "just use Manage Extensions":
 
@@ -147,13 +148,31 @@ function Find-InstalledCopies {
 }
 
 # VS holds its extension folders open, and VSIXInstaller writes into the hive VS reads at startup:
-# either one under a running instance leaves a half-applied state.
+# either one under a running instance leaves a half-applied state. Only the instances on the hive
+# being touched matter, though — the hives are separate folders and separate registry nodes, so a
+# normal instance neither locks the experimental extension folder nor minds it being rewritten.
+# That is what lets the chat pane in the normal instance stay open while a build is installed for
+# testing next door.
+# Reading the command line can fail (permissions, a process exiting mid-enumeration); an instance we
+# cannot classify counts as one on our hive, because a wrong guess here is a half-installed
+# extension.
 function Assert-VisualStudioClosed {
-    $running = Get-Process devenv -ErrorAction SilentlyContinue
-    if (-not $running) { return }
+    $onOurHive = @(
+        Get-CimInstance Win32_Process -Filter "Name='devenv.exe'" -ErrorAction SilentlyContinue |
+            Where-Object {
+                $cmd = $_.CommandLine
+                if (-not $cmd) { return $true }
+                $isExp = $cmd -match '/rootsuffix\s+\S+'
+                if ($Normal) { -not $isExp } else { $isExp }
+            }
+    )
+    if (-not $onOurHive) { return }
 
-    Write-Host "Visual Studio is running ($($running.Count) instance(s)). Close it first." -ForegroundColor Red
-    $running | Select-Object Id, MainWindowTitle | Format-Table | Out-String | Write-Host
+    $which = if ($Normal) { 'normal' } else { 'experimental' }
+    Write-Host "Visual Studio is running on the $which hive ($($onOurHive.Count) instance(s)). Close it first." -ForegroundColor Red
+    $onOurHive |
+        Select-Object @{ n = 'Id'; e = { $_.ProcessId } }, @{ n = 'CommandLine'; e = { $_.CommandLine } } |
+        Format-Table -Wrap | Out-String | Write-Host
     exit 1
 }
 
@@ -235,8 +254,16 @@ function Invoke-Uninstall {
     foreach ($copy in $copies) {
         if ($PSCmdlet.ShouldProcess($copy.Path, 'Remove extension folder')) {
             Write-Host "removing  $($copy.Path)"
-            Remove-Item $copy.Path -Recurse -Force
-            $removed = $true
+            try {
+                Remove-Item $copy.Path -Recurse -Force -ErrorAction Stop
+                $removed = $true
+            }
+            catch {
+                # An instance on this hive still has the assemblies loaded. The guard above should
+                # have caught it, so say which folder is stuck rather than dying on a raw exception.
+                Write-Host "  locked — close every Visual Studio on this hive and re-run: $($_.Exception.Message)" -ForegroundColor Red
+                exit 1
+            }
         }
     }
 


### PR DESCRIPTION
Testing a build meant closing every Visual Studio — including the one hosting the chat pane being used to write the code. The install-and-verify loop had to move to another editor and back.

It doesn't have to. The hives are separate folders under separate registry nodes, so a normal instance neither locks the experimental extension folder nor minds it being rewritten.

## Verified rather than assumed

With a normal instance open the whole time:

- writing into `…\18.0_ba9a3205Exp\Extensions` succeeded — no lock held by the normal instance
- `devenv /rootsuffix Exp /updateconfiguration` returned 0 in 20 s while it kept running
- a full `-Install` completed into both experimental hives
- the normal hive's copy (the Marketplace 1.0.0) was untouched afterwards
- the instance never restarted — 153 minutes of uptime across the install

## What changed

`Assert-VisualStudioClosed` classifies each `devenv` by its `/rootsuffix` and blocks only on the ones sharing the hive being written to. An instance whose command line can't be read counts as ours: a wrong guess there is a half-installed extension, which is the failure this guard exists to prevent.

The message now names the hive and prints the command line, so "close it first" says *which* one.

Removal grew a `catch` for the same reason. Uninstalling a version whose assemblies are still loaded is [the documented failure mode](https://visualstudioextensions.vlasovstudio.com/2021/11/14/installing-a-visual-studio-extension-for-a-rootsuffix/), and with the guard relaxed it stops being unreachable — it now names the stuck folder instead of dying on a raw exception.

The guard still fires correctly: `-Install -Normal` with a normal instance open exits 1, as before.
