### PR TITLE
feat(ci): a stable tag publishes to the Marketplace

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,9 +148,6 @@ jobs:
       # Marketplace takes neither a -rc suffix nor a second upload of the same version. Stable
       # releases are installed from the Marketplace, so attaching the file there would offer a
       # second copy that updates itself and one that doesn't.
-      #
-      # Marketplace upload stays manual for now: the portal asks for categories, screenshots and
-      # the overview, and those are set once by hand before automating around them.
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
@@ -160,3 +157,23 @@ jobs:
           generate_release_notes: true
           prerelease: ${{ steps.version.outputs.prerelease }}
           files: ${{ steps.version.outputs.prerelease == 'true' && 'src/Corsinvest.VisualStudio.Agents/bin/Release/*.vsix' || '' }}
+
+      # Stable only: the Marketplace rejects a -rc suffix, and previews are distributed as the
+      # attached .vsix instead. Runs after the GitHub release so a Marketplace failure leaves the
+      # release page standing rather than the reverse — the upload can be retried by hand, an
+      # already-published version cannot be re-tagged.
+      #
+      # vs-publish.json is the listing itself, not just credentials: publishing overwrites the
+      # Marketplace's categories, tags, overview and Q&A with whatever it says. It was filled in
+      # from what the portal already showed, so keep the two in step — a field edited on the portal
+      # and not here is reverted by the next release.
+      #
+      # VS_MARKETPLACE_TOKEN is a Marketplace PAT with Acquire + Manage, scoped to all accessible
+      # organizations — a narrower scope authenticates and then fails on the upload.
+      - name: Publish to the Marketplace
+        if: steps.version.outputs.prerelease == 'false'
+        uses: madskristensen/publish-marketplace@v2
+        with:
+          extension-file: src/Corsinvest.VisualStudio.Agents/bin/Release/Corsinvest.VisualStudio.Agents.vsix
+          publish-manifest-file: vs-publish.json
+          personal-access-code: ${{ secrets.VS_MARKETPLACE_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,11 @@ Full description in [docs/architecture.md](docs/architecture.md). What matters w
 `docs/*.md` is public and **written in English** (README, options, mcp-tools, sub-agents,
 architecture, context-and-usage, settings-and-data).
 
-`docs/marketplace-overview.md` is the odd one out: it is not documentation but the listing text,
-kept in git so edits are reviewable. Nothing reads it at build time — it is pasted into the portal
-by hand, and its images need absolute `raw.githubusercontent.com` URLs to resolve there.
+`docs/marketplace-overview.md` is the odd one out: it is not documentation but the listing text.
+`vs-publish.json` points the release workflow at it, so a stable tag uploads it along with the
+package — the file in git *is* what the Marketplace shows. Its images still need absolute
+`raw.githubusercontent.com` URLs: the portal resolves nothing relative.
+
+That manifest carries the rest of the listing too (categories, Q&A, price). Publishing overwrites
+them, so a field changed on the portal and not there is reverted by the next release.
 

--- a/vs-publish.json
+++ b/vs-publish.json
@@ -1,0 +1,26 @@
+{
+    "$schema": "http://json.schemastore.org/vsix-publish",
+    "categories": [ "coding", "other" ],
+    "identity": {
+        "internalName": "cv4vs-agents",
+        "tags": [
+            "agent",
+            "agentic",
+            "ai",
+            "anthropic",
+            "assistant",
+            "chat",
+            "claude",
+            "claude-code",
+            "coding-agent",
+            "llm",
+            "mcp"
+        ]
+    },
+    "overview": "docs/marketplace-overview.md",
+    "priceCategory": "free",
+    "publisher": "Corsinvest",
+    "private": false,
+    "qna": true,
+    "repo": "https://github.com/Corsinvest/cv4vs-agents"
+}


### PR DESCRIPTION
The Marketplace upload was the one manual step left in a release: build the Release VSIX, open the portal, attach it, and paste `docs/marketplace-overview.md` into the description box. A stable tag now does it.

`VsixPublisher` overwrites an extension that already exists, so a version bump is all it takes — the tag builds the package and the same job hands it over.

## The listing moves into git

`vs-publish.json` is not just credentials: publishing **overwrites** the Marketplace's categories, tags, overview, price and Q&A with whatever it says. It was filled in from what the portal already shows, field by field:

| Field | Value | Checked against |
|---|---|---|
| categories | `coding`, `other` | the portal's "Coding (+1)" dropdown |
| tags | the same eleven | the Tags list |
| publisher | `Corsinvest` | the publisher page |
| price / Q&A / repo | free / on / the GitHub URL | Categorization + Community & Support |

Name, version, logo, short description and supported editions are deliberately **not** in there — for a VSIX those come from `source.extension.vsixmanifest` inside the package, so the two can't drift.

The trade this makes: a field edited on the portal and not mirrored here is reverted by the next release. What it buys is the overview finally being reviewable in a PR rather than pasted by hand, which is what CLAUDE.md used to describe.

## Stable only

The Marketplace takes neither an `-rc` suffix nor a second upload of one version, and previews already ship as the `.vsix` attached to the GitHub release. The step is gated on `prerelease == 'false'`.

It runs **after** the release is created, so a failed upload leaves the release page standing. That asymmetry is deliberate: an upload can be retried by hand, a published version cannot be re-tagged.

## Needs a secret

`VS_MARKETPLACE_TOKEN` — a Marketplace PAT with **Acquire + Manage**, scoped to **all accessible organizations**. A narrower scope authenticates and then fails on the upload.

**This will need revisiting.** Azure DevOps retires all-accessible-organizations PATs on **2026-12-01** ([announcement](https://devblogs.microsoft.com/devops/retirement-of-global-personal-access-tokens-in-azure-devops/)); the March cut-off was withdrawn, so creating one still works today. Microsoft points at Entra ID workload identity federation instead, but the documented path covers `vsce` (VS Code) and says nothing about `VsixPublisher`. Worth checking whether an org-scoped PAT is enough before December — that would settle it without any of the Entra work.

## Verification

The manifest parses and its `overview` path resolves. Nothing else can be checked without publishing: the action only runs on a stable tag, and the first real proof will be v1.1.0.
