### PR TITLE
fix(chat): a file link that cannot be opened now says so

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Helpers.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Helpers.cs
@@ -213,15 +213,31 @@ internal sealed partial class WebViewMessageHandler
         }
     }
 
-    private static async Task OpenFileInEditorAsync(string filePath, int startLine, int endLine)
+    /// <summary>Say that a click did not open the file. The Output window is gated behind a log
+    /// level that defaults to None, so the Warn is invisible where it matters — this lands in the
+    /// chat. Short on purpose: the reader wants to know the click failed, not how VS treats project
+    /// files; the Warn keeps the detail for whoever is debugging. Keyed on the path so clicking the
+    /// same dead link twice doesn't stack.</summary>
+    private void NoticeOpenFailed(string path, string reason)
+    {
+        OutputWindowLogger.Warn($"[chat] can't open '{path}' — {reason}");
+        bridge.Send(BridgeMessages.ToWebView.Chat.Notice, new Contracts.NoticeNotification
+        {
+            Key = "openfile:" + path,
+            Severity = Contracts.NoticeVariantDto.Error,
+            Message = $"{Path.GetFileName(path)} — {reason}",
+            Position = Contracts.NoticePositionDto.Top,
+        });
+    }
+
+    private async Task OpenFileInEditorAsync(string filePath, int startLine, int endLine)
     {
         await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
         var dte = Package.GetGlobalService(typeof(DTE)) as DTE2;
         var window = OpenWindow(dte, filePath);
         if (window == null)
         {
-            // A click on a file link that does nothing at all reads as a broken link, so say why.
-            OutputWindowLogger.Warn($"[chat] Visual Studio would not open '{filePath}' — it refuses a file already open as a project or solution (its own .csproj, say)");
+            NoticeOpenFailed(filePath, "Visual Studio would not open it");
             return;
         }
         window.Activate();

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Open.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Open.cs
@@ -21,8 +21,17 @@ internal sealed partial class WebViewMessageHandler
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
             var p = data.ToObject<Contracts.IdeFileNotification>();
-            var filePath = ResolveFilePath(p.FilePath ?? "");
-            if (filePath == null) { return; }
+            var raw = p.FilePath ?? "";
+            var filePath = ResolveFilePath(raw);
+            if (filePath == null)
+            {
+                // Nothing was found anywhere ResolveFilePath looks, so name the path the link
+                // carried rather than one we resolved — that is what the user can act on. The
+                // reason stays open: moved, renamed, deleted, or a temp file Windows cleared out
+                // are all the same miss from here.
+                NoticeOpenFailed(raw, "not found");
+                return;
+            }
             // endLine defaults to startLine when the WebView omits it (single-line open).
             var endLine = p.EndLine != 0 ? p.EndLine : p.StartLine;
             await OpenFileInEditorAsync(filePath, p.StartLine, endLine);


### PR DESCRIPTION
Clicking a file path in the chat that no longer resolves did nothing at all — no editor, no message. From the outside that reads as a broken link rather than a missing file, and there was no way to tell which.

Two places were silent:

- `HandleIdeFile` — `ResolveFilePath` returns null and the handler just `return`s. Nothing was found as an absolute path, relative to the working directory, or by name under it.
- `OpenFileInEditorAsync` — VS itself refuses the file. This one *looked* handled (#52) but the `Warn` goes to the Output window, which is gated behind a log level that defaults to `None`. In practice nobody ever read it.

## What it says now

An error notice in the session stack, top of the chat:

```
Class1.cs — not found
ConsoleApp3.csproj — Visual Studio would not open it
```

Short on purpose. The reader wants to know the click failed; how VS treats project files belongs in the log, and the `Warn` still carries it for anyone debugging.

The wording stays vague about *why* the first one failed, deliberately: a miss from `ResolveFilePath` cannot tell a moved file from a renamed one from a temp file Windows cleared out. Claiming one of those would be a guess dressed as a diagnosis.

Keyed on the path, so clicking the same dead link twice doesn't stack notices.

## Notes

- A notice, not a dialog: a dead link is worth reporting, not worth interrupting for.
- `OpenFileInEditorAsync` loses its `static` — it needs the bridge to send. Single caller, no other effect.
- Composer attachments are unaffected: `HandleOpenAttachment` carries the bytes as base64 and rewrites the temp file on every click, so the file is always there.

## Verification

Build green. The notice path itself is manual — it needs a click on a link whose target has gone.
