### PR TITLE
fix(webview): the transcript stops being mutated under Lit

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Cli.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Cli.cs
@@ -65,7 +65,17 @@ internal sealed partial class WebViewMessageHandler
 
     private void HandleStop(JObject data, int? id)
     {
-        _ = client.InterruptAsync();
+        // The WebView frees itself the moment it asks (it can't wait on a wedged CLI), so a failed
+        // interrupt is invisible from the UI: it reads as stopped while the turn runs on. Nothing
+        // else observes this Task — the 10s request timeout would fault it into silence — so the
+        // log is the only place the divergence can surface.
+        _ = client.InterruptAsync().ContinueWith(t =>
+        {
+            if (t.IsFaulted)
+            {
+                OutputWindowLogger.Warn($"!!! interrupt failed: {t.Exception?.GetBaseException().Message}");
+            }
+        });
     }
 
     private void HandleSetPermissionMode(JObject data, int? id)

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.ClientEvents.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.ClientEvents.cs
@@ -251,6 +251,7 @@ public partial class ChatPaneControl
     private void OnResult(object sender, ResultEventArgs e)
         => Dispatcher.Invoke(() =>
         {
+            _turnInFlight = false;
             // NOTE: do NOT clear active sub-agents here. `result` ends the main turn, but
             // background agents (run_in_background / async) outlive it and keep running —
             // clearing here would hide the chip while they still work. Each agent sends its
@@ -429,6 +430,10 @@ public partial class ChatPaneControl
             var subtype = obj.Val("subtype", "");
             if (subtype == ClientMessages.SystemSubtype.Status)
             {
+                // The CLI reports a status the moment it starts working on a turn, and `result`
+                // ends it — the two bounds of "a turn is in flight", which OnOptionsApplied needs
+                // so it doesn't re-render the transcript out from under a running turn.
+                _turnInFlight = true;
                 // Forward the raw work status ("compacting" at start, null→"" at end). The WebView
                 // maps known values to a spinner label; VS Code does the same.
                 _bridge.Send(BridgeMessages.ToWebView.Chat.Status, new Contracts.StatusNotification

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
@@ -252,6 +252,9 @@ public partial class ChatPaneControl : PaneControlBase
     // True while background agents are running (from background_tasks_changed). Gates the
     // "turn finished" attention notification so async agents don't trigger a premature one.
     private bool _hasBackgroundTasks;
+    // True between the CLI's first status for a turn and its `result`. Keeps Options → Apply from
+    // re-rendering the transcript mid-turn, which would drop the reply still being streamed.
+    private bool _turnInFlight;
 
     // When set (by PaneLauncher before the pane loads), this pane opens ON this
     // session instead of a fresh one — used to land a fork in its own pane.
@@ -369,6 +372,17 @@ public partial class ChatPaneControl : PaneControlBase
         var sid = _client?.SessionId;
         if (string.IsNullOrEmpty(sid)) { return; }
 
+        // Mid-turn the re-render would be destructive: the reply being streamed is not in the
+        // .jsonl yet, so Cleared drops it and the page read back is the transcript as it stood
+        // before the turn — the running turn disappears from the chat while the CLI is still
+        // working on it. The options above are already applied; the rows rendered so far keep
+        // the previous ones until the next re-render.
+        if (_turnInFlight)
+        {
+            OutputWindowLogger.Debug(() => $"[chat] options applied mid-turn on {sid} — settings only, transcript left alone");
+            return;
+        }
+
         // Reload the transcript into the WebView only; do NOT call ResumeSessionAsync
         // (a respawn isn't needed to re-render UI options, and triggered a crash).
         _bridge?.Send(BridgeMessages.ToWebView.Chat.Cleared, null);
@@ -468,6 +482,9 @@ public partial class ChatPaneControl : PaneControlBase
             McpMessageHandler = json => Mcp.McpServerHost.Instance.ServeMcpMessageAsync(json)
         };
         AttachClientEvents(_client);
+        // Unhook first, like MessageReceived below: the subscription lives on a singleton that
+        // outlives the client, so a second pass here would send every selection change twice.
+        IdeContextService.Instance.ContextChanged -= OnEditorContextChangedForChat;
         IdeContextService.Instance.ContextChanged += OnEditorContextChangedForChat;
 
         _handler = new WebViewMessageHandler(_bridge, _client, Entry);
@@ -506,7 +523,6 @@ public partial class ChatPaneControl : PaneControlBase
                 break;
         }
     }
-
 
     private void OnEditorContextChangedForChat(EditorContext ctx)
     {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/exchanges.test.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/exchanges.test.ts
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright (C) 2026 Corsinvest Srl
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildGroups } from './exchanges.ts';
+import type { UiAssistantEntry, UiUserEntry } from './types';
+
+const user = (id: number): UiUserEntry => ({ kind: 'text', id, role: 'user', text: `u${id}` });
+const bot = (id: number): UiAssistantEntry => ({
+    kind: 'text',
+    id,
+    role: 'assistant',
+    text: `a${id}`,
+});
+
+test('ogni messaggio utente apre un nuovo scambio', () => {
+    const groups = buildGroups([user(1), bot(2), user(3), bot(4)]);
+
+    assert.equal(groups.length, 2);
+    assert.deepEqual(
+        groups[0].map((e) => e.id),
+        [1, 2],
+    );
+    assert.deepEqual(
+        groups[1].map((e) => e.id),
+        [3, 4],
+    );
+});
+
+test('le entry prima del primo utente vanno in un gruppo di testa', () => {
+    const groups = buildGroups([bot(1), user(2), bot(3)]);
+
+    assert.equal(groups.length, 2);
+    assert.deepEqual(
+        groups[0].map((e) => e.id),
+        [1],
+    );
+    assert.deepEqual(
+        groups[1].map((e) => e.id),
+        [2, 3],
+    );
+});
+
+test('lista vuota produce zero gruppi', () => {
+    assert.deepEqual(buildGroups([]), []);
+});

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/exchanges.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/exchanges.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright (C) 2026 Corsinvest Srl
+
+import type { UiEntry } from './types';
+
+/**
+ * Group a transcript into exchanges: each user message opens one, and whatever precedes the first
+ * user message (a history page boundary) gets its own leading group.
+ *
+ * Pure and derived — cv-app calls this from a memoised getter instead of holding the groups as
+ * state. Two writers on one structure is what let the groups and the entries drift apart.
+ */
+export function buildGroups(entries: readonly UiEntry[]): UiEntry[][] {
+    const groups: UiEntry[][] = [];
+    let current: UiEntry[] = [];
+    for (const e of entries) {
+        if (e.kind === 'text' && e.role === 'user') {
+            if (current.length) {
+                groups.push(current);
+            }
+            current = [e];
+        } else {
+            current.push(e);
+        }
+    }
+    if (current.length) {
+        groups.push(current);
+    }
+    return groups;
+}

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/transcript.test.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/transcript.test.ts
@@ -4,11 +4,29 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { Transcript } from './transcript.ts';
-import type { UiUserEntry } from './types';
+import type { UiEntry, UiToolEntry, UiUserEntry } from './types';
 
 function userEntry(id: number, text = 't'): UiUserEntry {
     return { kind: 'text', id, role: 'user', text };
 }
+
+function toolEntry(id: number, toolUseId: string): UiToolEntry {
+    return {
+        kind: 'tool',
+        id,
+        toolUseId,
+        data: { id: toolUseId, name: 'Agent', input: {} },
+        status: 'pending',
+        result: '',
+        fullLineCount: 0,
+        editStartLine: 0,
+        editEndLine: 0,
+        elapsedSec: 0,
+    };
+}
+
+/** What cv-app uses to decide two children are the same row. */
+const childKey = (e: UiEntry): string => (e.kind === 'tool' ? e.toolUseId : `t${e.id}`);
 
 test('append: nuovo array, entry esistenti mantengono il riferimento', () => {
     const t = new Transcript();
@@ -82,4 +100,85 @@ test('appendText: id assente ritorna false', () => {
     const t = new Transcript();
 
     assert.equal(t.appendText(9, 'x'), false);
+});
+
+test('appendChild: parent, children e items nuovi; fratelli invariati', () => {
+    const t = new Transcript();
+    const parent = toolEntry(1, 'tool-1');
+    const sibling = userEntry(2);
+    t.append(parent);
+    t.append(sibling);
+
+    const ok = t.appendChild('tool-1', userEntry(3), childKey);
+
+    assert.equal(ok, true);
+    const p = t.entries[0] as UiToolEntry;
+    assert.notEqual(p, parent, 'il parent ha un riferimento nuovo');
+    assert.notEqual(p.children, parent.children, 'anche il blocco children');
+    assert.equal(p.children?.items.length, 1);
+    assert.equal(t.entries[1], sibling, 'il fratello mantiene il riferimento');
+});
+
+// Il difetto del 2026-07-31: il ring scartava un figlio mutando items in place, e il blocco
+// children del parent restava identico per ===. cv-tool-row non veniva aggiornato e i suoi
+// ChildPart puntavano a nodi rimossi.
+test('appendChild: il ring che scarta un figlio ricrea comunque il blocco children', () => {
+    const t = new Transcript();
+    t.append(toolEntry(1, 'tool-1'));
+    for (let i = 2; i <= 4; i++) {
+        t.appendChild('tool-1', userEntry(i), childKey);
+    }
+    const before = (t.entries[0] as UiToolEntry).children;
+
+    t.appendChild('tool-1', userEntry(5), childKey);
+
+    const after = (t.entries[0] as UiToolEntry).children;
+    assert.notEqual(after, before, 'il blocco children deve avere identita nuova');
+    assert.notEqual(after?.items, before?.items, 'e cosi items');
+    assert.equal(after?.items.length, 3, 'restano gli ultimi 3');
+    assert.equal(after?.hasMore, true);
+    assert.deepEqual(
+        after?.items.map((e) => e.id),
+        [3, 4, 5],
+    );
+});
+
+test('appendChild: showAll tiene tutto e fa upsert invece di duplicare', () => {
+    const t = new Transcript();
+    t.append(toolEntry(1, 'tool-1'));
+    t.update<UiToolEntry>(1, (e) => ({
+        ...e,
+        children: { items: [], hasMore: false, showAll: true },
+    }));
+    for (let i = 2; i <= 5; i++) {
+        t.appendChild('tool-1', userEntry(i), childKey);
+    }
+
+    // re-emissione dello stesso figlio: aggiorna in place, non duplica
+    t.appendChild('tool-1', userEntry(3, 'aggiornato'), childKey);
+
+    const p = t.entries[0] as UiToolEntry;
+    assert.equal(p.children?.items.length, 4, 'showAll tiene tutto, upsert non duplica');
+    assert.equal((p.children?.items[1] as UiUserEntry).text, 'aggiornato');
+});
+
+test('appendChild: parent inesistente ritorna false', () => {
+    const t = new Transcript();
+
+    assert.equal(t.appendChild('nope', userEntry(1), childKey), false);
+});
+
+test('appendChild annidato: l index risolve un figlio di figlio', () => {
+    const t = new Transcript();
+    t.append(toolEntry(1, 'outer'));
+    t.appendChild('outer', toolEntry(2, 'inner'), childKey);
+    t.appendChild('inner', userEntry(3, 'profondo'), childKey);
+
+    assert.equal(t.find(3)?.id, 3);
+    assert.equal(t.findTool('inner')?.id, 2);
+    assert.equal(
+        t.update<UiUserEntry>(3, (e) => ({ ...e, text: 'x' })),
+        true,
+        'update deve raggiungere un figlio di secondo livello',
+    );
 });

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/transcript.test.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/transcript.test.ts
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright (C) 2026 Corsinvest Srl
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Transcript } from './transcript.ts';
+import type { UiUserEntry } from './types';
+
+function userEntry(id: number, text = 't'): UiUserEntry {
+    return { kind: 'text', id, role: 'user', text };
+}
+
+test('append: nuovo array, entry esistenti mantengono il riferimento', () => {
+    const t = new Transcript();
+    const a = userEntry(1);
+    t.append(a);
+    const first = t.entries;
+
+    t.append(userEntry(2));
+
+    assert.notEqual(t.entries, first, 'entries deve essere un array nuovo');
+    assert.equal(t.entries[0], a, 'la entry esistente mantiene il riferimento');
+    assert.equal(t.entries.length, 2);
+});
+
+test('find: ritorna la entry per id, null se assente', () => {
+    const t = new Transcript();
+    const a = userEntry(7);
+    t.append(a);
+
+    assert.equal(t.find(7), a);
+    assert.equal(t.find(99), null);
+});
+
+test('clear: svuota entries e index', () => {
+    const t = new Transcript();
+    t.append(userEntry(1));
+
+    t.clear();
+
+    assert.equal(t.entries.length, 0);
+    assert.equal(t.find(1), null, 'index deve essere svuotato con le entries');
+});

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/transcript.test.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/transcript.test.ts
@@ -41,3 +41,45 @@ test('clear: svuota entries e index', () => {
     assert.equal(t.entries.length, 0);
     assert.equal(t.find(1), null, 'index deve essere svuotato con le entries');
 });
+
+test('update: sostituisce la entry, gli altri rami restano invariati', () => {
+    const t = new Transcript();
+    const a = userEntry(1, 'a');
+    const b = userEntry(2, 'b');
+    t.append(a);
+    t.append(b);
+
+    const ok = t.update<UiUserEntry>(1, (e) => ({ ...e, text: 'nuovo' }));
+
+    assert.equal(ok, true);
+    assert.notEqual(t.entries[0], a, 'la entry aggiornata ha un riferimento nuovo');
+    assert.equal((t.entries[0] as UiUserEntry).text, 'nuovo');
+    assert.equal(t.entries[1], b, 'i rami non toccati mantengono il riferimento');
+});
+
+test('update: id assente ritorna false senza lanciare', () => {
+    const t = new Transcript();
+
+    assert.equal(
+        t.update(42, (e) => e),
+        false,
+    );
+});
+
+test('appendText: concatena e ricrea solo quella entry', () => {
+    const t = new Transcript();
+    const a = userEntry(1, 'ab');
+    const b = userEntry(2, 'x');
+    t.append(a);
+    t.append(b);
+
+    assert.equal(t.appendText(1, 'cd'), true);
+    assert.equal((t.entries[0] as UiUserEntry).text, 'abcd');
+    assert.equal(t.entries[1], b, 'gli altri rami restano invariati');
+});
+
+test('appendText: id assente ritorna false', () => {
+    const t = new Transcript();
+
+    assert.equal(t.appendText(9, 'x'), false);
+});

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/transcript.test.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/transcript.test.ts
@@ -168,6 +168,71 @@ test('appendChild: parent inesistente ritorna false', () => {
     assert.equal(t.appendChild('nope', userEntry(1), childKey), false);
 });
 
+test('replaceAll: sostituisce l albero e ricostruisce l index da zero', () => {
+    const t = new Transcript();
+    t.append(userEntry(1));
+    t.append(toolEntry(2, 'tool-2'));
+    t.appendChild('tool-2', userEntry(3), childKey);
+
+    t.replaceAll([userEntry(10), toolEntry(11, 'nuovo')]);
+
+    assert.equal(t.entries.length, 2);
+    assert.equal(t.find(1), null, 'gli id vecchi non devono sopravvivere');
+    assert.equal(t.find(3), null, 'nemmeno quelli annidati');
+    assert.equal(t.find(10)?.id, 10);
+});
+
+test('replaceAll: indicizza anche i figli annidati gia presenti', () => {
+    const parent = toolEntry(1, 'p');
+    parent.children = { items: [userEntry(2)], hasMore: false, showAll: false };
+    const t = new Transcript();
+
+    t.replaceAll([parent]);
+
+    assert.equal(t.find(2)?.id, 2, 'i figli arrivati da history devono essere indicizzati');
+    assert.equal(
+        t.update<UiUserEntry>(2, (e) => ({ ...e, text: 'x' })),
+        true,
+    );
+});
+
+test('prepend: mette in testa e mantiene l index coerente', () => {
+    const t = new Transcript();
+    t.append(userEntry(5));
+
+    t.prepend([userEntry(1), userEntry(2)]);
+
+    assert.deepEqual(
+        t.entries.map((e) => e.id),
+        [1, 2, 5],
+    );
+    assert.equal(t.find(1)?.id, 1);
+    assert.equal(t.find(5)?.id, 5, 'anche gli id preesistenti restano risolvibili');
+});
+
+test('updateMany: aggiorna N entry in un colpo', () => {
+    const t = new Transcript();
+    t.append(userEntry(1, 'a'));
+    t.append(userEntry(2, 'b'));
+    const before = t.entries;
+
+    t.updateMany([1, 2], (e) => ('text' in e ? { ...e, text: e.text + '!' } : e));
+
+    assert.notEqual(t.entries, before);
+    assert.equal((t.entries[0] as UiUserEntry).text, 'a!');
+    assert.equal((t.entries[1] as UiUserEntry).text, 'b!');
+});
+
+test('findToolByAgentId: trova la riga Agent che ha lanciato il sub-agent', () => {
+    const t = new Transcript();
+    const row = toolEntry(1, 'tool-1');
+    row.agentId = 'agent-42';
+    t.append(row);
+
+    assert.equal(t.findToolByAgentId('agent-42')?.id, 1);
+    assert.equal(t.findToolByAgentId('nope'), null);
+});
+
 test('appendChild annidato: l index risolve un figlio di figlio', () => {
     const t = new Transcript();
     t.append(toolEntry(1, 'outer'));

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/transcript.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/transcript.ts
@@ -118,9 +118,50 @@ export class Transcript {
         return ok;
     }
 
+    /** Swap the whole transcript (a history page load). The index is rebuilt from scratch: one
+     *  that outlives its entries would resolve an id to a path that leads nowhere. */
+    replaceAll(entries: UiEntry[]): void {
+        this._entries = entries;
+        this._reindex();
+    }
+
+    /** Put an older page in front, keeping the rest as-is. */
+    prepend(older: UiEntry[]): void {
+        this._entries = [...older, ...this._entries];
+        this._reindex();
+    }
+
+    /** Update several entries at once — the streaming messages a turn ends with. */
+    updateMany(ids: number[], fn: (e: UiEntry) => UiEntry): void {
+        for (const id of ids) {
+            this.update(id, fn);
+        }
+    }
+
     /** Find a tool row by toolUseId, walking nested children. */
     findTool(toolUseId: string): UiToolEntry | null {
         return this._visitTools((e) => e.toolUseId === toolUseId);
+    }
+
+    /** Locate an Agent row by the sub-agent it spawned. Unique: only an Agent row carries an
+     *  agentId, and it names the transcript that row alone opened. */
+    findToolByAgentId(agentId: string): UiToolEntry | null {
+        return this._visitTools((e) => e.agentId === agentId);
+    }
+
+    /** Rebuild id → path for the whole tree, children included. History hands a page over with
+     *  its children already nested, where the live path builds them one appendChild at a time. */
+    private _reindex(): void {
+        this._index.clear();
+        const walk = (list: readonly UiEntry[], path: EntryPath): void => {
+            for (const e of list) {
+                this._index.set(e.id, path);
+                if (e.kind === 'tool' && e.children?.items.length) {
+                    walk(e.children.items, [...path, e.toolUseId]);
+                }
+            }
+        };
+        walk(this._entries, []);
     }
 
     /** First tool row matching `pred`, depth-first. */

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/transcript.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/transcript.ts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright (C) 2026 Corsinvest Srl
+
+import type { UiEntry } from './types';
+
+/** Chain of toolUseId from the root down to a nested entry; empty for a top-level one. */
+type EntryPath = string[];
+
+/**
+ * Owns the chat transcript and updates it without ever mutating an entry.
+ *
+ * Lit compares properties by reference, so a mutated object never triggers an update. Every
+ * mutating method here replaces the entry it touches AND rebuilds every object on the path from
+ * the root down to it — the entries array, each ancestor's `children`, `children.items`. Branches
+ * that did not change keep their identity, so Lit skips them. By construction, not by convention:
+ * that is what the previous `_commit` left to each caller to remember, and got wrong.
+ */
+export class Transcript {
+    private _entries: UiEntry[] = [];
+    /** id → path, so find/update are O(1) instead of walking the tree on every event. */
+    private _index = new Map<number, EntryPath>();
+
+    get entries(): readonly UiEntry[] {
+        return this._entries;
+    }
+
+    append(entry: UiEntry): void {
+        this._entries = [...this._entries, entry];
+        this._index.set(entry.id, []);
+    }
+
+    find(id: number): UiEntry | null {
+        const path = this._index.get(id);
+        return path ? this._walk(path, id) : null;
+    }
+
+    clear(): void {
+        this._entries = [];
+        this._index.clear();
+    }
+
+    /** Resolve an indexed path to the live entry, or null when the tree no longer holds it. */
+    private _walk(path: EntryPath, id: number): UiEntry | null {
+        let list: readonly UiEntry[] = this._entries;
+        for (const toolUseId of path) {
+            const parent = list.find((e) => e.kind === 'tool' && e.toolUseId === toolUseId);
+            if (parent?.kind !== 'tool' || !parent.children) {
+                return null;
+            }
+            list = parent.children.items;
+        }
+        return list.find((e) => e.id === id) ?? null;
+    }
+}

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/transcript.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/transcript.ts
@@ -39,6 +39,68 @@ export class Transcript {
         this._index.clear();
     }
 
+    /**
+     * Replace the entry with `id` by `fn(entry)`, rebuilding every object on the path down to it.
+     *
+     * Returns false when the id is no longer in the tree — an async callback (a sub-agent fetch, a
+     * compact summary) can resolve after /clear or a session switch, and must then do nothing.
+     */
+    update<T extends UiEntry>(id: number, fn: (e: T) => T): boolean {
+        const path = this._index.get(id);
+        if (!path) {
+            return false;
+        }
+        // The caller names the member it expects (update<UiToolEntry>); the walk below is
+        // type-blind, so the callback is widened for it.
+        const next = this._replace(this._entries, path, 0, id, (e) => fn(e as T));
+        if (!next) {
+            return false;
+        }
+        this._entries = next;
+        return true;
+    }
+
+    /** Append `delta` to a text entry. Same path rebuild as update(), used by the per-token
+     *  stream: the cost is the tree depth, not the transcript length. */
+    appendText(id: number, delta: string): boolean {
+        return this.update<UiEntry>(id, (e) =>
+            'text' in e ? ({ ...e, text: e.text + delta } as UiEntry) : e,
+        );
+    }
+
+    /** Rebuild `list` with the entry at `path[depth…]`/`id` replaced. Returns null when the path
+     *  no longer resolves, so a stale index cannot corrupt the tree. */
+    private _replace(
+        list: UiEntry[],
+        path: EntryPath,
+        depth: number,
+        id: number,
+        fn: (e: UiEntry) => UiEntry,
+    ): UiEntry[] | null {
+        if (depth === path.length) {
+            const i = list.findIndex((e) => e.id === id);
+            if (i < 0) {
+                return null;
+            }
+            const next = [...list];
+            next[i] = fn(list[i]);
+            return next;
+        }
+        const toolUseId = path[depth];
+        const i = list.findIndex((e) => e.kind === 'tool' && e.toolUseId === toolUseId);
+        const parent = i < 0 ? null : list[i];
+        if (parent?.kind !== 'tool' || !parent.children) {
+            return null;
+        }
+        const items = this._replace(parent.children.items, path, depth + 1, id, fn);
+        if (!items) {
+            return null;
+        }
+        const next = [...list];
+        next[i] = { ...parent, children: { ...parent.children, items } };
+        return next;
+    }
+
     /** Resolve an indexed path to the live entry, or null when the tree no longer holds it. */
     private _walk(path: EntryPath, id: number): UiEntry | null {
         let list: readonly UiEntry[] = this._entries;

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/transcript.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/transcript.ts
@@ -1,10 +1,22 @@
 // SPDX-License-Identifier: GPL-3.0-only
 // Copyright (C) 2026 Corsinvest Srl
 
-import type { UiEntry } from './types';
+import type { UiEntry, UiToolEntry } from './types';
 
 /** Chain of toolUseId from the root down to a nested entry; empty for a top-level one. */
 type EntryPath = string[];
+
+/** Replace the child sharing `key(entry)`, or append when there is none. */
+function upsert(list: UiEntry[], entry: UiEntry, key: (e: UiEntry) => string): UiEntry[] {
+    const k = key(entry);
+    const i = list.findIndex((e) => key(e) === k);
+    if (i < 0) {
+        return [...list, entry];
+    }
+    const next = [...list];
+    next[i] = entry;
+    return next;
+}
 
 /**
  * Owns the chat transcript and updates it without ever mutating an entry.
@@ -66,6 +78,71 @@ export class Transcript {
         return this.update<UiEntry>(id, (e) =>
             'text' in e ? ({ ...e, text: e.text + delta } as UiEntry) : e,
         );
+    }
+
+    /**
+     * Append `entry` under the tool row `parentToolUseId`. A collapsed row keeps a ring of the
+     * last three children and flags hasMore; showAll keeps the whole list and upserts, so a
+     * re-emitted row (pending → done) updates in place instead of duplicating.
+     *
+     * `upsertKey` comes from the caller: what makes two children the same row is a presentation
+     * decision (toolUseId for tools, uuid for text), and this class does not need to know it.
+     */
+    appendChild(
+        parentToolUseId: string,
+        entry: UiEntry,
+        upsertKey: (e: UiEntry) => string,
+    ): boolean {
+        const parent = this.findTool(parentToolUseId);
+        if (!parent) {
+            return false;
+        }
+        const parentPath = this._index.get(parent.id);
+        const ok = this.update<UiToolEntry>(parent.id, (p) => {
+            const kids = p.children ?? { items: [], hasMore: false, showAll: false };
+            if (kids.showAll) {
+                return { ...p, children: { ...kids, items: upsert(kids.items, entry, upsertKey) } };
+            }
+            return {
+                ...p,
+                children: {
+                    ...kids,
+                    hasMore: kids.hasMore || kids.items.length >= 3,
+                    items: [...kids.items, entry].slice(-3),
+                },
+            };
+        });
+        if (ok) {
+            this._index.set(entry.id, [...(parentPath ?? []), parentToolUseId]);
+        }
+        return ok;
+    }
+
+    /** Find a tool row by toolUseId, walking nested children. */
+    findTool(toolUseId: string): UiToolEntry | null {
+        return this._visitTools((e) => e.toolUseId === toolUseId);
+    }
+
+    /** First tool row matching `pred`, depth-first. */
+    private _visitTools(pred: (e: UiToolEntry) => boolean): UiToolEntry | null {
+        const visit = (list: readonly UiEntry[]): UiToolEntry | null => {
+            for (const e of list) {
+                if (e.kind !== 'tool') {
+                    continue;
+                }
+                if (pred(e)) {
+                    return e;
+                }
+                if (e.children?.items.length) {
+                    const hit = visit(e.children.items);
+                    if (hit) {
+                        return hit;
+                    }
+                }
+            }
+            return null;
+        };
+        return visit(this._entries);
     }
 
     /** Rebuild `list` with the entry at `path[depth…]`/`id` replaced. Returns null when the path

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/esbuild.config.mjs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/esbuild.config.mjs
@@ -7,7 +7,7 @@
 // later include dist/** as Content so the VSIX picks it up.
 
 import { context, build } from 'esbuild';
-import { mkdir, copyFile, cp, readdir } from 'node:fs/promises';
+import { mkdir, copyFile, cp, readdir, rm } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
 
@@ -57,8 +57,18 @@ async function mirrorTargets() {
     return targets;
 }
 
+// esbuild only writes, never deletes: a .map left by an earlier --dev build would survive a
+// Release one and be mirrored — and packaged — alongside a bundle that no longer references it.
+async function dropStaleMaps() {
+    if (dev || !existsSync('dist')) { return; }
+    for (const name of await readdir('dist')) {
+        if (name.endsWith('.map')) { await rm(path.join('dist', name)); }
+    }
+}
+
 async function mirrorDist() {
     if (!existsSync('dist')) { return; }
+    await dropStaleMaps();
     for (const dest of await mirrorTargets()) {
         await cp('dist', dest, { recursive: true });
     }
@@ -83,7 +93,12 @@ const config = {
     // would trigger strict CORS and be blocked on file: origins).
     format: 'iife',
     target: 'es2020',
-    sourcemap: dev ? 'inline' : false,
+    // External, not inline: inline pushes the bundle from 1.8mb to 9.5mb and the WebView pays
+    // that on every pane open. A .map next to it leaves the bundle alone — DevTools fetches it
+    // only when the panel is open — and mirrorTargets copies the whole dist/, so it follows the
+    // bundle into the Exp hives on its own. Off in Release: a minified stack there is the price
+    // of not shipping the sources.
+    sourcemap: dev ? true : false,
     minify: !dev,
     outfile: 'dist/bundle.js',
     logLevel: 'info',

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/eslint.config.js
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/eslint.config.js
@@ -22,7 +22,9 @@ export default tseslint.config(
     {
         languageOptions: {
             parserOptions: {
-                project: './tsconfig.json',
+                // Both: the app config excludes *.test.ts (they never reach the bundle), so
+                // without the test one every test file is a parse error here.
+                project: ['./tsconfig.json', './tsconfig.test.json'],
                 tsconfigRootDir: import.meta.dirname,
             },
         },

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/package-lock.json
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/package-lock.json
@@ -23,6 +23,7 @@
                 "@eslint/js": "^10.0.1",
                 "@types/diff": "^7.0.2",
                 "@types/dompurify": "^3.0.5",
+                "@types/node": "24.13.3",
                 "@typescript-eslint/eslint-plugin": "^8.65.0",
                 "@typescript-eslint/parser": "^8.65.0",
                 "esbuild": "^0.28.1",
@@ -774,6 +775,16 @@
             "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@types/node": {
+            "version": "24.13.3",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+            "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~7.18.0"
+            }
         },
         "node_modules/@types/trusted-types": {
             "version": "2.0.7",
@@ -1993,6 +2004,13 @@
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "typescript": ">=4.8.4 <6.1.0"
             }
+        },
+        "node_modules/undici-types": {
+            "version": "7.18.2",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+            "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/uri-js": {
             "version": "4.4.1",

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/package.json
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/package.json
@@ -7,6 +7,7 @@
     "scripts": {
         "gen-bridge": "node tools/gen-bridge.mjs",
         "build": "node tools/gen-bridge.mjs && node esbuild.config.mjs",
+        "build:dev": "node tools/gen-bridge.mjs && node esbuild.config.mjs --dev",
         "dev": "node tools/gen-bridge.mjs && node esbuild.config.mjs --watch",
         "typecheck": "tsc --noEmit",
         "lint": "eslint \"{core,ui}/**/*.ts\"",

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/package.json
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/package.json
@@ -9,12 +9,13 @@
         "build": "node tools/gen-bridge.mjs && node esbuild.config.mjs",
         "build:dev": "node tools/gen-bridge.mjs && node esbuild.config.mjs --dev",
         "dev": "node tools/gen-bridge.mjs && node esbuild.config.mjs --watch",
-        "typecheck": "tsc --noEmit",
+        "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
+        "test": "node --test \"core/**/*.test.ts\" \"ui/**/*.test.ts\"",
         "lint": "eslint \"{core,ui}/**/*.ts\"",
         "lint:fix": "eslint --fix \"{core,ui}/**/*.ts\"",
         "format": "prettier --write \"{core,ui}/**/*.ts\" \"*.ts\"",
         "format:check": "prettier --check \"{core,ui}/**/*.ts\" \"*.ts\"",
-        "check": "npm run typecheck && npm run lint && npm run format:check"
+        "check": "npm run typecheck && npm run lint && npm run format:check && npm run test"
     },
     "dependencies": {
         "@fluentui/svg-icons": "^1.1.331",
@@ -32,6 +33,7 @@
         "@eslint/js": "^10.0.1",
         "@types/diff": "^7.0.2",
         "@types/dompurify": "^3.0.5",
+        "@types/node": "24.13.3",
         "@typescript-eslint/eslint-plugin": "^8.65.0",
         "@typescript-eslint/parser": "^8.65.0",
         "esbuild": "^0.28.1",

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tsconfig.json
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tsconfig.json
@@ -30,5 +30,5 @@
         }
     },
     "include": ["index.ts", "globals.d.ts", "core/**/*.ts", "ui/**/*.ts"],
-    "exclude": ["node_modules", "dist"]
+    "exclude": ["node_modules", "dist", "**/*.test.ts"]
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tsconfig.test.json
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tsconfig.test.json
@@ -1,0 +1,14 @@
+// Tests run straight off the .ts through `node --test` (Node strips the types), never through
+// esbuild — so they import with an explicit .ts extension, which the bundle's own imports must
+// not carry. That is the one setting this config adds; everything else is the app's.
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "allowImportingTsExtensions": true,
+        "types": ["node"]
+    },
+    // The base excludes *.test.ts so the app build ignores them; restate it here without that
+    // entry, or extends would cancel the include below.
+    "include": ["core/**/*.test.ts", "ui/**/*.test.ts"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
@@ -84,7 +84,13 @@ export class CvApp extends LitElement {
     /** Owns the transcript. Deliberately not reactive — _mutate() is the one place that tells
      *  Lit something changed, so there is no second path that can forget to. */
     private _transcript = new Transcript();
+    /** The only thing Lit watches for a transcript change. Lit re-renders on a reactive property
+     *  it sees change by identity, and the tree lives in a plain object it cannot see into — so
+     *  _invalidate() bumps this instead. A counter and not a flag: Lit compares the value from
+     *  before the batch with the one after, so two invalidations in the same microtask would
+     *  toggle a boolean back to where it started and the render would be skipped. */
     @state() private _rev = 0;
+    /** Groups for the current tree, keyed by the array they were built from. */
     private _groupCache: { src: readonly UiEntry[]; groups: UiEntry[][] } | null = null;
     @state() private _subagentTasks = new Map<string, SubagentTask>();
     @state() private _isBusy = appState.isBusy;
@@ -120,10 +126,16 @@ export class CvApp extends LitElement {
         return this._groupCache.groups;
     }
 
+    /** Mark the rendered view stale. Transcript is deliberately not reactive — bumping this is
+     *  the one thing Lit watches, and the number itself means nothing. */
+    private _invalidate(): void {
+        this._rev++;
+    }
+
     /** Every transcript change goes through here, so one place tells Lit about all of them. */
     private _mutate(fn: () => void): void {
         fn();
-        this._rev++;
+        this._invalidate();
     }
 
     override createRenderRoot() {
@@ -226,7 +238,7 @@ export class CvApp extends LitElement {
                         // The final assistant notification carries the message time; live fallback = now.
                         streaming.timestamp = data?.timestamp ?? Date.now();
                         this._streamingMsgs.delete(parentId);
-                        this._invalidate(streaming);
+                        this._invalidate();
                     } else {
                         const entry = CvApp.buildAssistantEntry(data);
                         entry.timestamp = data?.timestamp ?? Date.now();
@@ -254,7 +266,7 @@ export class CvApp extends LitElement {
                         // Auto-follow only if already near the bottom.
                         const atBottom = this._isNearBottom();
                         streaming.text += delta;
-                        this._invalidate(streaming);
+                        this._invalidate();
                         if (atBottom) {
                             queueMicrotask(() => this._scrollToBottom('instant'));
                         }
@@ -295,7 +307,7 @@ export class CvApp extends LitElement {
                             entry.tokens = (entry.tokens ?? 0) + data.estimatedTokens;
                         }
                     }
-                    this._invalidate(entry);
+                    this._invalidate();
                 },
             ),
         );
@@ -320,7 +332,7 @@ export class CvApp extends LitElement {
                     entry.streaming = false;
                     entry.durationMs = entry.startedAt ? Date.now() - entry.startedAt : 0;
                     this._thinkingMsgs.delete(parentId);
-                    this._invalidate(entry);
+                    this._invalidate();
                 },
             ),
         );
@@ -366,10 +378,7 @@ export class CvApp extends LitElement {
                         for (const m of this._streamingMsgs.values()) {
                             m.streaming = false;
                         }
-                        // Keyed by parentToolUseId, so a sub-agent's message is nested and needs
-                        // its path refreshed like any other nested change. Before the clear —
-                        // after it there is nothing left to pass.
-                        this._invalidate(...this._streamingMsgs.values());
+                        this._invalidate();
                         this._streamingMsgs.clear();
                     }
                 },
@@ -464,7 +473,7 @@ export class CvApp extends LitElement {
                             name: data.name,
                             input: (data.input ?? {}) as Record<string, unknown>,
                         };
-                        this._invalidate(existing);
+                        this._invalidate();
                         return;
                     }
                     this._appendEntry(this.buildToolEntry(data), data.parentToolUseId ?? undefined);
@@ -484,7 +493,7 @@ export class CvApp extends LitElement {
                 }
                 const atBottom = this._isNearBottom();
                 CvApp.applyToolResult(tool, data);
-                this._invalidate(tool);
+                this._invalidate();
                 // The result grows the tool row (e.g. an answered ask); follow it down so the
                 // view doesn't stay stuck on the tool until the next message arrives.
                 if (atBottom) {
@@ -507,7 +516,7 @@ export class CvApp extends LitElement {
                     // Wire field is elapsedSeconds (from the host); the entry keeps it as
                     // elapsedSec (internal UI state).
                     tool.elapsedSec = data.elapsedSeconds ?? 0;
-                    this._invalidate(tool);
+                    this._invalidate();
                 },
             ),
         );
@@ -640,7 +649,7 @@ export class CvApp extends LitElement {
                         const row = this._findTool(toolUseId);
                         if (row) {
                             row.status = 'error';
-                            this._invalidate(row);
+                            this._invalidate();
                         }
                     }
                     const m = new Map(this._subagentTasks);
@@ -933,7 +942,7 @@ export class CvApp extends LitElement {
                     }
                     kids.items = [...kids.items, entry].slice(-3);
                 }
-                this._invalidate(parent);
+                this._invalidate();
                 return;
             }
         }
@@ -968,7 +977,7 @@ export class CvApp extends LitElement {
                 ? kids.items.length === 0 // history preview
                 : kids.hasMore; // Show all with more on disk than we hold
             if (!needFetch) {
-                this._invalidate(parent);
+                this._invalidate();
                 return;
             }
             fetchSubagent(agentId, { preview: !!preview })
@@ -1007,7 +1016,7 @@ export class CvApp extends LitElement {
                     pk.items = preview ? list.slice(-3) : list;
                     pk.hasMore = preview ? list.length > 3 : false;
                     pk.showAll = !preview;
-                    this._invalidate(p);
+                    this._invalidate();
                 })
                 .catch(() => {
                     /* timeout / not found — leave the kept children as-is */
@@ -1019,7 +1028,7 @@ export class CvApp extends LitElement {
             kids.showAll = false;
             kids.hasMore = kids.items.length > 3;
         }
-        this._invalidate(parent);
+        this._invalidate();
     };
 
     /** A compact separator's <details> opened for the first time: fetch the summary lazily
@@ -1040,7 +1049,7 @@ export class CvApp extends LitElement {
             .then((res) => {
                 entry.summary = res.summary;
                 entry.loaded = true;
-                this._invalidate(entry);
+                this._invalidate();
             })
             .catch(() => {
                 /* timeout / not found — leave "Loading…" as-is */
@@ -1233,13 +1242,6 @@ export class CvApp extends LitElement {
         // keep it, at top level.
         const seen = new Set(ordered.map((t) => t.taskId));
         appState.subagentTasks = [...ordered, ...linked.filter((t) => !seen.has(t.taskId))];
-    }
-
-    /** Temporary bridge while the call sites move to Transcript. The entries they name are still
-     *  mutated in place, so there is nothing to commit — the arguments are ignored and all this
-     *  does is mark the view stale. Gone once nothing calls it. */
-    private _invalidate(..._targets: Array<UiEntry | null | undefined>): void {
-        this._rev++;
     }
 
     /** Find a tool entry by toolUseId, walking nested children. */

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
@@ -5,6 +5,7 @@
 import { LitElement, html, nothing } from 'lit';
 import { customElement, query, state } from 'lit/decorators.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import { repeat } from 'lit/directives/repeat.js';
 import ChevronDown16Regular from '@fluentui/svg-icons/icons/chevron_down_16_regular.svg';
 import { bridge } from '../../core/bridge';
 import { Msg } from '../../core/bridge-messages';
@@ -1475,11 +1476,19 @@ export class CvApp extends LitElement {
         const leadUsers = group.slice(0, i);
         const response = group.slice(i);
         return html`<section class="cv-exchange">
-            ${leadUsers.map((e) => this.renderEntry(e))}
+            ${repeat(
+                leadUsers,
+                (e) => e.id,
+                (e) => this.renderEntry(e),
+            )}
             ${
                 response.length > 0
                     ? html`<div class="cv-response">
-                          ${response.map((e) => this.renderEntry(e))}
+                          ${repeat(
+                              response,
+                              (e) => e.id,
+                              (e) => this.renderEntry(e),
+                          )}
                           ${this.renderResponseActions(response)}
                       </div>`
                     : nothing
@@ -1560,7 +1569,11 @@ export class CvApp extends LitElement {
                         ? html`<cv-welcome></cv-welcome>`
                         : nothing
                 }
-                ${this._exchanges.map((group) => this.renderExchange(group))}
+                ${repeat(
+                    this._exchanges,
+                    (group) => group[0]?.id ?? -1,
+                    (group) => this.renderExchange(group),
+                )}
                 ${
                     this._isBusy && this._streamingMsgs.size === 0 && !this._awaitingUser
                         ? html`<cv-spinner .status=${this._status}></cv-spinner>`

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
@@ -111,10 +111,10 @@ export class CvApp extends LitElement {
      * (`''` for root). Lets a sub-agent stream concurrently with the root
      * without mixing the two; delta lookups default to `''`.
      */
-    private _streamingMsgs = new Map<string, UiAssistantEntry>();
+    private _streamingMsgs = new Map<string, number>();
     /** Currently-streaming thinking block, keyed by parentToolUseId (same nesting rule
      *  as _streamingMsgs). Never persisted — cleared on session clear. */
-    private _thinkingMsgs = new Map<string, UiThinkingEntry>();
+    private _thinkingMsgs = new Map<string, number>();
 
     /** Derived, never stored: recomputed only when the tree changes identity. Holding the groups
      *  as state gave them two writers, and that is how they and the entries drifted apart. */
@@ -231,14 +231,19 @@ export class CvApp extends LitElement {
                     if (!parentId && data?.usage) {
                         appState.contextUsage = data.usage;
                     }
-                    const streaming = this._streamingMsgs.get(parentId);
-                    if (streaming) {
-                        streaming.text = data?.text ?? streaming.text;
-                        streaming.streaming = false;
-                        // The final assistant notification carries the message time; live fallback = now.
-                        streaming.timestamp = data?.timestamp ?? Date.now();
+                    const streamingId = this._streamingMsgs.get(parentId);
+                    if (streamingId !== undefined) {
+                        this._mutate(() =>
+                            this._transcript.update<UiAssistantEntry>(streamingId, (e) => ({
+                                ...e,
+                                text: data?.text ?? e.text,
+                                streaming: false,
+                                // The final assistant notification carries the message time;
+                                // live fallback = now.
+                                timestamp: data?.timestamp ?? Date.now(),
+                            })),
+                        );
                         this._streamingMsgs.delete(parentId);
-                        this._invalidate();
                     } else {
                         const entry = CvApp.buildAssistantEntry(data);
                         entry.timestamp = data?.timestamp ?? Date.now();
@@ -255,18 +260,19 @@ export class CvApp extends LitElement {
                 (data) => {
                     const delta = data?.text ?? '';
                     const parentId = data?.parentToolUseId ?? '';
-                    let streaming = this._streamingMsgs.get(parentId);
-                    if (!streaming) {
-                        streaming = this._addText<UiAssistantEntry>(
-                            { role: 'assistant', text: delta, streaming: true },
+                    const streamingId = this._streamingMsgs.get(parentId);
+                    if (streamingId === undefined) {
+                        this._streamingMsgs.set(
                             parentId,
+                            this._addText<UiAssistantEntry>(
+                                { role: 'assistant', text: delta, streaming: true },
+                                parentId,
+                            ),
                         );
-                        this._streamingMsgs.set(parentId, streaming);
                     } else {
                         // Auto-follow only if already near the bottom.
                         const atBottom = this._isNearBottom();
-                        streaming.text += delta;
-                        this._invalidate();
+                        this._mutate(() => this._transcript.appendText(streamingId, delta));
                         if (atBottom) {
                             queueMicrotask(() => this._scrollToBottom('instant'));
                         }
@@ -280,9 +286,9 @@ export class CvApp extends LitElement {
                 Msg.toWebView.chat.thinkingDelta,
                 (data) => {
                     const parentId = data?.parentToolUseId ?? '';
-                    let entry = this._thinkingMsgs.get(parentId);
-                    if (!entry) {
-                        entry = this._addText<UiThinkingEntry>(
+                    let entryId = this._thinkingMsgs.get(parentId);
+                    if (entryId === undefined) {
+                        entryId = this._addText<UiThinkingEntry>(
                             {
                                 role: 'thinking',
                                 text: '',
@@ -292,22 +298,27 @@ export class CvApp extends LitElement {
                             },
                             parentId,
                         );
-                        this._thinkingMsgs.set(parentId, entry);
+                        this._thinkingMsgs.set(parentId, entryId);
                     }
-                    if (data?.text) {
-                        entry.text += data.text;
-                    }
-                    // Token: authoritative thinking_tokens (text empty + estimate>=0) SETS and locks;
-                    // deltas accumulate until then.
-                    if (data && data.estimatedTokens >= 0) {
-                        if (!data.text) {
-                            entry.tokens = data.estimatedTokens;
-                            entry.tokensAuthoritative = true;
-                        } else if (!entry.tokensAuthoritative) {
-                            entry.tokens = (entry.tokens ?? 0) + data.estimatedTokens;
-                        }
-                    }
-                    this._invalidate();
+                    this._mutate(() =>
+                        this._transcript.update<UiThinkingEntry>(entryId, (e) => {
+                            const next = { ...e };
+                            if (data?.text) {
+                                next.text += data.text;
+                            }
+                            // Token: authoritative thinking_tokens (text empty + estimate>=0) SETS
+                            // and locks; deltas accumulate until then.
+                            if (data && data.estimatedTokens >= 0) {
+                                if (!data.text) {
+                                    next.tokens = data.estimatedTokens;
+                                    next.tokensAuthoritative = true;
+                                } else if (!next.tokensAuthoritative) {
+                                    next.tokens = (next.tokens ?? 0) + data.estimatedTokens;
+                                }
+                            }
+                            return next;
+                        }),
+                    );
                 },
             ),
         );
@@ -317,22 +328,26 @@ export class CvApp extends LitElement {
                 Msg.toWebView.chat.thinkingEnded,
                 (data) => {
                     const parentId = data?.parentToolUseId ?? '';
-                    let entry = this._thinkingMsgs.get(parentId);
+                    let entryId = this._thinkingMsgs.get(parentId);
                     // A redacted_thinking block has no preceding delta → no entry yet: create a static,
                     // text-less one here so it still shows (like VS Code's "✻ Thinking…").
-                    if (!entry) {
+                    if (entryId === undefined) {
                         if (!data?.redacted) {
                             return;
                         }
-                        entry = this._addText<UiThinkingEntry>(
+                        entryId = this._addText<UiThinkingEntry>(
                             { role: 'thinking', text: '', redacted: true },
                             parentId,
                         );
                     }
-                    entry.streaming = false;
-                    entry.durationMs = entry.startedAt ? Date.now() - entry.startedAt : 0;
+                    this._mutate(() =>
+                        this._transcript.update<UiThinkingEntry>(entryId, (e) => ({
+                            ...e,
+                            streaming: false,
+                            durationMs: e.startedAt ? Date.now() - e.startedAt : 0,
+                        })),
+                    );
                     this._thinkingMsgs.delete(parentId);
-                    this._invalidate();
                 },
             ),
         );
@@ -375,10 +390,12 @@ export class CvApp extends LitElement {
                         });
                     }
                     if (this._streamingMsgs.size > 0) {
-                        for (const m of this._streamingMsgs.values()) {
-                            m.streaming = false;
-                        }
-                        this._invalidate();
+                        const ids = [...this._streamingMsgs.values()];
+                        this._mutate(() =>
+                            this._transcript.updateMany(ids, (e) =>
+                                'streaming' in e ? { ...e, streaming: false } : e,
+                            ),
+                        );
                         this._streamingMsgs.clear();
                     }
                 },
@@ -558,7 +575,10 @@ export class CvApp extends LitElement {
 
                     appState.loadingOlder = false;
                     this._mutate(() => this._transcript.replaceAll(out));
+                    // Both, like chat_cleared: the entries these named are not in the tree any
+                    // more, so a delta arriving for one would update nothing and look dropped.
                     this._streamingMsgs.clear();
+                    this._thinkingMsgs.clear();
                     // Land at the bottom. Re-jump for several frames because async-rendered
                     // children (markdown, diff2html, lazy images) keep growing scrollHeight.
                     void this.updateComplete.then(() => {
@@ -895,14 +915,16 @@ export class CvApp extends LitElement {
     // Generic over the concrete text-entry type: call sites pass the type argument explicitly
     // (e.g. _addText<UiAssistantEntry>({role:'assistant', …})) so `Omit` works on a single member
     // — Omit over the whole union would collapse to the common keys and drop the role-specific ones.
+    /** Returns the id, not the entry: the transcript replaces an entry on every change, so a
+     *  reference kept by the caller would name something the tree no longer holds. */
     private _addText<E extends Extract<UiEntry, { kind: 'text' }>>(
         msg: Omit<E, 'kind' | 'id'>,
         parentId = '',
-    ): E {
+    ): number {
         const entry = { kind: 'text', id: ++_entryIdSeq, ...msg } as E;
         this._appendEntry(entry, parentId);
         queueMicrotask(() => this._scrollToBottom());
-        return entry;
+        return entry.id;
     }
 
     /**

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
@@ -485,12 +485,16 @@ export class CvApp extends LitElement {
                     // Dedup by toolUseId (arrives twice: can_use_tool + assistant msg).
                     const existing = this._findTool(data.id);
                     if (existing) {
-                        existing.data = {
-                            id: data.id,
-                            name: data.name,
-                            input: (data.input ?? {}) as Record<string, unknown>,
-                        };
-                        this._invalidate();
+                        this._mutate(() =>
+                            this._transcript.update<UiToolEntry>(existing.id, (e) => ({
+                                ...e,
+                                data: {
+                                    id: data.id,
+                                    name: data.name,
+                                    input: (data.input ?? {}) as Record<string, unknown>,
+                                },
+                            })),
+                        );
                         return;
                     }
                     this._appendEntry(this.buildToolEntry(data), data.parentToolUseId ?? undefined);
@@ -509,8 +513,11 @@ export class CvApp extends LitElement {
                     return;
                 }
                 const atBottom = this._isNearBottom();
-                CvApp.applyToolResult(tool, data);
-                this._invalidate();
+                this._mutate(() =>
+                    this._transcript.update<UiToolEntry>(tool.id, (e) =>
+                        CvApp.applyToolResult(e, data),
+                    ),
+                );
                 // The result grows the tool row (e.g. an answered ask); follow it down so the
                 // view doesn't stay stuck on the tool until the next message arrives.
                 if (atBottom) {
@@ -532,8 +539,12 @@ export class CvApp extends LitElement {
                     }
                     // Wire field is elapsedSeconds (from the host); the entry keeps it as
                     // elapsedSec (internal UI state).
-                    tool.elapsedSec = data.elapsedSeconds ?? 0;
-                    this._invalidate();
+                    this._mutate(() =>
+                        this._transcript.update<UiToolEntry>(tool.id, (e) => ({
+                            ...e,
+                            elapsedSec: data.elapsedSeconds ?? 0,
+                        })),
+                    );
                 },
             ),
         );
@@ -618,7 +629,12 @@ export class CvApp extends LitElement {
                     // read the id.
                     const row = d.toolUseId ? this._findTool(d.toolUseId) : null;
                     if (row && !row.agentId) {
-                        row.agentId = d.taskId;
+                        this._mutate(() =>
+                            this._transcript.update<UiToolEntry>(row.id, (e) => ({
+                                ...e,
+                                agentId: d.taskId,
+                            })),
+                        );
                     }
                 },
             ),
@@ -668,8 +684,12 @@ export class CvApp extends LitElement {
                     if (d.status === 'failed' && toolUseId) {
                         const row = this._findTool(toolUseId);
                         if (row) {
-                            row.status = 'error';
-                            this._invalidate();
+                            this._mutate(() =>
+                                this._transcript.update<UiToolEntry>(row.id, (e) => ({
+                                    ...e,
+                                    status: 'error',
+                                })),
+                            );
                         }
                     }
                     const m = new Map(this._subagentTasks);
@@ -790,7 +810,9 @@ export class CvApp extends LitElement {
                     const d = ev.data as ToolResultNotification;
                     const hit = d.toolUseId ? findTool(d.toolUseId) : null;
                     if (hit) {
-                        CvApp.applyToolResult(hit, d);
+                        // Replay builds a fresh list nothing is rendering yet, so writing into
+                        // the entry here is safe — it reaches the tree already folded.
+                        Object.assign(hit, CvApp.applyToolResult(hit, d));
                     }
                     break;
                 }
@@ -951,20 +973,7 @@ export class CvApp extends LitElement {
                 ) {
                     return;
                 }
-                // First child under this parent creates the children block.
-                const kids = (parent.children ??= { items: [], hasMore: false, showAll: false });
-                if (kids.showAll) {
-                    // Show-all: keep the full list, upsert (a re-emitted tool row updates
-                    // in place — e.g. pending → done — instead of duplicating).
-                    kids.items = this._upsertChild(kids.items, entry);
-                } else {
-                    // Collapsed: ring of 3. A 4th child means more exist beyond the window.
-                    if (kids.items.length >= 3) {
-                        kids.hasMore = true;
-                    }
-                    kids.items = [...kids.items, entry].slice(-3);
-                }
-                this._invalidate();
+                this._mutate(() => this._transcript.appendChild(parentId, entry, CvApp._childKey));
                 return;
             }
         }
@@ -1183,16 +1192,17 @@ export class CvApp extends LitElement {
         };
     }
 
-    /** Apply a ToolResultNotification onto an already-built tool row (in place). */
-    private static applyToolResult(e: UiToolEntry, d: ToolResultNotification): void {
-        e.status = d.isError ? 'error' : 'done';
-        e.result = d.result ?? '';
-        e.fullLineCount = d.fullLineCount ?? 0;
-        e.editStartLine = d.editStartLine ?? 0;
-        e.editEndLine = d.editEndLine ?? 0;
-        if (d.agentId) {
-            e.agentId = d.agentId;
-        }
+    /** Fold a ToolResultNotification into a tool row, returning a new entry. */
+    private static applyToolResult(e: UiToolEntry, d: ToolResultNotification): UiToolEntry {
+        return {
+            ...e,
+            status: d.isError ? 'error' : 'done',
+            result: d.result ?? '',
+            fullLineCount: d.fullLineCount ?? 0,
+            editStartLine: d.editStartLine ?? 0,
+            editEndLine: d.editEndLine ?? 0,
+            ...(d.agentId ? { agentId: d.agentId } : {}),
+        };
     }
 
     /** Upsert `entry` into `list` by child key: replace the matching entry (keeps the

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
@@ -364,6 +364,10 @@ export class CvApp extends LitElement {
                 this._exchanges = [];
                 this._streamingMsgs.clear();
                 this._thinkingMsgs.clear();
+                // The transcript this turn belonged to is gone, so its `result` — the only thing
+                // that clears busy — would land on nothing. Without this the spinner outlives the
+                // session that started it, with no message under it to explain what it is waiting for.
+                appState.isBusy = false;
                 appState.currentSessionId = null;
                 appState.oldestLoadedOffset = -1;
                 appState.hasMoreHistory = false;

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
@@ -9,6 +9,8 @@ import ChevronDown16Regular from '@fluentui/svg-icons/icons/chevron_down_16_regu
 import { bridge } from '../../core/bridge';
 import { Msg } from '../../core/bridge-messages';
 import { fetchSubagent, fetchContextUsage, fetchCompactSummary } from '../../core/lazy';
+import { Transcript } from '../../core/transcript';
+import { buildGroups } from '../../core/exchanges';
 import './cv-notice-stack';
 import type { CvNoticeStack } from './cv-notice-stack';
 import './cv-welcome';
@@ -79,8 +81,11 @@ const CLI_EXITED_KEY = 'cli-exited';
  */
 @customElement('cv-app')
 export class CvApp extends LitElement {
-    @state() private _entries: UiEntry[] = [];
-    @state() private _exchanges: UiEntry[][] = [];
+    /** Owns the transcript. Deliberately not reactive — _mutate() is the one place that tells
+     *  Lit something changed, so there is no second path that can forget to. */
+    private _transcript = new Transcript();
+    @state() private _rev = 0;
+    private _groupCache: { src: readonly UiEntry[]; groups: UiEntry[][] } | null = null;
     @state() private _subagentTasks = new Map<string, SubagentTask>();
     @state() private _isBusy = appState.isBusy;
     @state() private _status = appState.status;
@@ -104,6 +109,22 @@ export class CvApp extends LitElement {
     /** Currently-streaming thinking block, keyed by parentToolUseId (same nesting rule
      *  as _streamingMsgs). Never persisted — cleared on session clear. */
     private _thinkingMsgs = new Map<string, UiThinkingEntry>();
+
+    /** Derived, never stored: recomputed only when the tree changes identity. Holding the groups
+     *  as state gave them two writers, and that is how they and the entries drifted apart. */
+    private get _exchanges(): UiEntry[][] {
+        const src = this._transcript.entries;
+        if (this._groupCache?.src !== src) {
+            this._groupCache = { src, groups: buildGroups(src) };
+        }
+        return this._groupCache.groups;
+    }
+
+    /** Every transcript change goes through here, so one place tells Lit about all of them. */
+    private _mutate(fn: () => void): void {
+        fn();
+        this._rev++;
+    }
 
     override createRenderRoot() {
         return this;
@@ -360,8 +381,7 @@ export class CvApp extends LitElement {
                 // Abort in-flight requests for the old session so their Promises reject
                 // instead of resolving against the new session (or hanging until timeout).
                 bridge.rejectAllPending('session changed');
-                this._entries = [];
-                this._exchanges = [];
+                this._mutate(() => this._transcript.clear());
                 this._streamingMsgs.clear();
                 this._thinkingMsgs.clear();
                 // The transcript this turn belonged to is gone, so its `result` — the only thing
@@ -528,8 +548,7 @@ export class CvApp extends LitElement {
                     }
 
                     appState.loadingOlder = false;
-                    this._entries = out;
-                    this._rebuildExchanges();
+                    this._mutate(() => this._transcript.replaceAll(out));
                     this._streamingMsgs.clear();
                     // Land at the bottom. Re-jump for several frames because async-rendered
                     // children (markdown, diff2html, lazy images) keep growing scrollHeight.
@@ -917,8 +936,7 @@ export class CvApp extends LitElement {
                 return;
             }
         }
-        this._entries = [...this._entries, entry];
-        this._rebuildExchanges();
+        this._mutate(() => this._transcript.append(entry));
     }
 
     /** Expand/collapse a nested Agent box (CustomEvent from cv-tool-row). */
@@ -1010,7 +1028,7 @@ export class CvApp extends LitElement {
         if (!uuid) {
             return;
         }
-        const entry = this._entries.find(
+        const entry = this._transcript.entries.find(
             (en): en is UiCompactEntry =>
                 en.kind === 'text' && en.role === 'compact' && en.uuid === uuid,
         );
@@ -1032,7 +1050,7 @@ export class CvApp extends LitElement {
      *  during a live chat, not on an empty transcript (nothing above it would be noise). */
     private _onModelSwitched = (e: CustomEvent<{ value: string }>): void => {
         const value = e.detail?.value;
-        if (!value || this._entries.length === 0) {
+        if (!value || this._transcript.entries.length === 0) {
             return;
         }
         this._addText({ role: 'status', text: `Switched to ${modelLabel(value)}` });
@@ -1169,7 +1187,10 @@ export class CvApp extends LitElement {
             if (!toolUseId) {
                 return undefined;
             }
-            const walk = (list: UiEntry[], container?: string): string | undefined | false => {
+            const walk = (
+                list: readonly UiEntry[],
+                container?: string,
+            ): string | undefined | false => {
                 for (const e of list) {
                     if (e.kind !== 'tool') {
                         continue;
@@ -1186,7 +1207,7 @@ export class CvApp extends LitElement {
                 }
                 return false; // not in this branch — distinct from "found, no container"
             };
-            const hit = walk(this._entries);
+            const hit = walk(this._transcript.entries);
             return hit === false ? undefined : hit;
         };
 
@@ -1213,45 +1234,16 @@ export class CvApp extends LitElement {
         appState.subagentTasks = [...ordered, ...linked.filter((t) => !seen.has(t.taskId))];
     }
 
-    /** Commit an in-place change to `target` so it reaches the DOM. Lit diffs properties by
-     *  identity and requestUpdate() only refreshes the component it's called on, so mutating a
-     *  row nested inside an Agent leaves every array ABOVE it untouched: the ancestors skip their
-     *  update and their renderChildren never re-reads the new list. Re-identifying just the
-     *  arrays on the path is Lit's prescribed top-down immutable flow, and leaves rows that
-     *  didn't change alone. Pass the row itself, or the Agent holding it for a text child. */
-    private _commit(...targets: Array<UiEntry | null | undefined>): void {
-        const wanted = targets.filter(Boolean) as UiEntry[];
-        if (wanted.length > 0) {
-            // Walk down re-identifying each children array that leads to a target; returns
-            // true for the branch that holds one, so the copy happens on the way back up.
-            const refresh = (list: UiEntry[]): boolean => {
-                let found = false;
-                for (const e of list) {
-                    if (e.kind !== 'tool' || !e.children?.items.length) {
-                        continue;
-                    }
-                    if (
-                        e.children.items.some((c) => wanted.includes(c)) ||
-                        refresh(e.children.items)
-                    ) {
-                        e.children = { ...e.children, items: [...e.children.items] };
-                        found = true;
-                    }
-                }
-                return found;
-            };
-            // render() maps _exchanges, not _entries: the entry objects are shared between the
-            // two, so only the group array holding the path needs a new identity.
-            this._exchanges = this._exchanges.map((g) =>
-                g.some((e) => wanted.includes(e)) || refresh(g) ? [...g] : g,
-            );
-        }
-        this._entries = [...this._entries];
+    /** Temporary bridge while the call sites move to Transcript: the entries they mutate are
+     *  still mutated in place, so all this can do is tell Lit to re-render. Removed once nothing
+     *  calls it. */
+    private _commit(..._targets: Array<UiEntry | null | undefined>): void {
+        this._rev++;
     }
 
     /** Find a tool entry by toolUseId, walking nested children. */
     private _findTool(toolUseId: string): UiToolEntry | null {
-        const visit = (list: UiEntry[]): UiToolEntry | null => {
+        const visit = (list: readonly UiEntry[]): UiToolEntry | null => {
             for (const e of list) {
                 if (e.kind !== 'tool') {
                     continue;
@@ -1268,13 +1260,13 @@ export class CvApp extends LitElement {
             }
             return null;
         };
-        return visit(this._entries);
+        return visit(this._transcript.entries);
     }
 
     /** Locate an Agent tool entry by the sub-agent it spawned. Unique: only an Agent row carries
      *  an agentId, and it names the transcript that row alone opened. */
     private _findToolByAgentId(agentId: string): UiToolEntry | null {
-        const visit = (list: UiEntry[]): UiToolEntry | null => {
+        const visit = (list: readonly UiEntry[]): UiToolEntry | null => {
             for (const e of list) {
                 if (e.kind !== 'tool') {
                     continue;
@@ -1291,30 +1283,7 @@ export class CvApp extends LitElement {
             }
             return null;
         };
-        return visit(this._entries);
-    }
-
-    /** Rebuilds _exchanges from _entries. Each user message opens a new
-     *  exchange; entries before the first user (history page boundary) go
-     *  in their own leading group. Called after structural changes only —
-     *  in-place mutations (streaming text, tool status) skip this. */
-    private _rebuildExchanges(): void {
-        const groups: UiEntry[][] = [];
-        let current: UiEntry[] = [];
-        for (const e of this._entries) {
-            if (e.kind === 'text' && e.role === 'user') {
-                if (current.length) {
-                    groups.push(current);
-                }
-                current = [e];
-            } else {
-                current.push(e);
-            }
-        }
-        if (current.length) {
-            groups.push(current);
-        }
-        this._exchanges = groups;
+        return visit(this._transcript.entries);
     }
 
     /** True when scrolled at/near the bottom. Gates stream auto-follow so
@@ -1391,8 +1360,7 @@ export class CvApp extends LitElement {
     private _prependWithAnchor(older: UiEntry[]): void {
         const el = this._messagesEl;
         if (!el) {
-            this._entries = [...older, ...this._entries];
-            this._rebuildExchanges();
+            this._mutate(() => this._transcript.prepend(older));
             appState.loadingOlder = false;
             return;
         }
@@ -1404,8 +1372,7 @@ export class CvApp extends LitElement {
             el.scrollTop = el.scrollHeight - distFromBottom;
         };
 
-        this._entries = [...older, ...this._entries];
-        this._rebuildExchanges();
+        this._mutate(() => this._transcript.prepend(older));
         // Commit the DOM synchronously and re-anchor in the SAME task, before
         // the browser can paint a frame at the stale scrollTop — that paint is
         // the residual upward flicker. updateComplete then handles the async
@@ -1558,7 +1525,7 @@ export class CvApp extends LitElement {
 
             <div id="messages" aria-live="polite">
                 ${
-                    this._entries.length === 0 && !this._isBusy
+                    this._transcript.entries.length === 0 && !this._isBusy
                         ? html`<cv-welcome></cv-welcome>`
                         : nothing
                 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
@@ -86,7 +86,7 @@ export class CvApp extends LitElement {
     private _transcript = new Transcript();
     /** The only thing Lit watches for a transcript change. Lit re-renders on a reactive property
      *  it sees change by identity, and the tree lives in a plain object it cannot see into — so
-     *  _invalidate() bumps this instead. A counter and not a flag: Lit compares the value from
+     *  _mutate() bumps this instead. A counter and not a flag: Lit compares the value from
      *  before the batch with the one after, so two invalidations in the same microtask would
      *  toggle a boolean back to where it started and the render would be skipped. */
     @state() private _rev = 0;
@@ -126,16 +126,10 @@ export class CvApp extends LitElement {
         return this._groupCache.groups;
     }
 
-    /** Mark the rendered view stale. Transcript is deliberately not reactive — bumping this is
-     *  the one thing Lit watches, and the number itself means nothing. */
-    private _invalidate(): void {
-        this._rev++;
-    }
-
     /** Every transcript change goes through here, so one place tells Lit about all of them. */
     private _mutate(fn: () => void): void {
         fn();
-        this._invalidate();
+        this._rev++;
     }
 
     override createRenderRoot() {
@@ -483,7 +477,7 @@ export class CvApp extends LitElement {
                         appState.contextUsage = data.usage;
                     }
                     // Dedup by toolUseId (arrives twice: can_use_tool + assistant msg).
-                    const existing = this._findTool(data.id);
+                    const existing = this._transcript.findTool(data.id);
                     if (existing) {
                         this._mutate(() =>
                             this._transcript.update<UiToolEntry>(existing.id, (e) => ({
@@ -508,7 +502,7 @@ export class CvApp extends LitElement {
                 if (!data?.toolUseId) {
                     return;
                 }
-                const tool = this._findTool(data.toolUseId);
+                const tool = this._transcript.findTool(data.toolUseId);
                 if (!tool) {
                     return;
                 }
@@ -533,7 +527,7 @@ export class CvApp extends LitElement {
                     if (!data?.toolUseId) {
                         return;
                     }
-                    const tool = this._findTool(data.toolUseId);
+                    const tool = this._transcript.findTool(data.toolUseId);
                     if (!tool) {
                         return;
                     }
@@ -627,7 +621,7 @@ export class CvApp extends LitElement {
                     // buildToolEntry; when it got in first, tag it here. Nothing marks the view
                     // stale — the row was just appended, so its render is still pending and will
                     // read the id.
-                    const row = d.toolUseId ? this._findTool(d.toolUseId) : null;
+                    const row = d.toolUseId ? this._transcript.findTool(d.toolUseId) : null;
                     if (row && !row.agentId) {
                         this._mutate(() =>
                             this._transcript.update<UiToolEntry>(row.id, (e) => ({
@@ -682,7 +676,7 @@ export class CvApp extends LitElement {
                     // asked for, so only 'failed' turns the row red.
                     const toolUseId = this._subagentTasks.get(d.taskId)?.toolUseId;
                     if (d.status === 'failed' && toolUseId) {
-                        const row = this._findTool(toolUseId);
+                        const row = this._transcript.findTool(toolUseId);
                         if (row) {
                             this._mutate(() =>
                                 this._transcript.update<UiToolEntry>(row.id, (e) => ({
@@ -961,7 +955,7 @@ export class CvApp extends LitElement {
      */
     private _appendEntry(entry: UiEntry, parentId?: string): void {
         if (parentId) {
-            const parent = this._findTool(parentId);
+            const parent = this._transcript.findTool(parentId);
             if (parent) {
                 // The sub-agent's first message echoes the prompt the Agent tool was
                 // launched with — it's already shown as the Agent row's IN, so drop the
@@ -985,12 +979,12 @@ export class CvApp extends LitElement {
         e: CustomEvent<{ agentId: string; expand: boolean; preview?: boolean }>,
     ): void => {
         const { agentId, expand, preview } = e.detail ?? {};
-        const parent = agentId ? this._findToolByAgentId(agentId) : null;
+        const parent = agentId ? this._transcript.findToolByAgentId(agentId) : null;
         if (!parent) {
             return;
         }
-        // Ensure the children block exists (a history Agent may not have fetched anything yet).
-        const kids = (parent.children ??= { items: [], hasMore: false, showAll: false });
+        // A history Agent may not have fetched anything yet.
+        const kids = parent.children ?? { items: [], hasMore: false, showAll: false };
         if (expand) {
             // Rule: history FETCHES, live SHOWS what it already has in memory.
             //  - preview (first chevron expand): fetch only if children are empty (history). Live
@@ -1002,22 +996,26 @@ export class CvApp extends LitElement {
             const showAll = !preview;
             // Show all sets the flag; preview (chevron open) leaves it false → renderChildren shows ≤3.
             // Row open/closed is the component's own `_expanded`, not tracked here.
-            kids.showAll = showAll;
+            this._mutate(() =>
+                this._transcript.update<UiToolEntry>(parent.id, (e) => ({
+                    ...e,
+                    children: { ...(e.children ?? kids), showAll },
+                })),
+            );
 
             const needFetch = preview
                 ? kids.items.length === 0 // history preview
                 : kids.hasMore; // Show all with more on disk than we hold
             if (!needFetch) {
-                this._invalidate();
                 return;
             }
             fetchSubagent(agentId, { preview: !!preview })
                 .then((data) => {
-                    const p = this._findToolByAgentId(data.agentId);
+                    const p = this._transcript.findToolByAgentId(data.agentId);
                     if (!p) {
                         return;
                     }
-                    const pk = (p.children ??= { items: [], hasMore: false, showAll: false });
+                    const pk = p.children ?? { items: [], hasMore: false, showAll: false };
                     const full = this._replayEvents(data.events ?? []);
                     // The transcript opens and closes with what the Agent row already shows in its
                     // own cells: the launch prompt (IN) and the closing report (OUT, from the
@@ -1044,10 +1042,17 @@ export class CvApp extends LitElement {
                     }
                     // Preview keeps the last 3 (and flags "…" if more); full keeps everything and is
                     // now complete in memory (hasMore=false → no more fetches).
-                    pk.items = preview ? list.slice(-3) : list;
-                    pk.hasMore = preview ? list.length > 3 : false;
-                    pk.showAll = !preview;
-                    this._invalidate();
+                    const items = preview ? list.slice(-3) : list;
+                    this._mutate(() =>
+                        this._transcript.update<UiToolEntry>(p.id, (e) => ({
+                            ...e,
+                            children: {
+                                items,
+                                hasMore: preview ? list.length > 3 : false,
+                                showAll: !preview,
+                            },
+                        })),
+                    );
                 })
                 .catch(() => {
                     /* timeout / not found — leave the kept children as-is */
@@ -1056,10 +1061,16 @@ export class CvApp extends LitElement {
             // "Reduce" (Show all → off): show the last 3 again, but KEEP the full list in memory so a
             // later Show all doesn't refetch (and live never can). renderChildren slices the view.
             // hasMore reflects that more is held than shown.
-            kids.showAll = false;
-            kids.hasMore = kids.items.length > 3;
+            this._mutate(() =>
+                this._transcript.update<UiToolEntry>(parent.id, (e) => {
+                    const c = e.children ?? kids;
+                    return {
+                        ...e,
+                        children: { ...c, showAll: false, hasMore: c.items.length > 3 },
+                    };
+                }),
+            );
         }
-        this._invalidate();
     };
 
     /** A compact separator's <details> opened for the first time: fetch the summary lazily
@@ -1078,9 +1089,13 @@ export class CvApp extends LitElement {
         }
         fetchCompactSummary(appState.currentSessionId, uuid)
             .then((res) => {
-                entry.summary = res.summary;
-                entry.loaded = true;
-                this._invalidate();
+                this._mutate(() =>
+                    this._transcript.update<UiCompactEntry>(entry.id, (en) => ({
+                        ...en,
+                        summary: res.summary,
+                        loaded: true,
+                    })),
+                );
             })
             .catch(() => {
                 /* timeout / not found — leave "Loading…" as-is */
@@ -1274,51 +1289,6 @@ export class CvApp extends LitElement {
         // keep it, at top level.
         const seen = new Set(ordered.map((t) => t.taskId));
         appState.subagentTasks = [...ordered, ...linked.filter((t) => !seen.has(t.taskId))];
-    }
-
-    /** Find a tool entry by toolUseId, walking nested children. */
-    private _findTool(toolUseId: string): UiToolEntry | null {
-        const visit = (list: readonly UiEntry[]): UiToolEntry | null => {
-            for (const e of list) {
-                if (e.kind !== 'tool') {
-                    continue;
-                }
-                if (e.toolUseId === toolUseId) {
-                    return e;
-                }
-                if (e.children?.items.length) {
-                    const hit = visit(e.children.items);
-                    if (hit) {
-                        return hit;
-                    }
-                }
-            }
-            return null;
-        };
-        return visit(this._transcript.entries);
-    }
-
-    /** Locate an Agent tool entry by the sub-agent it spawned. Unique: only an Agent row carries
-     *  an agentId, and it names the transcript that row alone opened. */
-    private _findToolByAgentId(agentId: string): UiToolEntry | null {
-        const visit = (list: readonly UiEntry[]): UiToolEntry | null => {
-            for (const e of list) {
-                if (e.kind !== 'tool') {
-                    continue;
-                }
-                if (e.agentId === agentId) {
-                    return e;
-                }
-                if (e.children?.items.length) {
-                    const hit = visit(e.children.items);
-                    if (hit) {
-                        return hit;
-                    }
-                }
-            }
-            return null;
-        };
-        return visit(this._transcript.entries);
     }
 
     /** True when scrolled at/near the bottom. Gates stream auto-follow so

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
@@ -677,8 +677,10 @@ export class CvApp extends LitElement {
             return;
         }
         e.preventDefault();
-        bridge.sendNotification(Msg.fromWebView.cli.stop, {});
-        appState.isBusy = false;
+        // Same gesture as the Stop button, so it goes through the composer's own stop: doing the
+        // interrupt here and nothing else left the queue intact, and the next flush then sent
+        // prompts the user had written behind a turn they had just cancelled.
+        this.querySelector('cv-prompt')?.stop();
     };
 
     /** Build UiEntry[] from a replayed page of typed events (chat_history / subagent_loaded).

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
@@ -226,7 +226,7 @@ export class CvApp extends LitElement {
                         // The final assistant notification carries the message time; live fallback = now.
                         streaming.timestamp = data?.timestamp ?? Date.now();
                         this._streamingMsgs.delete(parentId);
-                        this._commit(streaming);
+                        this._invalidate(streaming);
                     } else {
                         const entry = CvApp.buildAssistantEntry(data);
                         entry.timestamp = data?.timestamp ?? Date.now();
@@ -254,7 +254,7 @@ export class CvApp extends LitElement {
                         // Auto-follow only if already near the bottom.
                         const atBottom = this._isNearBottom();
                         streaming.text += delta;
-                        this._commit(streaming);
+                        this._invalidate(streaming);
                         if (atBottom) {
                             queueMicrotask(() => this._scrollToBottom('instant'));
                         }
@@ -295,7 +295,7 @@ export class CvApp extends LitElement {
                             entry.tokens = (entry.tokens ?? 0) + data.estimatedTokens;
                         }
                     }
-                    this._commit(entry);
+                    this._invalidate(entry);
                 },
             ),
         );
@@ -320,7 +320,7 @@ export class CvApp extends LitElement {
                     entry.streaming = false;
                     entry.durationMs = entry.startedAt ? Date.now() - entry.startedAt : 0;
                     this._thinkingMsgs.delete(parentId);
-                    this._commit(entry);
+                    this._invalidate(entry);
                 },
             ),
         );
@@ -369,7 +369,7 @@ export class CvApp extends LitElement {
                         // Keyed by parentToolUseId, so a sub-agent's message is nested and needs
                         // its path refreshed like any other nested change. Before the clear —
                         // after it there is nothing left to pass.
-                        this._commit(...this._streamingMsgs.values());
+                        this._invalidate(...this._streamingMsgs.values());
                         this._streamingMsgs.clear();
                     }
                 },
@@ -464,7 +464,7 @@ export class CvApp extends LitElement {
                             name: data.name,
                             input: (data.input ?? {}) as Record<string, unknown>,
                         };
-                        this._commit(existing);
+                        this._invalidate(existing);
                         return;
                     }
                     this._appendEntry(this.buildToolEntry(data), data.parentToolUseId ?? undefined);
@@ -484,7 +484,7 @@ export class CvApp extends LitElement {
                 }
                 const atBottom = this._isNearBottom();
                 CvApp.applyToolResult(tool, data);
-                this._commit(tool);
+                this._invalidate(tool);
                 // The result grows the tool row (e.g. an answered ask); follow it down so the
                 // view doesn't stay stuck on the tool until the next message arrives.
                 if (atBottom) {
@@ -507,7 +507,7 @@ export class CvApp extends LitElement {
                     // Wire field is elapsedSeconds (from the host); the entry keeps it as
                     // elapsedSec (internal UI state).
                     tool.elapsedSec = data.elapsedSeconds ?? 0;
-                    this._commit(tool);
+                    this._invalidate(tool);
                 },
             ),
         );
@@ -584,8 +584,9 @@ export class CvApp extends LitElement {
                     this._subagentTasks = m;
                     this._publishSubagentTasks(m);
                     // The Agent row is usually created after this and reads the id in
-                    // buildToolEntry; when it got in first, tag it here. No _commit — the row
-                    // was just appended, so its render is still pending and will read the id.
+                    // buildToolEntry; when it got in first, tag it here. Nothing marks the view
+                    // stale — the row was just appended, so its render is still pending and will
+                    // read the id.
                     const row = d.toolUseId ? this._findTool(d.toolUseId) : null;
                     if (row && !row.agentId) {
                         row.agentId = d.taskId;
@@ -639,7 +640,7 @@ export class CvApp extends LitElement {
                         const row = this._findTool(toolUseId);
                         if (row) {
                             row.status = 'error';
-                            this._commit(row);
+                            this._invalidate(row);
                         }
                     }
                     const m = new Map(this._subagentTasks);
@@ -932,7 +933,7 @@ export class CvApp extends LitElement {
                     }
                     kids.items = [...kids.items, entry].slice(-3);
                 }
-                this._commit(parent);
+                this._invalidate(parent);
                 return;
             }
         }
@@ -967,7 +968,7 @@ export class CvApp extends LitElement {
                 ? kids.items.length === 0 // history preview
                 : kids.hasMore; // Show all with more on disk than we hold
             if (!needFetch) {
-                this._commit(parent);
+                this._invalidate(parent);
                 return;
             }
             fetchSubagent(agentId, { preview: !!preview })
@@ -1006,7 +1007,7 @@ export class CvApp extends LitElement {
                     pk.items = preview ? list.slice(-3) : list;
                     pk.hasMore = preview ? list.length > 3 : false;
                     pk.showAll = !preview;
-                    this._commit(p);
+                    this._invalidate(p);
                 })
                 .catch(() => {
                     /* timeout / not found — leave the kept children as-is */
@@ -1018,7 +1019,7 @@ export class CvApp extends LitElement {
             kids.showAll = false;
             kids.hasMore = kids.items.length > 3;
         }
-        this._commit(parent);
+        this._invalidate(parent);
     };
 
     /** A compact separator's <details> opened for the first time: fetch the summary lazily
@@ -1039,7 +1040,7 @@ export class CvApp extends LitElement {
             .then((res) => {
                 entry.summary = res.summary;
                 entry.loaded = true;
-                this._commit(entry);
+                this._invalidate(entry);
             })
             .catch(() => {
                 /* timeout / not found — leave "Loading…" as-is */
@@ -1234,10 +1235,10 @@ export class CvApp extends LitElement {
         appState.subagentTasks = [...ordered, ...linked.filter((t) => !seen.has(t.taskId))];
     }
 
-    /** Temporary bridge while the call sites move to Transcript: the entries they mutate are
-     *  still mutated in place, so all this can do is tell Lit to re-render. Removed once nothing
-     *  calls it. */
-    private _commit(..._targets: Array<UiEntry | null | undefined>): void {
+    /** Temporary bridge while the call sites move to Transcript. The entries they name are still
+     *  mutated in place, so there is nothing to commit — the arguments are ignored and all this
+     *  does is mark the view stale. Gone once nothing calls it. */
+    private _invalidate(..._targets: Array<UiEntry | null | undefined>): void {
         this._rev++;
     }
 

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
@@ -5,7 +5,6 @@
 import { LitElement, html, nothing } from 'lit';
 import { customElement, query, state } from 'lit/decorators.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
-import { repeat } from 'lit/directives/repeat.js';
 import ChevronDown16Regular from '@fluentui/svg-icons/icons/chevron_down_16_regular.svg';
 import { bridge } from '../../core/bridge';
 import { Msg } from '../../core/bridge-messages';
@@ -1478,19 +1477,11 @@ export class CvApp extends LitElement {
         const leadUsers = group.slice(0, i);
         const response = group.slice(i);
         return html`<section class="cv-exchange">
-            ${repeat(
-                leadUsers,
-                (e) => e.id,
-                (e) => this.renderEntry(e),
-            )}
+            ${leadUsers.map((e) => this.renderEntry(e))}
             ${
                 response.length > 0
                     ? html`<div class="cv-response">
-                          ${repeat(
-                              response,
-                              (e) => e.id,
-                              (e) => this.renderEntry(e),
-                          )}
+                          ${response.map((e) => this.renderEntry(e))}
                           ${this.renderResponseActions(response)}
                       </div>`
                     : nothing
@@ -1571,11 +1562,7 @@ export class CvApp extends LitElement {
                         ? html`<cv-welcome></cv-welcome>`
                         : nothing
                 }
-                ${repeat(
-                    this._exchanges,
-                    (group) => group[0]?.id ?? -1,
-                    (group) => this.renderExchange(group),
-                )}
+                ${this._exchanges.map((group) => this.renderExchange(group))}
                 ${
                     this._isBusy && this._streamingMsgs.size === 0 && !this._awaitingUser
                         ? html`<cv-spinner .status=${this._status}></cv-spinner>`

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
@@ -943,16 +943,10 @@ export class CvApp extends LitElement {
         return entry.id;
     }
 
-    /**
-     * Append `entry` under the tool row `parentId`, or to the root list
-     * when no/unknown parent. Arrays are replaced (not mutated) for Lit.
-     *
-     * Memoria-minima: when appending a child under an Agent parent, keep only
-     * the last 3 children — a ring of 3 (`slice(-3)`). The `hasMore` flag flips
-     * true once a 4th child arrives (children.items already holds 3 before the push):
-     * the "…" indicator only signals "more exist", not the count, so a boolean
-     * is enough — no running counter needed.
-     */
+    /** Append `entry` under the tool row `parentId`, or to the root list when there is no parent
+     *  or it isn't in the tree. The ring of three and the upsert live in Transcript.appendChild;
+     *  what stays here is the one thing that is a rendering decision — dropping the sub-agent's
+     *  echo of its own launch prompt. */
     private _appendEntry(entry: UiEntry, parentId?: string): void {
         if (parentId) {
             const parent = this._transcript.findTool(parentId);

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-prompt.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-prompt.ts
@@ -86,6 +86,10 @@ function unsupportedMessage(names: string[]): string {
 // re-opened history image look identical. Slightly above the 16px render size for high-DPI.
 const THUMB_PX = 24;
 
+// Builtins that end or reset the current turn's state rather than adding to it: queueing these
+// behind a running turn would hold back the one command that gets the session out of it.
+const RESET_COMMANDS = new Set(['/clear', '/compact']);
+
 /** Downscale an image data-URL to a tiny PNG data-URL for the chip. Resolves to undefined on
  *  any failure (decode error, unsupported codec) — the chip then falls back to its file icon. */
 function makeThumb(dataUrl: string): Promise<string | undefined> {
@@ -277,6 +281,18 @@ export class CvPrompt extends LitElement implements CommandHost {
                 margin-bottom: 6px;
                 border-bottom: 1px solid var(--colorNeutralStroke2);
                 position: relative;
+            }
+            /* Same band as #attachments: what is staged above the box the user is typing in. */
+            #queued {
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+                gap: 8px;
+                padding: 0 2px 6px;
+                margin-bottom: 6px;
+                border-bottom: 1px solid var(--colorNeutralStroke2);
+                color: var(--colorNeutralForeground3);
+                font-size: 11px;
             }
         `,
     ];
@@ -913,7 +929,7 @@ export class CvPrompt extends LitElement implements CommandHost {
 
     private _onSendClick = (): void => {
         if (this._isBusy) {
-            this._stop();
+            this.stop();
         } else {
             this._submit();
         }
@@ -1125,7 +1141,9 @@ export class CvPrompt extends LitElement implements CommandHost {
         if (echo) {
             this._echoUserMessage(payload);
         }
-        if (this._isBusy) {
+        // A builtin that resets the session is also the way out of a stuck one, so it must not
+        // queue behind the very turn it is meant to clear — the CLI takes these mid-turn.
+        if (this._isBusy && !RESET_COMMANDS.has(text.trim().split(/\s+/, 1)[0])) {
             this._queue = [...this._queue, payload];
         } else {
             this._dispatch(payload);
@@ -1265,8 +1283,13 @@ export class CvPrompt extends LitElement implements CommandHost {
         }
     };
 
-    private _stop(): void {
+    /** Stop the turn: interrupt the CLI, drop anything queued behind it, free the UI.
+     *  Public because Esc (handled globally in cv-app) is the same gesture as the Stop
+     *  button — it must not stop halfway and leave the queue to fire on the next flush. */
+    stop(): void {
         bridge.sendNotification(Msg.fromWebView.cli.stop, {});
+        // Queued prompts were meant to follow the turn being stopped; flushing them after an
+        // interrupt would send messages the user never confirmed at a CLI they just halted.
         this._queue = [];
         // Optimistic reset: free the UI now in case the CLI is wedged and
         // never sends `result`.
@@ -1400,6 +1423,30 @@ export class CvPrompt extends LitElement implements CommandHost {
         this._ta?.focus();
     };
 
+    /** Messages typed while a turn was running, waiting for it to end. The bubble for each is
+     *  already in the transcript (the echo goes in on submit), so without this row a queued
+     *  message is indistinguishable from a sent one — the whole reason it looked like the chat
+     *  had swallowed them. */
+    private _renderQueue() {
+        const n = this._queue.length;
+        if (n === 0) {
+            return nothing;
+        }
+        return html`
+            <div id="queued" title=${this._queue.map((q) => q.text).join('\n\n')}>
+                <span>${n === 1 ? '1 message queued' : `${n} messages queued`}</span>
+                <fluent-button
+                    appearance="transparent"
+                    size="small"
+                    @click=${(): void => {
+                        this._queue = [];
+                    }}
+                    >Clear</fluent-button
+                >
+            </div>
+        `;
+    }
+
     private _renderChips() {
         if (this._attachments.length === 0) {
             return nothing;
@@ -1441,7 +1488,7 @@ export class CvPrompt extends LitElement implements CommandHost {
                 @drop=${this._onDrop}
             >
                 <cv-notice-stack></cv-notice-stack>
-                ${this._renderChips()}
+                ${this._renderQueue()} ${this._renderChips()}
                 <textarea
                     id="input"
                     placeholder=${

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-tool-row.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-tool-row.ts
@@ -5,6 +5,7 @@
 import { LitElement, html, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import { repeat } from 'lit/directives/repeat.js';
 import ArrowExpandAll16Regular from '@fluentui/svg-icons/icons/arrow_expand_all_16_regular.svg';
 import ArrowCollapseAll16Regular from '@fluentui/svg-icons/icons/arrow_collapse_all_16_regular.svg';
 import './cv-message';
@@ -186,36 +187,39 @@ export class CvToolRow extends LitElement implements ToolRowState {
                               </div>`
                             : nothing
                     }
-                    ${shown.map((c: UiEntry) =>
-                        c.kind === 'text' && c.role === 'thinking'
-                            ? html`<cv-thinking
-                                  .text=${c.text}
-                                  ?streaming=${!!c.streaming}
-                                  .tokens=${c.tokens ?? 0}
-                                  .durationMs=${c.durationMs ?? 0}
-                                  ?redacted=${!!c.redacted}
-                              ></cv-thinking>`
-                            : c.kind === 'text'
-                              ? html`<cv-message
-                                    .role=${c.role}
-                                    .text=${c.text}
-                                    ?streaming=${c.role === 'assistant' ? !!c.streaming : false}
-                                    ?isError=${c.role === 'slash-result' ? c.isError : false}
-                                ></cv-message>`
-                              : html`<cv-tool-row
-                                    .data=${c.data}
-                                    .status=${c.status}
-                                    .result=${c.result}
-                                    .elapsedSec=${c.elapsedSec}
-                                    .childItems=${c.children?.items ?? []}
-                                    .fullLineCount=${c.fullLineCount}
-                                    .editStartLine=${c.editStartLine}
-                                    .editEndLine=${c.editEndLine}
-                                    .agentId=${c.agentId ?? ''}
-                                    .containerAgentId=${this.agentId || this.containerAgentId}
-                                    .hasMore=${c.children?.hasMore ?? false}
-                                    .showAll=${c.children?.showAll ?? false}
-                                ></cv-tool-row>`,
+                    ${repeat(
+                        shown,
+                        (c: UiEntry) => c.id,
+                        (c: UiEntry) =>
+                            c.kind === 'text' && c.role === 'thinking'
+                                ? html`<cv-thinking
+                                      .text=${c.text}
+                                      ?streaming=${!!c.streaming}
+                                      .tokens=${c.tokens ?? 0}
+                                      .durationMs=${c.durationMs ?? 0}
+                                      ?redacted=${!!c.redacted}
+                                  ></cv-thinking>`
+                                : c.kind === 'text'
+                                  ? html`<cv-message
+                                        .role=${c.role}
+                                        .text=${c.text}
+                                        ?streaming=${c.role === 'assistant' ? !!c.streaming : false}
+                                        ?isError=${c.role === 'slash-result' ? c.isError : false}
+                                    ></cv-message>`
+                                  : html`<cv-tool-row
+                                        .data=${c.data}
+                                        .status=${c.status}
+                                        .result=${c.result}
+                                        .elapsedSec=${c.elapsedSec}
+                                        .childItems=${c.children?.items ?? []}
+                                        .fullLineCount=${c.fullLineCount}
+                                        .editStartLine=${c.editStartLine}
+                                        .editEndLine=${c.editEndLine}
+                                        .agentId=${c.agentId ?? ''}
+                                        .containerAgentId=${this.agentId || this.containerAgentId}
+                                        .hasMore=${c.children?.hasMore ?? false}
+                                        .showAll=${c.children?.showAll ?? false}
+                                    ></cv-tool-row>`,
                     )}
                 </div>
                 ${this._renderChildrenActions()}

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-tool-row.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-tool-row.ts
@@ -5,7 +5,6 @@
 import { LitElement, html, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
-import { repeat } from 'lit/directives/repeat.js';
 import ArrowExpandAll16Regular from '@fluentui/svg-icons/icons/arrow_expand_all_16_regular.svg';
 import ArrowCollapseAll16Regular from '@fluentui/svg-icons/icons/arrow_collapse_all_16_regular.svg';
 import './cv-message';
@@ -187,39 +186,36 @@ export class CvToolRow extends LitElement implements ToolRowState {
                               </div>`
                             : nothing
                     }
-                    ${repeat(
-                        shown,
-                        (c: UiEntry) => c.id,
-                        (c: UiEntry) =>
-                            c.kind === 'text' && c.role === 'thinking'
-                                ? html`<cv-thinking
-                                      .text=${c.text}
-                                      ?streaming=${!!c.streaming}
-                                      .tokens=${c.tokens ?? 0}
-                                      .durationMs=${c.durationMs ?? 0}
-                                      ?redacted=${!!c.redacted}
-                                  ></cv-thinking>`
-                                : c.kind === 'text'
-                                  ? html`<cv-message
-                                        .role=${c.role}
-                                        .text=${c.text}
-                                        ?streaming=${c.role === 'assistant' ? !!c.streaming : false}
-                                        ?isError=${c.role === 'slash-result' ? c.isError : false}
-                                    ></cv-message>`
-                                  : html`<cv-tool-row
-                                        .data=${c.data}
-                                        .status=${c.status}
-                                        .result=${c.result}
-                                        .elapsedSec=${c.elapsedSec}
-                                        .childItems=${c.children?.items ?? []}
-                                        .fullLineCount=${c.fullLineCount}
-                                        .editStartLine=${c.editStartLine}
-                                        .editEndLine=${c.editEndLine}
-                                        .agentId=${c.agentId ?? ''}
-                                        .containerAgentId=${this.agentId || this.containerAgentId}
-                                        .hasMore=${c.children?.hasMore ?? false}
-                                        .showAll=${c.children?.showAll ?? false}
-                                    ></cv-tool-row>`,
+                    ${shown.map((c: UiEntry) =>
+                        c.kind === 'text' && c.role === 'thinking'
+                            ? html`<cv-thinking
+                                  .text=${c.text}
+                                  ?streaming=${!!c.streaming}
+                                  .tokens=${c.tokens ?? 0}
+                                  .durationMs=${c.durationMs ?? 0}
+                                  ?redacted=${!!c.redacted}
+                              ></cv-thinking>`
+                            : c.kind === 'text'
+                              ? html`<cv-message
+                                    .role=${c.role}
+                                    .text=${c.text}
+                                    ?streaming=${c.role === 'assistant' ? !!c.streaming : false}
+                                    ?isError=${c.role === 'slash-result' ? c.isError : false}
+                                ></cv-message>`
+                              : html`<cv-tool-row
+                                    .data=${c.data}
+                                    .status=${c.status}
+                                    .result=${c.result}
+                                    .elapsedSec=${c.elapsedSec}
+                                    .childItems=${c.children?.items ?? []}
+                                    .fullLineCount=${c.fullLineCount}
+                                    .editStartLine=${c.editStartLine}
+                                    .editEndLine=${c.editEndLine}
+                                    .agentId=${c.agentId ?? ''}
+                                    .containerAgentId=${this.agentId || this.containerAgentId}
+                                    .hasMore=${c.children?.hasMore ?? false}
+                                    .showAll=${c.children?.showAll ?? false}
+                                ></cv-tool-row>`,
                     )}
                 </div>
                 ${this._renderChildrenActions()}


### PR DESCRIPTION
Two bugs with one cause: something rewrote the transcript while Lit was still rendering it.

## The crash

`Cannot set properties of null (setting 'data')`, thrown from deep inside Lit's `commitText`, after which **nothing in the chat rendered again** — the pane looked alive but frozen, and the console was the only place it showed.

`_commit` (added in 1.1.0; 1.0.0 had no such thing) rebuilt the array identities of a target's *ancestors*, but never the target's own `children` block:

```ts
if (e.children.items.some((c) => wanted.includes(c)) || refresh(e.children.items)) {
    e.children = { ...e.children, items: [...e.children.items] };
}
```

Callers mutated `parent.children.items` in place — the ring of three drops a child on every fourth append — then called `_commit(parent)`. The block kept its identity, so `cv-tool-row` skipped its update, its ChildParts pointed at removed nodes, and the next render wrote `.data` on null.

The rule ("replace, never mutate") lived in a comment and had to be remembered at fourteen call sites. It wasn't.

## The fix

A `Transcript` class owns the tree. Every mutating method replaces the entry it touches **and** rebuilds every object on the path from the root down to it; untouched branches keep their identity, so Lit still skips them. By construction, not by convention.

`cv-app` keeps one `@state` — a revision counter — and derives the exchange groups through a memoised getter. `_commit`, `_invalidate`, `_rebuildExchanges` and the two tree walks are gone.

A counter, not a flag: Lit compares the value from before the batch with the one after, so a boolean toggled twice in one microtask would look unchanged and the render would be skipped.

## Options → Apply mid-turn

Same shape, other side of the bridge. Applying options re-rendered the transcript from the `.jsonl`, where the reply still streaming does not exist yet — so it vanished from the chat while the CLI kept working on it. `_turnInFlight` now bounds a turn between the CLI's first status and its `result`, and a mid-turn apply changes settings only.

Also: a failed `InterruptAsync` used to fault into silence. The WebView frees itself the moment it asks — it can't wait on a wedged CLI — so a failed interrupt reads as "stopped" while the turn runs on. It is logged now.

## Tests

20 tests on `Transcript` and `buildGroups`, run by `node --test` with Node's native type stripping — no build step. `npm run check` now runs them.

The ring test is the one that matters: reintroducing the in-place mutation makes it fail. It asserts the `children` block gets a **new identity** even when the append only evicts a child, which is exactly the case the old code got wrong.

## Verified

- 4 sub-agents in parallel, ~12 minutes, including a mid-run stop with cancelled permissions — console clean. The same scenario crashed within 44 seconds before.
- Show all / Reduce / history scroll-up / `/clear` — all exercised by hand in the Exp hive.
- `msbuild` Debug green; the VSIX ships a minified bundle with no sourcemap.

## Not covered

`prepend` has no test for re-indexing a page that already carries nested children — `replaceAll` has one, `prepend` does not. It works (verified by hand), but the gap is real.

One clean run is not proof: this bug has looked fixed before. What changed is that the failure mode — mutate, then repair afterwards — no longer exists.
