### PR TITLE
fix(chat): Info no longer freezes the IDE when the renderer is busy

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
@@ -209,11 +209,24 @@ public partial class ChatPaneControl : PaneControlBase
         get
         {
             yield return ("WebView PID", _bridge?.BrowserProcessId?.ToString() ?? "(not started)");
-            // Blocking on the UI thread: the dialog is modal and about to show anyway, and the
-            // call is a single in-process round-trip to the browser.
+            // Blocking on the UI thread, with a deadline. The round-trip is in-process and
+            // normally instant, but the answer comes back through the browser — which needs this
+            // same thread to deliver it. A renderer that is busy or gone therefore hangs the IDE
+            // on a row that is only diagnostic. Two seconds, then "(unknown)": nobody opens this
+            // dialog for the renderer PID badly enough to freeze Visual Studio over it.
             var renderer = _bridge == null
                 ? null
-                : ThreadHelper.JoinableTaskFactory.Run(_bridge.RendererProcessIdAsync);
+                : ThreadHelper.JoinableTaskFactory.Run(async () =>
+                {
+                    var call = _bridge.RendererProcessIdAsync();
+                    var done = await Task.WhenAny(call, Task.Delay(2000)).ConfigureAwait(true);
+                    if (done != call)
+                    {
+                        OutputWindowLogger.Warn("[chat] renderer PID timed out — WebView not answering");
+                        return null;
+                    }
+                    return await call.ConfigureAwait(true);
+                });
             yield return ("WebView renderer", renderer?.ToString() ?? "(unknown)");
         }
     }


### PR DESCRIPTION
`More → Info` froze Visual Studio.

`ExtraSessionInfo` blocks the UI thread on `RendererProcessIdAsync`, and the answer travels back
through the browser — which needs that same thread to deliver it. `JoinableTaskFactory.Run` pumps
messages, which is why it usually gets through; a renderer that is busy or gone leaves nothing to
unblock it, and the IDE stops responding on a dialog that was only meant to print a PID.

Two seconds, then `(unknown)` and a `Warn`. The row is diagnostic, and the browser PID above it
comes from a property so it is always there — losing the renderer PID costs nothing next to
freezing the IDE.

Found while testing the 1.1.1 artifact in the Exp hive: clicking Info during a run hung the
instance. `msbuild` Debug green.
