### PR TITLE
fix(webview): Show all on a running agent no longer breaks the transcript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-07-31
+
+Two ways the chat could stop showing what the CLI was doing, and a dead link that said nothing.
+
+### Fixed
+
+- **The chat stops rendering mid-conversation.** With sub-agents running, the transcript could reach
+  a state where every later update threw and nothing appeared again — a pane that looked alive but
+  was frozen, with the reason visible only in the browser console. The tree was updated in place
+  while Lit still held references into it, so a row skipped its update and was left rendering into
+  nodes that no longer existed. The transcript is now rebuilt rather than mutated, which the type
+  system enforces instead of a comment.
+
+- **Options → Apply during a turn made the running reply disappear.** Applying options re-read the
+  transcript from the session file, where a reply still streaming does not exist yet. Mid-turn the
+  settings are now applied on their own and the transcript is left alone.
+
+- **A file link that cannot be opened says so.** Clicking a path that no longer resolves did nothing
+  at all, which reads as a broken feature rather than a missing file.
+
 ## [1.1.0] - 2026-07-31
 
 A pass over the chat's composer, the permission modes, and the sub-agents — plus the panes finally

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
       AssemblyInformationalVersion carries so a preview build can say it is one at runtime. Ship a
       stable release by dropping the suffix.
     -->
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
 
     <!--
       The same version without the suffix, for the places that take digits only: the VSIX Identity

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/transcript.test.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/transcript.test.ts
@@ -233,6 +233,36 @@ test('findToolByAgentId: trova la riga Agent che ha lanciato il sub-agent', () =
     assert.equal(t.findToolByAgentId('nope'), null);
 });
 
+// Il difetto del 2026-07-31 (secondo giro): "Show all" su un Agent ancora in esecuzione.
+// La fetch sostituisce children.items con l'intera cronologia, ma quei figli non erano mai
+// passati da appendChild — restano fuori dall'index. L'evento live che arriva subito dopo non
+// li trova, e l'update tocca il ramo sbagliato.
+test('update: sostituire children.items indicizza i figli arrivati da fuori', () => {
+    const t = new Transcript();
+    t.append(toolEntry(1, 'agent'));
+    t.appendChild('agent', userEntry(2), childKey);
+
+    // la fetch di "Show all": rimpiazza i 3 tenuti con la cronologia completa
+    t.update<UiToolEntry>(1, (e) => ({
+        ...e,
+        children: {
+            items: [userEntry(10), userEntry(11), toolEntry(12, 'inner')],
+            hasMore: false,
+            showAll: true,
+        },
+    }));
+
+    // l'agent sta ancora lavorando: arriva un evento per un figlio della lista sostituita
+    assert.equal(t.find(11)?.id, 11, 'i figli sostituiti devono essere raggiungibili');
+    assert.equal(
+        t.update<UiUserEntry>(11, (e) => ({ ...e, text: 'aggiornato' })),
+        true,
+        'update deve raggiungere un figlio arrivato dalla sostituzione',
+    );
+    assert.equal(t.findTool('inner')?.id, 12);
+    assert.equal(t.find(2), null, 'il figlio rimpiazzato non deve piu risolvere');
+});
+
 test('appendChild annidato: l index risolve un figlio di figlio', () => {
     const t = new Transcript();
     t.append(toolEntry(1, 'outer'));

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/transcript.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/transcript.ts
@@ -64,11 +64,24 @@ export class Transcript {
         }
         // The caller names the member it expects (update<UiToolEntry>); the walk below is
         // type-blind, so the callback is widened for it.
+        const before = this.find(id);
         const next = this._replace(this._entries, path, 0, id, (e) => fn(e as T));
         if (!next) {
             return false;
         }
         this._entries = next;
+        // A caller may hand over a whole new children list rather than append one at a time —
+        // "Show all" swaps the kept three for the fetched transcript. Those entries never went
+        // through appendChild, so nothing indexed them: a live event for one of them would find
+        // no path, or the stale path of the child it replaced, and update the wrong branch.
+        const after = this.find(id);
+        if (
+            before?.kind === 'tool' &&
+            after?.kind === 'tool' &&
+            before.children?.items !== after.children?.items
+        ) {
+            this._reindex();
+        }
         return true;
     }
 

--- a/src/Corsinvest.VisualStudio.Agents/source.extension.vsixmanifest
+++ b/src/Corsinvest.VisualStudio.Agents/source.extension.vsixmanifest
@@ -2,7 +2,7 @@
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011"
                  xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="Corsinvest.VisualStudio.Agents" Version="1.1.0" Language="en-US"
+    <Identity Id="Corsinvest.VisualStudio.Agents" Version="1.1.1" Language="en-US"
               Publisher="Corsinvest Srl" />
     <DisplayName>cv4vs Agents</DisplayName>
     <Description xml:space="preserve">Claude Code inside Visual Studio — agentic coding with a rich chat pane and an interactive terminal, wired into the editor, solution and debugger through an in-process MCP server.</Description>


### PR DESCRIPTION
The `Cannot set properties of null` crash was **not** fully fixed by #63. This is the case that
survived it.

## Reproduction

Open **Show all** on an Agent row **while the sub-agent is still working**, then close it. Every
later render throws, and the chat stops updating.

From the trace that caught it:

```
20:14:10  get_subagent  agentId=a3a6056863d2ffc14   ← Show all, agent still running
20:14:20  get_subagent  agentId=a3a6056863d2ffc14   ← again
20:14:31  chat_tool_permission  parentToolUseId=…   ← the agent is still emitting
20:14:34  chat_tool_result → throw
```

Earlier clean runs missed it because Show all was only ever opened **after** the agent had
finished — no live event arrived behind the swap.

## Cause

`_onChildrenToggle`'s fetch callback swaps `children.items` for the whole fetched transcript. Those
entries never went through `appendChild`, so nothing indexed them. The next live event for one of
them finds no path — or the stale path of the child it replaced — and `_replace` walks into the
wrong branch, leaving Lit with ChildParts pointing at removed nodes.

Same failure mode as #63, one level down: #63 stopped the tree being mutated, this stops the index
going stale under a wholesale swap.

## Fix

`update()` reindexes when the target's children list changes identity. One walk per swap, and a
swap only happens on expand/collapse — the per-token streaming path never reaches it.

## Test

Append a child, swap the list for entries that never went through `appendChild`, then update one of
them. Fails without the fix (`update` returns false, `find` returns null).

21 tests green.
