### PR TITLE
fix(webview): hovering a timestamp no longer kills the chat's rendering

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/time.test.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/time.test.ts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright (C) 2026 Corsinvest Srl
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { formatTimeAgo } from './time.ts';
+
+const MINUTE = 60_000;
+const HOUR = 3600_000;
+
+test('formatTimeAgo: il clock e iniettabile, non e Date.now cablato', () => {
+    const t = 1_000_000_000_000;
+
+    // Lo stesso timestamp letto a due momenti diversi deve dare due stringhe diverse: e quello che
+    // rende il refresh su hover una questione di stato, non di scrittura nel DOM.
+    const subito = formatTimeAgo(t, t + MINUTE);
+    const dopo = formatTimeAgo(t, t + 3 * HOUR);
+
+    assert.notEqual(subito, dopo, 'un clock piu avanti deve dare un testo diverso');
+});
+
+// Il testo esatto dipende dal locale di sistema (Intl.RelativeTimeFormat): asserire su stringhe
+// inglesi renderebbe il test verde solo sulle macchine in inglese. Quello che conta e' che unita
+// diverse diano stringhe diverse, e che il numero sia quello giusto.
+test('formatTimeAgo: sceglie l unita in base alla distanza', () => {
+    const t = 1_000_000_000_000;
+
+    const sec = formatTimeAgo(t, t + 30_000);
+    const min = formatTimeAgo(t, t + 5 * MINUTE);
+    const ore = formatTimeAgo(t, t + 5 * HOUR);
+
+    assert.notEqual(sec, min, 'secondi e minuti devono differire');
+    assert.notEqual(min, ore, 'minuti e ore devono differire');
+    assert.match(min, /5/, 'il numero deve comparire');
+    assert.match(ore, /5/);
+});
+
+test('formatTimeAgo: senza clock esplicito usa adesso', () => {
+    // Il default deve restare Date.now(): i chiamanti che non passano il clock non cambiano.
+    const esplicito = formatTimeAgo(1_000_000_000_000, 1_000_000_000_000 + 2 * MINUTE);
+    const implicito = formatTimeAgo(Date.now() - 2 * MINUTE);
+
+    assert.equal(implicito, esplicito, 'il default deve equivalere a passare Date.now()');
+});

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/time.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/time.ts
@@ -4,10 +4,8 @@
  */
 
 // Human "time ago" + absolute date/time for message action rows. Uses the platform Intl APIs
-// (browser locale). The relative form is computed on render and refreshed on hover — see
-// renderTimeAgo; there is no ticking timer.
-
-import { html, type TemplateResult } from 'lit';
+// (browser locale). Formatting only, no rendering: the stamp that refreshes itself on hover is
+// `ui/components/cv-time-ago`, which calls these.
 
 const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
 
@@ -21,9 +19,10 @@ const UNITS: Array<[Intl.RelativeTimeFormatUnit, number]> = [
     ['second', 1000],
 ];
 
-/** "20 minutes ago", "2 hours ago", "yesterday" — localized. */
-export function formatTimeAgo(ms: number): string {
-    const diff = ms - Date.now(); // negative = in the past
+/** "20 minutes ago", "2 hours ago", "yesterday" — localized. `now` is injectable so the caller
+ *  can re-render the same stamp against a later clock without reaching into the DOM. */
+export function formatTimeAgo(ms: number, now: number = Date.now()): string {
+    const diff = ms - now; // negative = in the past
     const abs = Math.abs(diff);
     for (const [unit, size] of UNITS) {
         if (abs >= size || unit === 'second') {
@@ -36,26 +35,4 @@ export function formatTimeAgo(ms: number): string {
 /** Full localized date + time, for the tooltip. */
 export function formatAbsolute(ms: number): string {
     return new Date(ms).toLocaleString();
-}
-
-/** The "x ago" stamp for an action row, refreshing itself when the pointer arrives.
- *
- *  Lit renders on property change, and elapsed time is not a property — so a stamp rendered when
- *  the message arrived said "1 second ago" for as long as the message stayed on screen. The action
- *  row is always in the DOM and only revealed by `opacity` on hover, so the hover alone changed
- *  nothing: no re-render came with it.
- *
- *  Writing the text straight onto the element on `mouseenter` is enough, and is why this is a plain
- *  function rather than a timer: the stamp is only legible while the row is revealed, and the row is
- *  only revealed under the pointer. A ticking timer would instead keep hundreds of history messages
- *  re-rendering to move "2 hours ago" to "3 hours ago", which nobody is reading. */
-export function renderTimeAgo(ms: number): TemplateResult {
-    return html`<span
-        class="cv-ts"
-        title=${formatAbsolute(ms)}
-        @mouseenter=${(e: Event) => {
-            (e.currentTarget as HTMLElement).textContent = formatTimeAgo(ms);
-        }}
-        >${formatTimeAgo(ms)}</span
-    >`;
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/esbuild.config.mjs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/esbuild.config.mjs
@@ -168,5 +168,10 @@ if (watch) {
 } else {
     await copyStatic();
     await build(config);
-    console.log('[esbuild] build complete → dist/bundle.js');
+    // Which bundle landed in dist\, not just that one did: MSBuild picks the script by
+    // configuration, so from the build output alone there is otherwise no way to tell whether a
+    // stack trace is about to name real functions or `t.$`.
+    console.log(
+        `[esbuild] build complete → dist/bundle.js (${dev ? 'dev: readable, sourcemaps' : 'production: minified, no sourcemaps'})`,
+    );
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/index.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/index.ts
@@ -9,6 +9,7 @@ import './ui/styles';
 
 // Components — order doesn't matter for registration.
 import './ui/components/cv-spinner';
+import './ui/components/cv-time-ago';
 import './ui/components/cv-model-list';
 import './ui/components/cv-permission-list';
 import './ui/components/cv-permission-selector';

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-message.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-message.ts
@@ -20,7 +20,6 @@ import { displayPathUi } from '../paths';
 import { parseIdeContextTags } from '../../core/ide';
 import { renderSlashCommand } from '../../core/slash-commands';
 import { openLightbox } from '../../core/dialog-host';
-import { renderTimeAgo } from '../../core/time';
 import type {
     IdeContextRef,
     ForkNotification,
@@ -191,7 +190,11 @@ export class CvMessage extends LitElement {
                       </button>`
                     : nothing
             }
-            ${this.timestamp > 0 ? renderTimeAgo(this.timestamp) : nothing}
+            ${
+                this.timestamp > 0
+                    ? html`<cv-time-ago .ms=${this.timestamp}></cv-time-ago>`
+                    : nothing
+            }
         </div>`;
     }
 

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-time-ago.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-time-ago.ts
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+import { LitElement, html } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { formatAbsolute, formatTimeAgo } from '../../core/time';
+
+/**
+ * The "x ago" stamp under a message, recomputed when the pointer arrives.
+ *
+ * Elapsed time is not a property, so nothing re-renders as it passes: a stamp drawn when the
+ * message arrived reads "1 second ago" for as long as the message stays on screen. The row is
+ * always in the DOM and only revealed by `opacity` on hover, so the hover is both the moment the
+ * stamp becomes legible and the only moment worth recomputing it.
+ *
+ * This exists as an element, rather than the plain template it used to be, for one reason: the
+ * hover must change rendered text, and the only safe way to do that is to let Lit render it again.
+ * The previous version wrote `textContent` onto the span holding the `${...}` binding, which
+ * destroyed that ChildPart's markers — after which every later render of the whole chat threw
+ * `Cannot set properties of null (setting 'data')` and the pane stopped updating entirely.
+ *
+ * Light DOM: `.cv-ts` is styled by the chat's global stylesheet, and the hover-reveal `opacity`
+ * lives on the parent row.
+ */
+@customElement('cv-time-ago')
+export class CvTimeAgo extends LitElement {
+    /** Epoch ms of the message. 0 renders nothing. */
+    @property({ type: Number }) ms = 0;
+
+    /** The clock the stamp was last computed against. Bumping it is what re-renders the text. */
+    @state() private _now = Date.now();
+
+    override createRenderRoot() {
+        return this;
+    }
+
+    override render() {
+        if (!this.ms) {
+            return html``;
+        }
+        return html`<span
+            class="cv-ts"
+            title=${formatAbsolute(this.ms)}
+            @mouseenter=${() => {
+                this._now = Date.now();
+            }}
+            >${formatTimeAgo(this.ms, this._now)}</span
+        >`;
+    }
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'cv-time-ago': CvTimeAgo;
+    }
+}

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/helpers/actions-row.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/helpers/actions-row.ts
@@ -9,7 +9,6 @@
 import { html, nothing } from 'lit';
 import '../components/cv-copy-btn';
 import '../components/cv-speak-btn';
-import { renderTimeAgo } from '../../core/time';
 
 /** Copy button (+ optional Read-aloud when `speak`) + "x ago" timestamp. Hover-gating is CSS:
  *  `.cv-response-actions` has base opacity 0 and a hover rule on the container reveals it — pass that
@@ -26,7 +25,7 @@ export function renderActionsRow(
         <div class="cv-response-actions ${extraClass}">
             <cv-copy-btn .text=${text} title=${title}></cv-copy-btn>
             ${speak ? html`<cv-speak-btn .text=${text}></cv-speak-btn>` : nothing}
-            ${ts > 0 ? renderTimeAgo(ts) : nothing}
+            ${ts > 0 ? html`<cv-time-ago .ms=${ts}></cv-time-ago>` : nothing}
         </div>
     `;
 }

--- a/src/Corsinvest.VisualStudio.Agents/Corsinvest.VisualStudio.Agents.csproj
+++ b/src/Corsinvest.VisualStudio.Agents/Corsinvest.VisualStudio.Agents.csproj
@@ -417,8 +417,28 @@
     <Folder Include="WebView2\images\" />
   </ItemGroup>
   <Target Name="BuildWebViewSrc" BeforeTargets="BeforeBuild" Condition="Exists('Chat\WebViewSrc\package.json')">
+    <!-- Debug builds the readable bundle, Release the minified one. A Debug build is something you
+         are about to F5 into and read a stack trace from, and a minified bundle names every frame
+         `t.$` — which is what made the 2026-07-31 crash take two days to place. `build:dev` also
+         mirrors dist\ into the Exp hives, so a TypeScript-only change is picked up by reopening the
+         pane; the mirror only writes to folders that already exist, so CI and a first build are
+         untouched. Release must stay `build`: the sourcemaps would otherwise ship in the VSIX. -->
+    <PropertyGroup>
+      <_WebViewNpmScript Condition="'$(Configuration)' == 'Debug'">build:dev</_WebViewNpmScript>
+      <_WebViewNpmScript Condition="'$(_WebViewNpmScript)' == ''">build</_WebViewNpmScript>
+    </PropertyGroup>
     <Exec Command="npm install --no-fund --no-audit" WorkingDirectory="$(MSBuildProjectDirectory)\Chat\WebViewSrc" Condition="!Exists('Chat\WebViewSrc\node_modules')" />
-    <Exec Command="npm run build" WorkingDirectory="$(MSBuildProjectDirectory)\Chat\WebViewSrc" />
+    <!-- Delete the sourcemaps a previous Debug build left behind. MSBuild globs dist\ during
+         evaluation, before this target runs, so those .map files are already in @(Content) — and a
+         Release build then removes them, leaving @(Content) pointing at files that no longer exist
+         (MSB3030 at copy time). Deleting them here means the glob below re-runs against a dist\
+         that npm is about to rewrite either way. -->
+    <ItemGroup Condition="'$(_WebViewNpmScript)' == 'build'">
+      <_WebViewStaleMaps Include="Chat\WebViewSrc\dist\**\*.map" />
+      <Content Remove="@(_WebViewStaleMaps)" />
+    </ItemGroup>
+    <Delete Files="@(_WebViewStaleMaps)" Condition="'$(_WebViewNpmScript)' == 'build'" />
+    <Exec Command="npm run $(_WebViewNpmScript)" WorkingDirectory="$(MSBuildProjectDirectory)\Chat\WebViewSrc" />
 
     <!-- Re-add what npm just produced. The static glob above ran during evaluation, before this
          target: on a clean check-out it found nothing, so without this the VSIX would install fine
@@ -430,6 +450,11 @@
          first, then attach the metadata to @(_WebViewDist). Remove first so the files the static
          glob did pick up are not added a second time. -->
     <ItemGroup>
+      <!-- Clear first: a Debug build leaves .map files in dist\, the static glob above picks them
+           up during evaluation, and the Release build then deletes them — leaving @(Content) with
+           two entries that no longer exist on disk (MSB3030 at copy time). Re-globbing after npm
+           is what makes the item list match what was actually produced. -->
+      <_WebViewDist Remove="@(_WebViewDist)" />
       <_WebViewDist Include="Chat\WebViewSrc\dist\**\*" />
       <Content Remove="Chat\WebViewSrc\dist\**\*" />
       <Content Include="@(_WebViewDist)">


### PR DESCRIPTION
This is the actual cause of `Cannot set properties of null (setting 'data')`. #63 and #66 were
correct in themselves but chased the wrong thing: it was never a data-identity problem.

## The bug

`core/time.ts` bound the stamp as `${formatTimeAgo(ms)}` inside a span, then wrote `textContent`
onto that same span on `mouseenter`:

```ts
return html`<span
    class="cv-ts"
    @mouseenter=${(e) => {
        e.currentTarget.textContent = formatTimeAgo(ms);   // line 57
    }}
    >${formatTimeAgo(ms)}</span                            // line 59: a ChildPart
>`;
```

The binding is a Lit ChildPart, held as `[marker][Text][marker]`. `textContent` destroys all three.
The opening marker survives detached, `nextSibling` is null, and the next render takes commitText's
fast path — verified against the installed `lit-html@3.3.2`:

```js
if (this._$committedValue !== nothing && isPrimitive(this._$committedValue)) {
    const node = wrap(this._$startNode).nextSibling;
    node.data = value;      // ← this._$AA.nextSibling.data = t, the exact minified frame
}
```

Lit does not catch it. The update aborts half-committed, and the same broken part is re-committed
on **every** later render — which is why one bad hover kills the pane for good.

## Why it took two days

Arming it needs only a hover: no click, no command, no trace in the bridge log. The crash lands on
whatever render comes next, often minutes later. So it looked like sub-agents, then Show all, then
session restore — all of which merely *produce renders*. The `_mutate` frame under Lit in every
stack was the victim, not the cause.

History sessions made it reproducible because entries from disk carry a real `timestamp`: an
8-hour-old session shows "8 hours ago", which is a stamp worth hovering.

## The fix

A `<cv-time-ago>` element. The hover bumps `@state` and Lit re-renders its own part — same
behaviour, no DOM write. Text Lit rendered can only be changed by letting Lit render it again.

Also:
- `formatTimeAgo(ms, now?)` takes the clock, so the refresh is testable without a DOM
- `time.ts` no longer imports `lit` — formatting only, which is what `core/` is for
- `renderTimeAgo` is gone: after the change it was a one-line wrapper that only forced `core/` to
  depend on `lit`

## Checked

- 24 tests green. The new ones assert the clock is injectable and locale-independent (asserting on
  English strings would only pass on English machines — the first draft did, and failed here).
- No other `textContent`/`innerText` write on a Lit-owned node anywhere in the WebView. The
  `innerHTML` sites in `cv-diff-preview` / `cv-diff-dialog` / `ui/diff.ts` were audited and are
  sound: they write into elements the template declares empty, so Lit holds no markers inside them.

## Not covered

The crash is fixed; the pane still has no guard for the general case. If any future code corrupts a
part the same way, the chat again dies silently with the reason visible only in the browser console.
A `window.onerror` notice ("reload the pane") is worth having and is on the TODO.
