### PR TITLE
chore(release): 1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [1.1.2] - 2026-08-01
+
+The chat could still stop rendering. 1.1.1 said that was fixed; it was not, and this is the actual
+cause.
+
+### Fixed
+
+- **Hovering a timestamp stopped the chat from rendering.** The "x ago" stamp under a message wrote
+  its own text into the element on hover — and that element's content belonged to the rendering
+  engine, which was left holding references to nodes that no longer existed. From that moment every
+  later update threw, and the pane went on looking alive while showing nothing new. One hover was
+  enough: no click, no command, nothing in any log, and the failure surfaced on whatever came next,
+  often minutes later. That delay is why the two fixes in 1.1.1 landed elsewhere — both were sound
+  in themselves, and neither was this.
+
+  The stamp is now a component that re-renders itself, so the text changes the only way it safely
+  can.
+
+### Changed
+
+- **A Debug build produces the readable WebView bundle**, with sourcemaps, instead of the minified
+  one. A stack trace from the chat now names real functions — which is most of the reason the crash
+  above took two days to find. Release is unchanged, and still ships without sourcemaps.
+
 ## [1.1.1] - 2026-07-31
 
 Ways the chat could stop showing what the CLI was doing, a dialog that froze the IDE, and a dead

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
       AssemblyInformationalVersion carries so a preview build can say it is one at runtime. Ship a
       stable release by dropping the suffix.
     -->
-    <Version>1.1.1</Version>
+    <Version>1.1.2</Version>
 
     <!--
       The same version without the suffix, for the places that take digits only: the VSIX Identity

--- a/src/Corsinvest.VisualStudio.Agents/source.extension.vsixmanifest
+++ b/src/Corsinvest.VisualStudio.Agents/source.extension.vsixmanifest
@@ -2,7 +2,7 @@
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011"
                  xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="Corsinvest.VisualStudio.Agents" Version="1.1.1" Language="en-US"
+    <Identity Id="Corsinvest.VisualStudio.Agents" Version="1.1.2" Language="en-US"
               Publisher="Corsinvest Srl" />
     <DisplayName>cv4vs Agents</DisplayName>
     <Description xml:space="preserve">Claude Code inside Visual Studio — agentic coding with a rich chat pane and an interactive terminal, wired into the editor, solution and debugger through an in-process MCP server.</Description>


### PR DESCRIPTION
Patch release. One fix since 1.1.1 — the actual cause of the chat freezing, which 1.1.1 said was
closed and was not.

## What's in it

**#67 — hovering a timestamp stopped the chat from rendering.** The "x ago" stamp wrote its own
text onto an element whose content Lit owned, destroying that ChildPart's markers. Every later
render then threw `Cannot set properties of null (setting 'data')`, and the pane went on looking
alive while showing nothing new.

Arming it took only a hover — no click, no command, nothing in any log — and the crash landed on
whatever render came next, often minutes later. That delay is why the two fixes in 1.1.1 landed
elsewhere: both were real defects worth having, and neither was this one.

Same PR: **a Debug build now produces the readable WebView bundle**, with sourcemaps. A minified
stack names every frame `t.$`, which is most of the reason the crash took two days to place.
Release is unchanged and still ships without sourcemaps.

## Version

Both places that carry it, which have to agree or the release workflow fails its own check:

- `Directory.Build.props`
- `source.extension.vsixmanifest` — the one the Marketplace reads

## Changelog

Additive only: the 1.1.1 entry is left as published, and the 1.1.2 entry says plainly that it did
not fix the crash. A changelog that quietly rewrites a wrong claim stops being a record.

## Not built

No local build was run for this branch — the bump is text only. Worth knowing before tagging:
`obj/<Config>/extension.vsixmanifest` is not regenerated while it exists, so a build straight after
a version edit can still package the old number. Deleting the intermediate is what makes it take
(this bit us on 1.1.1).

CI on this branch is the real check.
