### PR TITLE
fix(chat): the chat pane stops drawing over Visual Studio

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents.Contracts/ToWebViewDtos.cs
+++ b/src/Corsinvest.VisualStudio.Agents.Contracts/ToWebViewDtos.cs
@@ -364,6 +364,22 @@ public class SetComposerNotification
     public string Text { get; set; }
 }
 
+/// <summary>A keystroke the host claimed on the WebView's behalf (ui_host_key).
+/// <para>WebView2CompositionControl renders through Windows.UI.Composition, and its
+/// CoreWebView2CompositionController exposes SendMouseInput/SendPointerInput but no keyboard
+/// equivalent — so the keys it drops never reach the browser, and WPF hands them to Visual Studio
+/// instead. The pane claims those and forwards them here for the page to act on.</para></summary>
+public class HostKeyNotification
+{
+    /// <summary>DOM <c>KeyboardEvent.key</c> name ("Home", "End", …), not the WPF enum, so the
+    /// page compares against the same strings a real key event would carry.</summary>
+    public string Key { get; set; } = "";
+
+    public bool Ctrl { get; set; }
+    public bool Shift { get; set; }
+    public bool Alt { get; set; }
+}
+
 /// <summary>The ↑/↓ prompt history for a session (chat_prompt_history). The WebView
 /// keeps prompts; sessionId gates stale updates (only apply if it matches).</summary>
 public class PromptHistoryNotification

--- a/src/Corsinvest.VisualStudio.Agents/AgentsPackage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/AgentsPackage.cs
@@ -302,7 +302,13 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
         // Lazy MCP lifecycle: server runs only while >=1 session is open,
         // driven by PaneRegistry's 0->1 / ->0 transitions.
         Core.Panes.PaneRegistry.Instance.FirstSessionStarted += () => Mcp.McpServerHost.Instance.EnsureStarted();
-        Core.Panes.PaneRegistry.Instance.LastSessionEnded += () => Mcp.McpServerHost.Instance.Stop();
+        Core.Panes.PaneRegistry.Instance.LastSessionEnded += () =>
+        {
+            Mcp.McpServerHost.Instance.Stop();
+            // Same 0-session boundary: the controller behind the browser's task manager is shared
+            // by every pane, so it outlives any one of them but not all of them.
+            Chat.Pane.ChatWebView.CloseTaskManagerOwner();
+        };
 
         // Subscribe to solution events so the MCP lock file's workspaceFolders
         // stay in sync; otherwise a later `claude --ide` skips us in discovery.

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/BridgeMessages.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/BridgeMessages.cs
@@ -199,6 +199,9 @@ internal static class BridgeMessages
             /// claims it so VS doesn't move focus to an open editor). The WebView decides:
             /// stop generation if busy, close an open menu, else no-op.</summary>
             public const string Escape = "ui_escape";
+            /// <summary>A key the composition control dropped, claimed by the pane and forwarded
+            /// for the page to act on. See <c>HostKeyNotification</c>.</summary>
+            public const string HostKey = "ui_host_key";
         }
 
         /// <summary>Plugin-manager results + the global "plugins changed" broadcast.</summary>

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/BridgeMessages.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/BridgeMessages.cs
@@ -109,11 +109,6 @@ internal static class BridgeMessages
             /// <summary>The app mounted and painted its first frame — hide the
             /// native "Initializing…" placeholder now.</summary>
             public const string Ready = "webview_ready";
-
-            /// <summary>A real pointer-down happened inside the WebView: activate this pane's VS
-            /// frame. Fires only on genuine clicks in the chat (never during a sibling-tab switch),
-            /// unlike WPF focus events that can't cross the WebView2 HwndHost boundary.</summary>
-            public const string PaneActivate = "ui_pane_activate";
         }
     }
 
@@ -198,9 +193,6 @@ internal static class BridgeMessages
             public const string ThemeChanged = "ui_theme_changed";
             /// <summary>Ask the WebView to focus the prompt box (e.g. after a session switch).</summary>
             public const string FocusInput = "ui_focus_input";
-            /// <summary>Blur the prompt textarea (dual of FocusInput). Sent when the pane loses the
-            /// active VS frame, so the DOM drops focus and the caret stops blinking.</summary>
-            public const string BlurInput = "ui_blur_input";
             /// <summary>Pre-fill the composer with text (the forked-at message), focused and ready to send.</summary>
             public const string SetComposer = "ui_set_composer";
             /// <summary>Esc pressed: VS routed its Cancel command to the pane (ChatPaneWindow

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.cs
@@ -26,6 +26,9 @@ internal sealed partial class WebViewBridge(Microsoft.Web.WebView2.Wpf.WebView2C
 {
     private bool _ready;
     private bool _disposed;
+    // The bundle's first paint: NavigationCompleted fires again on every reload, and only the
+    // first one needs to seed the options and drain the queue.
+    private bool _firstLoadDone;
     private readonly ConcurrentQueue<(string type, object data)> _pending = new();
     private bool? _pendingTheme;
     private string _docCreatedScriptId;
@@ -68,37 +71,9 @@ internal sealed partial class WebViewBridge(Microsoft.Web.WebView2.Wpf.WebView2C
             webView.CoreWebView2.Settings.AreBrowserAcceleratorKeysEnabled = false;
             webView.CoreWebView2.Settings.IsStatusBarEnabled = false;
 
-            webView.CoreWebView2.PermissionRequested += (s, args) =>
-            {
-                if (args.PermissionKind == CoreWebView2PermissionKind.ClipboardRead)
-                {
-                    args.State = CoreWebView2PermissionState.Allow;
-                }
-            };
-
-            webView.CoreWebView2.NewWindowRequested += (s, args) =>
-            {
-                args.Handled = true;
-                ShellHelpers.OpenExternal(args.Uri);
-            };
-
-            var isFirstLoad = true;
-            webView.CoreWebView2.NavigationCompleted += (s, args) =>
-            {
-                // A navigation landing during teardown would re-arm _ready and drain the queue
-                // into a WebView being disposed.
-                if (_disposed) { return; }
-                _ready = true;
-                if (isFirstLoad)
-                {
-                    isFirstLoad = false;
-                    // Boot paint: give the bundle the VS Options (theme/font) for its first frame before the CLI
-                    // client exists. The one real ui_init (with model/permission/toggles) comes from
-                    // ChatPaneControl.OnCliStateReceived once initialize + get_settings land (no user turn needed).
-                    SendDirect(BridgeMessages.ToWebView.Ui.VsSettings, WebViewBridge.BuildVsOptions());
-                    while (_pending.TryDequeue(out var msg)) { SendDirect(msg.type, msg.data); }
-                }
-            };
+            webView.CoreWebView2.PermissionRequested += OnPermissionRequested;
+            webView.CoreWebView2.NewWindowRequested += OnNewWindowRequested;
+            webView.CoreWebView2.NavigationCompleted += OnNavigationCompleted;
 
             // Inject boot-time theme script BEFORE navigation to avoid FOUC (refreshed via InjectTheme).
             if (_pendingTheme.HasValue) { await RegisterBootThemeScriptAsync(_pendingTheme.Value); }
@@ -127,6 +102,45 @@ internal sealed partial class WebViewBridge(Microsoft.Web.WebView2.Wpf.WebView2C
         {
             OutputWindowLogger.LogException("WebViewBridge.Init", ex);
             throw;
+        }
+    }
+
+    // The three below are named, not lambdas, for the same reason as OnRawMessage: Dispose has to
+    // be able to -= them. They run on the controller being torn down, and an event still in flight
+    // would otherwise reach a bridge that has already released its WebView.
+
+    /// <summary>Paste needs clipboard read; nothing else is granted.</summary>
+    private void OnPermissionRequested(object sender, CoreWebView2PermissionRequestedEventArgs args)
+    {
+        if (args.PermissionKind == CoreWebView2PermissionKind.ClipboardRead)
+        {
+            args.State = CoreWebView2PermissionState.Allow;
+        }
+    }
+
+    /// <summary>Links open in the user's browser, never in a WebView window of our own.</summary>
+    private void OnNewWindowRequested(object sender, CoreWebView2NewWindowRequestedEventArgs args)
+    {
+        args.Handled = true;
+        ShellHelpers.OpenExternal(args.Uri);
+    }
+
+    /// <summary>First paint of the bundle: hand it the VS Options and drain whatever was queued
+    /// while it wasn't ready.</summary>
+    private void OnNavigationCompleted(object sender, CoreWebView2NavigationCompletedEventArgs args)
+    {
+        // A navigation landing during teardown would re-arm _ready and drain the queue
+        // into a WebView being disposed.
+        if (_disposed) { return; }
+        _ready = true;
+        if (!_firstLoadDone)
+        {
+            _firstLoadDone = true;
+            // Boot paint: give the bundle the VS Options (theme/font) for its first frame before the CLI
+            // client exists. The one real ui_init (with model/permission/toggles) comes from
+            // ChatPaneControl.OnCliStateReceived once initialize + get_settings land (no user turn needed).
+            SendDirect(BridgeMessages.ToWebView.Ui.VsSettings, BuildVsOptions());
+            while (_pending.TryDequeue(out var msg)) { SendDirect(msg.type, msg.data); }
         }
     }
 
@@ -208,12 +222,6 @@ internal sealed partial class WebViewBridge(Microsoft.Web.WebView2.Wpf.WebView2C
         }
     }
 
-    /// <summary>The browser's own task manager — the Edge one, with live memory/CPU per process.
-    /// It covers every pane on the user-data folder, panes in another VS instance included, which
-    /// is what makes it worth having: a stray renderer or a process count that doesn't add up is a
-    /// question about the whole browser, not about this pane.</summary>
-    public void OpenTaskManager() => webView.CoreWebView2?.OpenTaskManagerWindow();
-    /// <summary>Release the WebView2 control, and with it the CoreWebView2Controller and the
     /// renderer process behind this pane. VS keeps the closed tool window's control alive, so
     /// without this the renderer outlives the pane and the browser accumulates one per pane ever
     /// opened. Handlers are unhooked first: they run on the controller being torn down.</summary>
@@ -230,6 +238,9 @@ internal sealed partial class WebViewBridge(Microsoft.Web.WebView2.Wpf.WebView2C
                 core.WebMessageReceived -= OnRawMessage;
                 core.ContextMenuRequested -= OnContextMenuRequested;
                 core.WebResourceRequested -= OnIconRequested;
+                core.PermissionRequested -= OnPermissionRequested;
+                core.NewWindowRequested -= OnNewWindowRequested;
+                core.NavigationCompleted -= OnNavigationCompleted;
             }
             webView.Dispose();
         }
@@ -240,7 +251,13 @@ internal sealed partial class WebViewBridge(Microsoft.Web.WebView2.Wpf.WebView2C
     /// actually reaches the page. Without this a JS `element.focus()` only shows a
     /// blinking caret while keystrokes still go to VS — the WebView host must own
     /// the focus first. Call before posting ui_focus_input.</summary>
-    public void FocusWebView() => webView.Focus();
+    /// <summary>Guarded: a session switch can land after the pane closed, and Focus() on a
+    /// disposed control throws where every other member here quietly no-ops.</summary>
+    public void FocusWebView()
+    {
+        if (_disposed) { return; }
+        webView.Focus();
+    }
 
     /// <summary>Open WebView2's native find bar over the chat content (Ctrl+F). We host it
     /// ourselves because AreBrowserAcceleratorKeysEnabled=false turns off the browser's own Ctrl+F.

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.cs
@@ -247,12 +247,12 @@ internal sealed partial class WebViewBridge(Microsoft.Web.WebView2.Wpf.WebView2C
         catch (Exception ex) { OutputWindowLogger.LogException("WebViewBridge.Dispose", ex); }
     }
 
-    /// <summary>Give the WebView2 control the native (WPF) focus, so the keyboard
-    /// actually reaches the page. Without this a JS `element.focus()` only shows a
-    /// blinking caret while keystrokes still go to VS — the WebView host must own
-    /// the focus first. Call before posting ui_focus_input.</summary>
-    /// <summary>Guarded: a session switch can land after the pane closed, and Focus() on a
-    /// disposed control throws where every other member here quietly no-ops.</summary>
+    /// <summary>Give the WebView2 control the native (WPF) focus, so the keyboard actually reaches
+    /// the page. Without this a JS `element.focus()` only shows a blinking caret while keystrokes
+    /// still go to VS — the WebView host must own the focus first. Call before posting
+    /// ui_focus_input.
+    /// <para>Guarded: a session switch can land after the pane closed, and Focus() on a disposed
+    /// control throws where every other member here quietly no-ops.</para></summary>
     public void FocusWebView()
     {
         if (_disposed) { return; }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.cs
@@ -247,6 +247,20 @@ internal sealed partial class WebViewBridge(Microsoft.Web.WebView2.Wpf.WebView2C
         catch (Exception ex) { OutputWindowLogger.LogException("WebViewBridge.Dispose", ex); }
     }
 
+    /// <summary>Name the page after the pane, so the browser's task manager can tell one chat's
+    /// renderer from another's — every pane loads the same index.html, so they otherwise share one
+    /// title. Diagnostics only: nothing in the UI shows it.</summary>
+    public void SetDocumentTitle(string title)
+    {
+        if (_disposed || string.IsNullOrEmpty(title)) { return; }
+        try
+        {
+            _ = webView.CoreWebView2?.ExecuteScriptAsync(
+                $"document.title = {JsonConvert.SerializeObject(title)}");
+        }
+        catch (Exception ex) { OutputWindowLogger.LogException("WebViewBridge.SetDocumentTitle", ex); }
+    }
+
     /// <summary>Give the WebView2 control the native (WPF) focus, so the keyboard actually reaches
     /// the page. Without this a JS `element.focus()` only shows a blinking caret while keystrokes
     /// still go to VS — the WebView host must own the focus first. Call before posting

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.cs
@@ -21,7 +21,7 @@ namespace Corsinvest.VisualStudio.Agents.Chat.Host;
 /// Manages the WebView2 control: initialisation, posting messages to JS,
 /// and dispatching messages received from JS to the host via <see cref="MessageReceived"/>.
 /// </summary>
-internal sealed partial class WebViewBridge(Microsoft.Web.WebView2.Wpf.WebView2 webView, Dispatcher dispatcher)
+internal sealed partial class WebViewBridge(Microsoft.Web.WebView2.Wpf.WebView2CompositionControl webView, Dispatcher dispatcher)
     : IDisposable
 {
     private bool _ready;
@@ -45,9 +45,7 @@ internal sealed partial class WebViewBridge(Microsoft.Web.WebView2.Wpf.WebView2 
             // Initialize CoreWebView2 with our own user-data folder. Required
             // before touching any CoreWebView2 member below.
             var env = await CoreWebView2Environment.CreateAsync(null, AppPaths.WebView2Folder);
-            var controllerOpts = env.CreateCoreWebView2ControllerOptions();
-            controllerOpts.AllowHostInputProcessing = true;
-            await webView.EnsureCoreWebView2Async(env, controllerOpts);
+            await webView.EnsureCoreWebView2Async(env);
 
             // WebView2 defaults to an opaque WHITE background before the first paint, which flashes as
             // a blank/black block until the bundle renders. Make it transparent so the WPF host's

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.cs
@@ -45,12 +45,16 @@ internal sealed partial class WebViewBridge(Microsoft.Web.WebView2.Wpf.WebView2C
             // Initialize CoreWebView2 with our own user-data folder. Required
             // before touching any CoreWebView2 member below.
             var env = await CoreWebView2Environment.CreateAsync(null, AppPaths.WebView2Folder);
-            await webView.EnsureCoreWebView2Async(env);
 
-            // WebView2 defaults to an opaque WHITE background before the first paint, which flashes as
-            // a blank/black block until the bundle renders. Make it transparent so the WPF host's
-            // VsBrush.Window shows through (matches the theme) during that gap. On the WPF control the
-            // color lives on the control itself, not on CoreWebView2Controller.
+            // WebView2 defaults to an opaque WHITE background before the first paint, which flashes
+            // as a blank block until the bundle renders. Setting it on the control alone is too
+            // late — by then the controller exists and has already painted once — so it goes into
+            // the controller options, which is what "initialize the DefaultBackgroundColor early"
+            // is for. Transparent lets the WPF host's VsBrush.Window (themed) show through instead.
+            var controllerOpts = env.CreateCoreWebView2ControllerOptions();
+            controllerOpts.DefaultBackgroundColor = System.Drawing.Color.Transparent;
+            await webView.EnsureCoreWebView2Async(env, controllerOpts);
+
             webView.DefaultBackgroundColor = System.Drawing.Color.Transparent;
 
             webView.CoreWebView2.WebMessageReceived += OnRawMessage;
@@ -209,7 +213,6 @@ internal sealed partial class WebViewBridge(Microsoft.Web.WebView2.Wpf.WebView2C
     /// is what makes it worth having: a stray renderer or a process count that doesn't add up is a
     /// question about the whole browser, not about this pane.</summary>
     public void OpenTaskManager() => webView.CoreWebView2?.OpenTaskManagerWindow();
-
     /// <summary>Release the WebView2 control, and with it the CoreWebView2Controller and the
     /// renderer process behind this pane. VS keeps the closed tool window's control alive, so
     /// without this the renderer outlives the pane and the browser accumulates one per pane ever

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml
@@ -1,14 +1,16 @@
 <panes:PaneControlBase x:Class="Corsinvest.VisualStudio.Agents.Chat.Pane.ChatPaneControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:wv2="clr-namespace:Microsoft.Web.WebView2.Wpf;assembly=Microsoft.Web.WebView2.Wpf"
+             xmlns:chat="clr-namespace:Corsinvest.VisualStudio.Agents.Chat.Pane"
              xmlns:panes="clr-namespace:Corsinvest.VisualStudio.Agents.Core.Panes"
              Background="{DynamicResource VsBrush.Window}">
   <Grid>
-    <!-- CompositionControl, not WebView2: renders through Windows.UI.Composition inside the WPF
-         visual tree instead of a child HWND, so VS's floating tool windows can draw over the chat
-         (a child HWND always wins the z-order against WPF — the airspace issue). -->
-    <wv2:WebView2CompositionControl x:Name="WebView" />
+    <!-- ChatWebView derives from WebView2CompositionControl, which renders through
+         Windows.UI.Composition inside the WPF visual tree instead of a child HWND, so VS's
+         floating tool windows can draw over the chat (a child HWND always wins the z-order
+         against WPF — the airspace issue). The subclass adds back the caret keys that
+         composition rendering drops. -->
+    <chat:ChatWebView x:Name="WebView" />
     <StackPanel x:Name="StatusPanel" HorizontalAlignment="Center" VerticalAlignment="Center"
                 Height="48" Visibility="Visible">
       <TextBlock HorizontalAlignment="Center"

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml
@@ -5,7 +5,10 @@
              xmlns:panes="clr-namespace:Corsinvest.VisualStudio.Agents.Core.Panes"
              Background="{DynamicResource VsBrush.Window}">
   <Grid>
-    <wv2:WebView2 x:Name="WebView" />
+    <!-- CompositionControl, not WebView2: renders through Windows.UI.Composition inside the WPF
+         visual tree instead of a child HWND, so VS's floating tool windows can draw over the chat
+         (a child HWND always wins the z-order against WPF — the airspace issue). -->
+    <wv2:WebView2CompositionControl x:Name="WebView" />
     <StackPanel x:Name="StatusPanel" HorizontalAlignment="Center" VerticalAlignment="Center"
                 Height="48" Visibility="Visible">
       <TextBlock HorizontalAlignment="Center"

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml
@@ -11,13 +11,16 @@
          against WPF — the airspace issue). The subclass adds back the caret keys that
          composition rendering drops. -->
     <chat:ChatWebView x:Name="WebView" />
-    <StackPanel x:Name="StatusPanel" HorizontalAlignment="Center" VerticalAlignment="Center"
-                Height="48" Visibility="Visible">
-      <TextBlock HorizontalAlignment="Center"
+    <!-- Fills the pane and is opaque on purpose: the WebView is transparent until its first paint
+         (so no white flash), which would otherwise let the chat show through this placeholder while
+         it is still loading. Collapsed on webview_ready. -->
+    <Grid x:Name="StatusPanel" Background="{DynamicResource VsBrush.Window}" Visibility="Visible">
+      <!-- Text only, no progress bar: EnsureCoreWebView2Async blocks the UI thread for ~2s while
+           the composition controller and the browser processes come up (measured), so an
+           indeterminate bar would sit frozen for most of the wait — worse than saying nothing. -->
+      <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center"
                  Foreground="{DynamicResource VsBrush.WindowText}" FontSize="13"
                  Text="Initializing..."/>
-      <ProgressBar IsIndeterminate="True" Width="160" Height="2" Margin="0,8,0,0"
-                   Background="Transparent" BorderThickness="0"/>
-    </StackPanel>
+    </Grid>
   </Grid>
 </panes:PaneControlBase>

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
@@ -16,6 +16,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Input;
 
 namespace Corsinvest.VisualStudio.Agents.Chat.Pane;
 
@@ -290,7 +291,16 @@ public partial class ChatPaneControl : PaneControlBase
         Loaded += OnLoaded;
         Unloaded += OnUnloaded;
         WebView.HostKeyPressed += OnHostKeyPressed;
+        // Clicking into the chat is the user answering the attention notice, so take it down.
+        // Composition rendering is what makes this possible: the control lives in the WPF tree,
+        // so mouse events reach us. The HwndHost version had to be told from JS instead.
+        WebView.PreviewMouseDown += OnWebViewClicked;
     }
+
+    /// <summary>The user clicked into this pane: whatever InfoBar or toast was calling them here
+    /// has done its job.</summary>
+    private void OnWebViewClicked(object sender, MouseButtonEventArgs e)
+        => PaneAttentionService.Clear(Entry);
 
     /// <summary>A key <see cref="ChatWebView"/> claimed because composition rendering drops it:
     /// hand it to the page, which acts on whatever it has focused. Dropped silently before the
@@ -340,6 +350,7 @@ public partial class ChatPaneControl : PaneControlBase
         VSColorTheme.ThemeChanged -= OnVsThemeChanged;
         AgentsOptions.Applied -= OnOptionsApplied;
         WebView.HostKeyPressed -= OnHostKeyPressed;
+        WebView.PreviewMouseDown -= OnWebViewClicked;
         IdeContextService.Instance.ContextChanged -= OnEditorContextChanged;
         // EnsureClient hooked this on the IdeContextService singleton; without the unhook the
         // closed pane leaks (singleton keeps it alive) and its dead _client keeps logging

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
@@ -167,11 +167,6 @@ public partial class ChatPaneControl : PaneControlBase
         _bridge?.Send(BridgeMessages.ToWebView.Ui.FocusInput, null);
     }
 
-    /// <summary>Blur the WebView prompt (dual of <see cref="FocusInput"/>). Only the JS blur is
-    /// needed — no native focus dance, since we're dropping focus, not taking it.</summary>
-    public override void BlurInput()
-        => _bridge?.Send(BridgeMessages.ToWebView.Ui.BlurInput, null);
-
     /// <summary>Open the WebView2 native find bar (Ctrl+F), invoked by ChatPaneWindow when it
     /// intercepts the Find command from VS. Returns false if the WebView isn't ready.</summary>
     internal bool ShowFind()
@@ -290,10 +285,6 @@ public partial class ChatPaneControl : PaneControlBase
         InitializeComponent();
         Loaded += OnLoaded;
         Unloaded += OnUnloaded;
-        // Pane activation on a real in-chat click is driven from JS (pointerdown → bridge
-        // ui_pane_activate → OnBridgeMessage): WPF mouse/focus events can't cross the WebView2
-        // HwndHost boundary, and GotFocus fired repeatedly during sibling-tab switches, looping
-        // frame.Show() and blocking the switch. The JS click never fires during a tab switch.
     }
 
     private void OnLoaded(object sender, RoutedEventArgs e)
@@ -519,15 +510,6 @@ public partial class ChatPaneControl : PaneControlBase
                 // future ContextChanged events, so without this the badge stays empty until the
                 // first editor click. Force a snapshot emit now that the WebView can receive it.
                 IdeContextService.Instance.ForceEmitCurrentContext();
-                break;
-
-            // A real click inside the WebView (JS pointerdown → bridge): activate the VS frame so
-            // keys flow to the chat. Sent from JS because mouse events can't cross the HwndHost to
-            // WPF, and it fires only on genuine in-chat clicks (never during a sibling-tab switch).
-            case BridgeMessages.FromWebView.Ui.PaneActivate:
-                Pane?.ActivateFrame();
-                // The user clicked into this pane → any attention InfoBar for it has done its job.
-                PaneAttentionService.Clear(Entry);
                 break;
 
             // Everything else is chat protocol — hand it to the message handler.

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
@@ -541,6 +541,10 @@ public partial class ChatPaneControl : PaneControlBase
                 // long after this. Only on the pane that VS considers active, so opening a second
                 // chat in the background doesn't steal focus from the one being used.
                 if (Pane?.IsActiveFrame() == true) { FocusInput(); }
+                // Name this pane's page after the pane. The browser's task manager labels each row
+                // with the document title, and every chat ships the same index.html — so without
+                // this they all read "cv4vs Agents" and none of them says which pane it is.
+                _bridge?.SetDocumentTitle(Entry?.Title);
                 // Seed the IDE-context badge with the already-open editor: we only subscribe to
                 // future ContextChanged events, so without this the badge stays empty until the
                 // first editor click. Force a snapshot emit now that the WebView can receive it.

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
@@ -246,7 +246,7 @@ public partial class ChatPaneControl : PaneControlBase
             if (BuildInfo.IsPreRelease || devBuild || AgentsOptions.Chat.ShowWebViewDevEntries)
             {
                 yield return new ButtonAction("WebView DevTools", () => _bridge?.OpenDevTools(), "DevTools");
-                yield return new ButtonAction("WebView task manager", () => _bridge?.OpenTaskManager(), "TaskManager");
+                yield return new ButtonAction("WebView task manager", () => WebView.OpenTaskManager(), "TaskManager");
             }
         }
     }
@@ -285,7 +285,14 @@ public partial class ChatPaneControl : PaneControlBase
         InitializeComponent();
         Loaded += OnLoaded;
         Unloaded += OnUnloaded;
+        WebView.HostKeyPressed += OnHostKeyPressed;
     }
+
+    /// <summary>A key <see cref="ChatWebView"/> claimed because composition rendering drops it:
+    /// hand it to the page, which acts on whatever it has focused. Dropped silently before the
+    /// bridge is up — there is nothing focused to act on yet.</summary>
+    private void OnHostKeyPressed(Contracts.HostKeyNotification key)
+        => _bridge?.Send(BridgeMessages.ToWebView.Ui.HostKey, key);
 
     private void OnLoaded(object sender, RoutedEventArgs e)
         => ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
@@ -328,6 +335,7 @@ public partial class ChatPaneControl : PaneControlBase
     {
         VSColorTheme.ThemeChanged -= OnVsThemeChanged;
         AgentsOptions.Applied -= OnOptionsApplied;
+        WebView.HostKeyPressed -= OnHostKeyPressed;
         IdeContextService.Instance.ContextChanged -= OnEditorContextChanged;
         // EnsureClient hooked this on the IdeContextService singleton; without the unhook the
         // closed pane leaks (singleton keeps it alive) and its dead _client keeps logging

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
@@ -85,6 +85,10 @@ public partial class ChatPaneControl : PaneControlBase
         // client's Model/PermissionMode); the respawn's system/init re-arms the gate, which
         // re-populates the selector — no seed push needed here.
         _ = _client?.NewSessionAsync();
+        // Nothing else focuses the composer here: the pane is already active, so the frame doesn't
+        // change and PaneWindowBase's activation path never runs. Without this the user has to
+        // click into an empty chat before typing.
+        FocusInput();
     }
 
     /// <summary>Resume a past session in THIS pane: clear the transcript,
@@ -519,6 +523,13 @@ public partial class ChatPaneControl : PaneControlBase
             case BridgeMessages.FromWebView.Ui.Ready:
                 StatusPanel.Visibility = Visibility.Collapsed;
                 SetReady(true);
+                // First open: focus the composer now, not earlier. A ui_focus_input sent during
+                // startup lands before the bundle has mounted cv-prompt, so the textarea it looks
+                // for isn't there yet and the call is a no-op — which is why the pane opened
+                // needing a click. Later activations work because they come from a frame change,
+                // long after this. Only on the pane that VS considers active, so opening a second
+                // chat in the background doesn't steal focus from the one being used.
+                if (Pane?.IsActiveFrame() == true) { FocusInput(); }
                 // Seed the IDE-context badge with the already-open editor: we only subscribe to
                 // future ContextChanged events, so without this the badge stays empty until the
                 // first editor click. Force a snapshot emit now that the WebView can receive it.

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
@@ -406,7 +406,6 @@ public partial class ChatPaneControl : PaneControlBase
     {
         var workDir = Entry.WorkingDirectory;
         using var _ = OutputWindowLogger.PerfSpan($"InitAsync({workDir})");
-        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
         // Every "New Chat" pane starts FRESH (else N panes share one conversation). Exception: a
         // forked or workspace-restored pane — _startupSessionId points at the JSONL to resume
@@ -424,8 +423,14 @@ public partial class ChatPaneControl : PaneControlBase
         SessionInfo resumeInfo = null;
         if (restoreState)
         {
-            (permMode, resumePage, resumeInfo) = ReadSessionState(_startupSessionId);
+            // Off the UI thread: this reads and scans the session's .jsonl, which on a long
+            // session is disk work the dispatcher shouldn't be holding.
+            var sessionId = _startupSessionId;
+            (permMode, resumePage, resumeInfo) = await Task.Run(() => ReadSessionState(sessionId));
         }
+
+        // Everything below talks to the WebView and the client, so it belongs on the UI thread.
+        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
         _bridge.Send(BridgeMessages.ToWebView.Chat.Cleared, null);
         OutputWindowLogger.Info($"load: InitAsync sessionId={_startupSessionId ?? "(none)"} (mode={permMode})");

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatWebView.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatWebView.cs
@@ -9,7 +9,6 @@ using Microsoft.Web.WebView2.Wpf;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using System.Windows;
 using System.Windows.Input;
 
 namespace Corsinvest.VisualStudio.Agents.Chat.Pane;
@@ -66,9 +65,10 @@ internal sealed class ChatWebView : WebView2CompositionControl
         e.Handled = true;
     }
 
-    // A second, windowed controller kept alive only to own the task manager window — see
-    // OpenTaskManagerAsync.
-    private CoreWebView2Controller _taskManagerOwner;
+    // Static: the browser has ONE task manager, so one owner serves every pane. A per-pane field
+    // grew a spare renderer for each chat that had opened it, all of them then listed in the very
+    // window they had opened.
+    private static CoreWebView2Controller _taskManagerOwner;
 
     // The message-only window: a parent for things that must never be shown.
     private static readonly IntPtr HwndMessage = new(-3);
@@ -115,15 +115,13 @@ internal sealed class ChatWebView : WebView2CompositionControl
         }
     }
 
-    /// <summary>Drop the task-manager controller with the pane: it holds a browser-side controller
-    /// that would otherwise outlive the window it was created for.</summary>
-    protected override void OnVisualParentChanged(DependencyObject oldParent)
+    /// <summary>Release the shared task-manager owner. Called when the last pane goes: it can't be
+    /// tied to any single one, and closing it takes the task-manager window with it.</summary>
+    internal static void CloseTaskManagerOwner()
     {
-        base.OnVisualParentChanged(oldParent);
-        if (VisualParent != null) { return; }
-
-        try { _taskManagerOwner?.Close(); }
-        catch (Exception ex) { OutputWindowLogger.LogException($"{nameof(ChatWebView)}.Close", ex); }
+        if (_taskManagerOwner == null) { return; }
+        try { _taskManagerOwner.Close(); }
+        catch (Exception ex) { OutputWindowLogger.LogException($"{nameof(ChatWebView)}.CloseTaskManagerOwner", ex); }
         _taskManagerOwner = null;
     }
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatWebView.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatWebView.cs
@@ -97,7 +97,16 @@ internal sealed class ChatWebView : WebView2CompositionControl
             // HWND_MESSAGE is documented for exactly this — a WebView that never becomes visible —
             // and keeps the child window the controller creates out of our pane, where it would
             // otherwise land and take part in the z-order.
-            _taskManagerOwner ??= await core.Environment.CreateCoreWebView2ControllerAsync(HwndMessage);
+            if (_taskManagerOwner == null)
+            {
+                _taskManagerOwner = await core.Environment.CreateCoreWebView2ControllerAsync(HwndMessage);
+                // It shows up in the very list it opens, and "WebView2: about:blank" says nothing
+                // about why a second renderer is there. The task manager labels each row with the
+                // document title, so give it one.
+                _taskManagerOwner.CoreWebView2.NavigateToString(
+                    "<!doctype html><title>cv4vs Agents — task manager host</title>");
+            }
+
             _taskManagerOwner.CoreWebView2.OpenTaskManagerWindow();
         }
         catch (Exception ex)

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatWebView.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatWebView.cs
@@ -4,15 +4,13 @@
  */
 
 using Corsinvest.VisualStudio.Agents.Contracts;
-using Microsoft.VisualStudio.PlatformUI;
+using Microsoft.Web.WebView2.Core;
 using Microsoft.Web.WebView2.Wpf;
 using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
-using System.Windows.Interop;
-using System.Windows.Threading;
 
 namespace Corsinvest.VisualStudio.Agents.Chat.Pane;
 
@@ -68,194 +66,55 @@ internal sealed class ChatWebView : WebView2CompositionControl
         e.Handled = true;
     }
 
+    // A second, windowed controller kept alive only to own the task manager window — see
+    // OpenTaskManagerAsync.
+    private CoreWebView2Controller _taskManagerOwner;
+
+    // The message-only window: a parent for things that must never be shown.
+    private static readonly IntPtr HwndMessage = new(-3);
+
     /// <summary>The browser's own task manager — the Edge one, with live memory/CPU per process.
     /// It covers every pane on the user-data folder, panes in another VS instance included, which
     /// is what makes it worth having: a stray renderer or a process count that doesn't add up is a
     /// question about the whole browser, not about this pane.
-    /// <para>Under composition rendering the browser gives that window no usable frame: Windows
-    /// reserves the space once WS_CAPTION is set, but Chromium paints over it, so no title bar ever
-    /// shows — verified against every combination of SetWindowLong, RedrawWindow, resize and
-    /// hide/show. <see cref="HostTaskManagerWindow"/> sidesteps it: the frame belongs to a window
-    /// of ours and only the content stays theirs.</para></summary>
-    internal void OpenTaskManager()
-    {
-        var core = CoreWebView2;
-        if (core == null) { return; }
+    /// <para>Opened from a second controller, created windowed, because the window inherits the
+    /// hosting mode of whoever asks: our own controller is a composition one, and the task manager
+    /// it opens comes up with no usable frame — Windows reserves the caption space but Chromium
+    /// paints over it, so no title bar ever shows (verified against SetWindowLong, RedrawWindow,
+    /// resize, hide/show and reparenting). A windowed controller gets the window Chromium would
+    /// have given a normal app. It shares this environment, so it is the same browser process and
+    /// the same process list — it just never shows a page of its own.</para></summary>
+    internal void OpenTaskManager() => _ = OpenTaskManagerAsync();
 
-        // The browser only ever has one task manager; asking again would just raise its window.
-        if (_taskManagerHost != null)
+    private async Task OpenTaskManagerAsync()
+    {
+        try
         {
-            _taskManagerHost.Activate();
-            return;
+            var core = CoreWebView2;
+            if (core == null) { return; }
+
+            // The browser only ever has one task manager: a second call just raises its window.
+            // HWND_MESSAGE is documented for exactly this — a WebView that never becomes visible —
+            // and keeps the child window the controller creates out of our pane, where it would
+            // otherwise land and take part in the z-order.
+            _taskManagerOwner ??= await core.Environment.CreateCoreWebView2ControllerAsync(HwndMessage);
+            _taskManagerOwner.CoreWebView2.OpenTaskManagerWindow();
         }
-
-        // Hook FIRST: the point is to catch the window as it appears. Searching for it afterwards
-        // can't work — the chat's own windows live in the same process under the same class and
-        // are equally frameless, so nothing tells them apart. Being there when it appears does.
-        HookBrowserWindows(core.BrowserProcessId);
-        core.OpenTaskManagerWindow();
-    }
-
-    private const int GwlStyle = -16;
-    private const int WsChild = 0x40000000;
-    private const int WsPopup = unchecked((int)0x80000000);
-    private const uint SwpSizeOnly = 0x0004 | 0x0010; // SWP_NOZORDER | SWP_NOACTIVATE
-    // SHOW, not CREATE: at creation the window exists but Chromium has not finished configuring it.
-    private const uint EventObjectShow = 0x8002;
-    private const int ObjidWindow = 0;
-    private const int ChildidSelf = 0;
-    private const uint WineventOutOfContext = 0x0000;
-
-    [DllImport("user32.dll")]
-    private static extern IntPtr SetWinEventHook(uint min, uint max, IntPtr module, WinEventProc callback,
-                                                 uint processId, uint threadId, uint flags);
-
-    [DllImport("user32.dll")]
-    private static extern bool UnhookWinEvent(IntPtr hook);
-
-    [DllImport("user32.dll")]
-    private static extern int GetWindowLong(IntPtr hWnd, int index);
-
-    [DllImport("user32.dll")]
-    private static extern int SetWindowLong(IntPtr hWnd, int index, int value);
-
-    [DllImport("user32.dll")]
-    private static extern bool SetWindowPos(IntPtr hWnd, IntPtr after, int x, int y, int cx, int cy, uint flags);
-
-    [DllImport("user32.dll")]
-    private static extern IntPtr SetParent(IntPtr child, IntPtr parent);
-
-    [DllImport("user32.dll")]
-    private static extern bool GetClientRect(IntPtr hWnd, out Rect32 rect);
-
-    [DllImport("user32.dll")]
-    private static extern bool IsWindow(IntPtr hWnd);
-
-    [StructLayout(LayoutKind.Sequential)]
-    private struct Rect32 { public int Left, Top, Right, Bottom; }
-
-    private delegate void WinEventProc(IntPtr hook, uint eventType, IntPtr hWnd,
-                                       int objectId, int childId, uint threadId, uint time);
-
-    // Held for the lifetime of the hook: the callback is handed to unmanaged code, and a collected
-    // delegate would leave user32 calling into freed memory.
-    private WinEventProc _winEventCallback;
-    private IntPtr _winEventHook;
-    private DispatcherTimer _unhookTimer;
-    // Held because nothing else references this window: a collected one would take the HWND the
-    // browser's window is parented to down with it.
-    private DialogWindow _taskManagerHost;
-
-    /// <summary>Watch the browser process for a window being shown, briefly. Catching it as it
-    /// appears is what makes it identifiable at all: the chat's own windows live in the same
-    /// process under the same class and are equally frameless, but they were shown long ago.</summary>
-    private void HookBrowserWindows(uint browserPid)
-    {
-        Unhook();
-        _winEventCallback = OnBrowserWindowShown;
-        _winEventHook = SetWinEventHook(EventObjectShow, EventObjectShow, IntPtr.Zero,
-                                        _winEventCallback, browserPid, 0, WineventOutOfContext);
-        if (_winEventHook == IntPtr.Zero)
+        catch (Exception ex)
         {
-            OutputWindowLogger.Warn("[pane] task manager: window hook not installed");
-            return;
+            OutputWindowLogger.LogException($"{nameof(ChatWebView)}.{nameof(OpenTaskManager)}", ex);
         }
-
-        // The window appears within a few hundred ms. Keep the window short: a chat opened while
-        // this is armed shows a window of its own, and adopting that one would empty its pane.
-        _unhookTimer = new DispatcherTimer(DispatcherPriority.Background, Dispatcher)
-        {
-            Interval = TimeSpan.FromSeconds(2),
-        };
-        _unhookTimer.Tick += (s, e) => Unhook();
-        _unhookTimer.Start();
     }
 
-    private void OnBrowserWindowShown(IntPtr hook, uint eventType, IntPtr hWnd,
-                                      int objectId, int childId, uint threadId, uint time)
-    {
-        // Chromium creates plenty of objects; only a top-level window of its own is a candidate.
-        if (hWnd == IntPtr.Zero || objectId != ObjidWindow || childId != ChildidSelf) { return; }
-        if ((GetWindowLong(hWnd, GwlStyle) & WsChild) != 0) { return; }
-
-        Unhook();
-        HostTaskManagerWindow(hWnd);
-    }
-
-    /// <summary>Put the browser's window inside one of ours, so it gets a real title bar.</summary>
-    private void HostTaskManagerWindow(IntPtr child)
-    {
-        var host = new DialogWindow
-        {
-            Title = "WebView task manager",
-            Width = 1000,
-            Height = 700,
-            WindowStartupLocation = WindowStartupLocation.CenterOwner,
-        };
-
-        host.SourceInitialized += (s, e) =>
-        {
-            Helpers.WindowChrome.ApplyTheme(host);
-            var hostHandle = new WindowInteropHelper(host).Handle;
-            // A child window can't be a popup; swap the styles before reparenting or the window
-            // keeps trying to lay itself out as a top-level one.
-            var style = GetWindowLong(child, GwlStyle);
-            SetWindowLong(child, GwlStyle, (style | WsChild) & ~WsPopup);
-            SetParent(child, hostHandle);
-            FillHost(host, child);
-            OutputWindowLogger.Debug(() => $"[pane] task manager {child} hosted in {hostHandle}");
-        };
-
-        host.SizeChanged += (s, e) => FillHost(host, child);
-
-        // The browser owns the window it lends us and destroys it when it likes — opening another
-        // chat is enough. Without this the host stays up as an empty rectangle.
-        var watchdog = new DispatcherTimer(DispatcherPriority.Background, Dispatcher)
-        {
-            Interval = TimeSpan.FromMilliseconds(500),
-        };
-        watchdog.Tick += (s, e) =>
-        {
-            if (IsWindow(child)) { return; }
-            OutputWindowLogger.Debug(() => $"[pane] task manager {child} went away — closing host");
-            host.Close();
-        };
-        watchdog.Start();
-
-        host.Closed += (s, e) =>
-        {
-            watchdog.Stop();
-            _taskManagerHost = null;
-        };
-
-        _taskManagerHost = host;
-        host.Show();
-    }
-
-    private static void FillHost(Window host, IntPtr child)
-    {
-        var handle = new WindowInteropHelper(host).Handle;
-        if (handle == IntPtr.Zero || !GetClientRect(handle, out var rect)) { return; }
-        SetWindowPos(child, IntPtr.Zero, 0, 0, rect.Right, rect.Bottom, SwpSizeOnly);
-    }
-
-    private void Unhook()
-    {
-        _unhookTimer?.Stop();
-        _unhookTimer = null;
-        if (_winEventHook != IntPtr.Zero)
-        {
-            UnhookWinEvent(_winEventHook);
-            _winEventHook = IntPtr.Zero;
-        }
-        _winEventCallback = null;
-    }
-
-    /// <summary>Drop the hook with the control: the pane can be closed inside the seconds it stays
-    /// armed, and user32 must not be left holding a callback into a dead object.</summary>
+    /// <summary>Drop the task-manager controller with the pane: it holds a browser-side controller
+    /// that would otherwise outlive the window it was created for.</summary>
     protected override void OnVisualParentChanged(DependencyObject oldParent)
     {
         base.OnVisualParentChanged(oldParent);
-        if (VisualParent == null) { Unhook(); }
+        if (VisualParent != null) { return; }
+
+        try { _taskManagerOwner?.Close(); }
+        catch (Exception ex) { OutputWindowLogger.LogException($"{nameof(ChatWebView)}.Close", ex); }
+        _taskManagerOwner = null;
     }
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatWebView.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatWebView.cs
@@ -1,0 +1,261 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using Corsinvest.VisualStudio.Agents.Contracts;
+using Microsoft.VisualStudio.PlatformUI;
+using Microsoft.Web.WebView2.Wpf;
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Windows;
+using System.Windows.Input;
+using System.Windows.Interop;
+using System.Windows.Threading;
+
+namespace Corsinvest.VisualStudio.Agents.Chat.Pane;
+
+/// <summary>
+/// The chat's WebView2, forwarding the keys composition rendering drops.
+/// <para>Rendering through Windows.UI.Composition means input is handed to the browser by hand
+/// rather than reaching a child HWND. The forwarding is incomplete: CoreWebView2CompositionController
+/// has SendMouseInput and SendPointerInput but no keyboard counterpart, and the control leaves
+/// IKeyboardInputSink.TranslateAccelerator unimplemented. The dropped keys fall through to Visual
+/// Studio, which acts on them as its own commands — Home/End move the caret to the start/end of a
+/// document instead of a line.</para>
+/// <para>So claim them here and let the page act — the same shape as Esc, which
+/// <see cref="ChatPaneWindow"/> claims from VS and forwards over the bridge.</para>
+/// </summary>
+internal sealed class ChatWebView : WebView2CompositionControl
+{
+    /// <summary>Raised for a claimed key, in the shape the page expects.</summary>
+    internal event Action<HostKeyNotification> HostKeyPressed;
+
+    // Only keys verified as dropped. A key that already reaches the browser must stay out: claiming
+    // it sets Handled and would take it away from the page, breaking what works today (arrows,
+    // PageUp/PageDown and Ctrl+Left/Right all arrive fine). Esc and Ctrl+F are out for another
+    // reason — VS turns those into commands before any of this, and ChatPaneWindow already claims
+    // them through IOleCommandTarget.
+    //
+    // The value is the DOM KeyboardEvent.key name: the page then matches the same strings a real
+    // key event would carry, instead of translating WPF enum names.
+    private static readonly Dictionary<Key, string> ClaimedKeys = new()
+    {
+        [Key.Home] = "Home",
+        [Key.End] = "End",
+    };
+
+    // PreviewKeyDown, not KeyDown: the key has to be claimed before it tunnels down to whatever
+    // WPF would otherwise route it to.
+    protected override void OnPreviewKeyDown(KeyEventArgs e)
+    {
+        var mods = Keyboard.Modifiers;
+        // Alt+Home/End is browser navigation (back/forward), not ours to take.
+        if ((mods & ModifierKeys.Alt) != 0 || !ClaimedKeys.TryGetValue(e.Key, out var domKey))
+        {
+            base.OnPreviewKeyDown(e);
+            return;
+        }
+
+        HostKeyPressed?.Invoke(new HostKeyNotification
+        {
+            Key = domKey,
+            Ctrl = (mods & ModifierKeys.Control) != 0,
+            Shift = (mods & ModifierKeys.Shift) != 0,
+            Alt = false,
+        });
+        e.Handled = true;
+    }
+
+    /// <summary>The browser's own task manager — the Edge one, with live memory/CPU per process.
+    /// It covers every pane on the user-data folder, panes in another VS instance included, which
+    /// is what makes it worth having: a stray renderer or a process count that doesn't add up is a
+    /// question about the whole browser, not about this pane.
+    /// <para>Under composition rendering the browser gives that window no usable frame: Windows
+    /// reserves the space once WS_CAPTION is set, but Chromium paints over it, so no title bar ever
+    /// shows — verified against every combination of SetWindowLong, RedrawWindow, resize and
+    /// hide/show. <see cref="HostTaskManagerWindow"/> sidesteps it: the frame belongs to a window
+    /// of ours and only the content stays theirs.</para></summary>
+    internal void OpenTaskManager()
+    {
+        var core = CoreWebView2;
+        if (core == null) { return; }
+
+        // The browser only ever has one task manager; asking again would just raise its window.
+        if (_taskManagerHost != null)
+        {
+            _taskManagerHost.Activate();
+            return;
+        }
+
+        // Hook FIRST: the point is to catch the window as it appears. Searching for it afterwards
+        // can't work — the chat's own windows live in the same process under the same class and
+        // are equally frameless, so nothing tells them apart. Being there when it appears does.
+        HookBrowserWindows(core.BrowserProcessId);
+        core.OpenTaskManagerWindow();
+    }
+
+    private const int GwlStyle = -16;
+    private const int WsChild = 0x40000000;
+    private const int WsPopup = unchecked((int)0x80000000);
+    private const uint SwpSizeOnly = 0x0004 | 0x0010; // SWP_NOZORDER | SWP_NOACTIVATE
+    // SHOW, not CREATE: at creation the window exists but Chromium has not finished configuring it.
+    private const uint EventObjectShow = 0x8002;
+    private const int ObjidWindow = 0;
+    private const int ChildidSelf = 0;
+    private const uint WineventOutOfContext = 0x0000;
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr SetWinEventHook(uint min, uint max, IntPtr module, WinEventProc callback,
+                                                 uint processId, uint threadId, uint flags);
+
+    [DllImport("user32.dll")]
+    private static extern bool UnhookWinEvent(IntPtr hook);
+
+    [DllImport("user32.dll")]
+    private static extern int GetWindowLong(IntPtr hWnd, int index);
+
+    [DllImport("user32.dll")]
+    private static extern int SetWindowLong(IntPtr hWnd, int index, int value);
+
+    [DllImport("user32.dll")]
+    private static extern bool SetWindowPos(IntPtr hWnd, IntPtr after, int x, int y, int cx, int cy, uint flags);
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr SetParent(IntPtr child, IntPtr parent);
+
+    [DllImport("user32.dll")]
+    private static extern bool GetClientRect(IntPtr hWnd, out Rect32 rect);
+
+    [DllImport("user32.dll")]
+    private static extern bool IsWindow(IntPtr hWnd);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct Rect32 { public int Left, Top, Right, Bottom; }
+
+    private delegate void WinEventProc(IntPtr hook, uint eventType, IntPtr hWnd,
+                                       int objectId, int childId, uint threadId, uint time);
+
+    // Held for the lifetime of the hook: the callback is handed to unmanaged code, and a collected
+    // delegate would leave user32 calling into freed memory.
+    private WinEventProc _winEventCallback;
+    private IntPtr _winEventHook;
+    private DispatcherTimer _unhookTimer;
+    // Held because nothing else references this window: a collected one would take the HWND the
+    // browser's window is parented to down with it.
+    private DialogWindow _taskManagerHost;
+
+    /// <summary>Watch the browser process for a window being shown, briefly. Catching it as it
+    /// appears is what makes it identifiable at all: the chat's own windows live in the same
+    /// process under the same class and are equally frameless, but they were shown long ago.</summary>
+    private void HookBrowserWindows(uint browserPid)
+    {
+        Unhook();
+        _winEventCallback = OnBrowserWindowShown;
+        _winEventHook = SetWinEventHook(EventObjectShow, EventObjectShow, IntPtr.Zero,
+                                        _winEventCallback, browserPid, 0, WineventOutOfContext);
+        if (_winEventHook == IntPtr.Zero)
+        {
+            OutputWindowLogger.Warn("[pane] task manager: window hook not installed");
+            return;
+        }
+
+        // The window appears within a few hundred ms. Keep the window short: a chat opened while
+        // this is armed shows a window of its own, and adopting that one would empty its pane.
+        _unhookTimer = new DispatcherTimer(DispatcherPriority.Background, Dispatcher)
+        {
+            Interval = TimeSpan.FromSeconds(2),
+        };
+        _unhookTimer.Tick += (s, e) => Unhook();
+        _unhookTimer.Start();
+    }
+
+    private void OnBrowserWindowShown(IntPtr hook, uint eventType, IntPtr hWnd,
+                                      int objectId, int childId, uint threadId, uint time)
+    {
+        // Chromium creates plenty of objects; only a top-level window of its own is a candidate.
+        if (hWnd == IntPtr.Zero || objectId != ObjidWindow || childId != ChildidSelf) { return; }
+        if ((GetWindowLong(hWnd, GwlStyle) & WsChild) != 0) { return; }
+
+        Unhook();
+        HostTaskManagerWindow(hWnd);
+    }
+
+    /// <summary>Put the browser's window inside one of ours, so it gets a real title bar.</summary>
+    private void HostTaskManagerWindow(IntPtr child)
+    {
+        var host = new DialogWindow
+        {
+            Title = "WebView task manager",
+            Width = 1000,
+            Height = 700,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+        };
+
+        host.SourceInitialized += (s, e) =>
+        {
+            Helpers.WindowChrome.ApplyTheme(host);
+            var hostHandle = new WindowInteropHelper(host).Handle;
+            // A child window can't be a popup; swap the styles before reparenting or the window
+            // keeps trying to lay itself out as a top-level one.
+            var style = GetWindowLong(child, GwlStyle);
+            SetWindowLong(child, GwlStyle, (style | WsChild) & ~WsPopup);
+            SetParent(child, hostHandle);
+            FillHost(host, child);
+            OutputWindowLogger.Debug(() => $"[pane] task manager {child} hosted in {hostHandle}");
+        };
+
+        host.SizeChanged += (s, e) => FillHost(host, child);
+
+        // The browser owns the window it lends us and destroys it when it likes — opening another
+        // chat is enough. Without this the host stays up as an empty rectangle.
+        var watchdog = new DispatcherTimer(DispatcherPriority.Background, Dispatcher)
+        {
+            Interval = TimeSpan.FromMilliseconds(500),
+        };
+        watchdog.Tick += (s, e) =>
+        {
+            if (IsWindow(child)) { return; }
+            OutputWindowLogger.Debug(() => $"[pane] task manager {child} went away — closing host");
+            host.Close();
+        };
+        watchdog.Start();
+
+        host.Closed += (s, e) =>
+        {
+            watchdog.Stop();
+            _taskManagerHost = null;
+        };
+
+        _taskManagerHost = host;
+        host.Show();
+    }
+
+    private static void FillHost(Window host, IntPtr child)
+    {
+        var handle = new WindowInteropHelper(host).Handle;
+        if (handle == IntPtr.Zero || !GetClientRect(handle, out var rect)) { return; }
+        SetWindowPos(child, IntPtr.Zero, 0, 0, rect.Right, rect.Bottom, SwpSizeOnly);
+    }
+
+    private void Unhook()
+    {
+        _unhookTimer?.Stop();
+        _unhookTimer = null;
+        if (_winEventHook != IntPtr.Zero)
+        {
+            UnhookWinEvent(_winEventHook);
+            _winEventHook = IntPtr.Zero;
+        }
+        _winEventCallback = null;
+    }
+
+    /// <summary>Drop the hook with the control: the pane can be closed inside the seconds it stays
+    /// armed, and user32 must not be left holding a callback into a dead object.</summary>
+    protected override void OnVisualParentChanged(DependencyObject oldParent)
+    {
+        base.OnVisualParentChanged(oldParent);
+        if (VisualParent == null) { Unhook(); }
+    }
+}

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/bridge-messages.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/bridge-messages.ts
@@ -117,6 +117,7 @@ export const Msg = {
             focusInput: 'ui_focus_input',
             setComposer: 'ui_set_composer',
             escape: 'ui_escape',
+            hostKey: 'ui_host_key',
         },
         plugins: {
             listResult: 'plugins_list_result',

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/bridge-messages.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/bridge-messages.ts
@@ -61,7 +61,6 @@ export const Msg = {
         },
         ui: {
             ready: 'webview_ready',
-            paneActivate: 'ui_pane_activate',
         },
     },
     toWebView: {
@@ -116,7 +115,6 @@ export const Msg = {
             vsSettings: 'vs_settings',
             themeChanged: 'ui_theme_changed',
             focusInput: 'ui_focus_input',
-            blurInput: 'ui_blur_input',
             setComposer: 'ui_set_composer',
             escape: 'ui_escape',
         },

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated/HostKeyNotification.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated/HostKeyNotification.ts
@@ -1,0 +1,11 @@
+/**
+ * This is a TypeGen auto-generated file.
+ * Any changes made to this file can be lost when this file is regenerated.
+ */
+
+export interface HostKeyNotification {
+    key: string;
+    ctrl: boolean;
+    shift: boolean;
+    alt: boolean;
+}

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/types.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/types.ts
@@ -131,6 +131,9 @@ export type { GetSubagentResponse } from './generated/GetSubagentResponse';
 /** Prefill the composer (`ui_set_composer`). Generated from C# by TypeGen. */
 export type { SetComposerNotification } from './generated/SetComposerNotification';
 
+/** A key the host claimed for us (`ui_host_key`). Generated from C# by TypeGen. */
+export type { HostKeyNotification } from './generated/HostKeyNotification';
+
 /** Prompt history, slash-command catalogue, streamed text delta, tool-progress tick,
  *  CLI-started notice. Generated from C# by TypeGen — re-exported here. */
 export type { PromptHistoryNotification } from './generated/PromptHistoryNotification';

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-prompt.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-prompt.ts
@@ -480,10 +480,10 @@ export class CvPrompt extends LitElement implements CommandHost {
         }
         if (this._modelListOpen) {
             this._modelListOpen = false;
-            this._ta?.focus();
+            this._ta?.focus({ preventScroll: true });
         } else if (this._permissionListOpen) {
             this._permissionListOpen = false;
-            this._ta?.focus();
+            this._ta?.focus({ preventScroll: true });
         } else if (this._cmdOpen) {
             this._closeCommandMenu();
         } else if (this._atOpen) {
@@ -551,9 +551,13 @@ export class CvPrompt extends LitElement implements CommandHost {
         return this._ta?.value ?? '';
     }
 
-    /** Move keyboard focus to the prompt textarea (host ui_focus_input). */
+    /** Move keyboard focus to the prompt textarea (host ui_focus_input).
+     *  `preventScroll` because the host calls this while VS is still relaying the pane out — after
+     *  an InfoBar closes, say. The browser would measure a textarea that is momentarily outside the
+     *  viewport and scroll to it, and a frame later the layout settles: the scroll was pointless but
+     *  visible as a jump. The composer is pinned to the bottom and always in view anyway. */
     focusInput(): void {
-        this._ta?.focus();
+        this._ta?.focus({ preventScroll: true });
     }
 
     /** Pre-fill the composer with text and focus it, caret at the end (a forked
@@ -566,7 +570,7 @@ export class CvPrompt extends LitElement implements CommandHost {
         ta.value = text;
         this._hasText = text.trim().length > 0;
         this._autoResize();
-        ta.focus();
+        ta.focus({ preventScroll: true });
         ta.setSelectionRange(text.length, text.length);
     }
 
@@ -720,7 +724,7 @@ export class CvPrompt extends LitElement implements CommandHost {
             if (e.key === 'Escape') {
                 e.preventDefault();
                 this._modelListOpen = false;
-                this._ta?.focus();
+                this._ta?.focus({ preventScroll: true });
                 return;
             }
         }
@@ -745,7 +749,7 @@ export class CvPrompt extends LitElement implements CommandHost {
             if (e.key === 'Escape') {
                 e.preventDefault();
                 this._permissionListOpen = false;
-                this._ta?.focus();
+                this._ta?.focus({ preventScroll: true });
                 return;
             }
         }
@@ -888,7 +892,7 @@ export class CvPrompt extends LitElement implements CommandHost {
             this._atOpen = false;
             this._atItems = [];
         }
-        ta.focus();
+        ta.focus({ preventScroll: true });
     };
 
     private _micPrefix = '';
@@ -968,7 +972,7 @@ export class CvPrompt extends LitElement implements CommandHost {
         this._resetHistoryNav();
         this._attachments = [];
         this.clear();
-        this._ta.focus();
+        this._ta.focus({ preventScroll: true });
     }
 
     private _resetHistoryNav(): void {
@@ -1152,7 +1156,7 @@ export class CvPrompt extends LitElement implements CommandHost {
         if (!ta) {
             return;
         }
-        ta.focus();
+        ta.focus({ preventScroll: true });
         const start = ta.selectionStart ?? ta.value.length;
         const end = ta.selectionEnd ?? ta.value.length;
         const before = ta.value.slice(0, start);
@@ -1376,7 +1380,7 @@ export class CvPrompt extends LitElement implements CommandHost {
             }),
         );
         this._modelListOpen = false;
-        this._ta?.focus();
+        this._ta?.focus({ preventScroll: true });
     };
 
     /** Toolbar trigger asked for the model picker. Toggles (unlike openModelPicker(), which the
@@ -1389,7 +1393,7 @@ export class CvPrompt extends LitElement implements CommandHost {
         // Same reason as the permission trigger: navigation is driven from the textarea's
         // keydown, so give focus back after the click for the list to be keyboard-navigable.
         if (this._modelListOpen) {
-            this._ta?.focus();
+            this._ta?.focus({ preventScroll: true });
         }
     };
 
@@ -1403,7 +1407,7 @@ export class CvPrompt extends LitElement implements CommandHost {
         // menus are driven from), but clicking the toolbar trigger leaves focus on the
         // button — put it back so the list is keyboard-navigable straight away.
         if (this._permissionListOpen) {
-            this._ta?.focus();
+            this._ta?.focus({ preventScroll: true });
         }
     };
 
@@ -1414,7 +1418,7 @@ export class CvPrompt extends LitElement implements CommandHost {
             { mode: e.detail.value },
         );
         this._permissionListOpen = false;
-        this._ta?.focus();
+        this._ta?.focus({ preventScroll: true });
     };
 
     /** Messages typed while a turn was running, waiting for it to end. The bubble for each is

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-prompt.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-prompt.ts
@@ -556,12 +556,6 @@ export class CvPrompt extends LitElement implements CommandHost {
         this._ta?.focus();
     }
 
-    /** Drop keyboard focus from the prompt textarea (host ui_blur_input) so the DOM's focus
-     *  state matches reality and the caret stops blinking when the pane loses the VS frame. */
-    blurInput(): void {
-        this._ta?.blur();
-    }
-
     /** Pre-fill the composer with text and focus it, caret at the end (a forked
      *  pane drops the forked-at message here so the user can edit/resend it). */
     setComposerText(text: string): void {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/host-keys.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/host-keys.ts
@@ -1,0 +1,106 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+// Keys the host claimed for us: the WebView2 composition control has no way to hand a key to the
+// browser (SendMouseInput/SendPointerInput exist, no keyboard counterpart), so ChatWebView claims
+// the ones it drops and we act on them here. Only keys verified as dropped are forwarded —
+// arrows, PageUp/PageDown and Ctrl+Left/Right already reach the browser and are left alone.
+import type { HostKeyNotification } from '../core/types';
+
+/** A text field the caret can be moved in. `contenteditable` is out of scope: the chat has none,
+ *  and selection there needs Range work rather than an index pair. */
+type TextField = HTMLInputElement | HTMLTextAreaElement;
+
+/** Input types that carry a caret. `selectionStart` throws on number/email/date. */
+const CARET_INPUT_TYPES = new Set(['text', 'search', 'url', 'tel', 'password']);
+
+/** The focused text field, looking through shadow roots — most of the chat's inputs live in
+ *  component shadow DOM, where `document.activeElement` stops at the host element. */
+function focusedField(): TextField | null {
+    let el: Element | null = document.activeElement;
+    while (el?.shadowRoot?.activeElement) {
+        el = el.shadowRoot.activeElement;
+    }
+    if (el instanceof HTMLTextAreaElement) {
+        return el;
+    }
+    return el instanceof HTMLInputElement && CARET_INPUT_TYPES.has(el.type) ? el : null;
+}
+
+/** Start of the line holding `pos` (just past the previous newline, or 0). */
+function lineStart(value: string, pos: number): number {
+    return value.lastIndexOf('\n', pos - 1) + 1;
+}
+
+/** End of the line holding `pos` (the next newline, or the end of the text). */
+function lineEnd(value: string, pos: number): number {
+    const nl = value.indexOf('\n', pos);
+    return nl < 0 ? value.length : nl;
+}
+
+/** Act on a key the host claimed. One case per forwarded key — an unknown one is dropped rather
+ *  than guessed at, since the host only forwards what it was told to claim. */
+export function applyHostKey(e: HostKeyNotification): void {
+    switch (e.key) {
+        case 'Home':
+        case 'End':
+            moveCaret(e.key === 'Home', e.ctrl, e.shift);
+            break;
+    }
+}
+
+/**
+ * Home/End on whatever is focused: `toStart` picks the direction, `wholeText` (Ctrl) spans the
+ * whole value instead of the current line, `extend` (Shift) keeps the selection anchor. With
+ * nothing focused, scroll the transcript like the browser would.
+ */
+function moveCaret(toStart: boolean, wholeText: boolean, extend: boolean): void {
+    const field = focusedField();
+    if (!field) {
+        scrollTranscript(toStart);
+        return;
+    }
+
+    const value = field.value;
+    // Which end moves: with Shift the anchor stays put and the focus end travels, so read the
+    // caret from selectionEnd/Start depending on which side the selection grew from.
+    const caret =
+        field.selectionDirection === 'backward'
+            ? (field.selectionStart ?? 0)
+            : (field.selectionEnd ?? 0);
+
+    const target = toStart
+        ? wholeText
+            ? 0
+            : lineStart(value, caret)
+        : wholeText
+          ? value.length
+          : lineEnd(value, caret);
+
+    if (!extend) {
+        field.setSelectionRange(target, target);
+        return;
+    }
+
+    // Extending: hold the anchor (the end the selection did NOT grow from) and move the other.
+    const anchor =
+        field.selectionDirection === 'backward'
+            ? (field.selectionEnd ?? 0)
+            : (field.selectionStart ?? 0);
+    field.setSelectionRange(
+        Math.min(anchor, target),
+        Math.max(anchor, target),
+        target < anchor ? 'backward' : 'forward',
+    );
+}
+
+/** No text field focused: Home/End scroll the transcript, as they would in a plain page.
+ *  `#messages` is the scroller and cv-app renders into the light DOM, so a plain query finds it. */
+function scrollTranscript(toTop: boolean): void {
+    const el = document.querySelector('#messages');
+    const target = el instanceof HTMLElement ? el : document.scrollingElement;
+    if (target) {
+        target.scrollTo({ top: toTop ? 0 : target.scrollHeight });
+    }
+}

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/init.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/init.ts
@@ -142,14 +142,6 @@ function wireBridgeHandlers(): void {
         input?.focusInput();
     });
 
-    // Host tells us the pane lost the active VS frame → blur the prompt so its caret stops
-    // blinking (the WebView2 gets no DOM blur across the HwndHost boundary on its own).
-    bridge.onNotification(Msg.toWebView.ui.blurInput, () => {
-        const input = document.querySelector('cv-prompt') as
-            import('./components/cv-prompt').CvPrompt | null;
-        input?.blurInput();
-    });
-
     // Forked pane: pre-fill the composer with the forked-at message text.
     bridge.onNotification<SetComposerNotification>(Msg.toWebView.ui.setComposer, (data) => {
         const input = document.querySelector('cv-prompt') as
@@ -218,16 +210,6 @@ function wireBridgeHandlers(): void {
     bridge.onNotification<ModelsNotification>(Msg.toWebView.chat.models, (data) => {
         state.models = Array.isArray(data?.models) ? data.models : [];
     });
-
-    // Real click inside the WebView → ask the host to activate this VS pane, so keys flow to the
-    // chat. WPF mouse/focus events can't cross the WebView2 HwndHost boundary; a DOM pointerdown
-    // is the only reliable "the user clicked in the chat" signal, and it never fires while
-    // switching to a sibling VS tab (that click lands outside the WebView).
-    window.addEventListener(
-        'pointerdown',
-        () => bridge.sendNotification(Msg.fromWebView.ui.paneActivate, {}),
-        true,
-    );
 }
 
 /**

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/init.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/init.ts
@@ -13,6 +13,7 @@ import { normPath } from '../core/path';
 import { closeTopDialog } from '../core/dialog-focus';
 import { setExtraLinkableExtensions } from '../core/file-links';
 import type {
+    HostKeyNotification,
     InitPayloadNotification,
     ModelsNotification,
     PermissionMode,
@@ -25,6 +26,7 @@ import type {
     Theme,
     VsOptionsDto,
 } from '../core/types';
+import { applyHostKey } from './host-keys';
 import { installDebugApi } from './debug';
 import { logger } from '../core/logger';
 import { initFluent, applyFluentTheme, applyFontScale } from './fluent';
@@ -147,6 +149,13 @@ function wireBridgeHandlers(): void {
         const input = document.querySelector('cv-prompt') as
             import('./components/cv-prompt').CvPrompt | null;
         input?.setComposerText(data?.text ?? '');
+    });
+
+    // A key the composition control dropped, claimed by the pane on our behalf — see host-keys.ts.
+    bridge.onNotification<HostKeyNotification>(Msg.toWebView.ui.hostKey, (data) => {
+        if (data?.key) {
+            applyHostKey(data);
+        }
     });
 
     // Esc: VS routed its Cancel command to the pane (ChatPaneWindow claims it so VS

--- a/src/Corsinvest.VisualStudio.Agents/Cli/Pane/CliPaneControl.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Cli/Pane/CliPaneControl.cs
@@ -41,9 +41,6 @@ internal class CliPaneControl : PaneControlBase, ITerminalConnection, IDisposabl
     /// <summary>Focus = the terminal.</summary>
     public override void FocusInput() => FocusTerminal();
 
-    /// <summary>No DOM caret in the ConPTY terminal — nothing to blur.</summary>
-    public override void BlurInput() { }
-
     // No editable title for the CLI pane: the interactive terminal doesn't expose its live
     // session id (raw ConPTY, not stream-json), so there's nothing to track/rename. The base's
     // SupportsTitleEditing default is false, but state it explicitly for clarity; SessionTitle

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/DevInfoDialog.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/DevInfoDialog.xaml.cs
@@ -4,6 +4,7 @@
  */
 
 using Microsoft.VisualStudio.PlatformUI;
+using Microsoft.VisualStudio.Shell;
 using System.Windows;
 
 namespace Corsinvest.VisualStudio.Agents.Core.Panes;
@@ -18,7 +19,11 @@ public partial class DevInfoDialog : DialogWindow
         InitializeComponent();
         TxtInfo.Text = info;
         // The content follows the theme through WPF; the title bar and border need telling separately.
-        SourceInitialized += (s, e) => Helpers.WindowChrome.ApplyTheme(this);
+        SourceInitialized += (s, e) =>
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            Helpers.WindowChrome.ApplyTheme(this);
+        };
     }
 
     private void OnCopy_Click(object sender, RoutedEventArgs e)

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/DevInfoDialog.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/DevInfoDialog.xaml.cs
@@ -17,6 +17,8 @@ public partial class DevInfoDialog : DialogWindow
     {
         InitializeComponent();
         TxtInfo.Text = info;
+        // The content follows the theme through WPF; the title bar and border need telling separately.
+        SourceInitialized += (s, e) => Helpers.WindowChrome.ApplyTheme(this);
     }
 
     private void OnCopy_Click(object sender, RoutedEventArgs e)

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/IPaneControl.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/IPaneControl.cs
@@ -72,10 +72,6 @@ public interface IPaneControl
     /// Called after switching/loading a session.</summary>
     void FocusInput();
 
-    /// <summary>Drop input focus (dual of <see cref="FocusInput"/>). Called when the pane loses
-    /// the active VS frame. Chat blurs its WebView textarea; CLI has no DOM caret (no-op).</summary>
-    void BlurInput();
-
     /// <summary>Extra, kind-specific actions for the "More" (⋯) menu. Chat
     /// adds WebView DevTools; CLI returns none. Empty by default.</summary>
     IEnumerable<ButtonAction> MoreMenuActions { get; }

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneControlBase.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneControlBase.cs
@@ -162,7 +162,6 @@ public abstract class PaneControlBase : UserControl, IPaneControl
     public abstract void NewSession();
     public abstract void LoadSession(string sessionId);
     public abstract void FocusInput();
-    public abstract void BlurInput();
 
     public abstract IEnumerable<ButtonAction> MoreMenuActions { get; }
 }

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneToolbar.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneToolbar.xaml.cs
@@ -231,10 +231,6 @@ public partial class PaneToolbar : UserControl
         _historyPopup = popup;
         _historyPicker = picker;
         popup.IsOpen = true;
-        // Opened from the chat command the caret sits in WebView2 — a separate HWND. Blurring it
-        // only clears the DOM caret (and asynchronously at that), so Win32 focus has to be pulled
-        // onto the popup's own window or the search box takes no typing.
-        _pane.BlurInput();
         // At Render priority the popup has its own HwndSource; before that there's nothing to
         // focus. FocusSearch runs at the same priority, so it lands right after this.
         Dispatcher.BeginInvoke(System.Windows.Threading.DispatcherPriority.Render, new Action(() =>

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneWindowBase.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneWindowBase.cs
@@ -89,19 +89,6 @@ public abstract class PaneWindowBase : ToolWindowPane
     /// <summary>Build the hosted control (ChatPaneControl / CliPaneControl).</summary>
     protected abstract PaneControlBase CreateControl();
 
-    /// <summary>Tell VS this pane is the active window, so the shell routes keys and typing here
-    /// rather than to the editor it still considers active.</summary>
-    internal void ActivateFrame()
-    {
-        ThreadHelper.ThrowIfNotOnUIThread();
-        if (Frame is IVsWindowFrame frame)
-        {
-            // Show() activates the frame without changing its dock state — VS updates its
-            // "active window" to this pane, so keyboard input now flows to the WebView.
-            frame.Show();
-        }
-    }
-
     /// <summary>True when this pane's frame is VS's active window frame (the user is looking at it).
     /// VS hands out distinct COM proxies for the same window, so ReferenceEquals is unreliable —
     /// compare the hosted DocView object instead.</summary>

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneWindowBase.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneWindowBase.cs
@@ -89,11 +89,8 @@ public abstract class PaneWindowBase : ToolWindowPane
     /// <summary>Build the hosted control (ChatPaneControl / CliPaneControl).</summary>
     protected abstract PaneControlBase CreateControl();
 
-    /// <summary>Tell VS this pane is the active window. A WebView2 (HwndHost) takes native focus
-    /// without updating VS's logical focus, so the shell still thinks the editor is active and
-    /// routes keys (Home/End → tab switch) and typing there. Driven by a real in-WebView click
-    /// (JS pointerdown → bridge ui_pane_activate), since WPF mouse/focus events can't cross the
-    /// HwndHost boundary and GotFocus looped frame.Show() during sibling-tab switches.</summary>
+    /// <summary>Tell VS this pane is the active window, so the shell routes keys and typing here
+    /// rather than to the editor it still considers active.</summary>
     internal void ActivateFrame()
     {
         ThreadHelper.ThrowIfNotOnUIThread();
@@ -142,18 +139,6 @@ public abstract class PaneWindowBase : ToolWindowPane
         _assigned = true;
         OutputWindowLogger.Perf(() => $"{GetType().Name}: AssignPaneId={PaneId}");
         PaneControl.RegisterInstance(this);
-        // Blur our input when VS moves the active frame elsewhere (below). AssignPaneId is
-        // idempotent (early-returns when already assigned), so this subscribes once.
-        Ide.IdeContextService.ActiveFrameChanged += OnActiveFrameChanged;
-    }
-
-    /// <summary>When VS's active frame changes and this pane is no longer it, blur its input:
-    /// the WebView2 gets no DOM blur across the HwndHost boundary, so its caret would keep
-    /// blinking. Gate strictly on IsActiveFrame so the newly-active pane keeps its caret.</summary>
-    private void OnActiveFrameChanged()
-    {
-        ThreadHelper.ThrowIfNotOnUIThread();
-        if (!IsActiveFrame()) { PaneControl.BlurInput(); }
     }
 
     /// <summary>Inject the entry into the hosted control, then activate the in-IDE diff for its
@@ -251,7 +236,6 @@ public abstract class PaneWindowBase : ToolWindowPane
     {
         if (disposing)
         {
-            Ide.IdeContextService.ActiveFrameChanged -= OnActiveFrameChanged;
             OutputWindowLogger.Debug(() => $"[pane] frame disposed: {GetType().Name} #{PaneId}");
             try { PaneControl.DisposePane(); }
             catch (System.Exception ex) { OutputWindowLogger.LogException($"{GetType().Name}.Dispose", ex); }

--- a/src/Corsinvest.VisualStudio.Agents/Corsinvest.VisualStudio.Agents.csproj
+++ b/src/Corsinvest.VisualStudio.Agents/Corsinvest.VisualStudio.Agents.csproj
@@ -315,6 +315,7 @@
     <Compile Include="Chat\VsThemeReader.cs" />
     <Compile Include="PackageGuids.cs" />
     <Compile Include="Chat\Pane\ChatPaneWindow.cs" />
+    <Compile Include="Chat\Pane\ChatWebView.cs" />
     <Compile Include="Cli\Pane\CliPaneWindow.cs" />
     <Compile Include="Cli\Pane\CliPaneControl.cs" />
     <Compile Include="Cli\ConPty.cs" />

--- a/src/Corsinvest.VisualStudio.Agents/Corsinvest.VisualStudio.Agents.csproj
+++ b/src/Corsinvest.VisualStudio.Agents/Corsinvest.VisualStudio.Agents.csproj
@@ -312,6 +312,7 @@
     <Compile Include="Helpers\ShellHelpers.cs" />
     <Compile Include="Helpers\VsReflection.cs" />
     <Compile Include="Helpers\Win32Focus.cs" />
+    <Compile Include="Helpers\WindowChrome.cs" />
     <Compile Include="Chat\VsThemeReader.cs" />
     <Compile Include="PackageGuids.cs" />
     <Compile Include="Chat\Pane\ChatPaneWindow.cs" />

--- a/src/Corsinvest.VisualStudio.Agents/Helpers/WindowChrome.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Helpers/WindowChrome.cs
@@ -28,6 +28,10 @@ internal static class WindowChrome
     /// older build simply keeps its default chrome instead of failing.</para></summary>
     public static void ApplyTheme(Window window)
     {
+        // Reads themed colours off the shell, so it belongs on the UI thread — as does the
+        // SourceInitialized handler every caller hooks this from.
+        ThreadHelper.ThrowIfNotOnUIThread();
+
         var handle = new WindowInteropHelper(window).Handle;
         if (handle == IntPtr.Zero) { return; }
 

--- a/src/Corsinvest.VisualStudio.Agents/Helpers/WindowChrome.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Helpers/WindowChrome.cs
@@ -1,0 +1,74 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using Corsinvest.VisualStudio.Agents.Chat;
+using Microsoft.VisualStudio.PlatformUI;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using System;
+using System.Runtime.InteropServices;
+using System.Windows;
+using System.Windows.Interop;
+
+namespace Corsinvest.VisualStudio.Agents.Helpers;
+
+/// <summary>
+/// Themes the parts of a window WPF can't reach.
+/// <para>A dialog's content follows the VS theme through WPF resources, but the title bar and the
+/// border are drawn by Windows outside the visual tree — so a dark VS on a light Windows gets a
+/// white bar around themed content. DWM is the only way in.</para>
+/// </summary>
+internal static class WindowChrome
+{
+    /// <summary>Match a window's title bar and border to the current VS theme. Call once the window
+    /// has a handle (SourceInitialized); before that there is nothing to theme.
+    /// <para>Each attribute is best-effort: they arrived in different Windows versions, and an
+    /// older build simply keeps its default chrome instead of failing.</para></summary>
+    public static void ApplyTheme(Window window)
+    {
+        var handle = new WindowInteropHelper(window).Handle;
+        if (handle == IntPtr.Zero) { return; }
+
+        try
+        {
+            var dark = VsThemeReader.IsDark() ? 1 : 0;
+            // 20 since Windows 10 20H1; 19 was the pre-release id, worth trying as a fallback.
+            if (DwmSetWindowAttribute(handle, DwmwaUseImmersiveDarkMode, ref dark, sizeof(int)) != 0)
+            {
+                DwmSetWindowAttribute(handle, DwmwaUseImmersiveDarkModeLegacy, ref dark, sizeof(int));
+            }
+
+            // The border is drawn separately from the caption and stays light otherwise. Read from
+            // the theme rather than hardcoding, so it tracks whatever VS is set to.
+            var border = ThemedBorderColor();
+            DwmSetWindowAttribute(handle, DwmwaBorderColor, ref border, sizeof(int));
+        }
+        catch (Exception ex) { OutputWindowLogger.LogException($"{nameof(WindowChrome)}.{nameof(ApplyTheme)}", ex); }
+    }
+
+    /// <summary>The border colour as a COLORREF (0x00BBGGRR — the reverse of RGB), taken from the
+    /// same theme key the tool windows use. Falls back to DWMWA_COLOR_DEFAULT so Windows picks one
+    /// if the shell can't be reached.</summary>
+    private static int ThemedBorderColor()
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        try
+        {
+            var shell = Package.GetGlobalService(typeof(SVsUIShell)) as IVsUIShell5;
+            var c = shell.GetThemedWPFColor(EnvironmentColors.ToolWindowBorderColorKey);
+            return c.R | (c.G << 8) | (c.B << 16);
+        }
+        catch { return DwmwaColorDefault; }
+    }
+
+    private const int DwmwaUseImmersiveDarkModeLegacy = 19;
+    private const int DwmwaUseImmersiveDarkMode = 20;
+    // Windows 11 22000+; older builds fail the call and keep the default border.
+    private const int DwmwaBorderColor = 34;
+    private const int DwmwaColorDefault = unchecked((int)0xFFFFFFFF);
+
+    [DllImport("dwmapi.dll")]
+    private static extern int DwmSetWindowAttribute(IntPtr hWnd, int attribute, ref int value, int size);
+}

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.cs
@@ -56,11 +56,6 @@ internal sealed partial class IdeContextService : IDisposable
     private IWpfTextView _trackedView;
     private bool _subscribed;
 
-    /// <summary>Raised (UI thread) when VS's active window frame changes. Panes use it to blur
-    /// their input when they are no longer the active frame — the WebView2 gets no DOM blur across
-    /// the HwndHost boundary, so the caret would keep blinking otherwise.</summary>
-    internal static event Action ActiveFrameChanged;
-
     // Debounced push: SelectionChanged can fire rapidly while dragging; coalesce
     // to one emit per 150ms. The dedup below drops no-op re-emits on top.
     private Timer _debounce;
@@ -498,7 +493,6 @@ internal sealed partial class IdeContextService : IDisposable
             if (elementid == (uint)VSConstants.VSSELELEMID.SEID_WindowFrame)
             {
                 owner.TrackActiveView(varValueNew as IVsWindowFrame);
-                ActiveFrameChanged?.Invoke();
             }
             return VSConstants.S_OK;
         }

--- a/src/Corsinvest.VisualStudio.Agents/Menu/AboutDialog.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Menu/AboutDialog.xaml.cs
@@ -22,6 +22,8 @@ public partial class AboutDialog : DialogWindow
         TxtCopyright.Text = BuildInfo.Copyright;
         LnkRepo.NavigateUri = new Uri("https://github.com/Corsinvest/cv4vs-agents");
         LnkCorsinvest.NavigateUri = new Uri("https://www.corsinvest.it");
+        // The content follows the theme through WPF; the title bar and border need telling separately.
+        SourceInitialized += (s, e) => Helpers.WindowChrome.ApplyTheme(this);
     }
 
     private void OnLink_Click(object sender, RoutedEventArgs e)

--- a/src/Corsinvest.VisualStudio.Agents/Menu/AboutDialog.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Menu/AboutDialog.xaml.cs
@@ -4,6 +4,7 @@
  */
 
 using Microsoft.VisualStudio.PlatformUI;
+using Microsoft.VisualStudio.Shell;
 using System;
 using System.Windows;
 using System.Windows.Documents;
@@ -23,7 +24,11 @@ public partial class AboutDialog : DialogWindow
         LnkRepo.NavigateUri = new Uri("https://github.com/Corsinvest/cv4vs-agents");
         LnkCorsinvest.NavigateUri = new Uri("https://www.corsinvest.it");
         // The content follows the theme through WPF; the title bar and border need telling separately.
-        SourceInitialized += (s, e) => Helpers.WindowChrome.ApplyTheme(this);
+        SourceInitialized += (s, e) =>
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            Helpers.WindowChrome.ApplyTheme(this);
+        };
     }
 
     private void OnLink_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
The chat pane used to draw over everything Visual Studio put on top of it — a floating tool window, a notification bar — everywhere except the strip where the WebView wasn't. That's the WPF airspace problem: WebView2 hosts its browser in a child HWND, and a child HWND wins the z-order no matter where the visual tree puts it.

`WebView2CompositionControl` renders through Windows.UI.Composition inside the WPF tree instead, so z-order behaves like it does for every other control. The API is identical past `CoreWebView2`, so the switch itself is one XAML tag.

The rest of this branch is what the switch exposed.

## What the composition control gives back

The workarounds that existed only because of the HWND are gone: `AllowHostInputProcessing`, the JS `pointerdown` → `ui_pane_activate` round-trip, `ui_blur_input`, `ActiveFrameChanged`, and `ActivateFrame`. WPF now sees the mouse and updates its own focus, so the pane activates on a click by itself.

Clicking into a chat also takes down its attention notice again — that clear was part of the removed `ui_pane_activate` case and went with it by accident. It comes back on `PreviewMouseDown`, which is only possible because the control is in the WPF tree.

## What it takes away

Input reaches the browser only if the control forwards it, and the forwarding is incomplete: `CoreWebView2CompositionController` has `SendMouseInput` and `SendPointerInput` but no keyboard counterpart, and `IKeyboardInputSink.TranslateAccelerator` is left unimplemented. Home and End therefore fell through to VS, which ran them as document commands. `ChatWebView` claims those two and hands them to the page, which moves the caret itself — the same shape as Esc. Only keys verified as dropped are claimed: arrows, PageUp/PageDown and Ctrl+Left/Right still arrive on their own.

The browser's task manager came up as a bare `WS_POPUP`: Windows reserves the caption space once `WS_CAPTION` is set, but Chromium paints over it, so no title bar ever shows. Verified against `SetWindowLong`, `RedrawWindow`, forced resize, hide/show, and reparenting it into a window of ours. The window inherits the hosting mode of whoever asks for it, so it's asked from a second, windowed controller sharing the same environment — same browser process, same process list, no page of its own.

## Fixed along the way

- **White flash on open** — the background colour was set on the control, which is after the controller has already painted once. It moves into the controller options, which is what "initialize the `DefaultBackgroundColor` early" is for.
- **Frozen progress bar** — `EnsureCoreWebView2Async` blocks the UI thread for ~2s while the composition controller and browser processes start (measured). A bar that can't animate reads worse than plain text, so the placeholder is text only. Reading the resumed session's `.jsonl` does move off the UI thread.
- **Composer focus** — it needed a click before you could type: the focus request went out before the bundle had mounted `cv-prompt`. It now goes out on `webview_ready`, guarded on the pane being active so a background chat doesn't steal focus. New session never asked at all.
- **Composer jump** — `focus()` scrolls into view by default and the host calls it mid-relayout; `preventScroll` everywhere in the composer.
- **Handler cleanup** — three `CoreWebView2` events were subscribed with lambdas, so `Dispose` couldn't detach them. Named methods now. `FocusWebView` gets a `_disposed` guard: it was the one public member that threw on a disposed control.
- **Dialog chrome** — the title bar and border are drawn by Windows outside WPF's reach, so a dark VS on a light Windows showed a white bar. `WindowChrome.ApplyTheme` reads the colours from the theme keys the tool windows use.
- **Renderer names** — every pane loaded the same `index.html`, so the task manager listed "cv4vs Agents" three times over with no way to tell which was which. Each page is named after its pane now.

## Known costs

Documented by the spec, accepted here: potentially lower framerates (the control captures through a `GraphicsCaptureSession`), DRM content won't play, and `UseLayoutRounding` is forced on so anti-aliasing is off. None of them matter for a text chat.

## Not verified

IME and accented input in the composer. Everything else in this branch has been exercised by hand in the experimental hive.
