### PR TITLE
feat(log): say which pane a log line came from

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,22 @@ Full description in [docs/architecture.md](docs/architecture.md). What matters w
     happen"). **Info** — few, key lifecycle events. **Debug** — the internal flow of one feature.
     **Trace** — raw wire traffic. Use the lazy `() => $"..."` overloads for Debug/Trace.
   - Prefix new logs with an `[area]` tag (`[client]`, `[mcp]`, `[cli]`, `[sessions]`, …).
+  - **One class, two ways to get it.** `OutputWindowLogger.For(kind, () => paneId)` builds a
+    per-session logger that prepends `[chat#N]`/`[cli#N]` before the `[area]` tag — with several
+    panes open the Output window is one stream, and untagged lines can't be told apart. The id is a
+    `Func<int>` because `PaneId` lands *after* the control is built; capturing the value would tag
+    every start-up line `#0`. `OutputWindowLogger.Global` writes untagged.
+  - A pane injects its logger into what it owns (bridge, handler, client, transport, sessions), so
+    those classes take it in the constructor. A class used both ways (`ClaudeClient`,
+    `SessionManager`) takes it as an optional arg and falls back to `Global`.
+  - Use `Global` for: paths belonging to no session (MCP, IDE, package, stats); **static members**,
+    which have no instance to reach — in a primary-constructor class the parameter isn't even in
+    scope there (`CS9105`); and process-wide resources reached from a pane, like `ChatWebView`'s
+    shared task manager, where a pane tag would claim an ownership that isn't there.
+  - The Output window pane itself is process-wide, so `EnsurePaneOnUIThread`/`ActivatePane` stay
+    static: one pane for the extension, whoever logs into it.
+  - When converting a class, convert **every partial** of it: the compiler won't tell you that one
+    file still logs untagged.
   - A catch returning a default on a user-facing path must `LogException` or `Warn` — never swallow.
 
 ## Docs

--- a/src/Corsinvest.VisualStudio.Agents/AgentsPackage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/AgentsPackage.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -137,9 +137,9 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
             // shifts between Newtonsoft minor builds and would MissingMethodException
             // against VS's own Newtonsoft. See JsonExtensions.ToIndentedString.
             File.WriteAllText(settingsPath, root.ToIndentedString());
-            OutputWindowLogger.Info($"Pkg: set diffTool=auto in {settingsPath}");
+            OutputWindowLogger.Global.Info($"Pkg: set diffTool=auto in {settingsPath}");
         }
-        catch (Exception ex) { OutputWindowLogger.LogException("Pkg.EnsureDiffToolAuto", ex); }
+        catch (Exception ex) { OutputWindowLogger.Global.LogException("Pkg.EnsureDiffToolAuto", ex); }
     }
 
     /// <summary>Snapshot the open panes into the current solution's workspace.json. Called on solution
@@ -165,7 +165,7 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
         {
             _reloadWatch.Change(dueMs, System.Threading.Timeout.Infinite);
         }
-        OutputWindowLogger.Debug(() => $"[reload] watch armed for {dueMs} ms (folder={_closingSolutionFolder ?? "(none)"})");
+        OutputWindowLogger.Global.Debug(() => $"[reload] watch armed for {dueMs} ms (folder={_closingSolutionFolder ?? "(none)"})");
     }
 
     private void DisarmReloadWatch()
@@ -178,9 +178,9 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
         {
             await JoinableTaskFactory.SwitchToMainThreadAsync();
             _closingSolutionFolder = null;
-            OutputWindowLogger.Info($"[reload] watch elapsed — closing {Core.Panes.PaneRegistry.Instance.Entries.Count} pane(s)");
+            OutputWindowLogger.Global.Info($"[reload] watch elapsed — closing {Core.Panes.PaneRegistry.Instance.Entries.Count} pane(s)");
             try { Core.Panes.PaneRegistry.Instance.CloseAll(); }
-            catch (Exception ex) { OutputWindowLogger.LogException("Pkg.ReloadWatchElapsed", ex); }
+            catch (Exception ex) { OutputWindowLogger.Global.LogException("Pkg.ReloadWatchElapsed", ex); }
         }).FileAndForget(nameof(AgentsPackage));
 
     /// <summary>Reopen the panes saved for the current solution's workspace.json. Each saved pane is
@@ -191,7 +191,7 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
         var ws = Core.Workspace.WorkspaceStore.Load(folder);
         if (ws?.Panes == null)
         {
-            OutputWindowLogger.Debug(() => $"[restore] no workspace/panes for {folder ?? "(none)"}");
+            OutputWindowLogger.Global.Debug(() => $"[restore] no workspace/panes for {folder ?? "(none)"}");
             return;
         }
         // Load(forEdit:false) normally includes the native "Claude" profile → profiles[0] is the fallback.
@@ -204,7 +204,7 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
                 && Core.Panes.PaneRegistry.Instance.Entries.Any(e =>
                        string.Equals(e.ActiveSessionId, p.SessionId, StringComparison.OrdinalIgnoreCase)))
             {
-                OutputWindowLogger.Debug(() => $"[restore] session {p.SessionId} still open → skip");
+                OutputWindowLogger.Global.Debug(() => $"[restore] session {p.SessionId} still open → skip");
                 continue;
             }
             var kind = string.Equals(p.Kind, "Cli", StringComparison.OrdinalIgnoreCase)
@@ -222,7 +222,7 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
             }
             else
             {
-                OutputWindowLogger.Debug(() => $"[restore] session {p.SessionId} missing on disk → opening fresh");
+                OutputWindowLogger.Global.Debug(() => $"[restore] session {p.SessionId} missing on disk → opening fresh");
                 sessionId = null;
             }
             PaneLauncher.OpenNew(kind, profile, resumeSessionId: sessionId);
@@ -240,7 +240,7 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
         _ = JoinableTaskFactory.StartOnIdle(() =>
         {
             try { RestorePanesForCurrentSolution(); }
-            catch (Exception ex) { OutputWindowLogger.LogException("Pkg.RestorePanesDeferred", ex); }
+            catch (Exception ex) { OutputWindowLogger.Global.LogException("Pkg.RestorePanesDeferred", ex); }
         });
     }
 
@@ -259,12 +259,12 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
             _ = JoinableTaskFactory.StartOnIdle(() =>
             {
                 try { Core.Panes.PaneLauncher.ShowExisting(); }
-                catch (Exception ex) { OutputWindowLogger.LogException("Pkg.OnModeChange.Show", ex); }
+                catch (Exception ex) { OutputWindowLogger.Global.LogException("Pkg.OnModeChange.Show", ex); }
             });
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("Pkg.OnModeChange", ex);
+            OutputWindowLogger.Global.LogException("Pkg.OnModeChange", ex);
         }
         return VSConstants.S_OK;
     }
@@ -282,7 +282,7 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("Pkg.RefreshCurrentSolutionFolder", ex);
+            OutputWindowLogger.Global.LogException("Pkg.RefreshCurrentSolutionFolder", ex);
             CurrentSolutionFolder = null;
         }
     }
@@ -373,8 +373,8 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
         var had = Core.Panes.PaneRegistry.Instance.Entries.Count;
         var kept = 0;
         try { kept = Core.Panes.PaneRegistry.Instance.CloseWhereWorkdirDiffers(CurrentSolutionFolder); }
-        catch (Exception ex) { OutputWindowLogger.LogException("Pkg.OnAfterOpenSolution", ex); }
-        OutputWindowLogger.Info($"[reload] solution open on {CurrentSolutionFolder ?? "(none)"} — kept {kept} of {had} pane(s)");
+        catch (Exception ex) { OutputWindowLogger.Global.LogException("Pkg.OnAfterOpenSolution", ex); }
+        OutputWindowLogger.Global.Info($"[reload] solution open on {CurrentSolutionFolder ?? "(none)"} — kept {kept} of {had} pane(s)");
         // Bring back what the close hid. StartOnIdle for the same reason the restore defers: showing
         // a frame from inside this COM event freezes the shell, which is still mid-transition.
         if (kept > 0)
@@ -382,7 +382,7 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
             _ = JoinableTaskFactory.StartOnIdle(() =>
             {
                 try { Core.Panes.PaneLauncher.ShowExisting(); }
-                catch (Exception ex) { OutputWindowLogger.LogException("Pkg.ShowPanesOnReload", ex); }
+                catch (Exception ex) { OutputWindowLogger.Global.LogException("Pkg.ShowPanesOnReload", ex); }
             });
         }
         // Reopen the panes saved for THIS solution — minus the ones a reload just kept alive (see
@@ -393,7 +393,7 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
         // VS may restore editor tabs without firing a DTE event we listen to;
         // force an emit so MCP clients see the current file context now.
         try { Ide.IdeContextService.Instance.ForceEmitCurrentContext(); }
-        catch (Exception ex) { OutputWindowLogger.LogException("Pkg.ForceEmit", ex); }
+        catch (Exception ex) { OutputWindowLogger.Global.LogException("Pkg.ForceEmit", ex); }
         return VSConstants.S_OK;
     }
 
@@ -402,7 +402,7 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
 
     int IVsSolutionLoadEvents.OnBeforeOpenSolution(string pszSolutionFilename)
     {
-        OutputWindowLogger.Debug(() => $"[reload] solution opening: {pszSolutionFilename ?? "(none)"} — panes={Core.Panes.PaneRegistry.Instance.Entries.Count}");
+        OutputWindowLogger.Global.Debug(() => $"[reload] solution opening: {pszSolutionFilename ?? "(none)"} — panes={Core.Panes.PaneRegistry.Instance.Entries.Count}");
         // Rearm rather than disarm: if this load fails or is cancelled, OnAfterOpenSolution never
         // comes and no close event follows either — the solution was already closed — so the panes
         // would stay pinned forever.
@@ -426,12 +426,12 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
 
     int IVsSolutionEvents.OnAfterCloseSolution(object pUnkReserved)
     {
-        OutputWindowLogger.Debug(() => $"[reload] solution closed — panes={Core.Panes.PaneRegistry.Instance.Entries.Count}");
+        OutputWindowLogger.Global.Debug(() => $"[reload] solution closed — panes={Core.Panes.PaneRegistry.Instance.Entries.Count}");
         CurrentSolutionFolder = null;
         // Out of sight straight away, so closing a solution looks like it always did — but alive, so
         // a reload can hand them back with the session intact.
         try { Core.Panes.PaneLauncher.HideExisting(); }
-        catch (Exception ex) { OutputWindowLogger.LogException("Pkg.HidePanesOnClose", ex); }
+        catch (Exception ex) { OutputWindowLogger.Global.LogException("Pkg.HidePanesOnClose", ex); }
         // Armed here, not on the Before: unloading the projects happens in between and would eat the
         // window on a large solution.
         ArmReloadWatch(ReloadWatchCloseMs);
@@ -453,7 +453,7 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
 
     int IVsSolutionEvents.OnBeforeCloseSolution(object pUnkReserved)
     {
-        OutputWindowLogger.Debug(() => $"[reload] solution closing: {CurrentSolutionFolder ?? "(none)"} — panes={Core.Panes.PaneRegistry.Instance.Entries.Count}");
+        OutputWindowLogger.Global.Debug(() => $"[reload] solution closing: {CurrentSolutionFolder ?? "(none)"} — panes={Core.Panes.PaneRegistry.Instance.Entries.Count}");
         SaveWorkspace();
         // Last point where the folder is still known — OnAfterCloseSolution clears it. The panes are
         // NOT closed here: a reload would take the live CLI down with them, losing the turn in flight.

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/FileSuggestions.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/FileSuggestions.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -92,7 +92,7 @@ internal static class FileSuggestions
             result.AddRange(dirs);
             result.AddRange(files);
         }
-        catch (Exception ex) { OutputWindowLogger.LogException("FileSuggestions.Get", ex); }
+        catch (Exception ex) { OutputWindowLogger.Global.LogException("FileSuggestions.Get", ex); }
         return result;
     }
 
@@ -242,7 +242,7 @@ internal static class GitIgnoreCache
             }
             catch (Exception ex)
             {
-                OutputWindowLogger.LogException("GitIgnoreCache.Get", ex);
+                OutputWindowLogger.Global.LogException("GitIgnoreCache.Get", ex);
                 return null;
             }
         }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -21,7 +21,9 @@ namespace Corsinvest.VisualStudio.Agents.Chat.Host;
 /// Manages the WebView2 control: initialisation, posting messages to JS,
 /// and dispatching messages received from JS to the host via <see cref="MessageReceived"/>.
 /// </summary>
-internal sealed partial class WebViewBridge(Microsoft.Web.WebView2.Wpf.WebView2CompositionControl webView, Dispatcher dispatcher)
+internal sealed partial class WebViewBridge(Microsoft.Web.WebView2.Wpf.WebView2CompositionControl webView,
+                                            Dispatcher dispatcher,
+                                            OutputWindowLogger log)
     : IDisposable
 {
     private bool _ready;
@@ -86,7 +88,7 @@ internal sealed partial class WebViewBridge(Microsoft.Web.WebView2.Wpf.WebView2C
             {
                 // Mapping a missing folder throws a bare DirectoryNotFoundException that names
                 // nothing — say which path we resolved before it does.
-                OutputWindowLogger.Warn($"[webview] index.html not found at '{indexPath}' — the chat can't load");
+                log.Warn($"[webview] index.html not found at '{indexPath}' — the chat can't load");
             }
             webView.CoreWebView2.SetVirtualHostNameToFolderMapping("cv4vs.local", folder, CoreWebView2HostResourceAccessKind.Allow);
 
@@ -100,7 +102,7 @@ internal sealed partial class WebViewBridge(Microsoft.Web.WebView2.Wpf.WebView2C
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("WebViewBridge.Init", ex);
+            log.LogException("WebViewBridge.Init", ex);
             throw;
         }
     }
@@ -217,7 +219,7 @@ internal sealed partial class WebViewBridge(Microsoft.Web.WebView2.Wpf.WebView2C
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("WebViewBridge.RendererProcessId", ex);
+            log.LogException("WebViewBridge.RendererProcessId", ex);
             return null;
         }
     }
@@ -244,7 +246,7 @@ internal sealed partial class WebViewBridge(Microsoft.Web.WebView2.Wpf.WebView2C
             }
             webView.Dispose();
         }
-        catch (Exception ex) { OutputWindowLogger.LogException("WebViewBridge.Dispose", ex); }
+        catch (Exception ex) { log.LogException("WebViewBridge.Dispose", ex); }
     }
 
     /// <summary>Name the page after the pane, so the browser's task manager can tell one chat's
@@ -258,7 +260,7 @@ internal sealed partial class WebViewBridge(Microsoft.Web.WebView2.Wpf.WebView2C
             _ = webView.CoreWebView2?.ExecuteScriptAsync(
                 $"document.title = {JsonConvert.SerializeObject(title)}");
         }
-        catch (Exception ex) { OutputWindowLogger.LogException("WebViewBridge.SetDocumentTitle", ex); }
+        catch (Exception ex) { log.LogException("WebViewBridge.SetDocumentTitle", ex); }
     }
 
     /// <summary>Give the WebView2 control the native (WPF) focus, so the keyboard actually reaches
@@ -288,7 +290,7 @@ internal sealed partial class WebViewBridge(Microsoft.Web.WebView2.Wpf.WebView2C
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("WebViewBridge.ShowFind", ex);
+            log.LogException("WebViewBridge.ShowFind", ex);
         }
     }
 
@@ -342,7 +344,7 @@ internal sealed partial class WebViewBridge(Microsoft.Web.WebView2.Wpf.WebView2C
             ";
             _docCreatedScriptId = await core.AddScriptToExecuteOnDocumentCreatedAsync(script);
         }
-        catch (Exception ex) { OutputWindowLogger.LogException("RegisterBootThemeScript", ex); }
+        catch (Exception ex) { log.LogException("RegisterBootThemeScript", ex); }
     }
 
     public void Send(string type, object data)
@@ -352,7 +354,7 @@ internal sealed partial class WebViewBridge(Microsoft.Web.WebView2.Wpf.WebView2C
         // channel means a case forgot Send→SendResponse → the WebView Promise would time out.
         if (_responseChannels.Contains(type))
         {
-            OutputWindowLogger.Warn($"!!! Send() on response channel '{type}' — use SendResponse(id). The request Promise will time out.");
+            log.Warn($"!!! Send() on response channel '{type}' — use SendResponse(id). The request Promise will time out.");
         }
 #endif
         if (!_ready) { _pending.Enqueue((type, data)); return; }
@@ -374,10 +376,10 @@ internal sealed partial class WebViewBridge(Microsoft.Web.WebView2.Wpf.WebView2C
         try
         {
             var json = JsonConvert.SerializeObject(new { type, id, error = message }, _jsonSettings);
-            OutputWindowLogger.Trace(() => $"[bridge → web] {type} ERROR#{id} {message}");
+            log.Trace(() => $"[bridge → web] {type} ERROR#{id} {message}");
             webView.CoreWebView2?.PostWebMessageAsJson(json);
         }
-        catch (Exception ex) { OutputWindowLogger.LogException($"WebViewBridge.SendError[{type}]", ex); }
+        catch (Exception ex) { log.LogException($"WebViewBridge.SendError[{type}]", ex); }
     }
 
     // The 5 ToWebView channels that carry request responses. In DEBUG, Send() warns if called
@@ -414,7 +416,7 @@ internal sealed partial class WebViewBridge(Microsoft.Web.WebView2.Wpf.WebView2C
             // Trace bridge traffic; skip streaming/progress channels that would flood the log.
             if (!IsNoisyChannel(type))
             {
-                OutputWindowLogger.Trace(() => $"[bridge → web] {type} {StringHelpers.Truncate(json)}");
+                log.Trace(() => $"[bridge → web] {type} {StringHelpers.Truncate(json)}");
             }
             // CoreWebView2 is thread-affine (UI thread). Callers on a background thread
             // (e.g. a CLI-event handler continuation) would otherwise throw. Marshal the
@@ -422,7 +424,7 @@ internal sealed partial class WebViewBridge(Microsoft.Web.WebView2.Wpf.WebView2C
             if (dispatcher.CheckAccess()) { webView.CoreWebView2?.PostWebMessageAsJson(json); }
             else { dispatcher.BeginInvoke(new Action(() => webView.CoreWebView2?.PostWebMessageAsJson(json))); }
         }
-        catch (Exception ex) { OutputWindowLogger.LogException($"WebViewBridge.SendDirect[{type}]", ex); }
+        catch (Exception ex) { log.LogException($"WebViewBridge.SendDirect[{type}]", ex); }
     }
 
     private static bool IsNoisyChannel(string type)
@@ -464,7 +466,7 @@ internal sealed partial class WebViewBridge(Microsoft.Web.WebView2.Wpf.WebView2C
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.Warn("!!! IconRequested error: " + ex.Message);
+            log.Warn("!!! IconRequested error: " + ex.Message);
         }
     }
 
@@ -478,10 +480,10 @@ internal sealed partial class WebViewBridge(Microsoft.Web.WebView2.Wpf.WebView2C
             var data = node["data"] is JObject dataObj ? dataObj : [];
             // Correlation id for request/response; absent (null) for notifications.
             int? id = node["id"]?.Type == JTokenType.Integer ? (int)node["id"] : null;
-            OutputWindowLogger.Trace(() => $"[bridge ← web] {type} {StringHelpers.Truncate(raw)}");
+            log.Trace(() => $"[bridge ← web] {type} {StringHelpers.Truncate(raw)}");
             dispatcher.Invoke(() => MessageReceived?.Invoke(type, data, id));
         }
-        catch (Exception ex) { OutputWindowLogger.LogException("WebViewBridge.OnRawMessage", ex); }
+        catch (Exception ex) { log.LogException("WebViewBridge.OnRawMessage", ex); }
     }
 
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Chat.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Chat.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -278,7 +278,7 @@ internal sealed partial class WebViewMessageHandler
             catch (Exception ex)
             {
                 // Nothing opens and the click looks dead otherwise — say why.
-                OutputWindowLogger.LogException($"[chat] open attachment '{name}'", ex);
+                log.LogException($"[chat] open attachment '{name}'", ex);
             }
         }).FileAndForget(nameof(WebViewMessageHandler));
     }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Cli.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Cli.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -16,7 +16,7 @@ internal sealed partial class WebViewMessageHandler
         // The WebView echoes the user bubble itself (stream-json doesn't
         // reflect the submitted message back); the host only forwards to the CLI.
         var p = data.ToObject<Contracts.SendPromptNotification>();
-        OutputWindowLogger.Debug(() => $"[{BridgeMessages.FromWebView.Cli.SendPrompt}] text len={(p.Text ?? "").Length} sessionId={client.SessionId ?? "(none)"} running={client.IsRunning}");
+        log.Debug(() => $"[{BridgeMessages.FromWebView.Cli.SendPrompt}] text len={(p.Text ?? "").Length} sessionId={client.SessionId ?? "(none)"} running={client.IsRunning}");
         // attachments stays a raw JArray: BuildContentBlocks turns it into CLI blocks.
         var blocks = WebViewBridge.BuildContentBlocks(p.Text ?? "", data["attachments"] as JArray);
         client.SendPrompt(blocks, p.Uuid ?? "");
@@ -73,7 +73,7 @@ internal sealed partial class WebViewMessageHandler
         {
             if (t.IsFaulted)
             {
-                OutputWindowLogger.Warn($"!!! interrupt failed: {t.Exception?.GetBaseException().Message}");
+                log.Warn($"!!! interrupt failed: {t.Exception?.GetBaseException().Message}");
             }
         });
     }
@@ -88,7 +88,7 @@ internal sealed partial class WebViewMessageHandler
         {
             if (t.IsFaulted)
             {
-                OutputWindowLogger.Warn($"!!! set_permission_mode failed: {t.Exception?.GetBaseException().Message}");
+                log.Warn($"!!! set_permission_mode failed: {t.Exception?.GetBaseException().Message}");
             }
             // Either way, tell the WebView what the mode REALLY is. The selector switched
             // optimistically before asking, and the client only advances PermissionMode once
@@ -108,7 +108,7 @@ internal sealed partial class WebViewMessageHandler
         {
             if (t.IsFaulted)
             {
-                OutputWindowLogger.Warn($"!!! set_model failed: {t.Exception?.GetBaseException().Message}");
+                log.Warn($"!!! set_model failed: {t.Exception?.GetBaseException().Message}");
             }
             // Same rollback as the permission mode: the picker switched before asking, so echo
             // back what the client actually holds. Null means "Default", which the WebView

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Helpers.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Helpers.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -41,6 +41,8 @@ internal sealed partial class WebViewMessageHandler
         };
         return !string.IsNullOrEmpty(field) ? field : input.ToIndentedString();
     }
+    // The static helpers below log through OutputWindowLogger, not the pane logger: a primary
+    // constructor parameter isn't in scope in a static member (CS9105).
     private static string FindToolInput(string workingDirectory, string sessionId, string toolUseId, ClaudePaths paths, string toolName = "", string agentId = null)
     {
         if (string.IsNullOrEmpty(sessionId) || string.IsNullOrEmpty(toolUseId)) { return null; }
@@ -73,7 +75,7 @@ internal sealed partial class WebViewMessageHandler
                 catch { /* silent: skip malformed JSONL line */ }
             }
         }
-        catch (Exception ex) { OutputWindowLogger.LogException("FindToolInput/Result", ex); }
+        catch (Exception ex) { OutputWindowLogger.Global.LogException("FindToolInput/Result", ex); }
         return null;
     }
     private static string FindToolResult(string workingDirectory, string sessionId, string toolUseId, ClaudePaths paths, string agentId = null)
@@ -120,7 +122,7 @@ internal sealed partial class WebViewMessageHandler
                 catch { /* silent: skip malformed JSONL line */ }
             }
         }
-        catch (Exception ex) { OutputWindowLogger.LogException("FindToolInput/Result", ex); }
+        catch (Exception ex) { OutputWindowLogger.Global.LogException("FindToolInput/Result", ex); }
         return null;
     }
     private static bool TryOpenInVs(string filePath)
@@ -203,12 +205,12 @@ internal sealed partial class WebViewMessageHandler
         catch (ArgumentException ex)
         {
             // What VS throws for a project/solution file; the caller's Warn already names the file.
-            OutputWindowLogger.Debug(() => $"[chat] OpenFile refused: {ex.Message}");
+            OutputWindowLogger.Global.Debug(() => $"[chat] OpenFile refused: {ex.Message}");
             return null;
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("OpenFileInEditor", ex);
+            OutputWindowLogger.Global.LogException("OpenFileInEditor", ex);
             return null;
         }
     }
@@ -220,7 +222,7 @@ internal sealed partial class WebViewMessageHandler
     /// same dead link twice doesn't stack.</summary>
     private void NoticeOpenFailed(string path, string reason)
     {
-        OutputWindowLogger.Warn($"[chat] can't open '{path}' — {reason}");
+        log.Warn($"[chat] can't open '{path}' — {reason}");
         bridge.Send(BridgeMessages.ToWebView.Chat.Notice, new Contracts.NoticeNotification
         {
             Key = "openfile:" + path,
@@ -284,7 +286,7 @@ internal sealed partial class WebViewMessageHandler
             var found = FindFileByNameUnderRoot(wd, name);
             if (found != null) { return found; }
         }
-        OutputWindowLogger.Debug(() => $"[OpenFile] Path not found. raw='{filePath}' normalized='{normalized}' combined='{combined}' workingDir='{client.WorkingDirectory}'");
+        log.Debug(() => $"[OpenFile] Path not found. raw='{filePath}' normalized='{normalized}' combined='{combined}' workingDir='{client.WorkingDirectory}'");
         return null;
     }
 

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Misc.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Misc.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -33,7 +33,7 @@ internal sealed partial class WebViewMessageHandler
         }
         else
         {
-            OutputWindowLogger.Debug(() => $"[fork] ForkSession returned null (uuid={forkAtUuid}) — no pane opened");
+            log.Debug(() => $"[fork] ForkSession returned null (uuid={forkAtUuid}) — no pane opened");
         }
     }
 

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Open.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Open.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -68,7 +68,7 @@ internal sealed partial class WebViewMessageHandler
             }
             if (string.IsNullOrEmpty(content))
             {
-                OutputWindowLogger.Debug(() => $"[open-output] no content found for tool_use_id={toolUseId}");
+                log.Debug(() => $"[open-output] no content found for tool_use_id={toolUseId}");
                 return;
             }
             // Strip the CLI's <tool_use_error> wrapper (protocol detail).

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -14,7 +14,10 @@ namespace Corsinvest.VisualStudio.Agents.Chat.Host;
 /// <summary>
 /// Handles all messages received from the WebView JS and dispatches the appropriate action.
 /// </summary>
-internal sealed partial class WebViewMessageHandler(WebViewBridge bridge, IClaudeClient client, PaneEntry entry)
+internal sealed partial class WebViewMessageHandler(WebViewBridge bridge,
+                                                   IClaudeClient client,
+                                                   PaneEntry entry,
+                                                   OutputWindowLogger log)
 {
     // Subscribe to the stats indexer's completion once (first GetStats), so we forward a
     // StatsIndexDone notification to this WebView when a background pass finishes.

--- a/src/Corsinvest.VisualStudio.Agents/Chat/IconCacheService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/IconCacheService.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -61,14 +61,14 @@ internal static class IconCacheService
             // generic document rather than serve a file that isn't there.
             if (bytes == null && key != "file")
             {
-                OutputWindowLogger.Debug(() => $"[icons] no bitmap for '{key}' — using the generic document");
+                OutputWindowLogger.Global.Debug(() => $"[icons] no bitmap for '{key}' — using the generic document");
                 bytes = RenderMonikerToPng(KnownMonikers.Document, themeBg);
             }
             if (bytes != null) { File.WriteAllBytes(pngPath, bytes); }
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.Warn($"!!! IconCache failed for '{key}': {ex.Message}");
+            OutputWindowLogger.Global.Warn($"!!! IconCache failed for '{key}': {ex.Message}");
         }
         return pngPath;
     }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.ClientEvents.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.ClientEvents.cs
@@ -104,7 +104,7 @@ public partial class ChatPaneControl
                     // exceptions, so there's no unobserved-exception fallout from abandoning it here.
                     var timedOut = await Task.WhenAny(work, Task.Delay(3000)) != work;
                     var ctx = timedOut ? null : await work;
-                    if (timedOut) { OutputWindowLogger.Debug(() => $"[diag] check timed out (3s) for {filePath} — feedback dropped"); }
+                    if (timedOut) { _log.Debug(() => $"[diag] check timed out (3s) for {filePath} — feedback dropped"); }
                     if (!string.IsNullOrEmpty(ctx))
                     {
                         _client?.RespondToHookCallback(e.RequestId, new
@@ -120,7 +120,7 @@ public partial class ChatPaneControl
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("ChatPaneControl.OnHookCallback", ex);
+            _log.LogException("ChatPaneControl.OnHookCallback", ex);
             _client?.RespondToHookCallback(e.RequestId, new { @continue = true });
         }
     }
@@ -330,7 +330,7 @@ public partial class ChatPaneControl
 
         // Captured client's workdir, not the live Sessions property — this runs async and
         // must stay keyed on the client that started it, even if the pane's client is swapped.
-        var sessions = new SessionManager(PaneClaudePaths, client.WorkingDirectory);
+        var sessions = new SessionManager(PaneClaudePaths, client.WorkingDirectory, _log);
         // Skip the CLI round-trip entirely if the session already has a title
         // (resumed session, or generated on a previous run).
         if (sessions.HasTitle(sid)) { return; }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -71,7 +71,7 @@ public partial class ChatPaneControl : PaneControlBase
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("[chat] rename_session", ex);
+            _log.LogException("[chat] rename_session", ex);
         }
         Sessions.Rename(sessionId, newTitle);
     }
@@ -222,7 +222,7 @@ public partial class ChatPaneControl : PaneControlBase
                     var done = await Task.WhenAny(call, Task.Delay(2000)).ConfigureAwait(true);
                     if (done != call)
                     {
-                        OutputWindowLogger.Warn("[chat] renderer PID timed out — WebView not answering");
+                        _log.Warn("[chat] renderer PID timed out — WebView not answering");
                         return null;
                     }
                     return await call.ConfigureAwait(true);
@@ -256,6 +256,9 @@ public partial class ChatPaneControl : PaneControlBase
         }
     }
 
+    // Resolved per line, not captured: Entry (and its PaneId) is injected after construction.
+    // Assigned in the constructor because a field initializer can't reach an instance member.
+    private readonly OutputWindowLogger _log;
     private ClaudeClient _client;
     private WebViewBridge _bridge;
     private WebViewMessageHandler _handler;
@@ -287,6 +290,7 @@ public partial class ChatPaneControl : PaneControlBase
 
     public ChatPaneControl()
     {
+        _log = OutputWindowLogger.For("chat", () => Entry?.PaneId ?? 0);
         InitializeComponent();
         Loaded += OnLoaded;
         Unloaded += OnUnloaded;
@@ -314,11 +318,11 @@ public partial class ChatPaneControl : PaneControlBase
             if (_initialized) { return; }
             _initialized = true;
 
-            OutputWindowLogger.Info("load: OnLoaded start");
+            _log.Info("load: OnLoaded start");
 
-            _bridge = new WebViewBridge(WebView, Dispatcher);
+            _bridge = new WebViewBridge(WebView, Dispatcher, _log);
 
-            using (OutputWindowLogger.PerfSpan("WebView.Init"))
+            using (OutputWindowLogger.Global.PerfSpan("WebView.Init"))
             {
                 await _bridge.InitAsync();
             }
@@ -385,7 +389,7 @@ public partial class ChatPaneControl : PaneControlBase
     private void SendTheme()
     {
         ThreadHelper.ThrowIfNotOnUIThread();
-        try { _bridge?.InjectTheme(VsThemeReader.IsDark()); } catch (Exception ex) { OutputWindowLogger.LogException("SendTheme", ex); }
+        try { _bridge?.InjectTheme(VsThemeReader.IsDark()); } catch (Exception ex) { _log.LogException("SendTheme", ex); }
     }
 
     /// <summary>Options → Apply. Send vs_settings (updates state.ui: font size, sticky, …)
@@ -406,7 +410,7 @@ public partial class ChatPaneControl : PaneControlBase
         // the previous ones until the next re-render.
         if (_turnInFlight)
         {
-            OutputWindowLogger.Debug(() => $"[chat] options applied mid-turn on {sid} — settings only, transcript left alone");
+            _log.Debug(() => $"[chat] options applied mid-turn on {sid} — settings only, transcript left alone");
             return;
         }
 
@@ -420,7 +424,7 @@ public partial class ChatPaneControl : PaneControlBase
     private async Task InitAsync()
     {
         var workDir = Entry.WorkingDirectory;
-        using var _ = OutputWindowLogger.PerfSpan($"InitAsync({workDir})");
+        using var _ = OutputWindowLogger.Global.PerfSpan($"InitAsync({workDir})");
 
         // Every "New Chat" pane starts FRESH (else N panes share one conversation). Exception: a
         // forked or workspace-restored pane — _startupSessionId points at the JSONL to resume
@@ -448,7 +452,7 @@ public partial class ChatPaneControl : PaneControlBase
         await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
         _bridge.Send(BridgeMessages.ToWebView.Chat.Cleared, null);
-        OutputWindowLogger.Info($"load: InitAsync sessionId={_startupSessionId ?? "(none)"} (mode={permMode})");
+        _log.Info($"load: InitAsync sessionId={_startupSessionId ?? "(none)"} (mode={permMode})");
 
         // Client-first: the WebView starts empty here. Once the client starts, StartupAsync gathers
         // the CLI state (initialize + get_settings, no user turn) and OnCliStateReceived sends the one
@@ -467,7 +471,7 @@ public partial class ChatPaneControl : PaneControlBase
         // installed" panel as the CLI pane instead of throwing when the transport spawns a null exe.
         if (ClaudeInstall.ResolveExecutable() == null)
         {
-            OutputWindowLogger.Warn("[chat] claude.exe not found — showing 'not installed' panel");
+            _log.Warn("[chat] claude.exe not found — showing 'not installed' panel");
             Content = ClaudeInstall.BuildMissingPanel();
             return;
         }
@@ -504,7 +508,7 @@ public partial class ChatPaneControl : PaneControlBase
     {
         if (_client != null) { return; }
 
-        _client = new ClaudeClient
+        _client = new ClaudeClient(_log)
         {
             // IDE tools exposed as in-process SDK MCP server (mcp_set_servers after init).
             // Name must be "vs", NOT "ide" — the CLI reserves "ide" for its own internal
@@ -519,7 +523,7 @@ public partial class ChatPaneControl : PaneControlBase
         IdeContextService.Instance.ContextChanged -= OnEditorContextChangedForChat;
         IdeContextService.Instance.ContextChanged += OnEditorContextChangedForChat;
 
-        _handler = new WebViewMessageHandler(_bridge, _client, Entry);
+        _handler = new WebViewMessageHandler(_bridge, _client, Entry, _log);
         _bridge.MessageReceived -= OnBridgeMessage;
         _bridge.MessageReceived += OnBridgeMessage;
     }
@@ -562,19 +566,19 @@ public partial class ChatPaneControl : PaneControlBase
     {
         if (_client == null)
         {
-            OutputWindowLogger.Trace("[ChatSelection] skip: _client null");
+            _log.Trace(() => "[ChatSelection] skip: _client null");
             return;
         }
         // Eye closed for this session (the composer's IDE-context badge): don't leak the editor
         // selection into the chat. Send an empty selection so the CLI drops any cached one.
         if (ctx == null || Entry?.Options.SendSelection == false)
         {
-            OutputWindowLogger.Trace("[ChatSelection] no context / eye off → empty selection");
+            _log.Trace(() => "[ChatSelection] no context / eye off → empty selection");
             _client.SendSelectionChanged(string.Empty, null, null, 0, 0, 0, 0, isEmpty: true);
         }
         else
         {
-            OutputWindowLogger.Trace(() => $"[ChatSelection] file={ctx.FilePath} sel={ctx.HasSelection} lines={ctx.StartLine}-{ctx.EndLine} running={_client.IsRunning}");
+            _log.Trace(() => $"[ChatSelection] file={ctx.FilePath} sel={ctx.HasSelection} lines={ctx.StartLine}-{ctx.EndLine} running={_client.IsRunning}");
             _client.SendSelectionChanged(ctx.SelectedText ?? string.Empty,
                                          ctx.FilePath,
                                          PathHelpers.ToFileUri(ctx.FilePath),

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatWebView.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatWebView.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -111,7 +111,7 @@ internal sealed class ChatWebView : WebView2CompositionControl
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException($"{nameof(ChatWebView)}.{nameof(OpenTaskManager)}", ex);
+            OutputWindowLogger.Global.LogException($"{nameof(ChatWebView)}.{nameof(OpenTaskManager)}", ex);
         }
     }
 
@@ -121,7 +121,7 @@ internal sealed class ChatWebView : WebView2CompositionControl
     {
         if (_taskManagerOwner == null) { return; }
         try { _taskManagerOwner.Close(); }
-        catch (Exception ex) { OutputWindowLogger.LogException($"{nameof(ChatWebView)}.CloseTaskManagerOwner", ex); }
+        catch (Exception ex) { OutputWindowLogger.Global.LogException($"{nameof(ChatWebView)}.CloseTaskManagerOwner", ex); }
         _taskManagerOwner = null;
     }
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/ThumbnailGenerator.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/ThumbnailGenerator.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -69,7 +69,7 @@ internal static class ThumbnailGenerator
         catch (Exception ex)
         {
             // Unsupported codec (no WIC decoder), corrupt data, etc. — skip the preview.
-            OutputWindowLogger.LogException("ThumbnailGenerator.Make", ex);
+            OutputWindowLogger.Global.LogException("ThumbnailGenerator.Make", ex);
             return null;
         }
     }

--- a/src/Corsinvest.VisualStudio.Agents/Cli/Pane/CliPaneControl.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Cli/Pane/CliPaneControl.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -70,6 +70,9 @@ internal class CliPaneControl : PaneControlBase, ITerminalConnection, IDisposabl
             : $"{baseCmd} --resume {_activeSessionId}";
     }
 
+    // Resolved per line, not captured: Entry (and its PaneId) is injected after construction.
+    // Assigned in the constructor because a field initializer can't reach an instance member.
+    private readonly OutputWindowLogger _log;
     private TerminalControl _term;
     private TerminalProcess _process;
     private bool _started;
@@ -86,12 +89,13 @@ internal class CliPaneControl : PaneControlBase, ITerminalConnection, IDisposabl
 
     public CliPaneControl()
     {
-        OutputWindowLogger.Perf("CliPaneControl: ctor begin");
+        _log = OutputWindowLogger.For("cli", () => Entry?.PaneId ?? 0);
+        OutputWindowLogger.Global.Perf("CliPaneControl: ctor begin");
         try
         {
             // Probe Microsoft.Terminal.Wpf loadability first: otherwise the
             // next `new TerminalControl()` throws a generic TypeInitializationException.
-            OutputWindowLogger.Perf(() => $"CliPaneControl: TerminalControl assembly = {typeof(TerminalControl).Assembly.Location ?? "<dynamic>"}");
+            OutputWindowLogger.Global.Perf(() => $"CliPaneControl: TerminalControl assembly = {typeof(TerminalControl).Assembly.Location ?? "<dynamic>"}");
             _term = new TerminalControl
             {
                 Focusable = true,
@@ -99,11 +103,11 @@ internal class CliPaneControl : PaneControlBase, ITerminalConnection, IDisposabl
                 AutoResize = true,
             };
             Content = _term;
-            OutputWindowLogger.Perf("CliPaneControl: ctor done");
+            OutputWindowLogger.Global.Perf("CliPaneControl: ctor done");
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("CliPaneControl.ctor", ex);
+            _log.LogException("CliPaneControl.ctor", ex);
             throw;
         }
 
@@ -155,7 +159,7 @@ internal class CliPaneControl : PaneControlBase, ITerminalConnection, IDisposabl
                 }
                 catch (Exception ex)
                 {
-                    OutputWindowLogger.LogException("CliPane.Start", ex);
+                    _log.LogException("CliPane.Start", ex);
                 }
             }));
         }
@@ -200,14 +204,14 @@ internal class CliPaneControl : PaneControlBase, ITerminalConnection, IDisposabl
         // The session now exists on disk. A later respawn (e.g. solution-change) must --resume it,
         // NOT re-pass --session-id (which the CLI rejects as "already in use").
         _sessionIsNew = false;
-        OutputWindowLogger.Info($"CliPane: starting {cmd ?? "<null>"} in {Entry.WorkingDirectory}");
+        _log.Info($"CliPane: starting {cmd ?? "<null>"} in {Entry.WorkingDirectory}");
 
         // claude.exe must be installed via the official npm package (see
         // ClaudeCliLauncher for why no cmd-shim/PATH fallback). When missing,
         // swap in the inline "not installed" panel instead of a modal dialog.
         if (cmd == null)
         {
-            OutputWindowLogger.Warn("[cli] claude.exe not found — showing 'not installed' panel");
+            _log.Warn("[cli] claude.exe not found — showing 'not installed' panel");
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
             ShowMissingPanel();
             return;
@@ -242,7 +246,7 @@ internal class CliPaneControl : PaneControlBase, ITerminalConnection, IDisposabl
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("CliPane.StartOrRestart", ex);
+            _log.LogException("CliPane.StartOrRestart", ex);
             _process?.Dispose();
             _process = null;
         }
@@ -272,7 +276,7 @@ internal class CliPaneControl : PaneControlBase, ITerminalConnection, IDisposabl
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("CliPane.OutputToControl", ex);
+            _log.LogException("CliPane.OutputToControl", ex);
         }
     }
 
@@ -303,7 +307,7 @@ internal class CliPaneControl : PaneControlBase, ITerminalConnection, IDisposabl
         _ = Dispatcher.BeginInvoke(new Action(() =>
         {
             if (_disposed) { return; }
-            OutputWindowLogger.Info("[cli] claude.exe exited — auto-closing pane");
+            _log.Info("[cli] claude.exe exited — auto-closing pane");
             Pane?.ClosePane();
         }));
     }
@@ -323,7 +327,7 @@ internal class CliPaneControl : PaneControlBase, ITerminalConnection, IDisposabl
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("CliPane.ApplyTheme", ex);
+            _log.LogException("CliPane.ApplyTheme", ex);
         }
     }
 
@@ -353,7 +357,7 @@ internal class CliPaneControl : PaneControlBase, ITerminalConnection, IDisposabl
         _activeSessionId = sessionId;
         _sessionIsNew = false;   // picker/restore ids exist on disk (or null → the start block re-mints a fresh one)
         Entry.ActiveSessionId = sessionId;
-        OutputWindowLogger.Info($"CliPane: session → {sessionId ?? "<new>"}");
+        _log.Info($"CliPane: session → {sessionId ?? "<new>"}");
         if (_started) { _ = StartOrRestartAsync(); }
     }
 

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.Protocol.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.Protocol.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -20,7 +20,7 @@ namespace Corsinvest.VisualStudio.Agents.Core.Client;
 /// stream/result/rate-limit events) to handlers. The public API, lifecycle, and
 /// process management live in ClaudeClient.cs.
 /// </summary>
-public sealed partial class ClaudeClient
+internal sealed partial class ClaudeClient
 {
     private static readonly TimeSpan DefaultRequestTimeout = TimeSpan.FromSeconds(10);
     private static readonly TimeSpan InitializeTimeout = TimeSpan.FromSeconds(30);
@@ -117,7 +117,7 @@ public sealed partial class ClaudeClient
                         ? s
                         : (obj["request"] as JObject).Val("subtype", "");
 
-        OutputWindowLogger.Trace(() => $"[CLI line] type={type}{(string.IsNullOrEmpty(subtype) ? "" : $" subtype={subtype}")}");
+        _log.Trace(() => $"[CLI line] type={type}{(string.IsNullOrEmpty(subtype) ? "" : $" subtype={subtype}")}");
         switch (type)
         {
             case ClientMessages.Type.ControlResponse: HandleControlResponse(obj); break;
@@ -134,7 +134,7 @@ public sealed partial class ClaudeClient
             case ClientMessages.Type.ConversationReset:
                 ConversationReset?.Invoke(this, obj.Val("new_conversation_id"));
                 break;
-            default: OutputWindowLogger.Trace(() => $"[unhandled] type={type}"); break;
+            default: _log.Trace(() => $"[unhandled] type={type}"); break;
         }
     }
 
@@ -206,7 +206,7 @@ public sealed partial class ClaudeClient
                 // decline is the protocol's expected "unsupported" answer; an error would be a bug.
                 // Warn (not silent): from the user's side an MCP action silently didn't happen —
                 // this line is the only trace of why (e.g. an MCP login that never prompts).
-                OutputWindowLogger.Warn($"[client] elicitation from MCP server '{req.Val("mcp_server_name", "?")}' declined — no elicitation UI");
+                _log.Warn($"[client] elicitation from MCP server '{req.Val("mcp_server_name", "?")}' declined — no elicitation UI");
                 SendControlResponse(rid, success: true, response: new { action = "decline" });
                 break;
 
@@ -266,7 +266,7 @@ public sealed partial class ClaudeClient
             }
             catch (Exception ex)
             {
-                OutputWindowLogger.LogException("ClaudeClient.HandleMcpMessage", ex);
+                _log.LogException("ClaudeClient.HandleMcpMessage", ex);
                 SendControlResponse(rid, success: false, error: ex.Message);
             }
         });

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -18,9 +18,11 @@ namespace Corsinvest.VisualStudio.Agents.Core.Client;
 /// Concrete <see cref="IClaudeClient"/> implementation driving claude.exe through NDJSON
 /// stream-json on stdin/stdout and the bidirectional control protocol.
 /// </summary>
-public sealed partial class ClaudeClient : IClaudeClient
+internal sealed partial class ClaudeClient : IClaudeClient
 {
-    private NdjsonTransport _transport = new();
+    // Built in the constructor, not here: a field initializer runs before _log is assigned, so the
+    // first transport would lose the pane tag.
+    private NdjsonTransport _transport;
     private readonly ConcurrentDictionary<string, TaskCompletionSource<JObject>> _pending = new();
     private int _requestCounter;
 
@@ -89,7 +91,15 @@ public sealed partial class ClaudeClient : IClaudeClient
     private EventHandler<string> _onError;
     private EventHandler<(int exitCode, bool intentional)> _onExited;
 
-    public ClaudeClient() => AttachTransportEvents();
+    private readonly OutputWindowLogger _log;
+
+    // Optional: the context/usage probes build a client with no pane behind it (→ Global, unprefixed).
+    public ClaudeClient(OutputWindowLogger log = null)
+    {
+        _log = log ?? OutputWindowLogger.Global;
+        _transport = new NdjsonTransport(_log);
+        AttachTransportEvents();
+    }
 
     private void AttachTransportEvents()
     {
@@ -156,7 +166,7 @@ public sealed partial class ClaudeClient : IClaudeClient
         // detach listeners from the old one so its late Exited event doesn't bubble up.
         DetachTransportEvents();
         try { _transport.Dispose(); } catch { }
-        _transport = new NdjsonTransport();
+        _transport = new NdjsonTransport(_log);
         AttachTransportEvents();
 
         // Launch-only args. --include-partial-messages enables stream_event + tool_progress.
@@ -254,12 +264,12 @@ public sealed partial class ClaudeClient : IClaudeClient
             // won't reach the CLI (mcp__<name>__* calls fail) — surface it instead of a silent drop.
             if (resp?["errors"] is JObject errors && errors.HasValues)
             {
-                OutputWindowLogger.Warn($"[client] SDK MCP server '{name}' registration failed: {JsonExtensions.ToIndentedString(errors)}");
+                _log.Warn($"[client] SDK MCP server '{name}' registration failed: {JsonExtensions.ToIndentedString(errors)}");
             }
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("ClaudeClient.RegisterSdkMcpServer", ex);
+            _log.LogException("ClaudeClient.RegisterSdkMcpServer", ex);
         }
     }
 
@@ -360,7 +370,7 @@ public sealed partial class ClaudeClient : IClaudeClient
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("ClaudeClient.StartupAsync", ex);
+            _log.LogException("ClaudeClient.StartupAsync", ex);
         }
     }
 
@@ -370,7 +380,7 @@ public sealed partial class ClaudeClient : IClaudeClient
         if (_transport.IsRunning) { return; }
         if (_lastOptions == null)
         {
-            OutputWindowLogger.Warn("[client] SendPrompt before Prepare/StartAsync — transport not running, prompt dropped");
+            _log.Warn("[client] SendPrompt before Prepare/StartAsync — transport not running, prompt dropped");
             return;
         }
 
@@ -384,7 +394,7 @@ public sealed partial class ClaudeClient : IClaudeClient
             // Keep the profile's provider across respawns — else the pane silently reverts to native Claude.
             Env = _env ?? _lastOptions?.Env,
         };
-        OutputWindowLogger.Info($"=== auto-restart workdir={replay.WorkingDirectory} session={replay.ResumeSessionId ?? "(none)"}");
+        _log.Info($"=== auto-restart workdir={replay.WorkingDirectory} session={replay.ResumeSessionId ?? "(none)"}");
         StartProcess(replay);
     }
 
@@ -531,7 +541,7 @@ public sealed partial class ClaudeClient : IClaudeClient
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.Warn($"[client] rename_session refused ({ex.Message}) — falling back to the JSONL");
+            _log.Warn($"[client] rename_session refused ({ex.Message}) — falling back to the JSONL");
             return false;
         }
     }
@@ -571,7 +581,7 @@ public sealed partial class ClaudeClient : IClaudeClient
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.Warn($"[client] list_models refused ({ex.Message}) — keeping the catalogue from initialize");
+            _log.Warn($"[client] list_models refused ({ex.Message}) — keeping the catalogue from initialize");
             return [];
         }
     }
@@ -663,10 +673,10 @@ public sealed partial class ClaudeClient : IClaudeClient
     {
         if (!_transport.IsRunning)
         {
-            OutputWindowLogger.Trace("[ChatSelection] SendSelectionChanged skip: transport not running");
+            _log.Trace(() => "[ChatSelection] SendSelectionChanged skip: transport not running");
             return;
         }
-        OutputWindowLogger.Trace(() => $"[ChatSelection] SendSelectionChanged → filePath={filePath} isEmpty={isEmpty} line={startLine}-{endLine}");
+        _log.Trace(() => $"[ChatSelection] SendSelectionChanged → filePath={filePath} isEmpty={isEmpty} line={startLine}-{endLine}");
         _transport.Write(new
         {
             type = "request",
@@ -707,14 +717,14 @@ public sealed partial class ClaudeClient : IClaudeClient
             parent_tool_use_id = (string)null,
             uuid,
         };
-        OutputWindowLogger.Debug(() => $"[ClaudeClient.SendPrompt] BEFORE Write running={_transport.IsRunning} sessionId={SessionId ?? "(none)"} blocks={contentBlocks?.Count ?? 0}");
+        _log.Debug(() => $"[ClaudeClient.SendPrompt] BEFORE Write running={_transport.IsRunning} sessionId={SessionId ?? "(none)"} blocks={contentBlocks?.Count ?? 0}");
         try
         {
             _transport.Write(msg);
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("ClaudeClient.SendPrompt.Write", ex);
+            _log.LogException("ClaudeClient.SendPrompt.Write", ex);
             throw;
         }
     }
@@ -725,7 +735,7 @@ public sealed partial class ClaudeClient : IClaudeClient
         // tool_use_id keeps concurrent prompts from clobbering each other.
         if (string.IsNullOrEmpty(toolUseId) || !_toolRequestIds.TryRemove(toolUseId, out var requestId))
         {
-            OutputWindowLogger.Warn($"[client] permission for unknown/stale tool_use_id={toolUseId} — ignored");
+            _log.Warn($"[client] permission for unknown/stale tool_use_id={toolUseId} — ignored");
             return false;
         }
 

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeInstall.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeInstall.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -42,12 +42,12 @@ public static class ClaudeInstall
         {
             if (!configured.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
             {
-                OutputWindowLogger.Warn($"[cli] configured Claude executable must be an .exe (a .cmd/.bat/.ps1 shim can't be launched): {configured} — falling back to auto-detection");
+                OutputWindowLogger.Global.Warn($"[cli] configured Claude executable must be an .exe (a .cmd/.bat/.ps1 shim can't be launched): {configured} — falling back to auto-detection");
             }
             else if (File.Exists(configured)) { return configured; }
             else
             {
-                OutputWindowLogger.Warn($"[cli] configured Claude executable not found: {configured} — falling back to auto-detection");
+                OutputWindowLogger.Global.Warn($"[cli] configured Claude executable not found: {configured} — falling back to auto-detection");
             }
         }
 

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/NdjsonTransport.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/NdjsonTransport.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -41,8 +41,12 @@ internal sealed class NdjsonTransport : IDisposable
     public int Pid => _process?.Id ?? -1;
     public bool IsRunning => _process?.HasExited == false;
 
-    public NdjsonTransport()
+    private readonly OutputWindowLogger _log;
+
+    // Optional: the probes build a transport with no pane behind it (→ Global, unprefixed).
+    public NdjsonTransport(OutputWindowLogger log = null)
     {
+        _log = log ?? OutputWindowLogger.Global;
         _hJob = NativeMethods.CreateJobObject(IntPtr.Zero, null);
         if (_hJob != IntPtr.Zero)
         {
@@ -60,8 +64,8 @@ internal sealed class NdjsonTransport : IDisposable
     {
         if (_disposed) { return; }
 
-        OutputWindowLogger.Info($"=== transport start exe={exePath} workdir={workingDirectory}");
-        OutputWindowLogger.Debug($">>> args={arguments}");
+        _log.Info($"=== transport start exe={exePath} workdir={workingDirectory}");
+        _log.Debug(() => $">>> args={arguments}");
 
         var psi = new ProcessStartInfo
         {
@@ -88,7 +92,7 @@ internal sealed class NdjsonTransport : IDisposable
         {
             if (!string.IsNullOrEmpty(e.Data))
             {
-                OutputWindowLogger.Warn($"[stderr] {e.Data}");
+                _log.Warn($"[stderr] {e.Data}");
                 ErrorLine?.Invoke(this, e.Data);
             }
         };
@@ -102,7 +106,7 @@ internal sealed class NdjsonTransport : IDisposable
             NativeMethods.AssignProcessToJobObject(_hJob, _process.Handle);
         }
 
-        OutputWindowLogger.Info($"--- transport PID={_process.Id}");
+        _log.Info($"--- transport PID={_process.Id}");
 
         _readerThread = new Thread(ReadLoop) { IsBackground = true, Name = "ClaudeNdjsonReader" };
         _readerThread.Start();
@@ -116,13 +120,13 @@ internal sealed class NdjsonTransport : IDisposable
     {
         if (!IsRunning)
         {
-            OutputWindowLogger.Warn("!!! transport.Write called but IsRunning=false");
+            _log.Warn("!!! transport.Write called but IsRunning=false");
             return;
         }
         try
         {
             var json = JsonConvert.SerializeObject(message, Formatting.None);
-            OutputWindowLogger.Trace(() => $">>> stdin: {StringHelpers.Truncate(json, 500)}");
+            _log.Trace(() => $">>> stdin: {StringHelpers.Truncate(json, 500)}");
             // Lock so a worker-thread MCP response and a UI-thread write can't
             // interleave into one corrupt NDJSON line.
             lock (_writeLock)
@@ -133,13 +137,13 @@ internal sealed class NdjsonTransport : IDisposable
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("transport.Write", ex);
+            _log.LogException("transport.Write", ex);
         }
     }
 
     private void ReadLoop()
     {
-        OutputWindowLogger.Debug("--- transport ReadLoop started");
+        _log.Debug(() => "--- transport ReadLoop started");
         // Capture the reader locally: Dispose() (respawn) nulls out _process on
         // another thread, and reading the field here would NRE the moment the
         // process exits and ReadLine() returns. The local keeps this loop tied
@@ -152,29 +156,29 @@ internal sealed class NdjsonTransport : IDisposable
             while ((line = reader.ReadLine()) != null)
             {
                 var clean = line.Trim();
-                OutputWindowLogger.Trace(() => $"<<< RAW: {(clean.Length <= 500 ? clean : clean.Substring(0, 500) + "...")}");
+                _log.Trace(() => $"<<< RAW: {(clean.Length <= 500 ? clean : clean.Substring(0, 500) + "...")}");
                 if (clean.Length == 0 || clean[0] != '{') { continue; }
                 JObject obj;
                 try { obj = JObject.Parse(clean); }
                 catch (Exception ex)
                 {
-                    OutputWindowLogger.Warn($"!!! transport parse error: {ex.Message}");
+                    _log.Warn($"!!! transport parse error: {ex.Message}");
                     continue;
                 }
                 LineReceived?.Invoke(this, obj);
             }
-            OutputWindowLogger.Debug("--- transport ReadLoop ended (stdout closed)");
+            _log.Debug(() => "--- transport ReadLoop ended (stdout closed)");
         }
         catch (Exception ex)
         {
             // Closed stdout on a disposed respawn is expected — don't log it as a fault.
-            if (_disposed) { OutputWindowLogger.Debug(() => $"--- transport read loop ended (disposed): {ex.GetType().Name}"); }
-            else { OutputWindowLogger.LogException("transport.ReadLoop", ex); }
+            if (_disposed) { _log.Debug(() => $"--- transport read loop ended (disposed): {ex.GetType().Name}"); }
+            else { _log.LogException("transport.ReadLoop", ex); }
         }
 
         int exitCode = -1;
         try { exitCode = _process?.ExitCode ?? -1; } catch { /* silent: process may already be gone */ }
-        OutputWindowLogger.Info($"--- transport exit code={exitCode} disposed={_disposed}");
+        _log.Info($"--- transport exit code={exitCode} disposed={_disposed}");
 
         if (!_disposed) { Exited?.Invoke(this, (exitCode, false)); }
         else { Exited?.Invoke(this, (exitCode, _intentional)); }

--- a/src/Corsinvest.VisualStudio.Agents/Core/Context/ContextProbe.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Context/ContextProbe.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -50,7 +50,7 @@ internal static class ContextProbe
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.Warn($"[context] fetch failed for session '{sessionId}': {ex.Message}");
+            OutputWindowLogger.Global.Warn($"[context] fetch failed for session '{sessionId}': {ex.Message}");
             throw;
         }
         finally

--- a/src/Corsinvest.VisualStudio.Agents/Core/Context/ContextUsageControl.Render.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Context/ContextUsageControl.Render.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -369,7 +369,7 @@ public partial class ContextUsageControl
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("ContextUsageControl.OpenInEditor", ex);
+            OutputWindowLogger.Global.LogException("ContextUsageControl.OpenInEditor", ex);
         }
     }
 

--- a/src/Corsinvest.VisualStudio.Agents/Core/Context/ContextUsageControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Context/ContextUsageControl.xaml.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -75,7 +75,7 @@ public partial class ContextUsageControl : UserControl
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("ContextUsageControl.InitialSelection", ex);
+            OutputWindowLogger.Global.LogException("ContextUsageControl.InitialSelection", ex);
             return new StatsSelection { Scope = StatsScope.All };
         }
     }
@@ -232,7 +232,7 @@ public partial class ContextUsageControl : UserControl
             catch (OperationCanceledException) { /* superseded */ }
             catch (Exception ex)
             {
-                OutputWindowLogger.LogException("ContextUsageControl.Fetch", ex);
+                OutputWindowLogger.Global.LogException("ContextUsageControl.Fetch", ex);
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 if (!ct.IsCancellationRequested) { SetFetching(false); ShowUnavailable(); }
             }

--- a/src/Corsinvest.VisualStudio.Agents/Core/Context/ContextWindow.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Context/ContextWindow.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -36,14 +36,14 @@ public sealed class ContextWindow : ToolWindowPane
                 var window = pkg.FindToolWindow(typeof(ContextWindow), 0, create: true);
                 if (window?.Frame is not IVsWindowFrame frame)
                 {
-                    OutputWindowLogger.Warn("[context] the Context usage window has no frame — cannot show it");
+                    OutputWindowLogger.Global.Warn("[context] the Context usage window has no frame — cannot show it");
                     return;
                 }
                 ErrorHandler.ThrowOnFailure(frame.Show());
             }
             catch (Exception ex)
             {
-                OutputWindowLogger.LogException("ContextWindow.Open", ex);
+                OutputWindowLogger.Global.LogException("ContextWindow.Open", ex);
             }
         });
     }

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneAttentionInfoBar.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneAttentionInfoBar.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -49,7 +49,7 @@ internal sealed class PaneAttentionInfoBar : IVsInfoBarUIEvents
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("PaneAttentionInfoBar.TryShow", ex);
+            OutputWindowLogger.Global.LogException("PaneAttentionInfoBar.TryShow", ex);
             return null;
         }
     }

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneAttentionService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneAttentionService.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -100,7 +100,7 @@ internal static class PaneAttentionService
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.Warn($"[panes] toast dismiss failed for #{seq}: {ex.Message}");
+            OutputWindowLogger.Global.Warn($"[panes] toast dismiss failed for #{seq}: {ex.Message}");
         }
     }
 }

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneControlBase.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneControlBase.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -156,7 +156,7 @@ public abstract class PaneControlBase : UserControl, IPaneControl
 
             new DevInfoDialog(info).ShowDialog();
         }
-        catch (Exception ex) { OutputWindowLogger.LogException("Pane.ShowSessionInfo", ex); }
+        catch (Exception ex) { OutputWindowLogger.Global.LogException("Pane.ShowSessionInfo", ex); }
     }
 
     public abstract void NewSession();

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneLauncher.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneLauncher.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -48,7 +48,7 @@ internal static class PaneLauncher
             }
             catch (Exception ex)
             {
-                OutputWindowLogger.LogException($"PaneLauncher.HideExisting({entry.Title})", ex);
+                OutputWindowLogger.Global.LogException($"PaneLauncher.HideExisting({entry.Title})", ex);
             }
         }
     }
@@ -80,7 +80,7 @@ internal static class PaneLauncher
             catch (Exception ex)
             {
                 // One pane failing to come back must not stop the others.
-                OutputWindowLogger.LogException($"PaneLauncher.ShowExisting({entry.Title})", ex);
+                OutputWindowLogger.Global.LogException($"PaneLauncher.ShowExisting({entry.Title})", ex);
             }
         }
     }
@@ -99,7 +99,7 @@ internal static class PaneLauncher
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException($"PaneLauncher.Activate({entry.Title})", ex);
+            OutputWindowLogger.Global.LogException($"PaneLauncher.Activate({entry.Title})", ex);
         }
     }
 
@@ -135,10 +135,10 @@ internal static class PaneLauncher
     public static void OpenNew(PaneKind kind, Profile profile, string forkSessionId = null, string initialPrompt = null, string resumeSessionId = null)
     {
         var pkg = AgentsPackage.Instance;
-        if (pkg == null) { OutputWindowLogger.Warn("PaneLauncher: package not yet initialized"); return; }
+        if (pkg == null) { OutputWindowLogger.Global.Warn("PaneLauncher: package not yet initialized"); return; }
         var paneType = WindowType(kind);
 
-        OutputWindowLogger.Debug(() => $"PaneLauncher: OpenNew({paneType.Name}) requested");
+        OutputWindowLogger.Global.Debug(() => $"PaneLauncher: OpenNew({paneType.Name}) requested");
         _ = pkg.JoinableTaskFactory.RunAsync(async () =>
         {
             try
@@ -150,9 +150,9 @@ internal static class PaneLauncher
                     var existing = pkg.FindToolWindow(paneType, id, create: false);
                     if (existing != null) { continue; }
                     _nextPaneId[paneType] = id + 1;
-                    OutputWindowLogger.Info($"PaneLauncher: creating {paneType.Name} #{id}");
+                    OutputWindowLogger.Global.Info($"PaneLauncher: creating {paneType.Name} #{id}");
                     var pane = pkg.FindToolWindow(paneType, id, create: true);
-                    if (pane == null) { OutputWindowLogger.Warn($"PaneLauncher: FindToolWindow null for {paneType.Name} #{id}"); return; }
+                    if (pane == null) { OutputWindowLogger.Global.Warn($"PaneLauncher: FindToolWindow null for {paneType.Name} #{id}"); return; }
                     // VS doesn't always sync VSFPROPID_MultiInstanceToolNum
                     // before OnToolWindowCreated — pass the id we know for sure.
                     if (pane is PaneWindowBase paneWindow)
@@ -197,9 +197,9 @@ internal static class PaneLauncher
             }
             catch (Exception ex)
             {
-                OutputWindowLogger.LogException("PaneLauncher.OpenNew", ex);
+                OutputWindowLogger.Global.LogException("PaneLauncher.OpenNew", ex);
                 var inner = ex.InnerException;
-                while (inner != null) { OutputWindowLogger.LogException("  inner", inner); inner = inner.InnerException; }
+                while (inner != null) { OutputWindowLogger.Global.LogException("  inner", inner); inner = inner.InnerException; }
             }
         });
     }

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneRegistry.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneRegistry.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -44,7 +44,7 @@ public sealed class PaneRegistry
         Entries.Add(entry);
         if (wasEmpty && Entries.Count > 0)
         {
-            OutputWindowLogger.Info("[registry] first session started — MCP server will start");
+            OutputWindowLogger.Global.Info("[registry] first session started — MCP server will start");
             FirstSessionStarted?.Invoke();
         }
         return entry;
@@ -58,7 +58,7 @@ public sealed class PaneRegistry
         Entries.Remove(entry);
         if (Entries.Count == 0)
         {
-            OutputWindowLogger.Info("[registry] last session ended — MCP server will stop");
+            OutputWindowLogger.Global.Info("[registry] last session ended — MCP server will stop");
             LastSessionEnded?.Invoke();
         }
     }
@@ -71,7 +71,7 @@ public sealed class PaneRegistry
         foreach (var entry in Entries.ToArray())
         {
             try { entry.CloseAction?.Invoke(); }
-            catch (Exception ex) { OutputWindowLogger.LogException("PaneRegistry.CloseAll", ex); }
+            catch (Exception ex) { OutputWindowLogger.Global.LogException("PaneRegistry.CloseAll", ex); }
         }
     }
 
@@ -87,7 +87,7 @@ public sealed class PaneRegistry
         {
             if (SameFolder(entry.WorkingDirectory, workingDirectory)) { kept++; continue; }
             try { entry.CloseAction?.Invoke(); }
-            catch (Exception ex) { OutputWindowLogger.LogException("PaneRegistry.CloseWhereWorkdirDiffers", ex); }
+            catch (Exception ex) { OutputWindowLogger.Global.LogException("PaneRegistry.CloseWhereWorkdirDiffers", ex); }
         }
         return kept;
     }

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneToolbar.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneToolbar.xaml.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -291,7 +291,7 @@ public partial class PaneToolbar : UserControl
             if (!System.IO.Directory.Exists(folder)) { System.IO.Directory.CreateDirectory(folder); }
             ShellHelpers.OpenExternal(folder);
         }
-        catch (Exception ex) { OutputWindowLogger.LogException("PaneToolbar.SessionsFolder", ex); }
+        catch (Exception ex) { OutputWindowLogger.Global.LogException("PaneToolbar.SessionsFolder", ex); }
     }
 
     private static CrispImage MonikerImage(string iconId)

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneWindowBase.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneWindowBase.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -28,7 +28,7 @@ public abstract class PaneWindowBase : ToolWindowPane
 
     protected PaneWindowBase() : base(null)
     {
-        OutputWindowLogger.Perf(() => $"{GetType().Name}: ctor begin");
+        OutputWindowLogger.Global.Perf(() => $"{GetType().Name}: ctor begin");
         try
         {
             // Toolbar on top, control filling the rest; toolbar drives the pane
@@ -52,11 +52,11 @@ public abstract class PaneWindowBase : ToolWindowPane
             _toolbar.Attach(PaneControl);
             Content = dock;
 
-            OutputWindowLogger.Perf(() => $"{GetType().Name}: ctor done");
+            OutputWindowLogger.Global.Perf(() => $"{GetType().Name}: ctor done");
         }
         catch (System.Exception ex)
         {
-            OutputWindowLogger.LogException($"{GetType().Name}.ctor", ex);
+            OutputWindowLogger.Global.LogException($"{GetType().Name}.ctor", ex);
             throw;
         }
     }
@@ -124,7 +124,7 @@ public abstract class PaneWindowBase : ToolWindowPane
         if (PaneId == paneId && _assigned) { return; }
         PaneId = paneId;
         _assigned = true;
-        OutputWindowLogger.Perf(() => $"{GetType().Name}: AssignPaneId={PaneId}");
+        OutputWindowLogger.Global.Perf(() => $"{GetType().Name}: AssignPaneId={PaneId}");
         PaneControl.RegisterInstance(this);
     }
 
@@ -184,11 +184,11 @@ public abstract class PaneWindowBase : ToolWindowPane
         }
         catch (System.ObjectDisposedException)
         {
-            OutputWindowLogger.Warn("[panes] ActivatePane skipped: the pane was already closed");
+            OutputWindowLogger.Global.Warn("[panes] ActivatePane skipped: the pane was already closed");
         }
         catch (System.Runtime.InteropServices.COMException ex)
         {
-            OutputWindowLogger.LogException("[panes] ActivatePane", ex);
+            OutputWindowLogger.Global.LogException("[panes] ActivatePane", ex);
         }
     }
 
@@ -203,7 +203,7 @@ public abstract class PaneWindowBase : ToolWindowPane
         entry.DismissHistoryAction = () => _toolbar?.DismissSessionHistory() == true;
         PaneRegistry.Instance.Add(entry);
         SetSessionCaption(entry);
-        OutputWindowLogger.Info($"{GetType().Name}: attached pane #{PaneId} (seq {entry.SeqNo}), registry now has {PaneRegistry.Instance.Entries.Count} entries");
+        OutputWindowLogger.Global.Info($"{GetType().Name}: attached pane #{PaneId} (seq {entry.SeqNo}), registry now has {PaneRegistry.Instance.Entries.Count} entries");
     }
 
     /// <summary>Programmatically close this pane (used by the toolbar ✕).</summary>
@@ -223,9 +223,9 @@ public abstract class PaneWindowBase : ToolWindowPane
     {
         if (disposing)
         {
-            OutputWindowLogger.Debug(() => $"[pane] frame disposed: {GetType().Name} #{PaneId}");
+            OutputWindowLogger.Global.Debug(() => $"[pane] frame disposed: {GetType().Name} #{PaneId}");
             try { PaneControl.DisposePane(); }
-            catch (System.Exception ex) { OutputWindowLogger.LogException($"{GetType().Name}.Dispose", ex); }
+            catch (System.Exception ex) { OutputWindowLogger.Global.LogException($"{GetType().Name}.Dispose", ex); }
         }
         base.Dispose(disposing);
     }

--- a/src/Corsinvest.VisualStudio.Agents/Core/Plugins/PluginService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Plugins/PluginService.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -33,7 +33,7 @@ internal static class PluginService
         var (ok, stdout, _) = await RunRawAsync("plugin", "list", "--available", "--json");
         if (!ok || !(ExtractJson(stdout) is JObject root))
         {
-            OutputWindowLogger.Debug(() => "[plugins] list failed (process error or unparseable JSON) — returning empty");
+            OutputWindowLogger.Global.Debug(() => "[plugins] list failed (process error or unparseable JSON) — returning empty");
             return (Array.Empty<PluginDto>(), Array.Empty<AvailablePluginDto>());
         }
         var installed = (root["installed"] as JArray ?? new JArray()).Select(MapInstalled).ToArray();
@@ -182,7 +182,7 @@ internal static class PluginService
     private static Task<(bool ok, string stdout, string stderr)> RunRawAsync(params string[] args)
     {
         var exe = Core.Client.ClaudeInstall.ResolveExecutable();
-        if (exe == null) { OutputWindowLogger.Warn("[plugins] claude.exe not found — plugin operations unavailable"); return Task.FromResult((false, "", "claude.exe not found")); }
+        if (exe == null) { OutputWindowLogger.Global.Warn("[plugins] claude.exe not found — plugin operations unavailable"); return Task.FromResult((false, "", "claude.exe not found")); }
         // Plugins are global, so CWD doesn't affect the result — just need a valid one.
         var cwd = AgentsPackage.Instance?.CurrentSolutionFolder
                   ?? Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
@@ -208,7 +208,7 @@ internal static class PluginService
             var errTask = p.StandardError.ReadToEndAsync();
             if (!p.WaitForExit((int)RunTimeout.TotalMilliseconds))
             {
-                OutputWindowLogger.Warn("[plugins] operation timed out — killing the process");
+                OutputWindowLogger.Global.Warn("[plugins] operation timed out — killing the process");
                 try { p.Kill(); } catch { /* already gone */ }
                 return (false, "", "timeout");
             }

--- a/src/Corsinvest.VisualStudio.Agents/Core/Profiles/ProfileStore.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Profiles/ProfileStore.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -42,7 +42,7 @@ internal static class ProfileStore
         }
         catch (IOException)
         {
-            OutputWindowLogger.Warn("[profiles] failed to read profiles.json (IO) — profiles unavailable this session");
+            OutputWindowLogger.Global.Warn("[profiles] failed to read profiles.json (IO) — profiles unavailable this session");
             return [];
         }
     }
@@ -66,7 +66,7 @@ internal static class ProfileStore
         }
         catch (JsonException)
         {
-            OutputWindowLogger.Warn("[profiles] profiles.json is corrupt — ignoring, profiles will appear empty");
+            OutputWindowLogger.Global.Warn("[profiles] profiles.json is corrupt — ignoring, profiles will appear empty");
             return [];
         }
     }

--- a/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.Common.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.Common.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -16,7 +16,7 @@ namespace Corsinvest.VisualStudio.Agents.Core.Sessions;
 /// the 64 KB window reader, user-text extraction, toolUseResult field access, and path-token
 /// validation (the last two are also called from the WebView message handler).
 /// </summary>
-public sealed partial class SessionManager
+internal sealed partial class SessionManager
 {
     /// <summary>Read up to <see cref="LiteReadWindowBytes"/> from <paramref name="offset"/>,
     /// decode UTF-8 once (single block — no chunk seams to corrupt multi-byte chars),

--- a/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.History.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.History.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -19,14 +19,14 @@ namespace Corsinvest.VisualStudio.Agents.Core.Sessions;
 /// Session listing/metadata and mutations (rename/title/delete/fork) live in SessionManager.cs;
 /// shared JSONL parsing helpers in SessionManager.Common.cs.
 /// </summary>
-public sealed partial class SessionManager
+internal sealed partial class SessionManager
 {
     public HistoryPage ReadHistoryRaw(string sessionId)
         => ReadHistoryRaw(sessionId, HistoryBatchSize, -1, out _);
 
     public HistoryPage ReadHistoryRaw(string sessionId, int batchSize, long beforeOffset, out SessionInfo info)
     {
-        using var _ = OutputWindowLogger.PerfSpan($"ReadHistoryRaw({sessionId}, batch={batchSize}, before={beforeOffset})");
+        using var _ = OutputWindowLogger.Global.PerfSpan($"ReadHistoryRaw({sessionId}, batch={batchSize}, before={beforeOffset})");
         var page = new HistoryPage { Messages = [] };
         var folder = FolderFor();
         var path = Path.Combine(folder, sessionId + ".jsonl");
@@ -35,7 +35,7 @@ public sealed partial class SessionManager
         if (!File.Exists(path)) { return page; }
 
         var fileSize = new FileInfo(path).Length;
-        OutputWindowLogger.Perf(() => $"history file: {fileSize / 1024} KB");
+        OutputWindowLogger.Global.Perf(() => $"history file: {fileSize / 1024} KB");
 
         // `info` is built only on the initial load (beforeOffset == -1); lazy pages skip it.
         var isInitialLoad = beforeOffset < 0;
@@ -186,7 +186,7 @@ public sealed partial class SessionManager
                 page.HasMore = pos > 0;
             }
         }
-        catch (Exception ex) { OutputWindowLogger.LogException("SessionManager.ReadHistoryRaw", ex); }
+        catch (Exception ex) { _log.LogException("SessionManager.ReadHistoryRaw", ex); }
 
         if (info != null)
         {
@@ -202,7 +202,7 @@ public sealed partial class SessionManager
         // oldestIsPrompt tells whether the page ends on a real user prompt (good) or was cut by
         // reaching the file start / a metadata-only tail.
         var oldestIsPrompt = messagesNewestFirst.Count > 0 && IsRealUserPrompt(messagesNewestFirst[0]);
-        OutputWindowLogger.Perf(() => $"history: scanned {totalLinesScanned} lines ({skippedLines} skipped, {parsedLines} parsed), kept {messagesNewestFirst.Count} (batch={batchSize}) " +
+        OutputWindowLogger.Global.Perf(() => $"history: scanned {totalLinesScanned} lines ({skippedLines} skipped, {parsedLines} parsed), kept {messagesNewestFirst.Count} (batch={batchSize}) " +
             $"bytes[{page.OldestOffset}..{(isInitialLoad ? "END" : beforeOffset.ToString())}] hasMore={page.HasMore} oldestIsPrompt={oldestIsPrompt}");
         page.Messages = new JArray(messagesNewestFirst);
         return page;
@@ -217,7 +217,7 @@ public sealed partial class SessionManager
     /// meant to run off the UI thread after the initial render.</summary>
     public List<string> ReadUserPrompts(string sessionId)
     {
-        using var _ = OutputWindowLogger.PerfSpan($"ReadUserPrompts({sessionId})");
+        using var _ = OutputWindowLogger.Global.PerfSpan($"ReadUserPrompts({sessionId})");
         var promptsNewestFirst = new List<string>();
         var folder = FolderFor();
         var path = Path.Combine(folder, sessionId + ".jsonl");
@@ -273,7 +273,7 @@ public sealed partial class SessionManager
                 }
             }
         }
-        catch (Exception ex) { OutputWindowLogger.LogException("SessionManager.ReadUserPrompts", ex); }
+        catch (Exception ex) { _log.LogException("SessionManager.ReadUserPrompts", ex); }
 
         promptsNewestFirst.Reverse(); // chronological (oldest first) for the WebView
         return promptsNewestFirst;
@@ -463,7 +463,7 @@ public sealed partial class SessionManager
                     : content[blockIdx] as JObject;
             }
         }
-        catch (Exception ex) { OutputWindowLogger.LogException("SessionManager.ReadMessageBlock", ex); }
+        catch (Exception ex) { _log.LogException("SessionManager.ReadMessageBlock", ex); }
         return null;
     }
 
@@ -496,7 +496,7 @@ public sealed partial class SessionManager
                 return ""; // next line wasn't the summary
             }
         }
-        catch (Exception ex) { OutputWindowLogger.LogException("SessionManager.ReadCompactSummary", ex); }
+        catch (Exception ex) { _log.LogException("SessionManager.ReadCompactSummary", ex); }
         return "";
     }
 
@@ -548,7 +548,8 @@ public sealed partial class SessionManager
                     catch { /* a malformed sidecar only costs that one link */ }
                 }
             }
-            catch (Exception ex) { OutputWindowLogger.LogException("SessionManager.SubagentContext.Read", ex); }
+            // Static nested helper: no SessionManager instance, so no pane tag here.
+            catch (Exception ex) { OutputWindowLogger.Global.LogException("SessionManager.SubagentContext.Read", ex); }
             return ctx;
         }
 
@@ -571,7 +572,7 @@ public sealed partial class SessionManager
     /// tools); true reads the whole file. Missing file or empty agentId → empty page (no throw).</summary>
     public HistoryPage ReadSubagentHistory(string sessionId, string agentId, bool fullFile)
     {
-        using var _ = OutputWindowLogger.PerfSpan($"ReadSubagentHistory({agentId}, full={fullFile})");
+        using var _ = OutputWindowLogger.Global.PerfSpan($"ReadSubagentHistory({agentId}, full={fullFile})");
         // agentId/sessionId reach here from the WebView; reject anything that isn't a
         // plain id token so they can't traverse out of the session dir into the path.
         if (!IsSafePathToken(sessionId) || !IsSafePathToken(agentId)) { return new HistoryPage { Messages = [] }; }
@@ -597,6 +598,6 @@ public sealed partial class SessionManager
             }
             return BuildHistoryPageFromLines(lines, SubagentContext.Read(dir));
         }
-        catch (Exception ex) { OutputWindowLogger.LogException("SessionManager.ReadSubagentHistory", ex); return new HistoryPage { Messages = [] }; }
+        catch (Exception ex) { _log.LogException("SessionManager.ReadSubagentHistory", ex); return new HistoryPage { Messages = [] }; }
     }
 }

--- a/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -18,7 +18,7 @@ namespace Corsinvest.VisualStudio.Agents.Core.Sessions;
 /// <summary>Reads/writes CLI session JSONL files for one config-dir. The config-dir is
 /// constant for a pane's lifetime, so it's injected once via the constructor rather than
 /// threaded through every call — a config-dir can never be silently forgotten.</summary>
-public sealed partial class SessionManager
+internal sealed partial class SessionManager
 {
     // VS Code-style metadata scan: read a fixed 64 KB window from the start and
     // from the end of the JSONL in one read each, decode once, scan the lines.
@@ -30,10 +30,14 @@ public sealed partial class SessionManager
 
     private readonly ClaudePaths _paths;
     private readonly string _workingDirectory;
-    public SessionManager(ClaudePaths paths, string workingDirectory)
+    private readonly OutputWindowLogger _log;
+
+    // Optional: the session dialog builds one with no pane behind it (→ Global, unprefixed).
+    public SessionManager(ClaudePaths paths, string workingDirectory, OutputWindowLogger log = null)
     {
         _paths = paths ?? throw new ArgumentNullException(nameof(paths));
         _workingDirectory = workingDirectory ?? throw new ArgumentNullException(nameof(workingDirectory));
+        _log = log ?? OutputWindowLogger.Global;
     }
 
     // The session folder / a session .jsonl path for this instance's workdir, honouring
@@ -43,7 +47,7 @@ public sealed partial class SessionManager
 
     public List<SessionInfo> Load()
     {
-        using var _ = OutputWindowLogger.PerfSpan("SessionManager.Load");
+        using var _ = OutputWindowLogger.Global.PerfSpan("SessionManager.Load");
         var folder = FolderFor();
         if (!Directory.Exists(folder)) { return []; }
 
@@ -51,7 +55,7 @@ public sealed partial class SessionManager
             .OrderByDescending(f => f.LastWriteTime)
             .ToArray();
 
-        OutputWindowLogger.Perf(() => $"sessions: loading {files.Length} files");
+        OutputWindowLogger.Global.Perf(() => $"sessions: loading {files.Length} files");
 
         return files
             .AsParallel()
@@ -80,7 +84,7 @@ public sealed partial class SessionManager
             info.Title = StringHelpers.Truncate(rawTitle, 60);
             return info;
         }
-        catch { OutputWindowLogger.Debug(() => "[sessions] skipped an unreadable/corrupt session file"); return null; }
+        catch { _log.Debug(() => "[sessions] skipped an unreadable/corrupt session file"); return null; }
     }
 
     private static SessionInfo ScanMetadata(string path)
@@ -363,7 +367,7 @@ public sealed partial class SessionManager
                 if (!string.IsNullOrEmpty(uuid)) { uuidMap[uuid] = Guid.NewGuid().ToString(); }
                 kept.Add(obj);
             }
-            if (!foundCut) { OutputWindowLogger.Debug(() => "[sessions] fork-at uuid not found in source session → fork aborted"); return null; }
+            if (!foundCut) { _log.Debug(() => "[sessions] fork-at uuid not found in source session → fork aborted"); return null; }
 
             // Remap every id that references a message — leaving one pointing at an
             // old uuid would dangle, since those ids are all regenerated above.
@@ -379,7 +383,7 @@ public sealed partial class SessionManager
                 writer.WriteLine(obj.ToString(Formatting.None));
             }
         }
-        catch (Exception ex) { OutputWindowLogger.LogException("SessionManager.fork", ex); return null; }
+        catch (Exception ex) { _log.LogException("SessionManager.fork", ex); return null; }
 
         return new ForkResult { NewSessionId = newSessionId, ExcludedPrompt = excludedPrompt };
     }

--- a/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManagerControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManagerControl.xaml.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -80,7 +80,7 @@ public partial class SessionManagerControl : UserControl
         }
         catch
         {
-            OutputWindowLogger.Warn("[sessions] failed to load the session list — picker may be empty");
+            OutputWindowLogger.Global.Warn("[sessions] failed to load the session list — picker may be empty");
             // Silent: an unreadable folder shouldn't crash the picker.
         }
         ApplyActiveFlag();

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatisticsControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatisticsControl.xaml.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -73,7 +73,7 @@ public partial class StatisticsControl : UserControl
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("StatisticsControl.InitialSelection", ex);
+            OutputWindowLogger.Global.LogException("StatisticsControl.InitialSelection", ex);
             return new StatsSelection { Scope = StatsScope.All };
         }
     }
@@ -211,7 +211,7 @@ public partial class StatisticsControl : UserControl
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("StatisticsControl.Reload", ex);
+            OutputWindowLogger.Global.LogException("StatisticsControl.Reload", ex);
         }
     }
 

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatisticsWindow.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatisticsWindow.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -37,14 +37,14 @@ public sealed class StatisticsWindow : ToolWindowPane
                 var window = pkg.FindToolWindow(typeof(StatisticsWindow), 0, create: true);
                 if (window?.Frame is not Microsoft.VisualStudio.Shell.Interop.IVsWindowFrame frame)
                 {
-                    OutputWindowLogger.Warn("[stats] the Statistics window has no frame — cannot show it");
+                    OutputWindowLogger.Global.Warn("[stats] the Statistics window has no frame — cannot show it");
                     return;
                 }
                 Microsoft.VisualStudio.ErrorHandler.ThrowOnFailure(frame.Show());
             }
             catch (Exception ex)
             {
-                OutputWindowLogger.LogException("StatisticsWindow.Open", ex);
+                OutputWindowLogger.Global.LogException("StatisticsWindow.Open", ex);
             }
         });
     }

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsAggregator.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsAggregator.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -69,7 +69,7 @@ internal static class StatsAggregator
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("StatsAggregator.AggregateFile", ex);
+            OutputWindowLogger.Global.LogException("StatsAggregator.AggregateFile", ex);
             return null;
         }
         return (agg, size, cwd);

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsCache.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsCache.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -42,7 +42,7 @@ internal static class StatsCache
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("StatsCache.LoadProjectCwd", ex);
+            OutputWindowLogger.Global.LogException("StatsCache.LoadProjectCwd", ex);
             return null;
         }
     }
@@ -73,7 +73,7 @@ internal static class StatsCache
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("StatsCache.Load", ex);
+            OutputWindowLogger.Global.LogException("StatsCache.Load", ex);
         }
         return result;
     }
@@ -109,7 +109,7 @@ internal static class StatsCache
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("StatsCache.Save", ex);
+            OutputWindowLogger.Global.LogException("StatsCache.Save", ex);
         }
     }
 }

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsService.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -60,7 +60,7 @@ internal static class StatsService
                     IndexAllProjects(workingDirectory: null, ClaudePaths.ForProfile(profile), force);
                 }
             }
-            catch (Exception ex) { OutputWindowLogger.LogException(nameof(StatsService) + ".Index", ex); }
+            catch (Exception ex) { OutputWindowLogger.Global.LogException(nameof(StatsService) + ".Index", ex); }
             finally
             {
                 System.Threading.Volatile.Write(ref _indexing, 0);
@@ -80,7 +80,7 @@ internal static class StatsService
         {
             // paths is immutable, so capturing it in the closure is safe.
             try { IndexAllProjects(workingDirectory, paths); }
-            catch (Exception ex) { OutputWindowLogger.LogException(nameof(StatsService) + ".Index", ex); }
+            catch (Exception ex) { OutputWindowLogger.Global.LogException(nameof(StatsService) + ".Index", ex); }
             finally
             {
                 System.Threading.Volatile.Write(ref _indexing, 0);
@@ -372,7 +372,7 @@ internal static class StatsService
                 }
             }
         }
-        catch (Exception ex) { OutputWindowLogger.LogException(nameof(StatsService) + ".ProjectActiveDays", ex); }
+        catch (Exception ex) { OutputWindowLogger.Global.LogException(nameof(StatsService) + ".ProjectActiveDays", ex); }
         return seen;
     }
 
@@ -383,7 +383,7 @@ internal static class StatsService
     {
         if (string.IsNullOrEmpty(cwd))
         {
-            OutputWindowLogger.Warn("[stats] no cwd for this project — listing its sessions is not possible");
+            OutputWindowLogger.Global.Warn("[stats] no cwd for this project — listing its sessions is not possible");
             return [];
         }
         try
@@ -392,7 +392,7 @@ internal static class StatsService
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException(nameof(StatsService) + ".SessionsFor", ex);
+            OutputWindowLogger.Global.LogException(nameof(StatsService) + ".SessionsFor", ex);
             return [];
         }
     }
@@ -438,7 +438,7 @@ internal static class StatsService
             }
             return (cwd, hasData, lastActivity);
         }
-        catch (Exception ex) { OutputWindowLogger.LogException(nameof(StatsService) + ".ProjectCacheInfo", ex); }
+        catch (Exception ex) { OutputWindowLogger.Global.LogException(nameof(StatsService) + ".ProjectCacheInfo", ex); }
         return (null, null, lastActivity);
     }
 
@@ -453,7 +453,7 @@ internal static class StatsService
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException(nameof(StatsService) + ".CwdForProject", ex);
+            OutputWindowLogger.Global.LogException(nameof(StatsService) + ".CwdForProject", ex);
             return null;
         }
     }

--- a/src/Corsinvest.VisualStudio.Agents/Core/Usage/UsageControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Usage/UsageControl.xaml.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -94,7 +94,7 @@ public partial class UsageControl : UserControl
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("UsageControl.Fetch", ex);
+            OutputWindowLogger.Global.LogException("UsageControl.Fetch", ex);
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
             if (!cts.IsCancellationRequested) { ShowMessage("Usage unavailable for this profile."); }
         }
@@ -175,7 +175,7 @@ public partial class UsageControl : UserControl
     private void OnLinkNavigate(object sender, System.Windows.Navigation.RequestNavigateEventArgs e)
     {
         try { System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(e.Uri.AbsoluteUri) { UseShellExecute = true }); }
-        catch (Exception ex) { OutputWindowLogger.LogException("UsageControl.LinkNavigate", ex); }
+        catch (Exception ex) { OutputWindowLogger.Global.LogException("UsageControl.LinkNavigate", ex); }
         e.Handled = true;
     }
 

--- a/src/Corsinvest.VisualStudio.Agents/Core/Usage/UsageProbe.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Usage/UsageProbe.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -51,7 +51,7 @@ internal static class UsageProbe
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.Warn($"[usage] fetch failed for profile '{profile?.Name}': {ex.Message}");
+            OutputWindowLogger.Global.Warn($"[usage] fetch failed for profile '{profile?.Name}': {ex.Message}");
             throw;
         }
         finally

--- a/src/Corsinvest.VisualStudio.Agents/Core/Usage/UsageWindow.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Usage/UsageWindow.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -35,14 +35,14 @@ public sealed class UsageWindow : ToolWindowPane
                 var window = pkg.FindToolWindow(typeof(UsageWindow), 0, create: true);
                 if (window?.Frame is not IVsWindowFrame frame)
                 {
-                    OutputWindowLogger.Warn("[usage] the Usage window has no frame — cannot show it");
+                    OutputWindowLogger.Global.Warn("[usage] the Usage window has no frame — cannot show it");
                     return;
                 }
                 ErrorHandler.ThrowOnFailure(frame.Show());
             }
             catch (Exception ex)
             {
-                OutputWindowLogger.LogException("UsageWindow.Open", ex);
+                OutputWindowLogger.Global.LogException("UsageWindow.Open", ex);
             }
         });
     }

--- a/src/Corsinvest.VisualStudio.Agents/Core/Workspace/WorkspaceStore.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Workspace/WorkspaceStore.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -46,7 +46,7 @@ internal static class WorkspaceStore
             if (File.Exists(path)) { File.Delete(path); }
             File.Move(tmp, path);
         }
-        catch (Exception ex) { OutputWindowLogger.LogException("WorkspaceStore.Save", ex); }
+        catch (Exception ex) { OutputWindowLogger.Global.LogException("WorkspaceStore.Save", ex); }
     }
 
     /// <summary>Load the solution's workspace, or null if absent/unreadable.</summary>
@@ -59,6 +59,6 @@ internal static class WorkspaceStore
             if (!File.Exists(path)) { return null; }
             return JsonConvert.DeserializeObject<WorkspaceState>(File.ReadAllText(path));
         }
-        catch (Exception ex) { OutputWindowLogger.LogException("WorkspaceStore.Load", ex); return null; }
+        catch (Exception ex) { OutputWindowLogger.Global.LogException("WorkspaceStore.Load", ex); return null; }
     }
 }

--- a/src/Corsinvest.VisualStudio.Agents/Helpers/OutputWindowLogger.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Helpers/OutputWindowLogger.cs
@@ -10,8 +10,108 @@ using System;
 
 namespace Corsinvest.VisualStudio.Agents;
 
-internal static class OutputWindowLogger
+/// <summary>Writes to the extension's pane in the VS Output window.
+/// <para>Instances differ only by the tag they prepend: <see cref="For"/> gives a per-session one
+/// (<c>[chat#2]</c>) so several open panes can be told apart in what is a single stream, and
+/// <see cref="Global"/> writes untagged for everything that belongs to no session — MCP, IDE,
+/// package, and any static member with no instance to reach.</para>
+/// <para>The pane itself is process-wide, so it stays on the static side: one pane, created once.</para>
+/// </summary>
+internal sealed class OutputWindowLogger
 {
+    // A Func, not a string: PaneId is assigned after the control is built
+    // (PaneWindowBase.AssignPaneId), so a captured value would tag every start-up line "#0".
+    private readonly Func<string> _tag;
+
+    private OutputWindowLogger(Func<string> tag) => _tag = tag;
+
+    /// <summary>Logger for one pane: every line carries <c>[chat#N]</c> / <c>[cli#N]</c>.</summary>
+    public static OutputWindowLogger For(string kind, Func<int> paneId) => new(() => $"[{kind}#{paneId()}]");
+
+    /// <summary>Logger for code that belongs to no session. Writes with no tag.</summary>
+    public static readonly OutputWindowLogger Global = new(null);
+
+    private string P => _tag == null ? "" : _tag() + " ";
+
+    public void Error(string message) => Write(LogLevel.Error, message);
+    public void Warn(string message) => Write(LogLevel.Warn, message);
+    public void Info(string message) => Write(LogLevel.Info, message);
+    public void Debug(string message) => Write(LogLevel.Debug, message);
+    public void Trace(string message) => Write(LogLevel.Trace, message);
+
+    /// <summary>Lazy overload: the factory runs only when the level is on, so callers with an
+    /// interpolated message don't pay the string build (and its allocations) when it's off.</summary>
+    public void Debug(Func<string> messageFactory)
+    {
+        if (LogLevel.Debug > AgentsOptions.Debug.LogLevel) { return; }
+        Write(LogLevel.Debug, messageFactory());
+    }
+
+    public void Trace(Func<string> messageFactory)
+    {
+        if (LogLevel.Trace > AgentsOptions.Debug.LogLevel) { return; }
+        Write(LogLevel.Trace, messageFactory());
+    }
+
+    public void Perf(string message)
+    {
+        if (!AgentsOptions.Debug.EnablePerfLog) { return; }
+        WriteLine($"PERF {P}{message}");
+    }
+
+    /// <summary>Lazy overload: same reason as <see cref="Debug(Func{string})"/>.</summary>
+    public void Perf(Func<string> messageFactory)
+    {
+        if (!AgentsOptions.Debug.EnablePerfLog) { return; }
+        WriteLine($"PERF {P}{messageFactory()}");
+    }
+
+    public IDisposable PerfSpan(string label) =>
+        AgentsOptions.Debug.EnablePerfLog ? new PerfTimer(this, label) : NullDisposable.Instance;
+
+    private sealed class PerfTimer(OutputWindowLogger owner, string label) : IDisposable
+    {
+        private readonly DateTime _t0 = DateTime.Now;
+        public void Dispose() => owner.Perf($"{label} {(DateTime.Now - _t0).TotalMilliseconds:0}ms");
+    }
+
+    private sealed class NullDisposable : IDisposable
+    {
+        public static readonly NullDisposable Instance = new();
+        public void Dispose() { }
+    }
+
+    // Always logs (bypasses LogLevel) — losing exceptions silently would
+    // make the extension impossible to diagnose in production.
+    public void LogException(string context, Exception ex)
+    {
+        if (ex == null) { return; }
+        var ctx = P + (context ?? "");
+        var line = DateTime.Now.ToString("HH:mm:ss.fff") + " !!! "
+                 + (string.IsNullOrEmpty(ctx) ? "" : ctx + ": ")
+                 + ex.GetType().Name + ": " + ex.Message
+                 + Environment.NewLine + ex.StackTrace;
+        // The [AppId] prefix only matters in the debugger's Output stream, where our lines mix
+        // with everything else; our own pane is already dedicated to the extension.
+        System.Diagnostics.Debug.WriteLine("[" + AppConstants.AppId + "] " + line);
+        _pane?.OutputStringThreadSafe(line + Environment.NewLine);
+    }
+
+    private void Write(LogLevel level, string message)
+    {
+        if (level > AgentsOptions.Debug.LogLevel) { return; }
+        WriteLine($"{level.ToString().ToUpperInvariant()} {P}{message}");
+    }
+
+    private static void WriteLine(string body)
+    {
+        var line = DateTime.Now.ToString("HH:mm:ss.fff") + " " + body;
+        System.Diagnostics.Debug.WriteLine("[" + AppConstants.AppId + "] " + line);
+        _pane?.OutputStringThreadSafe(line + Environment.NewLine);
+    }
+
+    // The Output window pane is process-wide: one for the whole extension, whoever logs into it.
+
     private static IVsOutputWindowPane _pane;
 
     public static void EnsurePaneOnUIThread()
@@ -30,81 +130,6 @@ internal static class OutputWindowLogger
         var dte = Package.GetGlobalService(typeof(EnvDTE.DTE)) as EnvDTE.DTE;
         try { dte?.ExecuteCommand("View.Output"); } catch { /* command may not exist in all VS configs */ }
     }).FileAndForget(nameof(OutputWindowLogger));
-
-    public static void Error(string message) => Write(LogLevel.Error, message);
-    public static void Warn(string message) => Write(LogLevel.Warn, message);
-    public static void Info(string message) => Write(LogLevel.Info, message);
-    public static void Debug(string message) => Write(LogLevel.Debug, message);
-    public static void Trace(string message) => Write(LogLevel.Trace, message);
-
-    public static void Perf(string message)
-    {
-        if (!AgentsOptions.Debug.EnablePerfLog) { return; }
-        WriteLine($"PERF {message}");
-    }
-
-    /// <summary>Lazy overload: the factory runs only when perf logging is on, so callers with an
-    /// interpolated message don't pay the string build (and its allocations) when it's off (default).</summary>
-    public static void Perf(Func<string> messageFactory)
-    {
-        if (!AgentsOptions.Debug.EnablePerfLog) { return; }
-        WriteLine($"PERF {messageFactory()}");
-    }
-
-    public static IDisposable PerfSpan(string label) =>
-        AgentsOptions.Debug.EnablePerfLog ? new PerfTimer(label) : NullDisposable.Instance;
-
-    private sealed class PerfTimer(string label) : IDisposable
-    {
-        private readonly DateTime _t0 = DateTime.Now;
-        public void Dispose() => Perf($"{label} {(DateTime.Now - _t0).TotalMilliseconds:0}ms");
-    }
-
-    private sealed class NullDisposable : IDisposable
-    {
-        public static readonly NullDisposable Instance = new();
-        public void Dispose() { }
-    }
-
-    public static void Debug(Func<string> messageFactory)
-    {
-        if (LogLevel.Debug > AgentsOptions.Debug.LogLevel) { return; }
-        Write(LogLevel.Debug, messageFactory());
-    }
-
-    public static void Trace(Func<string> messageFactory)
-    {
-        if (LogLevel.Trace > AgentsOptions.Debug.LogLevel) { return; }
-        Write(LogLevel.Trace, messageFactory());
-    }
-
-    // Always logs (bypasses LogLevel) — losing exceptions silently would
-    // make the extension impossible to diagnose in production.
-    public static void LogException(string context, Exception ex)
-    {
-        if (ex == null) { return; }
-        var line = DateTime.Now.ToString("HH:mm:ss.fff") + " !!! "
-                 + (string.IsNullOrEmpty(context) ? "" : context + ": ")
-                 + ex.GetType().Name + ": " + ex.Message
-                 + Environment.NewLine + ex.StackTrace;
-        // The [AppId] prefix only matters in the debugger's Output stream, where our lines mix
-        // with everything else; our own pane is already dedicated to the extension.
-        System.Diagnostics.Debug.WriteLine("[" + AppConstants.AppId + "] " + line);
-        _pane?.OutputStringThreadSafe(line + Environment.NewLine);
-    }
-
-    private static void Write(LogLevel level, string message)
-    {
-        if (level > AgentsOptions.Debug.LogLevel) { return; }
-        WriteLine($"{level.ToString().ToUpperInvariant()} {message}");
-    }
-
-    private static void WriteLine(string body)
-    {
-        var line = DateTime.Now.ToString("HH:mm:ss.fff") + " " + body;
-        System.Diagnostics.Debug.WriteLine("[" + AppConstants.AppId + "] " + line);
-        _pane?.OutputStringThreadSafe(line + Environment.NewLine);
-    }
 
     private static void EnsurePane()
     {

--- a/src/Corsinvest.VisualStudio.Agents/Helpers/ShellHelpers.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Helpers/ShellHelpers.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -23,7 +23,7 @@ internal static class ShellHelpers
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("ShellHelpers.OpenExternal", ex);
+            OutputWindowLogger.Global.LogException("ShellHelpers.OpenExternal", ex);
         }
     }
 }

--- a/src/Corsinvest.VisualStudio.Agents/Helpers/Win32Focus.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Helpers/Win32Focus.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -88,7 +88,7 @@ internal static class Win32Focus
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("Win32Focus.ShowToast", ex);
+            OutputWindowLogger.Global.LogException("Win32Focus.ShowToast", ex);
             return null;
         }
     }
@@ -145,7 +145,7 @@ internal static class Win32Focus
                 var id = type.GetField("id", flags)?.GetValue(icon);
                 if (window == null || window.Handle == IntPtr.Zero || id == null)
                 {
-                    OutputWindowLogger.Warn("[panes] balloon retract skipped: NotifyIcon internals not found");
+                    OutputWindowLogger.Global.Warn("[panes] balloon retract skipped: NotifyIcon internals not found");
                     return;
                 }
 
@@ -161,12 +161,12 @@ internal static class Win32Focus
                 };
                 if (!Shell_NotifyIcon(NIM_MODIFY, ref data))
                 {
-                    OutputWindowLogger.Warn("[panes] balloon retract refused by the shell");
+                    OutputWindowLogger.Global.Warn("[panes] balloon retract refused by the shell");
                 }
             }
             catch (Exception ex)
             {
-                OutputWindowLogger.Warn($"[panes] balloon retract failed: {ex.Message}");
+                OutputWindowLogger.Global.Warn($"[panes] balloon retract failed: {ex.Message}");
             }
         }
     }

--- a/src/Corsinvest.VisualStudio.Agents/Helpers/WindowChrome.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Helpers/WindowChrome.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -49,7 +49,7 @@ internal static class WindowChrome
             var border = ThemedBorderColor();
             DwmSetWindowAttribute(handle, DwmwaBorderColor, ref border, sizeof(int));
         }
-        catch (Exception ex) { OutputWindowLogger.LogException($"{nameof(WindowChrome)}.{nameof(ApplyTheme)}", ex); }
+        catch (Exception ex) { OutputWindowLogger.Global.LogException($"{nameof(WindowChrome)}.{nameof(ApplyTheme)}", ex); }
     }
 
     /// <summary>The border colour as a COLORREF (0x00BBGGRR — the reverse of RGB), taken from the

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.Operations.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.Operations.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -111,7 +111,7 @@ internal sealed partial class IdeContextService
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("Ide.BuildAsync", ex);
+            OutputWindowLogger.Global.LogException("Ide.BuildAsync", ex);
             return new BuildResult { Ok = false, Message = $"Build error: {ex.Message}" };
         }
     }
@@ -219,7 +219,7 @@ internal sealed partial class IdeContextService
                 CollectProject(p, result.Projects);
             }
         }
-        catch (Exception ex) { OutputWindowLogger.LogException("Ide.GetProjectStructureAsync", ex); }
+        catch (Exception ex) { OutputWindowLogger.Global.LogException("Ide.GetProjectStructureAsync", ex); }
         return result;
     }
 
@@ -443,7 +443,7 @@ internal sealed partial class IdeContextService
                 return frame.IsVisible() == VSConstants.S_OK;
             }
         }
-        catch (Exception ex) { OutputWindowLogger.LogException("Ide.IsFileVisible", ex); }
+        catch (Exception ex) { OutputWindowLogger.Global.LogException("Ide.IsFileVisible", ex); }
         return false;
     }
 
@@ -486,7 +486,7 @@ internal sealed partial class IdeContextService
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("Ide.OpenFile", ex);
+            OutputWindowLogger.Global.LogException("Ide.OpenFile", ex);
             return false;
         }
     }
@@ -573,7 +573,7 @@ internal sealed partial class IdeContextService
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException($"Ide.{dteCommand}", ex);
+            OutputWindowLogger.Global.LogException($"Ide.{dteCommand}", ex);
             return false;
         }
     }
@@ -595,7 +595,7 @@ internal sealed partial class IdeContextService
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("Ide.ExecuteInteractiveCode", ex);
+            OutputWindowLogger.Global.LogException("Ide.ExecuteInteractiveCode", ex);
             return false;
         }
     }

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -90,11 +90,11 @@ internal sealed partial class IdeContextService : IDisposable
                     ?.GetService<IVsEditorAdaptersFactoryService>();
             if (_editorAdapters == null)
             {
-                OutputWindowLogger.Warn("[ide-context] editor adapters unavailable — selection tracking will not fire");
+                OutputWindowLogger.Global.Warn("[ide-context] editor adapters unavailable — selection tracking will not fire");
             }
             else
             {
-                OutputWindowLogger.Info("[ide-context] editor-events subscribed");
+                OutputWindowLogger.Global.Info("[ide-context] editor-events subscribed");
             }
             _debounce = new Timer(_ => OnDebounceElapsed(), null, Timeout.Infinite, Timeout.Infinite);
 
@@ -105,7 +105,7 @@ internal sealed partial class IdeContextService : IDisposable
             _subscribed = true;
             TrackActiveView();
         }
-        catch (Exception ex) { OutputWindowLogger.LogException("Ide.SubscribeToEditorEvents", ex); }
+        catch (Exception ex) { OutputWindowLogger.Global.LogException("Ide.SubscribeToEditorEvents", ex); }
     }
 
     /// <summary>(Re)attach the SelectionChanged listener to the active text
@@ -152,7 +152,7 @@ internal sealed partial class IdeContextService : IDisposable
             _trackedView.Closed += OnViewClosed;
             CaptureAndSchedule();
         }
-        catch (Exception ex) { OutputWindowLogger.LogException("Ide.TrackActiveView", ex); }
+        catch (Exception ex) { OutputWindowLogger.Global.LogException("Ide.TrackActiveView", ex); }
     }
 
     private void UntrackView()
@@ -213,7 +213,7 @@ internal sealed partial class IdeContextService : IDisposable
             // synthetic path like "\temp\readonly\Grep output" / "Temp.txt").
             if (string.IsNullOrEmpty(filePath) || !File.Exists(filePath))
             {
-                OutputWindowLogger.Trace(() => $"[ide-context] drop: path missing/synthetic='{filePath}'");
+                OutputWindowLogger.Global.Trace(() => $"[ide-context] drop: path missing/synthetic='{filePath}'");
                 ScheduleEmit(null);
                 return;
             }
@@ -238,7 +238,7 @@ internal sealed partial class IdeContextService : IDisposable
             };
             ScheduleEmit(ctx);
         }
-        catch (Exception ex) { OutputWindowLogger.LogException("Ide.CaptureAndSchedule", ex); }
+        catch (Exception ex) { OutputWindowLogger.Global.LogException("Ide.CaptureAndSchedule", ex); }
     }
 
     private void ScheduleEmit(EditorContext ctx)
@@ -304,7 +304,7 @@ internal sealed partial class IdeContextService : IDisposable
         if (ctx.HasSelection) { RememberSelection(ctx.ToSelection()); }
 
         try { ContextChanged?.Invoke(ctx); }
-        catch (Exception ex) { OutputWindowLogger.LogException("Ide.ContextChanged", ex); }
+        catch (Exception ex) { OutputWindowLogger.Global.LogException("Ide.ContextChanged", ex); }
     }
 
     /// <summary>Synchronous snapshot of the editor for the live badge
@@ -353,7 +353,7 @@ internal sealed partial class IdeContextService : IDisposable
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("Ide.GetCurrentContext", ex);
+            OutputWindowLogger.Global.LogException("Ide.GetCurrentContext", ex);
             return null;
         }
     }
@@ -382,7 +382,7 @@ internal sealed partial class IdeContextService : IDisposable
                     }
                 }
             }
-            catch (Exception ex) { OutputWindowLogger.LogException("Ide.SaveIfDirty", ex); }
+            catch (Exception ex) { OutputWindowLogger.Global.LogException("Ide.SaveIfDirty", ex); }
         }).FileAndForget("cv4vs/Ide.SaveIfDirty");
     }
 
@@ -411,7 +411,7 @@ internal sealed partial class IdeContextService : IDisposable
                 }
             }
         }
-        catch (Exception ex) { OutputWindowLogger.LogException("Ide.SaveDocumentAsync", ex); }
+        catch (Exception ex) { OutputWindowLogger.Global.LogException("Ide.SaveDocumentAsync", ex); }
         return false;
     }
 
@@ -430,7 +430,7 @@ internal sealed partial class IdeContextService : IDisposable
                 if (PathEquals(FrameMoniker(frame), target)) { return FrameDirty(frame); }
             }
         }
-        catch (Exception ex) { OutputWindowLogger.LogException("Ide.IsDocumentDirtyAsync", ex); }
+        catch (Exception ex) { OutputWindowLogger.Global.LogException("Ide.IsDocumentDirtyAsync", ex); }
         return null;
     }
 

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.Inspection.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.Inspection.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -42,7 +42,7 @@ internal sealed partial class IdeDebugService
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("IdeDebugService.ContinueAsync", ex);
+            OutputWindowLogger.Global.LogException("IdeDebugService.ContinueAsync", ex);
             return new DebugResult { Ok = false, Reason = "Failed to continue." };
         }
     }
@@ -74,7 +74,7 @@ internal sealed partial class IdeDebugService
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("IdeDebugService.StepAsync", ex);
+            OutputWindowLogger.Global.LogException("IdeDebugService.StepAsync", ex);
             return new StepResult { Ok = false, Reason = "Failed to step." };
         }
     }
@@ -118,7 +118,7 @@ internal sealed partial class IdeDebugService
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("IdeDebugService.GetCallStackAsync", ex);
+            OutputWindowLogger.Global.LogException("IdeDebugService.GetCallStackAsync", ex);
             return new CallStackResult { Ok = false, Reason = "Failed to get call stack." };
         }
     }
@@ -156,7 +156,7 @@ internal sealed partial class IdeDebugService
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("IdeDebugService.GetLocalsAsync", ex);
+            OutputWindowLogger.Global.LogException("IdeDebugService.GetLocalsAsync", ex);
             return new LocalsResult { Ok = false, Reason = "Failed to get locals." };
         }
     }
@@ -193,7 +193,7 @@ internal sealed partial class IdeDebugService
         }
         catch (Exception exc)
         {
-            OutputWindowLogger.LogException("IdeDebugService.EvaluateAsync", exc);
+            OutputWindowLogger.Global.LogException("IdeDebugService.EvaluateAsync", exc);
             return new EvalResult { Ok = false, Reason = "Failed to evaluate." };
         }
     }

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -73,7 +73,7 @@ internal sealed partial class IdeDebugService
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("IdeDebugService.GetStateAsync", ex);
+            OutputWindowLogger.Global.LogException("IdeDebugService.GetStateAsync", ex);
             return new DebugState { Mode = "unknown" };
         }
     }
@@ -97,7 +97,7 @@ internal sealed partial class IdeDebugService
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("IdeDebugService.StartAsync", ex);
+            OutputWindowLogger.Global.LogException("IdeDebugService.StartAsync", ex);
             return new DebugResult { Ok = false, Reason = "Failed to start debugging." };
         }
     }
@@ -119,7 +119,7 @@ internal sealed partial class IdeDebugService
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("IdeDebugService.StopAsync", ex);
+            OutputWindowLogger.Global.LogException("IdeDebugService.StopAsync", ex);
             return new DebugResult { Ok = false, Reason = "Failed to stop debugging." };
         }
     }
@@ -162,7 +162,7 @@ internal sealed partial class IdeDebugService
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("IdeDebugService.SetBreakpointAsync", ex);
+            OutputWindowLogger.Global.LogException("IdeDebugService.SetBreakpointAsync", ex);
             return new DebugResult { Ok = false, Reason = "Failed to set breakpoint." };
         }
     }
@@ -200,7 +200,7 @@ internal sealed partial class IdeDebugService
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("IdeDebugService.SetFunctionBreakpointAsync", ex);
+            OutputWindowLogger.Global.LogException("IdeDebugService.SetFunctionBreakpointAsync", ex);
             return new DebugResult { Ok = false, Reason = "Failed to set function breakpoint." };
         }
     }
@@ -237,7 +237,7 @@ internal sealed partial class IdeDebugService
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("IdeDebugService.RemoveBreakpointAsync", ex);
+            OutputWindowLogger.Global.LogException("IdeDebugService.RemoveBreakpointAsync", ex);
             return new DebugResult { Ok = false, Reason = "Failed to remove breakpoint." };
         }
     }
@@ -260,7 +260,7 @@ internal sealed partial class IdeDebugService
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("IdeDebugService.ClearBreakpointsAsync", ex);
+            OutputWindowLogger.Global.LogException("IdeDebugService.ClearBreakpointsAsync", ex);
             return new DebugResult { Ok = false, Reason = "Failed to clear breakpoints." };
         }
     }
@@ -298,7 +298,7 @@ internal sealed partial class IdeDebugService
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("IdeDebugService.ListBreakpointsAsync", ex);
+            OutputWindowLogger.Global.LogException("IdeDebugService.ListBreakpointsAsync", ex);
             return new BreakpointsResult { Ok = false, Reason = "Failed to list breakpoints." };
         }
     }
@@ -321,7 +321,7 @@ internal sealed partial class IdeDebugService
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("IdeDebugService.BreakAsync", ex);
+            OutputWindowLogger.Global.LogException("IdeDebugService.BreakAsync", ex);
             return new DebugResult { Ok = false, Reason = "Failed to break." };
         }
     }
@@ -355,7 +355,7 @@ internal sealed partial class IdeDebugService
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("IdeDebugService.ListProcessesAsync", ex);
+            OutputWindowLogger.Global.LogException("IdeDebugService.ListProcessesAsync", ex);
             return new ProcessesResult { Ok = false, Reason = "Failed to list processes." };
         }
     }
@@ -405,7 +405,7 @@ internal sealed partial class IdeDebugService
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("IdeDebugService.AttachAsync", ex);
+            OutputWindowLogger.Global.LogException("IdeDebugService.AttachAsync", ex);
             return new DebugResult { Ok = false, Reason = "Failed to attach (admin rights may be required)." };
         }
     }
@@ -432,7 +432,7 @@ internal sealed partial class IdeDebugService
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("IdeDebugService.RestartAsync", ex);
+            OutputWindowLogger.Global.LogException("IdeDebugService.RestartAsync", ex);
             return new DebugResult { Ok = false, Reason = "Failed to restart debugging." };
         }
     }
@@ -456,7 +456,7 @@ internal sealed partial class IdeDebugService
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("IdeDebugService.StartWithoutDebuggingAsync", ex);
+            OutputWindowLogger.Global.LogException("IdeDebugService.StartWithoutDebuggingAsync", ex);
             return (false, "Failed to start without debugging.");
         }
     }
@@ -490,7 +490,7 @@ internal sealed partial class IdeDebugService
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("IdeDebugService.ApplyHotReloadAsync", ex);
+            OutputWindowLogger.Global.LogException("IdeDebugService.ApplyHotReloadAsync", ex);
             return new DebugResult { Ok = false, Reason = "Hot Reload failed or not available (no changes, or a rude edit needing restart)." };
         }
     }
@@ -514,7 +514,7 @@ internal sealed partial class IdeDebugService
             var groups = dbg.GetType().GetProperty("ExceptionGroups")?.GetValue(dbg);
             if (groups == null)
             {
-                OutputWindowLogger.Debug(() => "[debug] Debugger3.ExceptionGroups unavailable — exception-break config skipped");
+                OutputWindowLogger.Global.Debug(() => "[debug] Debugger3.ExceptionGroups unavailable — exception-break config skipped");
                 return new DebugResult { Ok = false, Reason = "Exception settings not available (no solution loaded?)." };
             }
 
@@ -537,7 +537,7 @@ internal sealed partial class IdeDebugService
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("IdeDebugService.SetExceptionBreakAsync", ex);
+            OutputWindowLogger.Global.LogException("IdeDebugService.SetExceptionBreakAsync", ex);
             return new DebugResult { Ok = false, Reason = "Failed to set exception break." };
         }
     }

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeDiagnosticsTracker.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeDiagnosticsTracker.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -43,7 +43,7 @@ internal sealed class IdeDiagnosticsTracker
         // Fallback to filePath when toolUseId is missing (edge case) — collision-prone but better
         // than dropping the baseline outright.
         _baseline[Key(toolUseId ?? filePath)] = (ReadFileDiagnosticsAsync(filePath), DateTime.UtcNow);
-        OutputWindowLogger.Debug(() => $"[diag] baseline capture started for {filePath}");
+        OutputWindowLogger.Global.Debug(() => $"[diag] baseline capture started for {filePath}");
     }
 
     public async Task<string> FindNewDiagnosticsAsync(string toolUseId, string filePath, bool editorVisible)
@@ -51,7 +51,7 @@ internal sealed class IdeDiagnosticsTracker
         if (string.IsNullOrEmpty(filePath)) { return null; }
         _baseline.TryRemove(Key(toolUseId ?? filePath), out var b);           // consume the baseline
         var before = b.Diags != null ? await b.Diags : [];
-        OutputWindowLogger.Debug(() => $"[diag] check start {filePath} visible={editorVisible} baseline={before.Count} items");
+        OutputWindowLogger.Global.Debug(() => $"[diag] check start {filePath} visible={editorVisible} baseline={before.Count} items");
 
         // The Error List refreshes after the edit lands; wait like VS Code. Visible editors settle
         // faster (2×750ms, bail at first hit); background files get a single 1000ms wait.
@@ -63,15 +63,15 @@ internal sealed class IdeDiagnosticsTracker
             var after = await ReadFileDiagnosticsAsync(filePath);
             sw.Stop();
             var step = i;
-            OutputWindowLogger.Debug(() => $"[diag] step {step + 1}: read {after.Count} items in {sw.ElapsedMilliseconds}ms (after {steps[step]}ms wait)");
+            OutputWindowLogger.Global.Debug(() => $"[diag] step {step + 1}: read {after.Count} items in {sw.ElapsedMilliseconds}ms (after {steps[step]}ms wait)");
             var added = after.Where(a => !before.Any(x => SameDiag(x, a))).ToList();
             if (added.Count > 0)
             {
-                OutputWindowLogger.Debug(() => $"[diag] {added.Count} new diagnostics for {filePath}");
+                OutputWindowLogger.Global.Debug(() => $"[diag] {added.Count} new diagnostics for {filePath}");
                 return Format(filePath, added);
             }
         }
-        OutputWindowLogger.Debug(() => $"[diag] no new diagnostics for {filePath}");
+        OutputWindowLogger.Global.Debug(() => $"[diag] no new diagnostics for {filePath}");
         return null;
     }
 
@@ -87,7 +87,7 @@ internal sealed class IdeDiagnosticsTracker
         {
             // Must not fault: this task is awaited both as the baseline and inside the post-edit
             // read, and a faulted baseline would throw out of FindNewDiagnosticsAsync's await.
-            OutputWindowLogger.LogException("IdeDiagnosticsTracker.ReadFileDiagnosticsAsync", ex);
+            OutputWindowLogger.Global.LogException("IdeDiagnosticsTracker.ReadFileDiagnosticsAsync", ex);
             return [];
         }
     }

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeDiffViewer.Listeners.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeDiffViewer.Listeners.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -35,7 +35,7 @@ internal sealed partial class IdeDiffViewer
                 var match = owner.FindPendingTempPath(path);
                 if (match != null) { owner.TryResolve(match, FileSaved); }
             }
-            catch (Exception ex) { OutputWindowLogger.LogException("RdtSaveListener.OnAfterSave", ex); }
+            catch (Exception ex) { OutputWindowLogger.Global.LogException("RdtSaveListener.OnAfterSave", ex); }
             return VSConstants.S_OK;
         }
 
@@ -151,7 +151,7 @@ internal sealed partial class IdeDiffViewer
             }
             catch (Exception ex)
             {
-                OutputWindowLogger.LogException("DiffInfoBar.TryAttach", ex);
+                OutputWindowLogger.Global.LogException("DiffInfoBar.TryAttach", ex);
                 return null;
             }
         }

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeDiffViewer.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeDiffViewer.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -185,7 +185,7 @@ internal sealed partial class IdeDiffViewer
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
             try { pending.InfoBar?.Close(); } catch { /* best effort */ }
             try { pending.Frame?.CloseFrame((uint)__FRAMECLOSE.FRAMECLOSE_NoSave); }
-            catch (Exception ex) { OutputWindowLogger.LogException("IdeDiffViewer.AutoClose", ex); }
+            catch (Exception ex) { OutputWindowLogger.Global.LogException("IdeDiffViewer.AutoClose", ex); }
 
             // Cleanup pending + open-frames registration (file is
             // auto-removed by VS since we marked it temporary).
@@ -195,7 +195,7 @@ internal sealed partial class IdeDiffViewer
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("IdeDiffViewer.Open", ex);
+            OutputWindowLogger.Global.LogException("IdeDiffViewer.Open", ex);
             return new DiffResult { Status = DiffRejected };
         }
     }
@@ -230,7 +230,7 @@ internal sealed partial class IdeDiffViewer
                 if (!string.IsNullOrEmpty(toolUseId)) { _chatDiffs[toolUseId] = frame; }
             }
         }
-        catch (Exception ex) { OutputWindowLogger.LogException("IdeDiffViewer.ShowFromContents", ex); }
+        catch (Exception ex) { OutputWindowLogger.Global.LogException("IdeDiffViewer.ShowFromContents", ex); }
     }
 
     /// <summary>Close a specific diff frame by tab name. Lookup is
@@ -243,7 +243,7 @@ internal sealed partial class IdeDiffViewer
         await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
         if (!_openFrames.TryGetValue(tabName, out var frame)) { return; }
         try { frame.CloseFrame((uint)__FRAMECLOSE.FRAMECLOSE_NoSave); }
-        catch (Exception ex) { OutputWindowLogger.LogException("IdeDiffViewer.CloseTab", ex); }
+        catch (Exception ex) { OutputWindowLogger.Global.LogException("IdeDiffViewer.CloseTab", ex); }
         _openFrames.Remove(tabName);
     }
 
@@ -260,7 +260,7 @@ internal sealed partial class IdeDiffViewer
         foreach (var kv in snapshot)
         {
             try { kv.Value.CloseFrame((uint)__FRAMECLOSE.FRAMECLOSE_NoSave); closed++; }
-            catch (Exception ex) { OutputWindowLogger.LogException("IdeDiffViewer.CloseAll", ex); }
+            catch (Exception ex) { OutputWindowLogger.Global.LogException("IdeDiffViewer.CloseAll", ex); }
             _openFrames.Remove(kv.Key);
         }
         return closed;
@@ -306,7 +306,7 @@ internal sealed partial class IdeDiffViewer
     {
         ThreadHelper.ThrowIfNotOnUIThread();
         try { frame.CloseFrame((uint)__FRAMECLOSE.FRAMECLOSE_NoSave); }
-        catch (Exception ex) { OutputWindowLogger.LogException("IdeDiffViewer.CloseChatFrame", ex); }
+        catch (Exception ex) { OutputWindowLogger.Global.LogException("IdeDiffViewer.CloseChatFrame", ex); }
         _chatDiffs.Remove(toolUseId);
         foreach (var kv in new List<KeyValuePair<string, IVsWindowFrame>>(_openFrames))
         {
@@ -374,7 +374,7 @@ internal sealed partial class IdeDiffViewer
         ThreadHelper.ThrowIfNotOnUIThread();
         if (Package.GetGlobalService(typeof(SVsDifferenceService)) is not IVsDifferenceService svc)
         {
-            OutputWindowLogger.Warn("[diff] difference service unavailable — diff cannot open");
+            OutputWindowLogger.Global.Warn("[diff] difference service unavailable — diff cannot open");
             return null;
         }
         uint opts = 0;

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.Definition.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.Definition.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -52,7 +52,7 @@ internal sealed partial class IdeNavigationService
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("IdeNavigationService.EnsureDefProbed", ex);
+            OutputWindowLogger.Global.LogException("IdeNavigationService.EnsureDefProbed", ex);
             return false;
         }
     }
@@ -96,7 +96,7 @@ internal sealed partial class IdeNavigationService
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("IdeNavigationService.GetDefinitionAsync", ex);
+            OutputWindowLogger.Global.LogException("IdeNavigationService.GetDefinitionAsync", ex);
             return new NavResult { Supported = false, Reason = "Navigation failed (internal API changed?)." };
         }
     }

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.References.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.References.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -73,7 +73,7 @@ internal sealed partial class IdeNavigationService
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("IdeNavigationService.EnsureRefsProbed", ex);
+            OutputWindowLogger.Global.LogException("IdeNavigationService.EnsureRefsProbed", ex);
             return false;
         }
     }
@@ -131,7 +131,7 @@ internal sealed partial class IdeNavigationService
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException($"IdeNavigationService.RunFindUsagesAsync({kind})", ex);
+            OutputWindowLogger.Global.LogException($"IdeNavigationService.RunFindUsagesAsync({kind})", ex);
             return new NavResult { Supported = false, Reason = $"Find-{kind} failed (internal API changed?)." };
         }
     }

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.Rename.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.Rename.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -75,7 +75,7 @@ internal sealed partial class IdeNavigationService
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("IdeNavigationService.EnsureRenameProbed", ex);
+            OutputWindowLogger.Global.LogException("IdeNavigationService.EnsureRenameProbed", ex);
             return false;
         }
     }
@@ -180,7 +180,7 @@ internal sealed partial class IdeNavigationService
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("IdeNavigationService.RenameSymbolAsync", ex);
+            OutputWindowLogger.Global.LogException("IdeNavigationService.RenameSymbolAsync", ex);
             return new RenameResult { Supported = false, Reason = "Rename failed (internal API changed?)." };
         }
     }

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.Search.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.Search.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -69,7 +69,7 @@ internal sealed partial class IdeNavigationService
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("IdeNavigationService.EnsureSearchProbed", ex);
+            OutputWindowLogger.Global.LogException("IdeNavigationService.EnsureSearchProbed", ex);
             return false;
         }
     }
@@ -127,7 +127,7 @@ internal sealed partial class IdeNavigationService
         catch (OperationCanceledException) { throw; }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("IdeNavigationService.SearchWorkspaceAsync", ex);
+            OutputWindowLogger.Global.LogException("IdeNavigationService.SearchWorkspaceAsync", ex);
             return new SearchResult { Supported = false, Reason = "Search failed (internal API changed?)." };
         }
     }
@@ -224,7 +224,7 @@ internal sealed partial class IdeNavigationService
         catch (Exception ex)
         {
             // Signature mismatch or API change — log once, return whatever we collected so far.
-            OutputWindowLogger.LogException("IdeNavigationService.InvokeNavigateToSearchAsync", ex);
+            OutputWindowLogger.Global.LogException("IdeNavigationService.InvokeNavigateToSearchAsync", ex);
         }
         return results;
     }

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.Symbols.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.Symbols.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -59,7 +59,7 @@ internal sealed partial class IdeNavigationService
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("IdeNavigationService.EnsureSymbolsProbed", ex);
+            OutputWindowLogger.Global.LogException("IdeNavigationService.EnsureSymbolsProbed", ex);
             return false;
         }
     }
@@ -96,7 +96,7 @@ internal sealed partial class IdeNavigationService
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("IdeNavigationService.GetDocumentSymbolsAsync", ex);
+            OutputWindowLogger.Global.LogException("IdeNavigationService.GetDocumentSymbolsAsync", ex);
             return new SymbolsResult { Supported = false, Reason = "Document symbols failed (internal API changed?)." };
         }
     }

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -92,14 +92,14 @@ internal sealed partial class IdeNavigationService
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("IdeNavigationService.EnsureProbed", ex);
+            OutputWindowLogger.Global.LogException("IdeNavigationService.EnsureProbed", ex);
             return false;
         }
     }
 
     private static bool ProbeFailed(string step)
     {
-        OutputWindowLogger.Debug(() => $"[IdeNavigationService] navigation unavailable — probe failed at: {step}");
+        OutputWindowLogger.Global.Debug(() => $"[IdeNavigationService] navigation unavailable — probe failed at: {step}");
         return false;
     }
 

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeOutputService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeOutputService.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -105,7 +105,7 @@ internal sealed class IdeOutputService
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("IdeOutputService.ReadAsync", ex);
+            OutputWindowLogger.Global.LogException("IdeOutputService.ReadAsync", ex);
             return new OutputResult { Ok = false, Reason = "Failed to read output window." };
         }
     }
@@ -131,7 +131,7 @@ internal sealed class IdeOutputService
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("IdeOutputService.ClearAsync", ex);
+            OutputWindowLogger.Global.LogException("IdeOutputService.ClearAsync", ex);
             return new OutputResult { Ok = false, Reason = "Failed to clear output pane." };
         }
     }
@@ -157,7 +157,7 @@ internal sealed class IdeOutputService
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("IdeOutputService.ActivateAsync", ex);
+            OutputWindowLogger.Global.LogException("IdeOutputService.ActivateAsync", ex);
             return new OutputResult { Ok = false, Reason = "Failed to activate output pane." };
         }
     }

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/JsonRpcDispatcher.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/JsonRpcDispatcher.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -58,7 +58,7 @@ internal sealed class JsonRpcDispatcher
         // Notifications (id absent): spec forbids any response.
         if (id == null)
         {
-            OutputWindowLogger.Trace(() => $"Mcp: notification '{method}' (ignored)");
+            OutputWindowLogger.Global.Trace(() => $"Mcp: notification '{method}' (ignored)");
             return null;
         }
 
@@ -78,7 +78,7 @@ internal sealed class JsonRpcDispatcher
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException($"Mcp.{method}", ex);
+            OutputWindowLogger.Global.LogException($"Mcp.{method}", ex);
             return Error(id, -32603, $"Internal error: {ex.Message}");
         }
     }

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/McpServerHost.LockFile.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/McpServerHost.LockFile.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -120,7 +120,7 @@ internal sealed partial class McpServerHost
                     var pid = (int?)obj?["pid"] ?? 0;
                     if (pid > 0 && IsProcessAlive(pid)) { continue; }
                     File.Delete(f);
-                    OutputWindowLogger.Debug(() => $"Mcp: cleaned orphan lock {Path.GetFileName(f)}");
+                    OutputWindowLogger.Global.Debug(() => $"Mcp: cleaned orphan lock {Path.GetFileName(f)}");
                 }
                 catch { /* unreadable / locked: skip */ }
             }

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/McpServerHost.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/McpServerHost.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -99,7 +99,7 @@ internal sealed partial class McpServerHost
             _dispatcher = new JsonRpcDispatcher(BuildToolRegistry());
 
             SyncLockFolders(); // publish a lock into every profile's config-dir
-            OutputWindowLogger.Info($"Mcp: server started on 127.0.0.1:{_port}");
+            OutputWindowLogger.Global.Info($"Mcp: server started on 127.0.0.1:{_port}");
 
             // Subscribe to editor changes (idempotent; the WebView chat path may also call it).
             Microsoft.VisualStudio.Shell.ThreadHelper.JoinableTaskFactory.Run(async () =>
@@ -116,7 +116,7 @@ internal sealed partial class McpServerHost
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("Mcp.Start", ex);
+            OutputWindowLogger.Global.LogException("Mcp.Start", ex);
             // Best-effort cleanup so we don't leave a half-open listener.
             try { _listener?.Stop(); } catch { }
             _listener = null;
@@ -151,11 +151,11 @@ internal sealed partial class McpServerHost
             _listener?.Stop();
             _ = IdeDiffViewer.Instance.CancelAllPendingAsync();
             DeleteAllLockFiles();
-            OutputWindowLogger.Info("Mcp: server stopped");
+            OutputWindowLogger.Global.Info("Mcp: server stopped");
         }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("Mcp.Stop", ex);
+            OutputWindowLogger.Global.LogException("Mcp.Stop", ex);
         }
         finally
         {
@@ -183,7 +183,7 @@ internal sealed partial class McpServerHost
                 foreach (var folder in folders) { WriteLockFile(folder); }
             });
         }
-        catch (Exception ex) { OutputWindowLogger.LogException("Mcp.RewriteLockFile", ex); }
+        catch (Exception ex) { OutputWindowLogger.Global.LogException("Mcp.RewriteLockFile", ex); }
     }
 
     //  Tool registry
@@ -255,7 +255,7 @@ internal sealed partial class McpServerHost
             catch (ObjectDisposedException) { break; }
             catch (Exception ex)
             {
-                OutputWindowLogger.LogException("Mcp.Accept", ex);
+                OutputWindowLogger.Global.LogException("Mcp.Accept", ex);
                 continue;
             }
 
@@ -271,14 +271,14 @@ internal sealed partial class McpServerHost
                    ?? ctx.Request.Headers["Authorization"];
         if (string.IsNullOrEmpty(auth) || !auth.EndsWith(_authToken, StringComparison.Ordinal))
         {
-            OutputWindowLogger.Warn("[mcp] rejected client: missing/invalid auth token (401)");
+            OutputWindowLogger.Global.Warn("[mcp] rejected client: missing/invalid auth token (401)");
             ctx.Response.StatusCode = 401;
             ctx.Response.Close();
             return;
         }
         if (!ctx.Request.IsWebSocketRequest)
         {
-            OutputWindowLogger.Debug(() => "[mcp] non-websocket request dropped (400)");
+            OutputWindowLogger.Global.Debug(() => "[mcp] non-websocket request dropped (400)");
             ctx.Response.StatusCode = 400;
             ctx.Response.Close();
             return;
@@ -290,7 +290,7 @@ internal sealed partial class McpServerHost
         try { wsCtx = await ctx.AcceptWebSocketAsync(subProtocol: "mcp"); }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("Mcp.AcceptWebSocket", ex);
+            OutputWindowLogger.Global.LogException("Mcp.AcceptWebSocket", ex);
             return;
         }
 
@@ -323,7 +323,7 @@ internal sealed partial class McpServerHost
                 while (!res.EndOfMessage);
 
                 var raw = sb.ToString();
-                OutputWindowLogger.Trace(() => $"Mcp: <- {StringHelpers.Truncate(raw, 200)}");
+                OutputWindowLogger.Global.Trace(() => $"Mcp: <- {StringHelpers.Truncate(raw, 200)}");
                 var reply = await _dispatcher.HandleMessageAsync(raw);
                 // Seed initial context on tools/list (not initialized): the CLI's useIdeSelection
                 // hook only subscribes once the server reaches 'connected', around tools/list time.
@@ -334,7 +334,7 @@ internal sealed partial class McpServerHost
                 }
                 if (reply != null && ws.State == WebSocketState.Open)
                 {
-                    OutputWindowLogger.Trace(() => $"Mcp: -> {StringHelpers.Truncate(reply, 200)}");
+                    OutputWindowLogger.Global.Trace(() => $"Mcp: -> {StringHelpers.Truncate(reply, 200)}");
                     var bytes = Encoding.UTF8.GetBytes(reply);
                     await ws.SendAsync(new ArraySegment<byte>(bytes),
                         WebSocketMessageType.Text, endOfMessage: true, ct);
@@ -344,13 +344,13 @@ internal sealed partial class McpServerHost
         catch (OperationCanceledException) { /* expected on shutdown */ }
         catch (Exception ex)
         {
-            OutputWindowLogger.LogException("Mcp.ClientLoop", ex);
+            OutputWindowLogger.Global.LogException("Mcp.ClientLoop", ex);
             // WebSocket exceptions wrap the real cause in InnerException — unwrap for diagnostics.
             var inner = ex.InnerException;
             int depth = 0;
             while (inner != null && depth++ < 5)
             {
-                OutputWindowLogger.LogException($"Mcp.ClientLoop.inner[{depth}]", inner);
+                OutputWindowLogger.Global.LogException($"Mcp.ClientLoop.inner[{depth}]", inner);
                 inner = inner.InnerException;
             }
         }
@@ -436,12 +436,12 @@ internal sealed partial class McpServerHost
                     isEmpty: !ctx.HasSelection);
             }
             if (ws.State != WebSocketState.Open) { return; }
-            OutputWindowLogger.Trace(() => $"Mcp: -> (initial) {StringHelpers.Truncate(json, 200)}");
+            OutputWindowLogger.Global.Trace(() => $"Mcp: -> (initial) {StringHelpers.Truncate(json, 200)}");
             var bytes = Encoding.UTF8.GetBytes(json);
             await ws.SendAsync(new ArraySegment<byte>(bytes),
                 WebSocketMessageType.Text, endOfMessage: true, CancellationToken.None);
         }
-        catch (Exception ex) { OutputWindowLogger.LogException("Mcp.SendInitialContext", ex); }
+        catch (Exception ex) { OutputWindowLogger.Global.LogException("Mcp.SendInitialContext", ex); }
     }
 
     private static string BuildSelectionNotification(
@@ -476,7 +476,7 @@ internal sealed partial class McpServerHost
             if (_clients.Count == 0) { return; }
             snapshot = [.. _clients];
         }
-        OutputWindowLogger.Trace(() => $"Mcp: broadcast to {snapshot.Length} client(s) -> {StringHelpers.Truncate(json, 200)}");
+        OutputWindowLogger.Global.Trace(() => $"Mcp: broadcast to {snapshot.Length} client(s) -> {StringHelpers.Truncate(json, 200)}");
         var bytes = Encoding.UTF8.GetBytes(json);
         foreach (var conn in snapshot)
         {
@@ -489,7 +489,7 @@ internal sealed partial class McpServerHost
                 {
                     if (t.Exception != null)
                     {
-                        OutputWindowLogger.LogException("Mcp.Broadcast", t.Exception);
+                        OutputWindowLogger.Global.LogException("Mcp.Broadcast", t.Exception);
                     }
                 }, TaskScheduler.Default);
         }

--- a/src/Corsinvest.VisualStudio.Agents/Menu/GlobalMenuCommands.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Menu/GlobalMenuCommands.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -27,7 +27,7 @@ internal static class GlobalMenuCommands
         await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
         if (await package.GetServiceAsync(typeof(IMenuCommandService)) is not OleMenuCommandService svc)
         {
-            OutputWindowLogger.Warn("[menu] no command service — the View entries won't respond");
+            OutputWindowLogger.Global.Warn("[menu] no command service — the View entries won't respond");
             return;
         }
 
@@ -77,6 +77,6 @@ internal static class GlobalMenuCommands
         => svc.AddCommand(new MenuCommand((_, _) =>
         {
             try { run(); }
-            catch (Exception ex) { OutputWindowLogger.LogException($"GlobalMenu.0x{id:X}", ex); }
+            catch (Exception ex) { OutputWindowLogger.Global.LogException($"GlobalMenu.0x{id:X}", ex); }
         }, new CommandID(PackageGuids.AgentsCommandSet, id)));
 }


### PR DESCRIPTION
With several chats open the Output window is a single stream. Two sessions interleave, nothing says which pane emitted what, and anything multi-instance becomes guesswork to diagnose.

```
09:31:07.940 DEBUG [chat#2] [client] set_model → opus[1m]
09:31:08.115 DEBUG [chat#1] [client] set_model → sonnet
09:31:08.220 DEBUG [mcp] nav_go_to_definition
```

## How

`OutputWindowLogger` becomes instantiable. Two ways to get one:

- **`For(kind, () => paneId)`** — prepends `[chat#N]`/`[cli#N]` before the existing `[area]` tag.
- **`Global`** — no prefix, for code that belongs to no session.

The pane id is a `Func<int>`, not a value: `PaneId` is assigned *after* the control is built (`PaneWindowBase.AssignPaneId`), so capturing it would label every start-up line `#0` — the lines that matter most when something goes wrong at open.

Classes a pane owns take the logger in their constructor: `WebViewBridge`, `WebViewMessageHandler`, `ClaudeClient`, `NdjsonTransport`, `SessionManager`. The two also built outside a pane — `ClaudeClient` from the context/usage probes, `SessionManager` from the session dialog — take it as an optional argument and fall back to `Global`.

## What stays on `Global`, and why

Not everything can or should carry a pane tag:

- **Paths that belong to no session** — MCP, IDE services, package, stats.
- **Static members** — no instance to reach, and in a primary-constructor class the parameter isn't even in scope there (`CS9105`). Four helpers in `WebViewMessageHandler.Helpers.cs`, `SubagentContext.Read`, plus the `static class` helpers (`FileSuggestions`, `IconCacheService`, `ThumbnailGenerator`).
- **`ChatWebView`'s task manager** — one browser-wide window shared by every pane; a pane tag would claim an ownership that isn't there.
- **The Output pane itself** — process-wide, so `EnsurePane`/`ActivatePane` stay static.

## Coverage

| | |
|---|---|
| tagged with their pane | 83 |
| `Global` (no session, or static) | 203 |

## Also in here

- `ClaudeClient` and `SessionManager` become `internal`: nothing references this assembly, and a `public` constructor can't take an `internal` parameter (`CS0051`).
- `Perf`/`PerfSpan` move onto the instance too — profiling two chats, which one it was is half the information.

## Verified

Green MSBuild, then by hand in the Exp instance with two chats open at Log level = Debug: each pane's lines carry its own caption number, global lines carry none, start-up lines show the right number rather than `#0`, and the tag survives a working-directory change (which respawns the CLI and rotates the transport).
