### PR TITLE
fix(chat): the arrows walk a wrapped draft before reaching the history

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-prompt.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-prompt.ts
@@ -802,9 +802,11 @@ export class CvPrompt extends LitElement implements CommandHost {
                 return;
             }
         }
-        // Prompt history (shell-style ↑/↓): ↑ recalls an older prompt only when the
-        // caret is on the first line, ↓ goes forward only on the last line — so
-        // navigating a multi-line draft with the arrows still works. No modifiers.
+        // Prompt history (shell-style ↑/↓): ↑ recalls an older prompt only from the
+        // first visual line, ↓ goes forward only from the last one — so navigating a
+        // multi-line draft with the arrows still works. No modifiers. The key is NOT
+        // swallowed here: _historyOnArrow needs the caret to move first to tell the
+        // two cases apart, and decides once the default has run.
         if (
             (e.key === 'ArrowUp' || e.key === 'ArrowDown') &&
             !e.shiftKey &&
@@ -812,17 +814,7 @@ export class CvPrompt extends LitElement implements CommandHost {
             !e.altKey &&
             !e.metaKey
         ) {
-            if (e.key === 'ArrowUp' && this._caretOnFirstLine()) {
-                if (this._historyPrev()) {
-                    e.preventDefault();
-                    return;
-                }
-            } else if (e.key === 'ArrowDown' && this._caretOnLastLine()) {
-                if (this._historyNext()) {
-                    e.preventDefault();
-                    return;
-                }
-            }
+            this._historyOnArrow(e.key === 'ArrowUp' ? -1 : 1);
         }
         // Shift+Tab cycles through permission modes (Anthropic CLI parity).
         if (e.key === 'Tab' && e.shiftKey && !e.ctrlKey && !e.altKey && !e.metaKey) {
@@ -980,18 +972,40 @@ export class CvPrompt extends LitElement implements CommandHost {
         this._historyDraft = '';
     }
 
-    /** True if the caret is on the first visual line (so ↑ recalls history rather
-     *  than moving the cursor up within a multi-line draft). */
-    private _caretOnFirstLine(): boolean {
+    /** ↑/↓ drive the prompt history, but only from the first/last **visual** line —
+     *  anywhere else they must still move the caret, recalled prompt included: a long
+     *  one is there to be edited, and losing it to the next history entry on the first
+     *  ↑ is the same bug in the other direction. Soft wrap has no `\n` to look for, and
+     *  only the engine that laid the text out knows where the visual lines fall, so let
+     *  the default run and read the outcome: a caret that did not move had no line to
+     *  move to. */
+    private _historyOnArrow(dir: -1 | 1): void {
         const ta = this._ta;
-        return ta.value.lastIndexOf('\n', (ta.selectionStart ?? 0) - 1) < 0;
-    }
-
-    /** True if the caret is on the last visual line (so ↓ goes forward in history
-     *  rather than moving the cursor down). */
-    private _caretOnLastLine(): boolean {
-        const ta = this._ta;
-        return ta.value.indexOf('\n', ta.selectionEnd ?? 0) < 0;
+        if (ta.selectionStart !== ta.selectionEnd) {
+            return; // a selection collapses instead of moving — not a line change
+        }
+        const before = ta.selectionStart ?? 0;
+        // Read the caret only once the default action has moved it — keydown fires
+        // before that. A macrotask is the way to land after it: a microtask drains at
+        // the end of THIS task and would always see the caret unmoved, and rAF ties
+        // the read to the paint cycle, which has nothing to do with the caret.
+        setTimeout(() => {
+            // Moved at all → there was a line to move to, so the caret was not on the
+            // edge line and the history stays out of it. Landing on 0/value.length is
+            // NOT a reliable second signal: ↓ from a long line onto a short last one
+            // ends at value.length having genuinely changed line, and a recalled prompt
+            // starts there to begin with. So the caret sitting mid-line on the edge row
+            // costs one extra keypress to reach the history — the way a shell behaves,
+            // and the harmless way to be wrong: the draft is never lost.
+            if ((ta.selectionStart ?? 0) !== before) {
+                return;
+            }
+            if (dir === -1) {
+                this._historyPrev();
+            } else {
+                this._historyNext();
+            }
+        }, 0);
     }
 
     /** ↑: recall an older prompt. Returns true if it handled the key. */
@@ -1008,7 +1022,7 @@ export class CvPrompt extends LitElement implements CommandHost {
         } else {
             return true; // at the oldest — swallow the key, stay put
         }
-        this._applyHistoryEntry(this._promptHistory[this._historyIdx]);
+        this._applyHistoryEntry(this._promptHistory[this._historyIdx], -1);
         return true;
     }
 
@@ -1029,11 +1043,15 @@ export class CvPrompt extends LitElement implements CommandHost {
         return true;
     }
 
-    /** Apply a recalled entry, caret at the end (ready to edit, shell-style). */
-    private _applyHistoryEntry(text: string): void {
+    /** Apply a recalled entry, caret parked on the edge line the arrow came from: ↑
+     *  leaves it at the start, ↓ at the end (VS Code and zsh both keep the caret on
+     *  that line). Parking it at the far end instead would make the next press climb
+     *  the whole recalled prompt before it could reach the entry beyond it. */
+    private _applyHistoryEntry(text: string, dir: -1 | 1 = 1): void {
         const ta = this._ta;
         ta.value = text;
-        ta.setSelectionRange(text.length, text.length);
+        const caret = dir === -1 ? 0 : text.length;
+        ta.setSelectionRange(caret, caret);
         this._hasText = text.trim().length > 0;
         this._autoResize();
     }

--- a/tools/extension.ps1
+++ b/tools/extension.ps1
@@ -116,9 +116,12 @@ function Get-InstanceName {
     if ($HiveName -like '*Exp') { "$name (experimental)" } else { $name }
 }
 
-# Returns the folder of every installed copy, across both layouts: VSIXInstaller writes
-# Extensions\<random>\ while the F5 deploy writes Extensions\Corsinvest\<display name>\, hence
-# -Depth 2 and the match on the manifest rather than on the folder name.
+# Returns the folder of every installed copy, across every layout: VSIXInstaller writes
+# Extensions\<random>\, the F5 deploy writes Extensions\Corsinvest\<display name>\, and a
+# per-version install adds a third level, Extensions\<publisher>\<display name>\<version>\ —
+# hence -Depth 3 and the match on the manifest rather than on the folder name. Too shallow a
+# depth is silent: nothing matches, and the script reports "Nothing installed" over a hive that
+# has copies in it, so -Uninstall leaves them behind and -Install stacks on top.
 function Find-InstalledCopies {
     if (-not (Test-Path $hiveRoot)) { return @() }
 
@@ -129,7 +132,7 @@ function Find-InstalledCopies {
             $extensions = Join-Path $hive.FullName 'Extensions'
             if (-not (Test-Path $extensions)) { return }
 
-            Get-ChildItem $extensions -Recurse -Depth 2 -Filter 'extension.vsixmanifest' -ErrorAction SilentlyContinue |
+            Get-ChildItem $extensions -Recurse -Depth 3 -Filter 'extension.vsixmanifest' -ErrorAction SilentlyContinue |
                 Where-Object { (Get-Content $_.FullName -Raw -ErrorAction SilentlyContinue) -match $IdentityPattern } |
                 ForEach-Object {
                     $identity = ([xml](Get-Content $_.FullName -Raw)).PackageManifest.Metadata.Identity


### PR DESCRIPTION
## The bug

A draft that only wraps carries no `\n`, but `_caretOnFirstLine`/`_caretOnLastLine` looked for one. Every visual line of a long paragraph therefore counted as the first line — and as the last — so a single ArrowUp swapped the draft for the previous prompt instead of moving the caret up a line.

## Why not measure the caret

Nothing in the DOM says which visual line a `<textarea>` caret sits on: the browser did the wrapping and does not expose it. The usual answer is a mirror div — a hidden clone kept in sync with the composer's font, padding, width and word-break, in shadow DOM, forever — and its known bugs sit on trailing spaces, which is exactly the wrap point.

So instead of rebuilding that geometry, ask the engine that produced it: let the default action run, then read the caret in a macrotask. A caret that did not move had no line to move to, so it was on the edge line. `keydown` fires before the caret moves, which is why the read has to be deferred at all.

## Also fixed

Recalling an entry now parks the caret on the edge line the arrow came from — start for ArrowUp, end for ArrowDown — matching VS Code and zsh. It used to always park at the end, so the next ArrowUp had to climb the whole recalled prompt before it could reach the entry beyond it.

## Known divergence, on purpose

With the caret mid-line on the edge row it takes one extra press to reach the history: the first press is what moves the caret to the end of that line. VS Code and zsh gate on the line alone. Closing the gap needs the caret geometry, and that is not worth a hidden clone of the composer — and this way of being wrong is the harmless one, since the draft is never lost.

## Second commit

`extension.ps1` searched for `extension.vsixmanifest` at `-Depth 2`, but a per-version install puts it three levels down (`Extensions\<publisher>\<display name>\<version>\`). Nothing matched, and the failure was silent: `-Status` reported "Nothing installed" over a hive holding two copies, `-Uninstall` removed neither, and `-Install` would have stacked a third on top.

## Testing

Manual, in the experimental instance: walking a wrapped draft in both directions, entering the history from either edge, and scrolling through recalled multi-line prompts. `npm run typecheck`, `lint` and `format` are clean.
