### PR TITLE
fix(client): a write can no longer be lost to a respawn

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.Protocol.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.Protocol.cs
@@ -47,7 +47,11 @@ internal sealed partial class ClaudeClient
     /// </summary>
     private Task<JObject> SendControlRequestAsync(string subtype, object extra, TimeSpan? timeout = null)
     {
-        if (!_transport.IsRunning) { return Task.FromException<JObject>(new InvalidOperationException("CLI not running")); }
+        // One read of the field, then work off the local: a respawn between the check and the
+        // write would otherwise register the pending request against one transport and send it
+        // down another, leaving the caller to wait out the timeout for an answer nobody heard.
+        var transport = _transport;
+        if (!transport.IsRunning) { return Task.FromException<JObject>(new InvalidOperationException("CLI not running")); }
 
         var id = NextRequestId();
         var tcs = new TaskCompletionSource<JObject>();
@@ -60,7 +64,7 @@ internal sealed partial class ClaudeClient
             foreach (var prop in extraObj.Properties()) { request[prop.Name] = prop.Value; }
         }
 
-        _transport.Write(new
+        transport.Write(new
         {
             type = "control_request",
             request_id = id,
@@ -81,9 +85,10 @@ internal sealed partial class ClaudeClient
 
     private void SendControlResponse(string requestId, bool success, object response = null, string error = null)
     {
-        if (!_transport.IsRunning) { return; }
+        var transport = _transport;
+        if (!transport.IsRunning) { return; }
 
-        _transport.Write(new
+        transport.Write(new
         {
             type = "control_response",
             response = success

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.cs
@@ -21,8 +21,11 @@ namespace Corsinvest.VisualStudio.Agents.Core.Client;
 internal sealed partial class ClaudeClient : IClaudeClient
 {
     // Built in the constructor, not here: a field initializer runs before _log is assigned, so the
-    // first transport would lose the pane tag.
-    private NdjsonTransport _transport;
+    // first transport would lose the pane tag. Volatile because StartProcess swaps it on respawn
+    // while MCP worker threads are reading it to write — without it they can go on addressing the
+    // disposed instance. Readers that then USE it must copy it to a local first: the field can
+    // change between two reads of it.
+    private volatile NdjsonTransport _transport;
     private readonly ConcurrentDictionary<string, TaskCompletionSource<JObject>> _pending = new();
     private int _requestCounter;
 
@@ -671,13 +674,14 @@ internal sealed partial class ClaudeClient : IClaudeClient
                                       int startLine, int startChar, int endLine, int endChar,
                                       bool isEmpty)
     {
-        if (!_transport.IsRunning)
+        var transport = _transport;
+        if (!transport.IsRunning)
         {
             _log.Trace(() => "[ChatSelection] SendSelectionChanged skip: transport not running");
             return;
         }
         _log.Trace(() => $"[ChatSelection] SendSelectionChanged → filePath={filePath} isEmpty={isEmpty} line={startLine}-{endLine}");
-        _transport.Write(new
+        transport.Write(new
         {
             type = "request",
             channelId = "",
@@ -717,10 +721,11 @@ internal sealed partial class ClaudeClient : IClaudeClient
             parent_tool_use_id = (string)null,
             uuid,
         };
-        _log.Debug(() => $"[ClaudeClient.SendPrompt] BEFORE Write running={_transport.IsRunning} sessionId={SessionId ?? "(none)"} blocks={contentBlocks?.Count ?? 0}");
+        var transport = _transport;
+        _log.Debug(() => $"[ClaudeClient.SendPrompt] BEFORE Write running={transport.IsRunning} sessionId={SessionId ?? "(none)"} blocks={contentBlocks?.Count ?? 0}");
         try
         {
-            _transport.Write(msg);
+            transport.Write(msg);
         }
         catch (Exception ex)
         {

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/NdjsonTransport.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/NdjsonTransport.cs
@@ -118,21 +118,26 @@ internal sealed class NdjsonTransport : IDisposable
     /// </summary>
     public void Write(object message)
     {
-        if (!IsRunning)
-        {
-            _log.Warn("!!! transport.Write called but IsRunning=false");
-            return;
-        }
         try
         {
             var json = JsonConvert.SerializeObject(message, Formatting.None);
             _log.Trace(() => $">>> stdin: {StringHelpers.Truncate(json, 500)}");
             // Lock so a worker-thread MCP response and a UI-thread write can't
-            // interleave into one corrupt NDJSON line.
+            // interleave into one corrupt NDJSON line. The liveness check belongs
+            // INSIDE it: checked outside, Dispose() can null _stdin in between, and
+            // the write then dies in the catch below — silently, as far as the caller
+            // is concerned, leaving a SendControlRequestAsync to wait out its timeout
+            // instead of failing now.
             lock (_writeLock)
             {
-                _stdin.WriteLine(json);
-                _stdin.Flush();
+                var stdin = _stdin;
+                if (!IsRunning || stdin == null)
+                {
+                    _log.Warn("!!! transport.Write called but the process is gone");
+                    return;
+                }
+                stdin.WriteLine(json);
+                stdin.Flush();
             }
         }
         catch (Exception ex)
@@ -194,8 +199,14 @@ internal sealed class NdjsonTransport : IDisposable
     {
         if (_disposed) { return; }
         _disposed = true;
-        try { _stdin?.Close(); } catch { /* silent: cleanup */ }
-        _stdin = null;
+        // Under the write lock: a Write() already inside it holds a local copy of the
+        // stream and must be allowed to finish its line, rather than have it closed
+        // out from under it mid-flush.
+        lock (_writeLock)
+        {
+            try { _stdin?.Close(); } catch { /* silent: cleanup */ }
+            _stdin = null;
+        }
         try { if (_process?.HasExited == false) { _process.Kill(); } } catch { /* silent: cleanup */ }
         try { _process?.Dispose(); } catch { /* silent: cleanup */ }
         _process = null;


### PR DESCRIPTION
## The bug

`NdjsonTransport.Write` tested `IsRunning` *outside* `_writeLock`, while `Dispose` set `_stdin = null`. A process exiting between the check and the lock left the write to die in the catch block — silently, as far as the caller was concerned. A `SendControlRequestAsync` whose line was lost then waited out its full timeout instead of failing immediately: press something in the chat, nothing happens, and N seconds later a timeout arrives instead of an error.

## The fix

**Inside the lock.** The liveness check now sits in `_writeLock`, working off a local copy of the stream, and `Dispose` closes under that same lock so a write already in flight can finish its line rather than have the stream shut mid-flush.

**`volatile` on `_transport`.** `StartProcess` swaps it on every respawn while MCP worker threads are reading it to write; without `volatile` they can keep addressing the disposed instance.

**Locals at the four call sites.** `volatile` guarantees a fresh read, not that two reads return the same object — and every writer here reads the field twice, once to check and once to write. For `SendControlRequestAsync` that means registering the pending request against one transport and sending it down another. `SendControlRequestAsync`, `SendControlResponse`, `SendSelectionChanged` and `SendPrompt` each take a local copy first, the way `ReadLoop` already captures its reader.

## Testing

This is not directly observable in either direction — the window is microseconds wide, and the app behaves the same before and after. What the manual pass in the experimental instance does establish is that all four write paths still work across session changes (prompts, permission responses, model/mode changes, selection updates), which is what rules out a deadlock on the lock now held during `Dispose` — the one risk the change itself introduces.

The rest of the confidence comes from the code: the check and the write are under one lock, and each operation works off a single read of the field.
