### PR TITLE
fix(chat): the first history knows the working directory it renders against

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents.Contracts/BridgeGenerationSpec.cs
+++ b/src/Corsinvest.VisualStudio.Agents.Contracts/BridgeGenerationSpec.cs
@@ -98,8 +98,8 @@ public class BridgeGenerationSpec : GenerationSpec
         AddInterface<InitConfigDto>();
         AddInterface<VsOptionsDto>();
         AddInterface<InitPayloadNotification>()
-            .Member(x => nameof(x.CliState)).Null()
             .Member(x => nameof(x.VsOptions)).Null();
+        AddInterface<CliStateNotification>();
         AddInterface<AccountDto>();
         // Usage (get_usage), decoded once in HandleGetUsage into this typed shape.
         AddInterface<RateWindowDto>()

--- a/src/Corsinvest.VisualStudio.Agents.Contracts/ToWebViewDtos.cs
+++ b/src/Corsinvest.VisualStudio.Agents.Contracts/ToWebViewDtos.cs
@@ -511,14 +511,24 @@ public class VsOptionsDto
     public int LogLevel { get; set; }
 }
 
-/// <summary>The init payload (ui_init): the WebView's whole boot state, all 3 categories in one
-/// shot (config, CLI state, VS options). The gate populates it when ready — no loading
-/// placeholder (the previous Loading/LoadingMessage fields were always false/null).</summary>
+/// <summary>The init payload (ui_init): what the host knows on its own — pane config and VS
+/// options. Sent as soon as the WebView is up, before any history, so the first rows already
+/// have the working directory they need to shorten paths against.
+/// <para>The CLI's own state travels separately, on cli_state: it is not available until
+/// claude.exe has answered initialize + get_settings, seconds later, and holding this back for
+/// it was what left that first history rendering absolute paths.</para></summary>
 public class InitPayloadNotification
 {
     public InitConfigDto Config { get; set; }
-    public CliStateDto CliState { get; set; }
     public VsOptionsDto VsOptions { get; set; }
+}
+
+/// <summary>The CLI's startup state (cli_state), from initialize + get_settings — model, effort,
+/// toggles. Sent on every startup, so a respawn re-seeds the UI without re-sending pane config
+/// and VS options that did not change.</summary>
+public class CliStateNotification
+{
+    public CliStateDto CliState { get; set; }
 }
 
 /// <summary>The signed-in account shown in the Account & Usage dialog (nested in chat_usage).</summary>

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/BridgeMessages.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/BridgeMessages.cs
@@ -107,7 +107,7 @@ internal static class BridgeMessages
         public static class Ui
         {
             /// <summary>The app mounted and painted its first frame — hide the
-            /// native "Initializing…" placeholder now.</summary>
+            /// native "Initializing…" placeholder now. The host answers it with ui_init.</summary>
             public const string Ready = "webview_ready";
         }
     }
@@ -132,6 +132,7 @@ internal static class BridgeMessages
             public const string Started = "cli_started";
             public const string Exited = "cli_exited";
             public const string Error = "cli_error";
+            public const string State = "cli_state";                       // initialize + get_settings, re-sent on respawn
             public const string ModelChanged = "cli_model_changed";
             public const string PermissionModeChanged = "cli_permission_mode_changed";
         }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.ClientEvents.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.ClientEvents.cs
@@ -133,22 +133,17 @@ public partial class ChatPaneControl
         return await IdeDiagnosticsTracker.Instance.FindNewDiagnosticsAsync(toolUseId, filePath, visible);
     }
 
-    // The ONE ui_init, seeded from the CLI's startup state (initialize + get_settings, gathered by
-    // ClaudeClient.StartupAsync WITHOUT a user turn — system/init only arrives on the first turn, too
-    // late to enable the toolbar). Fired on every startup (open + respawn). PermissionMode isn't in
-    // the CLI's reply — we pass it via --permission-mode, so it's read from the client here.
+    // The CLI's startup state (initialize + get_settings, gathered by ClaudeClient.StartupAsync
+    // WITHOUT a user turn — system/init only arrives on the first turn, too late to enable the
+    // toolbar). Fired on every startup (open + respawn). PermissionMode isn't in the CLI's reply —
+    // we pass it via --permission-mode, so it's read from the client here.
+    // Its own message, not ui_init: this lands seconds after the pane opens, and the config the
+    // WebView needs to render its first history cannot wait for it.
     private void OnCliStateReceived(object sender, CliStateReceivedEventArgs e)
         => Dispatcher.Invoke(() =>
         {
-            _bridge.Send(BridgeMessages.ToWebView.Ui.Init, new Contracts.InitPayloadNotification
+            _bridge.Send(BridgeMessages.ToWebView.Cli.State, new Contracts.CliStateNotification
             {
-                Config = new Contracts.InitConfigDto
-                {
-                    WorkingDirectory = Entry.WorkingDirectory ?? "",
-#if DEBUG
-                    InDev = true,
-#endif
-                },
                 CliState = new Contracts.CliStateDto
                 {
                     // Empty model → the webview shows "Default"; get_settings usually fills it in.
@@ -168,7 +163,6 @@ public partial class ChatPaneControl
                         Verbs = e.SpinnerVerbs.Verbs,
                     },
                 },
-                VsOptions = WebViewBridge.BuildVsOptions(),
             });
         });
 

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
@@ -124,6 +124,22 @@ public partial class ChatPaneControl : PaneControlBase
         return (mode, page, info);
     }
 
+    /// <summary>Push the boot state the host owns outright — pane config and VS options. Neither
+    /// waits on claude.exe, so this goes out the moment the WebView is up, ahead of any history.
+    /// The CLI's own state follows on cli_state when it answers.</summary>
+    private void SendUiInit()
+        => _bridge?.Send(BridgeMessages.ToWebView.Ui.Init, new Contracts.InitPayloadNotification
+        {
+            Config = new Contracts.InitConfigDto
+            {
+                WorkingDirectory = Entry.WorkingDirectory ?? "",
+#if DEBUG
+                InDev = true,
+#endif
+            },
+            VsOptions = WebViewBridge.BuildVsOptions(),
+        });
+
     /// <summary>Send a loaded history page to the WebView (messages + paging), then kick off the
     /// input ↑/↓ prompt history load in the background. Loading a session's transcript always loads
     /// its prompt history too — same act; both read the entry's constant workdir.</summary>
@@ -454,13 +470,15 @@ public partial class ChatPaneControl : PaneControlBase
         _bridge.Send(BridgeMessages.ToWebView.Chat.Cleared, null);
         _log.Info($"load: InitAsync sessionId={_startupSessionId ?? "(none)"} (mode={permMode})");
 
-        // Client-first: the WebView starts empty here. Once the client starts, StartupAsync gathers
-        // the CLI state (initialize + get_settings, no user turn) and OnCliStateReceived sends the one
-        // fully-populated ui_init — enabling the toolbar. permMode below is what we pass via
-        // --permission-mode (the CLI doesn't report it); OnCliStateReceived reads it off the client.
+        // Before the history, never after: those rows shorten their paths against the working
+        // directory, and a row drawn without one keeps the absolute path it was born with. This
+        // is why ui_init no longer waits for the CLI — permMode below is what we pass via
+        // --permission-mode (the CLI doesn't report it), and the rest of the CLI's state follows
+        // on cli_state when StartupAsync has gathered it, seconds later, enabling the toolbar.
         // Seed the resumed session's transcript + title (after Cleared, from the read above).
         // SendHistoryPage → LoadPromptHistory read the entry's constant workdir, so this works even
         // though _client doesn't exist yet on the resume-path.
+        SendUiInit();
         if (restoreState)
         {
             SendHistoryPage(resumePage, _startupSessionId);

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/bridge-messages.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/bridge-messages.ts
@@ -74,6 +74,7 @@ export const Msg = {
             started: 'cli_started',
             exited: 'cli_exited',
             error: 'cli_error',
+            state: 'cli_state',
             modelChanged: 'cli_model_changed',
             permissionModeChanged: 'cli_permission_mode_changed',
         },

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated/CliStateNotification.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated/CliStateNotification.ts
@@ -1,0 +1,10 @@
+/**
+ * This is a TypeGen auto-generated file.
+ * Any changes made to this file can be lost when this file is regenerated.
+ */
+
+import { CliStateDto } from './CliStateDto';
+
+export interface CliStateNotification {
+    cliState: CliStateDto;
+}

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated/InitPayloadNotification.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated/InitPayloadNotification.ts
@@ -4,11 +4,9 @@
  */
 
 import { InitConfigDto } from './InitConfigDto';
-import { CliStateDto } from './CliStateDto';
 import { VsOptionsDto } from './VsOptionsDto';
 
 export interface InitPayloadNotification {
     config: InitConfigDto;
-    cliState: CliStateDto | null;
     vsOptions: VsOptionsDto | null;
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/types.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/types.ts
@@ -162,6 +162,9 @@ export type { ExchangeEndedNotification } from './generated/ExchangeEndedNotific
 // greppable across both languages; do not hand-edit the generated files.
 export type { VsOptionsDto } from './generated/VsOptionsDto';
 export type { InitPayloadNotification } from './generated/InitPayloadNotification';
+// The CLI's own startup state, on its own message: it arrives seconds after the init payload,
+// once claude.exe has answered initialize + get_settings.
+export type { CliStateNotification } from './generated/CliStateNotification';
 
 export type PermissionMode = 'default' | 'acceptEdits' | 'plan' | 'auto' | 'bypassPermissions';
 

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/init.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/init.ts
@@ -13,6 +13,7 @@ import { normPath } from '../core/path';
 import { closeTopDialog } from '../core/dialog-focus';
 import { setExtraLinkableExtensions } from '../core/file-links';
 import type {
+    CliStateNotification,
     HostKeyNotification,
     InitPayloadNotification,
     ModelsNotification,
@@ -59,37 +60,15 @@ function applyVsOptions(o: VsOptionsDto): void {
 }
 
 function wireBridgeHandlers(): void {
+    // Pane config + VS options: everything the host has without asking the CLI. Arrives right
+    // after ui_ready, ahead of the first history, so paths are shortened from the very first row.
     bridge.onNotification<InitPayloadNotification>(Msg.toWebView.ui.init, (data) => {
         if (!data?.config) {
             return;
         }
-        const wasInitialized = state.initialized;
-        // Pane config
         state.workingDirectory = normPath(data.config.workingDirectory);
         state.inDev = data.config.inDev;
 
-        // CLI state — always applied (the CLI init is the reliable source on every respawn).
-        const c = data.cliState;
-        if (c) {
-            state.currentModel = c.model;
-            state.permissionMode = (c.permissionMode as PermissionMode) || 'default';
-            if (c.effortLevel) {
-                state.effortLevel = c.effortLevel;
-            }
-            state.ultracodeEnabled = !!c.ultracode;
-            state.thinkingEnabled = !!c.alwaysThinkingEnabled;
-            if (c.switchModelsOnFlag !== null && c.switchModelsOnFlag !== undefined) {
-                state.switchModelsOnFlag = c.switchModelsOnFlag;
-            }
-            // Absent → false: a missing policy means the mode is allowed.
-            state.bypassPermissionsDisabled = !!c.bypassPermissionsDisabled;
-            state.fastMode = (c.fastModeState ?? 'off') !== 'off';
-            // Custom spinner verbs from settings (replace/append the defaults). Migrated
-            // from vsOptions into cliState — applied here rather than in applyVsOptions.
-            setVerbsConfig(c.spinnerVerbsConfig ?? null);
-        }
-
-        // VS Options
         if (data.vsOptions) {
             applyVsOptions(data.vsOptions);
             // The welcome screen reads appVersion/appCopyright from state at render time, but
@@ -101,17 +80,32 @@ function wireBridgeHandlers(): void {
                     (HTMLElement & { requestUpdate?(): void }) | null
             )?.requestUpdate?.();
         }
-
-        const firstInit = !wasInitialized;
         state.initialized = true;
-        // Tell the host the app has mounted and painted its first frame, so it can
-        // hide the native "Initializing…" placeholder exactly when the chat is
-        // visible underneath — no white gap, no double placeholder.
-        if (firstInit) {
-            requestAnimationFrame(() =>
-                requestAnimationFrame(() => bridge.sendNotification(Msg.fromWebView.ui.ready, {})),
-            );
+    });
+
+    // The CLI's startup state, seconds behind the rest: claude.exe has to answer initialize +
+    // get_settings first. Re-sent on every respawn, which is the reliable source for these.
+    bridge.onNotification<CliStateNotification>(Msg.toWebView.cli.state, (data) => {
+        const c = data?.cliState;
+        if (!c) {
+            return;
         }
+        state.currentModel = c.model;
+        state.permissionMode = (c.permissionMode as PermissionMode) || 'default';
+        if (c.effortLevel) {
+            state.effortLevel = c.effortLevel;
+        }
+        state.ultracodeEnabled = !!c.ultracode;
+        state.thinkingEnabled = !!c.alwaysThinkingEnabled;
+        if (c.switchModelsOnFlag !== null && c.switchModelsOnFlag !== undefined) {
+            state.switchModelsOnFlag = c.switchModelsOnFlag;
+        }
+        // Absent → false: a missing policy means the mode is allowed.
+        state.bypassPermissionsDisabled = !!c.bypassPermissionsDisabled;
+        state.fastMode = (c.fastModeState ?? 'off') !== 'off';
+        // Custom spinner verbs from settings (replace/append the defaults). Migrated
+        // from vsOptions into cliState — applied here rather than in applyVsOptions.
+        setVerbsConfig(c.spinnerVerbsConfig ?? null);
     });
 
     // VS Options re-pushed standalone when the user changes the Options page while
@@ -237,4 +231,13 @@ export function init(): void {
     wireBridgeHandlers();
     installDebugApi();
     bridge.start();
+
+    // Tell the host the app has mounted and painted its first frame, so it can hide the native
+    // "Initializing…" placeholder exactly when the chat is visible underneath — no white gap, no
+    // double placeholder. Two frames, because the first only schedules the initial render.
+    // Announced from here rather than on receiving ui_init: the host now answers this signal WITH
+    // ui_init, and waiting for the payload to declare ourselves ready would deadlock the pair.
+    requestAnimationFrame(() =>
+        requestAnimationFrame(() => bridge.sendNotification(Msg.fromWebView.ui.ready, {})),
+    );
 }


### PR DESCRIPTION
## The bug

The first history a pane showed rendered absolute paths even with *Show relative paths* on. Every history loaded afterwards — scroll-up, session switch — was correct.

`ui_init` carried three things at once: pane config, VS options, and the CLI's startup state. The third is only available once `claude.exe` has answered `initialize` + `get_settings`, so the whole payload waited for it. From a real log:

```
17:23:02.027  chat_history_loaded
17:23:02.069  ui_init            ← 42ms too late
17:23:07.361  cli_state          ← what everything was waiting for, 5s in
```

Those rows shorten their paths against `state.workingDirectory`; with it still empty, `relPath` returns the whole path. Forward slashes are the tell — restoring backslashes needs the workdir too.

## The fix

Split the payload by where the data comes from:

| message | carries | when |
|---|---|---|
| `ui_init` | pane config + VS options | in `InitAsync`, the line before the history |
| `cli_state` | the CLI's startup state | whenever `StartupAsync` has it — open and every respawn |

Nothing in `ui_init` needs the CLI, so nothing holds it back. It is sent from the same method as the history, one line earlier, so neither can win a race against the other — an earlier attempt hung it off `webview_ready` and still lost, because the history comes from `InitAsync`, which was already running.

Splitting also stops a respawn from re-sending pane config and VS options that did not change.

## Also

`webview_ready` used to be announced from *inside* the `ui_init` handler. The host now answers that signal with `ui_init`, so waiting for the payload before declaring ourselves ready would deadlock the pair. It is announced at the end of bootstrap instead — where being mounted is what it actually reports.

## Why not re-render

The TODO proposed forcing a re-render once the workdir arrived. That means rebuilding the transcript tree, and with Lit still diffing these lists by position, rebuilding rows loses their local state (`_expanded`, show-all). Sending the workdir before anything needs it leaves nothing to re-render.

## Testing

Manual, in the experimental instance: opening VS with the solution so the pane restores its previous session — the case that showed the bug — plus an empty chat to confirm the placeholder still clears and the toolbar still enables when `cli_state` lands. `npm run typecheck`, `lint` and `format` are clean.
