### PR TITLE
fix(chat): the diff dialog's title row lines up, with lighter mode icons

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-diff-dialog.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-diff-dialog.ts
@@ -161,6 +161,7 @@ export class CvDiffDialog extends CvDialogBase {
                         slot="title-action"
                         .options=${MODES}
                         .activeValue=${this._mode}
+                        icon-size="14"
                         @change=${this._onModeChange}
                     ></cv-segmented>
 

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-segmented.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-segmented.ts
@@ -25,11 +25,13 @@ export interface SegOption<V extends string = string> {
  * accent) and the rest `subtle`; only layout (join + end radii) is styled here.
  *
  * Buttons size to their content. Emits `change` (CustomEvent, `detail.value`) on
- * selection; re-selecting the active option is a no-op.
+ * selection; re-selecting the active option is a no-op. `icon-size` overrides the
+ * 20px Fluent draws a slotted glyph at, for rows where that reads too heavy.
  *
  *   <cv-segmented
  *       .options=${[{value:'all',label:'All'}, …]}
  *       .activeValue=${current}
+ *       icon-size="14"
  *       @change=${(e) => onChange(e.detail.value)}
  *   ></cv-segmented>
  */
@@ -62,6 +64,19 @@ export class CvSegmented<V extends string = string> extends LitElement {
                 border-top-right-radius: var(--borderRadiusMedium);
                 border-bottom-right-radius: var(--borderRadiusMedium);
             }
+            /* Sized only when icon-size was given: the fallback of unset leaves the glyph size
+               Fluent picked in place, so nothing that already looks right moves. The slot wrapper
+               shrinks with the glyph, or the button keeps the taller line box around it. */
+            .seg [slot='start'] {
+                display: inline-flex;
+                align-items: center;
+                width: var(--seg-icon, unset);
+                height: var(--seg-icon, unset);
+            }
+            .seg [slot='start'] svg {
+                width: var(--seg-icon, unset);
+                height: var(--seg-icon, unset);
+            }
             fluent-tooltip {
                 padding: 4px 8px;
                 white-space: nowrap;
@@ -73,6 +88,9 @@ export class CvSegmented<V extends string = string> extends LitElement {
     @property({ attribute: false }) activeValue?: V;
     /** Show only the icon (label becomes the tooltip). Needs each option to have an `icon`. */
     @property({ type: Boolean, attribute: 'icon-only' }) iconOnly = false;
+    /** Glyph size in px. Fluent draws a slotted icon at 20px, which is a lot next to a small
+     *  button's text; unset leaves that alone so nothing that already looks right moves. */
+    @property({ type: Number, attribute: 'icon-size' }) iconSize?: number;
 
     private _select(v: V): void {
         if (v === this.activeValue) {
@@ -89,7 +107,11 @@ export class CvSegmented<V extends string = string> extends LitElement {
 
     override render(): TemplateResult {
         return html`
-            <div class="seg ${this.iconOnly ? 'icon-only' : ''}" role="group">
+            <div
+                class="seg ${this.iconOnly ? 'icon-only' : ''}"
+                style=${this.iconSize ? `--seg-icon: ${this.iconSize}px` : nothing}
+                role="group"
+            >
                 ${this.options.map((o) => {
                     // A fluent-tooltip anchored by id gives a reliable tooltip (the button's own
                     // `title` attribute isn't surfaced across the shadow boundary). Always show it —

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/diff.css
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/diff.css
@@ -92,9 +92,13 @@ cv-diff-dialog fluent-dialog-body::part(content) {
     flex-direction: column;
 }
 /* rc.24's sticky title row offsets the mode dropdown's popup by one row;
- * static fixes the pointer hit-test (title is always visible anyway). */
+ * static fixes the pointer hit-test (title is always visible anyway).
+ * Centred because the row holds three things of three different heights — text 19px, the mode
+ * buttons 24px, the close button 32px — and Fluent starts them all at the top, which left their
+ * middles 7px apart down the row. */
 cv-diff-dialog fluent-dialog-body::part(title) {
     position: static;
+    align-items: center;
 }
 .cv-diff-dialog-title {
     display: inline-flex;


### PR DESCRIPTION
Two things about the diff dialog's title row, both obvious once you look at it next to the close button.

## Nothing in the row was vertically centred

Fluent's dialog title uses `align-items: flex-start`, so all three items start at the same top edge while being three different heights. Measured:

| | top | height | centre |
|---|---|---|---|
| title text | 47.1 | 18.6 | 56.3 |
| mode buttons | 47.1 | 24.0 | 59.1 |
| close button | 47.1 | 32.0 | 63.1 |

Nearly 7px of drift from one end of the row to the other. `align-items: center` goes into the override `cv-diff-dialog` already keeps on `::part(title)`, so no other dialog is affected.

## The mode icons were heavier than everything near them

Fluent draws a slotted glyph at 20px; every action icon in the chat is drawn at 14 (`iconStyles` pins those, but only for `fluent-button[icon-only]`, and these are slotted into `start` instead).

`cv-segmented` now takes an `icon-size`, and the diff dialog asks for 14. Left unset it falls back to `unset`, so the four other components using the control — command menu, popover list, segmented slider, stats dialog — keep exactly the size they have today.

## Testing

Manual, in the experimental instance. `npm run typecheck`, `lint` and `format:check` are clean.
