### PR TITLE
refactor(stats): centralise the day key, and make the chart dates readable

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/CvBarChart.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/CvBarChart.cs
@@ -123,20 +123,37 @@ internal sealed class CvBarChart : Grid
         SetRowCol(plot, 0, 1);
         Children.Add(plot);
 
-        // X axis: ~8 evenly spaced date labels.
-        var xAxis = new UniformGrid { Rows = 1, Columns = bars.Count, Margin = new Thickness(0, 2, 0, 0) };
-        var step = bars.Count <= 12 ? 1 : bars.Count / 8;
-        for (var i = 0; i < bars.Count; i++)
+        // X axis: ~8 evenly spaced date labels, each centred on its bar.
+        //
+        // A grid column per bar would be the obvious thing, and was — but a column is one bar wide,
+        // a few pixels, and the date is cut off inside it however few labels are drawn. Laying them
+        // out by hand lets each one spill over its neighbours, which is free: the bars either side
+        // of a labelled one have no label of their own.
+        var xAxis = new Canvas { Height = 14, Margin = new Thickness(0, 2, 0, 0), ClipToBounds = false };
+        var step = bars.Count <= 12 ? 1 : Math.Max(1, bars.Count / 8);
+        var slots = new List<(int Index, TextBlock Label)>();
+        for (var i = 0; i < bars.Count; i += step)
         {
-            var show = bars.Count <= 12 || (step > 0 && i % step == 0);
-            xAxis.Children.Add(new TextBlock
+            var label = new TextBlock
             {
-                Text = show ? ShortDate(bars[i].Date) : "",
+                Text = ShortDate(bars[i].Date),
                 FontSize = 10,
                 Opacity = 0.6,
-                HorizontalAlignment = HorizontalAlignment.Center,
-            });
+            };
+            // Measured up front: a Canvas hands out no width, so centring needs the text's own.
+            label.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
+            slots.Add((i, label));
+            xAxis.Children.Add(label);
         }
+        // Positioned on resize, because bar width is only known once the plot has been given one.
+        xAxis.SizeChanged += (_, e) =>
+        {
+            var barWidth = e.NewSize.Width / bars.Count;
+            foreach (var (index, label) in slots)
+            {
+                Canvas.SetLeft(label, (index + 0.5) * barWidth - label.DesiredSize.Width / 2);
+            }
+        };
         SetRowCol(xAxis, 1, 1);
         Children.Add(xAxis);
     }

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsAggregator.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsAggregator.cs
@@ -202,6 +202,20 @@ internal static class StatsAggregator
     {
         if (tsMs <= 0) { return "unknown"; }
         var dt = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddMilliseconds(tsMs).ToLocalTime();
-        return dt.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+        return DateKey(dt);
     }
+
+    /// <summary>The key a day's bucket is filed under. Nothing on disk uses this shape — the JSONL
+    /// carries an ISO timestamp, and this is what we index it by — so producer and readers only
+    /// agree as long as they go through here. They used to each write the format out, which fails
+    /// quietly: change one and the lookups simply return nothing. Empty heatmap, no exception.</summary>
+    internal static string DateKey(DateTime local)
+        => local.ToString(DayKeyFormat, CultureInfo.InvariantCulture);
+
+    /// <summary>Read a key back into the day it stands for. False on anything this did not write.</summary>
+    internal static bool TryParseDateKey(string key, out DateTime day)
+        => DateTime.TryParseExact(key, DayKeyFormat, CultureInfo.InvariantCulture,
+                                  DateTimeStyles.None, out day);
+
+    private const string DayKeyFormat = "yyyy-MM-dd";
 }

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsChart.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsChart.cs
@@ -141,7 +141,7 @@ internal static class StatsChart
             var col = new HeatCell[7];
             for (var day = 0; day < 7; day++)
             {
-                var ds = cur.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+                var ds = StatsAggregator.DateKey(cur);
                 var future = cur > today;
                 var count = future ? 0 : (infos.TryGetValue(ds, out var inf) ? inf.Messages : 0);
                 var info = infos.TryGetValue(ds, out var i2) ? i2 : new DayInfo { Date = ds };

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsService.cs
@@ -604,21 +604,23 @@ internal static class StatsService
         // current: walk back from today while the day is active.
         int current = 0;
         var day = DateTime.Now.Date;
-        while (set.Contains(day.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)))
+        while (set.Contains(StatsAggregator.DateKey(day)))
         {
             current++;
             day = day.AddDays(-1);
         }
 
-        // longest: scan sorted dates for the max run of consecutive days.
+        // longest: scan sorted dates for the max run of consecutive days. Skipping what does not
+        // parse also skips the "unknown" bucket an entry with no usable timestamp lands in.
         var sorted = set.OrderBy(d => d, StringComparer.Ordinal).ToList();
         int longest = 1, run = 1;
-        for (int i = 1; i < sorted.Count; i++)
+        DateTime? previous = null;
+        foreach (var key in sorted)
         {
-            var prev = DateTime.ParseExact(sorted[i - 1], "yyyy-MM-dd", CultureInfo.InvariantCulture);
-            var cur = DateTime.ParseExact(sorted[i], "yyyy-MM-dd", CultureInfo.InvariantCulture);
-            run = (cur - prev).Days == 1 ? run + 1 : 1;
+            if (!StatsAggregator.TryParseDateKey(key, out var cur)) { continue; }
+            run = previous is DateTime prev && (cur - prev).Days == 1 ? run + 1 : 1;
             if (run > longest) { longest = run; }
+            previous = cur;
         }
         return (current, longest);
     }
@@ -980,7 +982,6 @@ internal static class StatsService
         if (range == StatsRange.All) { return (null, null); }
         var today = DateTime.Now.Date;
         var days = range == StatsRange.Last7d ? 6 : 29; // inclusive of today
-        var from = today.AddDays(-days).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
-        return (from, today.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+        return (StatsAggregator.DateKey(today.AddDays(-days)), StatsAggregator.DateKey(today));
     }
 }


### PR DESCRIPTION
Two independent fixes in the stats area, one commit each.

## The day key was written out in seven places

`"yyyy-MM-dd"` with `InvariantCulture` appeared across three files: `StatsAggregator.DateKey` produced the keys and was `private`, so `StatsChart` and `StatsService` each rewrote the format to look them up, and `StatsService` parsed them back with `ParseExact`.

Nothing on disk uses that shape — the JSONL carries an ISO timestamp, and this is purely how day buckets are indexed in memory — so producer and readers only agree as long as someone keeps them in step by hand. They fail quietly when they drift: lookups return nothing, the heatmap comes up empty, the streaks read zero, and nothing is raised anywhere.

`DateKey(DateTime)` and `TryParseDateKey` are `internal` now, the format stays private, and the call sites ask for a key instead of spelling one. `InvariantCulture` goes with it — it was half the contract and was being repeated at every site too.

`TryParse` also closes a throw waiting to happen: `DateKey(long)` files an entry with no usable timestamp under `"unknown"`, and the streak scan called `ParseExact` on whatever keys it found. That bucket is skipped now, and the scan carries the previous parsed day rather than indexing back into the list — which would have compared the wrong pair once anything was skipped.

Left alone: `SessionManagerControl` uses the same literal without `InvariantCulture`, but as a label shown after "just now"/"5m"/"3h". Nobody reads it back, and tying it to the indexing format would couple UI text to a storage decision.

## The daily-tokens dates were cut in half

The x-axis read `2/`, `6/`, `1/` — month missing.

Not a matter of too many labels: about eight are drawn out of thirty. They sat in a `UniformGrid` with one column per bar, so each was given a cell one bar wide — a few pixels — and the text was cut to fit inside it. Drawing fewer would not have helped, since every label lands in a cell that size no matter how many there are.

They are laid out on a `Canvas` now, each measured and centred over its own bar, free to spill across its neighbours — which costs nothing, because the bars either side of a labelled one carry no label. Positioning happens on `SizeChanged`, a bar's width being unknown until the plot has been given one.

The bars keep their `UniformGrid`: a column per bar is exactly right there.

## Testing

Build green (2 projects, 0 failed), plus the Statistics dialog checked by hand: heatmap populated, streaks sensible, dates readable in full.
