### PR TITLE
fix(stats): the cache stops failing on long paths

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsAggregator.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsAggregator.cs
@@ -22,6 +22,33 @@ internal static class StatsAggregator
 {
     private const string SyntheticModel = "<synthetic>";
 
+    /// <summary>The working directory a session ran in, from the first record that carries one.
+    /// Stops there — the caller wants the project's identity, not its contents, and asks before the
+    /// cache path (which is derived from that identity) can be known, so aggregating first is not an
+    /// option. Null when no record says, or on I/O error.</summary>
+    public static string ReadCwd(string path)
+    {
+        try
+        {
+            using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using var reader = new StreamReader(fs);
+            string line;
+            while ((line = reader.ReadLine()) != null)
+            {
+                // Same cheap pre-filter AggregateFile uses: only user and assistant turns carry a
+                // cwd, and parsing every line of a 16 MB file is the cost worth avoiding.
+                if (line.IndexOf("\"cwd\":", StringComparison.Ordinal) < 0) { continue; }
+                JObject obj;
+                try { obj = JObject.Parse(line); }
+                catch { continue; }
+                var cwd = obj.Val("cwd", "");
+                if (!string.IsNullOrEmpty(cwd)) { return cwd; }
+            }
+        }
+        catch (Exception ex) { OutputWindowLogger.Global.LogException("StatsAggregator.ReadCwd", ex); }
+        return null;
+    }
+
     /// <summary>Parse one .jsonl into a <see cref="FileAggregate"/>, reading from
     /// <paramref name="fromOffset"/> bytes. Pass a non-null <paramref name="seed"/> to accumulate
     /// onto an existing aggregate (append delta); null starts fresh. Returns the aggregate, the new

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsAggregator.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsAggregator.cs
@@ -33,10 +33,13 @@ internal static class StatsAggregator
             using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             using var reader = new StreamReader(fs);
             string line;
-            while ((line = reader.ReadLine()) != null)
+            // Bounded: every turn carries a cwd, so one is within the first few records of any file
+            // that has one at all. Reading on would only mean scanning a 16 MB session end to end to
+            // conclude what the first page already said.
+            for (var seen = 0; seen < CwdScanLines && (line = reader.ReadLine()) != null; seen++)
             {
-                // Same cheap pre-filter AggregateFile uses: only user and assistant turns carry a
-                // cwd, and parsing every line of a 16 MB file is the cost worth avoiding.
+                // The same cheap pre-filter AggregateFile uses, for the same reason: parsing every
+                // line is the cost worth avoiding.
                 if (line.IndexOf("\"cwd\":", StringComparison.Ordinal) < 0) { continue; }
                 JObject obj;
                 try { obj = JObject.Parse(line); }
@@ -48,6 +51,10 @@ internal static class StatsAggregator
         catch (Exception ex) { OutputWindowLogger.Global.LogException("StatsAggregator.ReadCwd", ex); }
         return null;
     }
+
+    /// <summary>Records ReadCwd looks at before giving up. Generous: the cwd is on the first user or
+    /// assistant turn, and the records ahead of it are session/hook noise.</summary>
+    private const int CwdScanLines = 200;
 
     /// <summary>Parse one .jsonl into a <see cref="FileAggregate"/>, reading from
     /// <paramref name="fromOffset"/> bytes. Pass a non-null <paramref name="seed"/> to accumulate

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsCache.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsCache.cs
@@ -20,7 +20,10 @@ namespace Corsinvest.VisualStudio.Agents.Core.Stats;
 /// </summary>
 internal static class StatsCache
 {
-    private const int Version = 6;
+    // 7: projectCwd moved out, to project.json beside the project's own data — it was a fact about
+    // the project sitting in each profile's cache. A version that does not match rebuilds from
+    // scratch, which is how the existing caches shed the field.
+    private const int Version = 7;
 
     /// <summary>One cached file: its aggregate + the mtime/size it was computed at.</summary>
     internal sealed class Entry
@@ -28,23 +31,6 @@ internal static class StatsCache
         public long Mtime { get; set; }
         public long Size { get; set; }
         public FileAggregate Aggregate { get; set; }
-    }
-
-    /// <summary>The project's working directory, stored once at the cache root (the most recent
-    /// session's cwd). Null on missing / version mismatch / not yet written.</summary>
-    public static string LoadProjectCwd(string cacheFile)
-    {
-        if (!File.Exists(cacheFile)) { return null; }
-        try
-        {
-            var root = JObject.Parse(File.ReadAllText(cacheFile));
-            return root.Val("version", 0) != Version ? null : root.Val("projectCwd", (string)null);
-        }
-        catch (Exception ex)
-        {
-            OutputWindowLogger.Global.LogException("StatsCache.LoadProjectCwd", ex);
-            return null;
-        }
     }
 
     /// <summary>Load the cache from a file (name → entry). Empty on missing / version
@@ -81,7 +67,7 @@ internal static class StatsCache
     /// <summary>Persist the cache atomically (temp + replace) so a crash mid-write can't corrupt
     /// it. Concurrent writers (two panes on the same project) are last-write-wins — the aggregate
     /// is deterministic, so a re-write is idempotent.</summary>
-    public static void Save(string cacheFile, Dictionary<string, Entry> entries, string projectCwd)
+    public static void Save(string cacheFile, Dictionary<string, Entry> entries)
     {
         try
         {
@@ -89,7 +75,6 @@ internal static class StatsCache
             var root = new JObject
             {
                 ["version"] = Version,
-                ["projectCwd"] = projectCwd,
                 ["files"] = new JObject(),
             };
             var files = (JObject)root["files"];

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsService.cs
@@ -411,10 +411,10 @@ internal static class StatsService
         return Path.GetFileName(projectDir.TrimEnd('\\', '/'));
     }
 
-    /// <summary>Read-only cache probe for a project: its working directory (the projectCwd stored at
-    /// the cache root), whether it has any real activity, and each main session's last-activity time
-    /// (for grouping sessions by the day worked, not the file's creation day). hasData is null when
-    /// nothing is cached yet, true when a cached aggregate has messages, false when it has none.</summary>
+    /// <summary>Read-only cache probe for a project: its working directory (read from a session),
+    /// whether it has any real activity, and each main session's last-activity time (for grouping
+    /// sessions by the day worked, not the file's creation day). hasData is null when nothing is
+    /// cached yet, true when a cached aggregate has messages, false when it has none.</summary>
     private static (string cwd, bool? hasData, Dictionary<string, DateTime> lastActivity)
         ProjectCacheInfo(ClaudePaths paths, string projectDir)
     {
@@ -424,7 +424,7 @@ internal static class StatsService
             var cacheFile = CacheFileFor(paths, projectDir);
             var cache = StatsCache.Load(cacheFile);
             if (cache.Count == 0) { return (null, null, lastActivity); } // not indexed yet
-            var cwd = StatsCache.LoadProjectCwd(cacheFile); // stored once at the cache root
+            var cwd = ProjectCwdOf(projectDir); // read from a session, not from the cache
             var hasData = false;
             foreach (var kv in cache)
             {
@@ -442,14 +442,15 @@ internal static class StatsService
         return (null, null, lastActivity);
     }
 
-    /// <summary>The working directory of a project (the projectCwd stored at the cache root), for a
-    /// --resume that needs a real cwd. Read-only; null when the project isn't indexed yet.</summary>
+    /// <summary>The working directory of a project, for a --resume that needs a real cwd. Read from
+    /// the sessions themselves, so it answers for a project that was never indexed too — where the
+    /// cache it used to come from would have been empty.</summary>
     public static string CwdForProject(Profile profile, string projectDir)
     {
         if (profile == null || string.IsNullOrEmpty(projectDir)) { return null; }
         try
         {
-            return StatsCache.LoadProjectCwd(CacheFileFor(ClaudePaths.ForProfile(profile), projectDir));
+            return ProjectCwdOf(projectDir);
         }
         catch (Exception ex)
         {
@@ -480,10 +481,30 @@ internal static class StatsService
         foreach (var projectDir in ordered) { IndexProject(projectDir, paths, force); }
     }
 
-    // The projectDir is the CLI's dir (source of .jsonl); the cache lives in OUR data folder,
-    // keyed by config-id + the same project-hash (the projectDir's basename).
+    // The projectDir is the CLI's dir (source of .jsonl); the cache lives in OUR data folder, named
+    // after the project's real working directory. That path is not recoverable from the CLI folder
+    // name — the separators are gone — so it comes from the `cwd` a session record carries. A
+    // project with no readable session falls back to the CLI folder name: a cache under an odd name
+    // beats no cache at all.
     private static string CacheFileFor(ClaudePaths paths, string projectDir)
-        => AppPaths.ProjectProfileFileByHash(paths, Path.GetFileName(projectDir.TrimEnd('\\', '/')), "stats-cache.json");
+        => AppPaths.ProjectProfileFile(paths, ProjectCwdOf(projectDir) ?? projectDir, "stats-cache.json");
+
+    /// <summary>The working directory a CLI project folder's sessions ran in, from the first file
+    /// that says. One read of one file: this answers before the cache path is known, so it cannot
+    /// ask the cache.</summary>
+    private static string ProjectCwdOf(string projectDir)
+    {
+        try
+        {
+            foreach (var file in EnumerateSessionFiles(projectDir, ids: null))
+            {
+                var cwd = StatsAggregator.ReadCwd(file.FullName);
+                if (!string.IsNullOrEmpty(cwd)) { return cwd; }
+            }
+        }
+        catch (Exception ex) { OutputWindowLogger.Global.LogException(nameof(StatsService) + ".ProjectCwdOf", ex); }
+        return null;
+    }
 
     /// <summary>Refresh one project's cache: re-read changed files (delta for grown ones), prune
     /// vanished, persist. This is the heavy step; Aggregate below only reads the result.</summary>
@@ -496,31 +517,20 @@ internal static class StatsService
             : StatsCache.Load(cacheFile);
         var files = EnumerateSessionFiles(projectDir, ids: null);
         var updated = new ConcurrentDictionary<string, StatsCache.Entry>();
-        // cwd of each freshly-read file (not the reused ones) — used to pick the project label.
-        var freshCwd = new ConcurrentDictionary<string, string>();
         Parallel.ForEach(files, new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount },
             file =>
             {
                 var key = RelativeKey(projectDir, file.FullName);
                 cache.TryGetValue(key, out var cached);
-                var (entry, cwd) = RefreshFile(file, cached);
+                // The cwd RefreshFile also reports is no longer wanted here: the project's path is
+                // what named the folder this cache sits in, so it is known before indexing starts
+                // and recorded once, in project.json, instead of once per profile.
+                var (entry, _) = RefreshFile(file, cached);
                 if (entry != null) { updated[key] = entry; }
-                if (!string.IsNullOrEmpty(cwd)) { freshCwd[key] = cwd; }
             });
         var next = new Dictionary<string, StatsCache.Entry>(StringComparer.OrdinalIgnoreCase);
         foreach (var kv in updated) { next[kv.Key] = kv.Value; }
-
-        // Project label = the most recent session's cwd (a moved older file keeps a stale cwd). The
-        // cwd isn't persisted per file, so pick it among the files re-read this pass, ranked by their
-        // last-activity time; if none were re-read, keep whatever cwd the cache already had.
-        string projectCwd = StatsCache.LoadProjectCwd(cacheFile);
-        long best = long.MinValue;
-        foreach (var kv in freshCwd)
-        {
-            var ts = next.TryGetValue(kv.Key, out var e) ? e.Aggregate?.LastTimestampMs ?? 0 : 0;
-            if (ts >= best) { projectCwd = kv.Value; best = ts; }
-        }
-        StatsCache.Save(cacheFile, next, projectCwd);
+        StatsCache.Save(cacheFile, next);
     }
 
     /// <summary>Aggregate then map to the wire DTO (streaks, %, favorite model computed here).</summary>

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsService.cs
@@ -55,10 +55,21 @@ internal static class StatsService
         {
             try
             {
-                foreach (var profile in ProfileStore.Load(forEdit: false))
+                // Both lists: `false` is the one to index (native profile included, disabled ones
+                // dropped), `true` adds back the disabled — this pass also decides which data
+                // folders are still claimed, and a profile that is merely switched off will want
+                // its own back when it is switched on again.
+                var live = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                var configs = ProfileStore.Load(forEdit: false)
+                    .Concat(ProfileStore.Load(forEdit: true))
+                    .Select(ClaudePaths.ForProfile)
+                    .GroupBy(p => p.ConfigId, StringComparer.OrdinalIgnoreCase)
+                    .Select(g => g.First());
+                foreach (var paths in configs)
                 {
-                    IndexAllProjects(workingDirectory: null, ClaudePaths.ForProfile(profile), force);
+                    IndexAllProjects(workingDirectory: null, paths, force, live);
                 }
+                PruneUnclaimedFolders(live);
             }
             catch (Exception ex) { OutputWindowLogger.Global.LogException(nameof(StatsService) + ".Index", ex); }
             finally
@@ -168,19 +179,23 @@ internal static class StatsService
         var root = new FolderBuild { Segment = "", FullPath = "" };
         foreach (var p in projects)
         {
-            // The cwd's last segment is the project itself; the ones before it are folders.
+            // Walked to the folder the project IS, not to the one above it. A project whose cwd also
+            // has projects beneath it — C:\Users\daniele.corsini, with AppData and source under it —
+            // would otherwise be filed one level up while its own name branched separately, showing
+            // the same folder twice. Filed here, it meets that branch and ToFolderNode folds the two
+            // into the single node a folder with nothing under it already produces.
             var segs = SplitPath(p.cwd);
             var node = root;
-            for (var i = 0; i < segs.Count - 1; i++)
+            foreach (var seg in segs)
             {
-                if (!node.Sub.TryGetValue(segs[i], out var child))
+                if (!node.Sub.TryGetValue(seg, out var child))
                 {
                     child = new FolderBuild
                     {
-                        Segment = segs[i],
-                        FullPath = node.FullPath.Length == 0 ? segs[i] : node.FullPath + "\\" + segs[i],
+                        Segment = seg,
+                        FullPath = node.FullPath.Length == 0 ? seg : node.FullPath + "\\" + seg,
                     };
-                    node.Sub[segs[i]] = child;
+                    node.Sub[seg] = child;
                 }
                 node = child;
             }
@@ -215,24 +230,34 @@ internal static class StatsService
             var subNode = ToFolderNode(sub, profile, minDay, includeDays);
             if (subNode != null) { children.Add(subNode); }
         }
+
+        // The project filed here IS this folder, so its Days and Sessions hang off this node rather
+        // than off a child repeating the same name — which is what a folder with nothing else under
+        // it already looked like. More than one only happens when two profiles share a cwd; the
+        // extras stay as children, since there is one node to be absorbed into.
+        StatsTreeNode self = null;
         foreach (var p in fb.Projects.OrderBy(p => p.label, StringComparer.OrdinalIgnoreCase))
         {
             var prjNode = BuildProjectNode(profile, p.dir, p.cwd, p.label, p.lastActivity, minDay, includeDays);
-            if (prjNode != null) { children.Add(prjNode); }
+            if (prjNode == null) { continue; }
+            if (self == null) { self = prjNode; } else { children.Add(prjNode); }
         }
-        if (children.Count == 0) { return null; } // nothing in range under this folder
+        if (children.Count == 0 && self == null) { return null; } // nothing in range under this folder
 
         var node = new StatsTreeNode
         {
             Label = label,
             Tooltip = fb.FullPath,
-            Selection = new StatsSelection
+            // The folder's own project wins the selection: clicking the row then reports that
+            // project's numbers rather than the sum of everything filed beneath it.
+            Selection = self?.Selection ?? new StatsSelection
             {
                 Scope = StatsScope.Folder,
                 Profile = profile,
                 ProjectDirs = CollectProjectDirs(fb),
             },
         };
+        if (self != null) { node.Children.AddRange(self.Children); }
         node.Children.AddRange(children);
         return node;
     }
@@ -465,7 +490,10 @@ internal static class StatsService
     /// <summary>Refresh every project's cache. When a workspace is given, its project is done first
     /// so its stats are ready soonest; a null/empty workspace (the all-profiles pass) just does them
     /// all in folder order. Pure I/O + parse → per-project cache file; nothing kept in RAM.</summary>
-    private static void IndexAllProjects(string workingDirectory, ClaudePaths paths, bool force = false)
+    /// <param name="claimed">When given, collects the data folder each indexed project resolved to.
+    /// The all-profiles pass uses it to tell a folder still in use from one left behind.</param>
+    private static void IndexAllProjects(string workingDirectory, ClaudePaths paths, bool force = false,
+                                         HashSet<string> claimed = null)
     {
         // No workspace (all-profiles pass): no "current" project to front-load.
         var current = string.IsNullOrEmpty(workingDirectory) ? null : paths.SessionFolder(workingDirectory);
@@ -478,7 +506,17 @@ internal static class StatsService
                 if (!string.Equals(d, current, StringComparison.OrdinalIgnoreCase)) { ordered.Add(d); }
             }
         }
-        foreach (var projectDir in ordered) { IndexProject(projectDir, paths, force); }
+        foreach (var projectDir in ordered)
+        {
+            IndexProject(projectDir, paths, force);
+            // The project folder, not the profile subfolder the cache file sits in: what gets kept
+            // or removed is the whole project, across every profile that ever used it.
+            if (claimed != null)
+            {
+                var cwd = ProjectCwdOf(projectDir) ?? projectDir;
+                claimed.Add(Core.Workspace.ProjectStore.FolderName(cwd));
+            }
+        }
     }
 
     // The projectDir is the CLI's dir (source of .jsonl); the cache lives in OUR data folder, named
@@ -489,22 +527,64 @@ internal static class StatsService
     private static string CacheFileFor(ClaudePaths paths, string projectDir)
         => AppPaths.ProjectProfileFile(paths, ProjectCwdOf(projectDir) ?? projectDir, "stats-cache.json");
 
+    /// <summary>Remove the data folders no project claimed during a full pass. What is left there is
+    /// either from the old naming scheme — every folder was the whole path with its separators
+    /// replaced, before they grew past what Windows allows — or belongs to a project that is gone.
+    /// <para>Only ever called after the pass that visits every profile, enabled or not: a partial
+    /// pass would report folders as unclaimed simply because nobody looked for them. And skipped
+    /// entirely when that pass found nothing at all, which is what a failure looks like from here —
+    /// deleting everything because the profiles could not be read is the one outcome worth guarding
+    /// against.</para></summary>
+    private static void PruneUnclaimedFolders(HashSet<string> claimed)
+    {
+        if (claimed.Count == 0) { return; }
+        try
+        {
+            foreach (var folder in Core.Workspace.ProjectStore.All())
+            {
+                if (claimed.Contains(Path.GetFileName(folder))) { continue; }
+                try
+                {
+                    Directory.Delete(folder, recursive: true);
+                    OutputWindowLogger.Global.Debug(() => $"[stats] removed unclaimed data folder {Path.GetFileName(folder)}");
+                }
+                catch (Exception ex) { OutputWindowLogger.Global.LogException(nameof(StatsService) + ".Prune", ex); }
+            }
+        }
+        catch (Exception ex) { OutputWindowLogger.Global.LogException(nameof(StatsService) + ".PruneUnclaimedFolders", ex); }
+    }
+
     /// <summary>The working directory a CLI project folder's sessions ran in, from the first file
-    /// that says. One read of one file: this answers before the cache path is known, so it cannot
-    /// ask the cache.</summary>
+    /// that says. This answers before the cache path is known — the cache lives at a path derived
+    /// from it — so it cannot ask the cache.
+    /// <para>Memoised for the process: CacheFileFor asks on every call, an indexing pass calls it
+    /// once per project per profile, and the answer cannot change while we run — a session's cwd is
+    /// written when it starts. Without this the pass reopens the same .jsonl a dozen times.</para>
+    /// </summary>
     private static string ProjectCwdOf(string projectDir)
     {
+        // Null only under Hot Reload, which adds the field without running its initialiser. Worth
+        // surviving rather than throwing: a throw here empties the claimed set, and an empty claimed
+        // set is what the pruning below reads as "nothing is in use".
+        if (_projectCwd?.TryGetValue(projectDir, out var known) == true) { return known; }
+        string cwd = null;
         try
         {
             foreach (var file in EnumerateSessionFiles(projectDir, ids: null))
             {
-                var cwd = StatsAggregator.ReadCwd(file.FullName);
-                if (!string.IsNullOrEmpty(cwd)) { return cwd; }
+                cwd = StatsAggregator.ReadCwd(file.FullName);
+                if (!string.IsNullOrEmpty(cwd)) { break; }
             }
         }
         catch (Exception ex) { OutputWindowLogger.Global.LogException(nameof(StatsService) + ".ProjectCwdOf", ex); }
-        return null;
+        // Cached even when null: a project whose sessions carry no cwd would otherwise be re-scanned
+        // in full every single time, which is the slowest case there is.
+        if (_projectCwd != null) { _projectCwd[projectDir] = cwd; }
+        return cwd;
     }
+
+    private static readonly ConcurrentDictionary<string, string> _projectCwd =
+        new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>Refresh one project's cache: re-read changed files (delta for grown ones), prune
     /// vanished, persist. This is the heavy step; Aggregate below only reads the result.</summary>

--- a/src/Corsinvest.VisualStudio.Agents/Core/Workspace/ProjectStore.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Workspace/ProjectStore.cs
@@ -1,0 +1,116 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using Corsinvest.VisualStudio.Agents.Helpers;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Corsinvest.VisualStudio.Agents.Core.Workspace;
+
+/// <summary>Our per-project data folder: what it is called, and the file that says which project it
+/// holds. The two belong together — the name carries a hash and cannot be read back, so a folder
+/// that loses its descriptor is anonymous for good.
+/// <para>The name used to be the whole working directory with its separators replaced, which ran
+/// past the 248 characters .NET Framework allows a directory: the stats cache then failed to save
+/// on every attempt, silently, and the statistics re-read every .jsonl each time they opened.</para>
+/// </summary>
+internal static class ProjectStore
+{
+    private const string DescriptorFile = "project.json";
+
+    /// <summary>Longest tail kept in the folder name. The tail is there to be recognised by eye —
+    /// the hash is what makes the name unique — so it only has to be long enough for that.</summary>
+    private const int MaxTail = 30;
+
+    /// <summary>Hash characters kept. Eight hex digits, with the tail already telling most projects
+    /// apart, puts a collision far below anything one machine will produce.</summary>
+    private const int HashChars = 8;
+
+    /// <summary>The folder name for a working directory: its last segment, plus a hash of the whole
+    /// path. Pure — touches nothing.
+    /// <para>The tail, where the CLI truncates from the head: projects on one machine share a long
+    /// prefix and differ at the end, so cutting from the front would leave them looking identical.
+    /// The hash covers the full path, so two projects with the same tail under different roots
+    /// still land in different folders.</para></summary>
+    public static string FolderName(string workingDirectory)
+    {
+        var full = Path.GetFullPath(workingDirectory);
+        var hash = ShortHash(full);
+        var tail = Sanitize(Path.GetFileName(full.TrimEnd(Path.DirectorySeparatorChar,
+                                                          Path.AltDirectorySeparatorChar)));
+        if (tail.Length > MaxTail) { tail = tail.Substring(0, MaxTail); }
+        // A root like "K:\" has no tail to show; the hash alone still identifies it.
+        return tail.Length == 0 ? hash : $"{tail}-{hash}";
+    }
+
+    /// <summary>The project's data folder, created, descriptor written. Written here and nowhere
+    /// else, so a folder cannot come into being without one.</summary>
+    public static string FolderFor(string workingDirectory)
+    {
+        var full = Path.GetFullPath(workingDirectory);
+        var folder = Path.Combine(AppPaths.ProjectsRoot, FolderName(full));
+        try
+        {
+            Directory.CreateDirectory(folder);
+            var descriptor = Path.Combine(folder, DescriptorFile);
+            // Only when missing: the path that produced this folder cannot change without changing
+            // the hash, so a descriptor that is already there is never stale.
+            if (!File.Exists(descriptor))
+            {
+                File.WriteAllText(descriptor, new JObject { ["path"] = full }.ToString());
+            }
+        }
+        catch (Exception ex) { OutputWindowLogger.Global.LogException("ProjectStore.FolderFor", ex); }
+        return folder;
+    }
+
+    /// <summary>The project a folder belongs to. Null when the descriptor is missing or unreadable —
+    /// there is no other way back, the name being a one-way hash.</summary>
+    public static string PathOf(string projectFolder)
+    {
+        if (string.IsNullOrEmpty(projectFolder)) { return null; }
+        try
+        {
+            var descriptor = Path.Combine(projectFolder, DescriptorFile);
+            return File.Exists(descriptor)
+                    ? JObject.Parse(File.ReadAllText(descriptor)).Val("path", (string)null)
+                    : null;
+        }
+        catch (Exception ex)
+        {
+            OutputWindowLogger.Global.LogException("ProjectStore.PathOf", ex);
+            return null;
+        }
+    }
+
+    /// <summary>Every project folder on disk. For inspection, and for pruning the ones whose project
+    /// is gone — which nothing does yet.</summary>
+    public static IEnumerable<string> All()
+        => Directory.Exists(AppPaths.ProjectsRoot)
+            ? Directory.GetDirectories(AppPaths.ProjectsRoot)
+            : [];
+
+    private static string Sanitize(string name)
+        => new(name.Select(c => char.IsLetterOrDigit(c) ? c : '-').ToArray());
+
+    /// <summary>Lower-cased before hashing: Windows paths are case-insensitive, so K:\Source and
+    /// k:\source are one project and have to reach one folder.</summary>
+    private static string ShortHash(string value)
+    {
+        using var sha = SHA1.Create();
+        var bytes = sha.ComputeHash(Encoding.UTF8.GetBytes(value.ToLowerInvariant()));
+        var sb = new StringBuilder(HashChars + 2);
+        for (var i = 0; sb.Length < HashChars && i < bytes.Length; i++)
+        {
+            sb.Append(bytes[i].ToString("x2"));
+        }
+        return sb.ToString(0, HashChars);
+    }
+}

--- a/src/Corsinvest.VisualStudio.Agents/Corsinvest.VisualStudio.Agents.csproj
+++ b/src/Corsinvest.VisualStudio.Agents/Corsinvest.VisualStudio.Agents.csproj
@@ -261,6 +261,7 @@
     <Compile Include="Core\Context\ContextUsageControl.Render.cs">
       <DependentUpon>ContextUsageControl.xaml.cs</DependentUpon>
     </Compile>
+    <Compile Include="Core\Workspace\ProjectStore.cs" />
     <Compile Include="Core\Workspace\WorkspaceState.cs" />
     <Compile Include="Core\Workspace\WorkspaceStore.cs" />
     <Compile Include="Chat\ContentBlockTranslator.cs" />

--- a/src/Corsinvest.VisualStudio.Agents/Utils/AppPaths.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Utils/AppPaths.cs
@@ -40,11 +40,12 @@ internal static class AppPaths
         return Path.Combine(baseDir, "WebView2", "index.html");
     }
 
-    /// <summary>Root of OUR per-project data: <DataFolder>/data/projects/<project-hash>/. This is the
-    /// PER-SOLUTION scope (independent of profile): workspace.json lives here; per-profile files live
-    /// in the <config-id>/ subfolder below.</summary>
+    /// <summary>Root of OUR per-project data: <ProjectsRoot>/<folder>/. This is the PER-SOLUTION
+    /// scope (independent of profile): workspace.json lives here; per-profile files live in the
+    /// <config-id>/ subfolder below. ProjectStore names the folder and creates it — deliberately
+    /// not this class, which is otherwise all Path.Combine and touches nothing.</summary>
     public static string ProjectFolder(string workingDirectory)
-        => Path.Combine(DataFolder, "data", "projects", ClaudePaths.ProjectFolderName(workingDirectory));
+        => Core.Workspace.ProjectStore.FolderFor(workingDirectory);
 
     /// <summary>The per-solution workspace file (open panes). Depends only on the solution folder,
     /// not on any profile — the panes' profiles are stored inside the JSON.</summary>
@@ -59,9 +60,4 @@ internal static class AppPaths
     /// <summary>A file inside the per-(project, profile) folder (by workdir). Caller creates the dir at Save.</summary>
     public static string ProjectProfileFile(ClaudePaths paths, string workingDirectory, string fileName)
         => Path.Combine(ProjectProfileFolder(paths, workingDirectory), fileName);
-
-    /// <summary>Same, given the project-hash directly (StatsService enumerates CLI projectDirs whose
-    /// basename IS the hash — avoids recomputing it).</summary>
-    public static string ProjectProfileFileByHash(ClaudePaths paths, string projectHash, string fileName)
-        => Path.Combine(DataFolder, "data", "projects", projectHash, paths.ConfigId, fileName);
 }

--- a/src/Corsinvest.VisualStudio.Agents/Utils/AppPaths.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Utils/AppPaths.cs
@@ -28,6 +28,10 @@ internal static class AppPaths
     /// </summary>
     public static readonly string IconCacheFolder = Path.Combine(DataFolder, "icons");
 
+    /// <summary>Where the per-project folders live. ProjectStore names what goes inside — it needs
+    /// the root without going back through ProjectFolder, which delegates to it.</summary>
+    public static readonly string ProjectsRoot = Path.Combine(DataFolder, "data", "projects");
+
     public static string WebViewHtml()
     {
         // The TS+Lit WebView is built from WebViewSrc/ into WebView2/ at


### PR DESCRIPTION
Spec and plan: `docs/internal/specs/todo/2026-08-04-short-project-paths-{design,plan}.md` (gitignored).

## The bug

`StatsCache.Save` threw `PathTooLongException` — .NET Framework 4.8 caps a directory path at 248 characters and ours went past it. Not transient: the path depends only on where the project lives, so once it fails for a solution it fails on every save. The `catch` logs and moves on, so the cache was never written and the statistics re-read every `.jsonl` each time they opened. Slow but working, which is why nobody noticed.

Measured on this machine:

| segment | chars |
|---|---|
| fixed prefix `…\Corsinvest\cv4vs-agents\data\projects` | 76 |
| project folder, worst case seen | 138 |
| `configId` | 32 |
| `stats-cache.json` | 16 |
| **total, broken case** | **264** |
| total, typical project | 170 |

Two segments were whole paths turned into folder names by `Regex.Replace(path, "[^a-zA-Z0-9]", "-")`.

Before touching anything, everything else we write was measured too: `profiles.json` 75, `icons\` 99, `WebView2\` 186 (a depth the WebView2 runtime picks, not us). The fault sits in one place, `data\projects\`, which is the only spot where we nest path-as-folder-name twice.

## What changed

**The folder is `<tail>-<sha1-8>`** — `cv4vs-agents-a3f9c21b`. The tail, not the head where the CLI truncates: projects on one machine share a long prefix and differ at the end, so cutting from the front would leave them looking identical. The hash covers the whole path, so two projects with the same tail under different roots still separate. Worst case drops from 264 to about 140.

**`project.json` sits beside the data.** A hash cannot be read back, so this is the only route from a folder to the project it holds. One per folder rather than one index for all: two VS instances on two solutions would write a shared file at once (the lock-file problem from #75, and that one had a single process), and losing one descriptor costs one project where losing an index costs every one of them.

**`ProjectStore` owns both halves** — the name and the descriptor are one decision, and splitting them would let a folder exist without one. It lives beside `WorkspaceStore`, which already does this for panes. `AppPaths` stays what it is: `Path.Combine` and nothing else.

**`projectCwd` left `StatsCache`.** The project's path was stored in every profile's cache, written only *after* indexing — so with a long path, never. It also had to be guessed: `IndexProject` ranked the freshly-read files by last activity to pick one. The path is now known before indexing starts, being what named the folder. `StatsCache.Version` 6 → 7, so caches on disk rebuild themselves.

**`configId` is untouched.** 32 readable characters, bounded by nature (`~/.claude` or close), and shortening the project folder alone leaves 100 characters of headroom. Changing only what breaks.

**No migration.** The cache regenerates; saved panes are lost once. A compatibility branch would outlive the reason it was written.

## Found while testing

**Reading the cwd cost a scan per lookup.** `CacheFileFor` used to be `Path.Combine` and is now a file read, called from five places — the progress bar stopped coming back down. `ReadCwd` gives up after 200 records (every turn carries a cwd), and the answer is memoised for the process, nulls included.

**Half the storage was rubbish.** 54 old folders against 53 in use. The full pass visits every project there is, so what it does not visit is unclaimed: it now collects what it resolved and removes the rest. Guarded twice — every config dir including disabled profiles and the native one (the enabled-only list omits the native profile, which holds most projects, so alone it would have swept everything), and an empty claimed set is treated as "the profiles could not be read", which does nothing.

**A folder that is also a project appeared twice.** `BuildFolderTree` filed a project under the segments *before* its own, so `C:\Users\daniele.corsini` went under `Users` while `AppData` and `source` branched a `daniele.corsini` of their own beside it. Projects are filed in the node they are now, and the branch carries their Days and Sessions — the way a folder with nothing else under it already looked.

## Testing

Manual, in the experimental instance, with the folders inspected on disk between runs:

- 53 new folders against 53 CLI project folders — nothing lost — each with a `project.json` whose path resolves
- the 138-character project that used to fail now indexes and appears in the tree
- statistics work: heatmap, streaks, 7d/30d filters, project labels reading as names
- saved panes lost once, as the spec expected

Build green throughout (2 projects, 0 failed).
