### PR TITLE
fix(sessions): read a session whose project path is very long

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.History.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.History.cs
@@ -29,7 +29,7 @@ internal sealed partial class SessionManager
         using var _ = OutputWindowLogger.Global.PerfSpan($"ReadHistoryRaw({sessionId}, batch={batchSize}, before={beforeOffset})");
         var page = new HistoryPage { Messages = [] };
         var folder = FolderFor();
-        var path = Path.Combine(folder, sessionId + ".jsonl");
+        var path = FileFor(sessionId);
 
         info = null;
         if (!File.Exists(path)) { return page; }
@@ -220,7 +220,7 @@ internal sealed partial class SessionManager
         using var _ = OutputWindowLogger.Global.PerfSpan($"ReadUserPrompts({sessionId})");
         var promptsNewestFirst = new List<string>();
         var folder = FolderFor();
-        var path = Path.Combine(folder, sessionId + ".jsonl");
+        var path = FileFor(sessionId);
         if (!File.Exists(path)) { return promptsNewestFirst; }
 
         const int ChunkBytes = 64 * 1024;
@@ -448,7 +448,7 @@ internal sealed partial class SessionManager
     {
         if (string.IsNullOrEmpty(uuid)) { return null; }
         var folder = FolderFor();
-        var path = Path.Combine(folder, sessionId + ".jsonl");
+        var path = FileFor(sessionId);
         if (!File.Exists(path)) { return null; }
         try
         {
@@ -472,7 +472,7 @@ internal sealed partial class SessionManager
     public string ReadCompactSummary(string sessionId, string boundaryUuid)
     {
         if (!IsSafePathToken(sessionId) || string.IsNullOrEmpty(boundaryUuid)) { return ""; }
-        var path = Path.Combine(FolderFor(), sessionId + ".jsonl");
+        var path = FileFor(sessionId);
         if (!File.Exists(path)) { return ""; }
         try
         {
@@ -577,7 +577,7 @@ internal sealed partial class SessionManager
         // plain id token so they can't traverse out of the session dir into the path.
         if (!IsSafePathToken(sessionId) || !IsSafePathToken(agentId)) { return new HistoryPage { Messages = [] }; }
         var folder = FolderFor();
-        var dir = Path.Combine(folder, sessionId, "subagents");
+        var dir = LongPath(Path.Combine(folder, sessionId, "subagents"));
         var path = Path.Combine(dir, $"agent-{agentId}.jsonl");
         if (!File.Exists(path)) { return new HistoryPage { Messages = [] }; }
         try

--- a/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.cs
@@ -42,8 +42,18 @@ internal sealed partial class SessionManager
 
     // The session folder / a session .jsonl path for this instance's workdir, honouring
     // this instance's config-dir. One place each so the path construction lives in a single spot.
-    private string FolderFor() => _paths.SessionFolder(_workingDirectory);
-    private string FileFor(string sessionId) => Path.Combine(_paths.SessionFolder(_workingDirectory), sessionId + ".jsonl");
+    private string FolderFor() => LongPath(_paths.SessionFolder(_workingDirectory));
+    private string FileFor(string sessionId) => LongPath(Path.Combine(_paths.SessionFolder(_workingDirectory), sessionId + ".jsonl"));
+
+    /// <summary>Past 260 characters .NET Framework refuses the path outright — DirectoryNotFoundException
+    /// on a file that is plainly there — and the CLI happily writes session files that long: its own
+    /// folder name is most of the working directory, and a GUID plus ".jsonl" follows. The \\?\ prefix
+    /// hands the path to Win32 unchecked.
+    /// <para>Applied in the two accessors above, so every read and write below inherits it without
+    /// having to know. Only past the limit: the prefix would otherwise turn up in logs and in
+    /// anything comparing these paths against one built elsewhere.</para></summary>
+    private static string LongPath(string path)
+        => path.Length < 260 || path.StartsWith(@"\\", StringComparison.Ordinal) ? path : @"\\?\" + path;
 
     public List<SessionInfo> Load()
     {
@@ -58,8 +68,11 @@ internal sealed partial class SessionManager
         OutputWindowLogger.Global.Perf(() => $"sessions: loading {files.Length} files");
 
         return files
+            // FullName, not FolderFor's own prefixing: a folder can sit under the limit while the
+            // file inside it goes over — the CLI's folder name is nearly the whole workdir, and a
+            // GUID plus ".jsonl" is another 41 characters on top.
             .AsParallel()
-            .Select(f => ReadSessionFile(f.FullName))
+            .Select(f => ReadSessionFile(LongPath(f.FullName)))
             .Where(x => x != null)
             .OrderByDescending(x => x.LastUsedAt)
             .ToList();
@@ -84,7 +97,7 @@ internal sealed partial class SessionManager
             info.Title = StringHelpers.Truncate(rawTitle, 60);
             return info;
         }
-        catch { _log.Debug(() => "[sessions] skipped an unreadable/corrupt session file"); return null; }
+        catch (Exception ex) { _log.Warn($"[sessions] skipped {Path.GetFileName(path)}: {ex.GetType().Name}: {ex.Message}"); return null; }
     }
 
     private static SessionInfo ScanMetadata(string path)
@@ -335,11 +348,11 @@ internal sealed partial class SessionManager
     public ForkResult ForkSession(string sessionId, string resumeAtMessageUuid)
     {
         var folder = FolderFor();
-        var srcPath = Path.Combine(folder, sessionId + ".jsonl");
+        var srcPath = FileFor(sessionId);
         if (!File.Exists(srcPath)) { return null; }
 
         var newSessionId = Guid.NewGuid().ToString();
-        var dstPath = Path.Combine(folder, newSessionId + ".jsonl");
+        var dstPath = FileFor(newSessionId);
         string excludedPrompt = null;
 
         try

--- a/src/Corsinvest.VisualStudio.Agents/Utils/ClaudePaths.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Utils/ClaudePaths.cs
@@ -41,14 +41,43 @@ public sealed class ClaudePaths
     // `replace(/[^a-zA-Z0-9]/g, "-")` — every non-alphanumeric char becomes '-', case PRESERVED.
     // So C:\Users\jane.doe → C--Users-jane-doe (the dot in the username becomes a dash too; an
     // earlier version left dots intact and lowercased, missing the folder).
-    // Not replicated (rare on Windows): the CLI also realpath's the cwd
-    // (symlink/junction canonicalization) and, for names >200 chars, truncates + appends a hash.
-    // Shared so the CLI-reader path (SessionFolder) and our own data path use the SAME hash.
+    // Not replicated (rare on Windows): the CLI also realpath's the cwd (symlink/junction
+    // canonicalization). The >200-char case IS handled, by SessionFolder rather than here.
     public static string ProjectFolderName(string workingDirectory)
         => Regex.Replace(Path.GetFullPath(workingDirectory), "[^a-zA-Z0-9]", "-");
 
+    /// <summary>Longest folder name the CLI writes before it truncates — filesystems cap a single
+    /// path component at 255 bytes, and it leaves room for the suffix it adds.</summary>
+    private const int MaxSanitizedLength = 200;
+
+    /// <summary>The CLI's session folder for a working directory.
+    /// <para>Past 200 characters the name is truncated and a hash appended, and the hash is not
+    /// reproducible from here: it varies with how the CLI was built. So the folder is found by its
+    /// prefix rather than computed — which also survives the day that suffix changes shape. Short
+    /// names, the overwhelming majority, never reach the directory listing.</para></summary>
     public string SessionFolder(string workingDirectory)
-        => Path.Combine(ProjectsFolder, ProjectFolderName(workingDirectory));
+    {
+        var name = ProjectFolderName(workingDirectory);
+        if (name.Length <= MaxSanitizedLength) { return Path.Combine(ProjectsFolder, name); }
+
+        // The untruncated name, on the chance an older CLI wrote one.
+        var verbatim = Path.Combine(ProjectsFolder, name);
+        if (Directory.Exists(verbatim)) { return verbatim; }
+
+        var prefix = name.Substring(0, MaxSanitizedLength) + "-";
+        try
+        {
+            foreach (var dir in Directory.EnumerateDirectories(ProjectsFolder))
+            {
+                if (Path.GetFileName(dir).StartsWith(prefix, StringComparison.Ordinal)) { return dir; }
+            }
+        }
+        catch (Exception ex) { OutputWindowLogger.Global.LogException("ClaudePaths.SessionFolder", ex); }
+        // Nothing there yet. Return the truncated stem without a hash: no session exists to be
+        // found, and a path this long is only ever read from — the CLI creates the real folder,
+        // hash and all, the first time it writes one.
+        return Path.Combine(ProjectsFolder, name.Substring(0, MaxSanitizedLength));
+    }
 
     /// <summary>Stable filesystem-safe id for this config-dir, used to namespace our own per-config-dir
     /// data (e.g. stats). Derived from the resolved config-dir path with the same folder-name rule, so it


### PR DESCRIPTION
A pre-existing gap, found while working on #79 and kept out of it: that one is about where *we* store data, this is about reading where the CLI stores its. Two faults in a row — the second only became visible once the first was fixed.

## 1. The folder was never found

Past 200 characters the CLI truncates the project folder name and appends a suffix. We only applied the regex, so for such a project we looked under the full name, found nothing, and reported a project with no sessions at all.

**Not solved by computing the same suffix.** It is a hash, and which one it is depends on how the CLI was built — so reproducing it from here means guessing at something that can change under us. Getting it wrong would replace "finds nothing" with "confidently looks in the wrong place".

The folder is matched on its prefix instead: the first 200 characters are ours to compute exactly, and whatever follows the separator does not have to be understood. That also survives the day the suffix changes shape. A name under 200 characters returns before touching the disk.

## 2. The file could not be opened

With the folder resolved, the history was still empty:

```
[sessions] loading 1 files
[sessions] skipped 481f7b33-….jsonl: DirectoryNotFoundException: Impossibile trovare una parte del percorso '…'
```

.NET Framework refuses a file path over 260 characters — and refuses it as `DirectoryNotFoundException`, "cannot find part of the path", for a file plainly sitting there. `\\?\` hands the path to Win32 unchecked.

The folder can be under the limit while the file inside it is over: the folder is named after nearly the whole working directory, then a GUID and `.jsonl` add 41 characters. Measured on the test project — **folder 253, file 292**.

Applied in `FolderFor`/`FileFor` so every read and write inherits it, and only past the limit, or the prefix would show up in logs and in path comparisons. The five places that rebuilt `Path.Combine(folder, sessionId + ".jsonl")` by hand now call `FileFor` — that repetition is what would otherwise have needed the prefix pasted into each, and what would have let the next one added quietly go without.

**The catch that hid it** said only "unreadable/corrupt session file". It now names the file and the exception, which is how the real cause surfaced.

## Known limit

Two projects sharing their first 200 characters resolve to whichever is listed first. Closing it means reading `cwd` out of a candidate's `.jsonl` and comparing — `StatsAggregator.ReadCwd` from #79 already does the reading. Left out: it needs a path over 200 characters *and* a second sharing all of it.

## Also considered

The CLI can tell us the transcript path outright, in the payload it sends when a session starts. Probing the wire shows that event fires ~20ms before our own initialisation is acknowledged, so the callback we register is not in place yet for the one occurrence that would matter. Later ones do reach us, so it could refine an answer, never provide the first. Nothing in the startup handshake carries the path either.

## Testing

Reproduced end to end. A test project was created under a 226-character path; the folder written for it came out as 200 characters of stem plus a 6-character suffix, confirming the truncation. Before: "No sessions found". After: the session lists and opens.
