### PR TITLE
docs(comments): comment hygiene — drop another editor's internals

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents.Contracts/ContextUsageDtos.cs
+++ b/src/Corsinvest.VisualStudio.Agents.Contracts/ContextUsageDtos.cs
@@ -88,8 +88,7 @@ public class ContextTokenGroupDto
     public int Tokens { get; set; }
 }
 
-/// <summary>Breakdown of the "Messages" category into its parts — the detail the VS Code
-/// dialog doesn't surface.</summary>
+/// <summary>Breakdown of the "Messages" category into its parts.</summary>
 public class ContextMessageBreakdownDto
 {
     public int ToolCallTokens { get; set; }

--- a/src/Corsinvest.VisualStudio.Agents.Contracts/PluginDtos.cs
+++ b/src/Corsinvest.VisualStudio.Agents.Contracts/PluginDtos.cs
@@ -31,8 +31,8 @@ public class AvailablePluginDto
     public string Version { get; set; }
     public int InstallCount { get; set; }
     // How to read Source: a ready-to-open URL (git-subdir already resolved to repo/tree/main/<path>
-    // host-side), a marketplace-relative "./path" (the WebView joins it onto the marketplace repo,
-    // like VS Code), or None.
+    // host-side), a marketplace-relative "./path" (the WebView joins it onto the marketplace repo),
+    // or None.
     public PluginSourceKindDto SourceKind { get; set; }
     public string Source { get; set; }
 }

--- a/src/Corsinvest.VisualStudio.Agents.Contracts/ToWebViewDtos.cs
+++ b/src/Corsinvest.VisualStudio.Agents.Contracts/ToWebViewDtos.cs
@@ -53,8 +53,8 @@ public class ModelInfoDto
 {
     public string Value { get; set; }
     // The real served model id this catalogue entry maps to (e.g. "claude-opus-4-8[1m]"). Used
-    // to resolve a served id back to its entry — like the VS Code extension — instead of guessing
-    // by family name, which is fragile with alternative providers (env-var remapped models).
+    // to resolve a served id back to its entry instead of guessing by family name, which is
+    // fragile with alternative providers (env-var remapped models).
     public string ResolvedModel { get; set; }
     public string DisplayName { get; set; }
     public string Description { get; set; }
@@ -88,7 +88,7 @@ public class CliStateDto
     public bool? SwitchModelsOnFlag { get; set; }
     public bool? Ultracode { get; set; }
     // effective.permissions.disableBypassPermissionsMode == "disable": an org policy forbids the
-    // bypass mode, so the selector must not offer it (VS Code gates on the same key).
+    // bypass mode, so the selector must not offer it.
     public bool? BypassPermissionsDisabled { get; set; }
     // From init.fast_mode_state (off|cooldown|on). The webview derives only the on/off toggle
     // (on = state != "off"); cooldown is not currently surfaced distinctly. Replaces the

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/FileSuggestions.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/FileSuggestions.cs
@@ -36,10 +36,9 @@ internal static class FileSuggestions
             // Backslashes accepted as separators so a path pasted from Explorer still matches.
             var qLower = query.Replace('\\', '/').ToLowerInvariant();
 
-            // One walk of the whole tree, filtered on the relative path — the way the VS Code
-            // extension asks `workspace.findFiles` for `**/*`. A depth cap or a minimum query
-            // length would only mean a file that exists cannot be found, which is the one thing
-            // this menu is for. Pruning ignored directories keeps the cost off node_modules.
+            // One walk of the whole tree, filtered on the relative path. A depth cap or a minimum
+            // query length would only mean a file that exists cannot be found, which is the one
+            // thing this menu is for. Pruning ignored directories keeps the cost off node_modules.
             // Keyed by relative path so directories and files can be interleaved in tree order at
             // the end: a folder immediately followed by what matched inside it. Listing every
             // directory first reads fine with five of them and not at all once they nest, which is
@@ -55,8 +54,8 @@ internal static class FileSuggestions
                 // One budget for every row, files and derived folders alike, and the walk stops when
                 // it is gone. Counting only files let folders keep coming after the cut, leaving a
                 // tail of directories whose contents had all been dropped — `tools/cli-probe/` and
-                // nothing under it. Alphabetical order means the cut lands wherever it lands; that
-                // is the same deal the VS Code extension takes with its own limit of 100.
+                // nothing under it. Alphabetical order means the cut lands wherever it lands, which
+                // is the trade any capped file picker makes.
                 if (hits.Count >= MaxRows || ++visited > MaxVisited) { break; }
 
                 var rel = PathHelpers.Relative(root, file);
@@ -74,8 +73,7 @@ internal static class FileSuggestions
                     var dirRel = rel.Substring(0, slash);
                     // Sorted under the trailing slash, which is what interleaves the two kinds:
                     // "docs/" sorts before "docs/chat/" and both before "docs/readme.md", because
-                    // '/' orders below every letter. The VS Code extension gets the same result by
-                    // sorting its combined list on the path with that slash appended.
+                    // '/' orders below every letter.
                     var dirKey = dirRel + "/";
                     if (hits.ContainsKey(dirKey)) { continue; }
                     if (!string.IsNullOrEmpty(qLower) && !dirRel.ToLowerInvariant().Contains(qLower)) { continue; }
@@ -83,8 +81,7 @@ internal static class FileSuggestions
                     {
                         // Whole relative path on one line, no parent column beside it — nested
                         // folders are the common case here, and a bare leaf leaves you guessing
-                        // which of the four `cv4vs-*` you are looking at. (The VS Code extension
-                        // renders directory rows the same way: one `path`, no second column.)
+                        // which of the four `cv4vs-*` you are looking at.
                         Name = dirKey,
                         Path = Path.Combine(root, dirRel.Replace('/', Path.DirectorySeparatorChar)),
                         Dir = string.Empty,
@@ -107,9 +104,8 @@ internal static class FileSuggestions
         return result;
     }
 
-    /// <summary>Rows shown, files and derived directories together. Higher than the 100 the VS Code
-    /// extension asks `workspace.findFiles` for, because the cut is not the same thing: the walk is
-    /// alphabetical, so a low cap does not sample the tree, it stops partway through and hides
+    /// <summary>Rows shown, files and derived directories together. Deliberately generous: the walk
+    /// is alphabetical, so a low cap does not sample the tree, it stops partway through and hides
     /// everything from there to the end of the alphabet — `tools/` never showed up. Bounded all the
     /// same: cv-popover-list renders every row it is given, with no virtualisation.</summary>
     private const int MaxRows = 600;
@@ -312,7 +308,8 @@ internal static class GitIgnoreCache
 
 /// <summary>
 /// Lightweight `.gitignore` matcher: plain names, anchored <c>/</c>, dir-only trailing <c>/</c>,
-/// basic <c>*</c>/<c>?</c> globs. Skips negations and brace expansions (as the VS Code extension does).
+/// basic <c>*</c>/<c>?</c> globs. Skips negations and brace expansions — rare enough that a full
+/// gitignore implementation would not pay for itself here.
 /// </summary>
 internal sealed class GitIgnore
 {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.Payloads.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.Payloads.cs
@@ -139,8 +139,8 @@ internal sealed partial class WebViewBridge
                 }
                 else
                 {
-                    // Text-like file: decode the base64 back to UTF-8 (same as the
-                    // VS Code extension's `atob(...)` before the text block).
+                    // Text-like file: the CLI expects a plain text block, so decode the
+                    // base64 back to UTF-8 rather than attaching it as binary data.
                     string textData;
                     try
                     {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Misc.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Misc.cs
@@ -19,10 +19,9 @@ internal sealed partial class WebViewMessageHandler
 {
     private void HandleFork(JObject data, int? id)
     {
-        // Fork like VS Code: write a brand-new JSONL truncated BEFORE the
-        // clicked message (fresh uuids), open it in its OWN pane (this
-        // session stays untouched), and pre-fill that message's text into
-        // the new composer for editing/resend.
+        // Fork: write a brand-new JSONL truncated BEFORE the clicked message
+        // (fresh uuids), open it in its OWN pane (this session stays untouched),
+        // and pre-fill that message's text into the new composer for editing/resend.
         var p = data.ToObject<Contracts.ForkNotification>();
         var forkAtUuid = p.MessageUuid ?? "";
         var forkSourceId = p.SessionId ?? client.SessionId;

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.ClientEvents.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.ClientEvents.cs
@@ -73,7 +73,7 @@ public partial class ChatPaneControl
 
     /// <summary>PreToolUse/PostToolUse hooks (Edit/Write/[Multi]Edit/Read): autosave (save the target
     /// file if it's open dirty, so Claude sees live edits) plus post-edit diagnostics (baseline on
-    /// PreToolUse, new-diagnostics check on PostToolUse — always on, like VS Code). async void because
+    /// PreToolUse, new-diagnostics check on PostToolUse — always on). async void because
     /// the diagnostics check awaits the Error List settling; the try/catch guarantees a response is
     /// always sent so our failure never blocks Claude's tool.</summary>
     private async void OnHookCallback(object sender, HookCallbackEventArgs e)
@@ -175,7 +175,7 @@ public partial class ChatPaneControl
         {
             // Publish the model catalogue only on the first init (fresh pane, no --resume).
             // --resume grafts the session model id onto the catalogue (e.g. duplicating "opus[1m]"),
-            // dirtying the picker on later inits; VS Code avoids this the same way.
+            // dirtying the picker on later inits.
             // Slash commands are re-published every time (they don't dirty).
             if (!_catalogPublished)
             {
@@ -310,8 +310,8 @@ public partial class ChatPaneControl
         }).FileAndForget(nameof(ChatPaneControl));
     }
 
-    // Auto-title the session after its first exchange (like VS Code): ask the CLI
-    // for a short title from the first prompt and save it as the AI title. Done
+    // Auto-title the session after its first exchange: ask the CLI for a short
+    // title from the first prompt and save it as the AI title. Done
     // once per session and only while the CLI is alive (the only time we can ask);
     // SetAiTitle no-ops if the user already set a custom title. The session list
     // (WPF) picks it up from disk next time it loads — no live refresh needed.
@@ -429,7 +429,7 @@ public partial class ChatPaneControl
                 // so it doesn't re-render the transcript out from under a running turn.
                 _turnInFlight = true;
                 // Forward the raw work status ("compacting" at start, null→"" at end). The WebView
-                // maps known values to a spinner label; VS Code does the same.
+                // maps known values to a spinner label; unknown ones fall back to the generic one.
                 _bridge.Send(BridgeMessages.ToWebView.Chat.Status, new Contracts.StatusNotification
                 {
                     Status = obj.Val("status", "") ?? "",
@@ -455,7 +455,8 @@ public partial class ChatPaneControl
             else if (subtype == ClientMessages.SystemSubtype.TaskStarted)
             {
                 var taskType = obj.Val("task_type", (string)null);
-                // Only local_agent tasks appear as sub-agent chips (matches VS Code extension behaviour).
+                // Only local_agent tasks appear as sub-agent chips; other task types have no pane of
+                // their own to open.
                 if (taskType != "local_agent") { return; }
                 _bridge.Send(BridgeMessages.ToWebView.Chat.SubagentStarted, new Contracts.SubagentStartedNotification
                 {
@@ -572,8 +573,8 @@ public partial class ChatPaneControl
             }
         });
 
-    // Map rate_limit_info to a banner: "allowed" clears it, else a message
-    // (wording mirrors the VS Code extension). Webview de-dupes by `key`.
+    // Map rate_limit_info to a banner: "allowed" clears it, else a message.
+    // Webview de-dupes by `key`.
     private void OnRateLimit(object sender, RateLimitEventArgs e)
         => Dispatcher.Invoke(() =>
         {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
@@ -499,7 +499,7 @@ public partial class ChatPaneControl : PaneControlBase
         // connects to THIS VS's server directly. Idempotent: returns the running port if already up.
         var ssePort = Mcp.McpServerHost.Instance.EnsureStarted();
         // Start the CLI now (not lazily on first prompt) so its `initialize` runs
-        // and the model catalogue / slash commands reach the UI on open, like VS Code.
+        // and the model catalogue / slash commands reach the UI as soon as the pane opens.
         await _client.StartAsync(new ClientOptions
         {
             WorkingDirectory = workDir,

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/ai-models.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/ai-models.ts
@@ -21,9 +21,9 @@ export function resolveModelValue(value: string | null | undefined): string {
         return 'default';
     }
     const models = appState.models;
-    // Match the served id against the catalogue the way the VS Code extension does — by the
-    // explicit `resolvedModel` field, not by guessing the family from the name (which breaks for
-    // env-var-remapped providers like GLM/z.ai). `value` may itself carry a [1m] suffix.
+    // Match the served id against the catalogue by the explicit `resolvedModel` field, not by
+    // guessing the family from the name (which breaks for env-var-remapped providers like
+    // GLM/z.ai). `value` may itself carry a [1m] suffix.
     // Strip the [1m] (1M-context) suffix from BOTH sides: the served id in the transcript may
     // lack it (`claude-opus-4-8`) while the catalogue's resolvedModel carries it
     // (`claude-opus-4-8[1m]`), so compare the bare forms too.
@@ -116,12 +116,12 @@ export function contextPercent(u: ContextUsageDto): number {
     return Math.min(100, Math.max(0, (consumedTokens(u) / limit) * 100));
 }
 
-/** Buffer the CLI keeps free on top of the output reservation (VS Code uses
- *  the same ~13k figure when sizing the auto-compact window). */
+/** Buffer the CLI keeps free on top of the output reservation, so our gauge
+ *  reaches 100% at the point the CLI actually auto-compacts. */
 const AUTO_COMPACT_RESERVE = 13_000;
 
-/** Usable window before auto-compaction: contextWindow − maxOutput − buffer
- *  (mirrors VS Code). 0 until the window is known. */
+/** Usable window before auto-compaction: contextWindow − maxOutput − buffer.
+ *  0 until the window is known. */
 export function autoCompactWindow(): number {
     const limit = appState.contextWindow;
     if (limit <= 0) {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/commands/model-controls.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/commands/model-controls.ts
@@ -64,7 +64,7 @@ export class ThinkingCommand extends ChatCommand {
     override run(host: CommandHost): void {
         const next = !appState.thinkingEnabled;
         appState.thinkingEnabled = next;
-        // Runtime thinking channel (VS Code's): 31999 + summarized to enable, 0 to disable.
+        // Runtime thinking channel: a non-zero budget + 'summarized' enables, 0 disables.
         host.setMaxThinkingTokens(next ? 31999 : 0, next ? 'summarized' : null);
     }
 }
@@ -127,8 +127,8 @@ export class EffortCommand extends ChatCommand {
     override readonly aliases = ['effort', 'reasoning', 'thinking'];
 
     /** The slider's effort stops for the current model (from the CLI), then an
-     *  "ultracode" stop when available: model supports xhigh (matches VS Code's
-     *  ultracodeAvailable). */
+     *  "ultracode" stop when the model supports xhigh — ultracode is xhigh plus a
+     *  flag, so without that level there is no stop to offer. */
     private stopValues(): string[] {
         const levels = currentEffortLevels() ?? [];
         const ultraAvailable = levels.includes('xhigh');
@@ -158,8 +158,8 @@ export class EffortCommand extends ChatCommand {
         return effortLabel(appState.effortLevel, appState.ultracodeEnabled);
     }
     /** Set the active stop. The ultracode stop is effort=xhigh + the ultracode
-     *  flag (like VS Code); any other stop clears ultracode. `max` is selectable
-     *  but not persisted by the CLI enum, so it isn't pushed to settings. */
+     *  flag; any other stop clears ultracode. `max` is selectable but not
+     *  persisted by the CLI enum, so it isn't pushed to settings. */
     setLevel(host: CommandHost, idx: number): void {
         const stops = this.stopValues();
         const value = stops[Math.max(0, Math.min(idx, stops.length - 1))];

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/file-links.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/file-links.ts
@@ -335,8 +335,8 @@ export interface FileRef {
     end: number;
 }
 
-// Step 1, the anchor: every ".ext" in the text (1-10 chars, VS Code's cap), not followed by more
-// word chars. Global — one run of text can hold several refs.
+// Step 1, the anchor: every ".ext" in the text (1-10 chars — past that it is prose, not a suffix),
+// not followed by more word chars. Global — one run of text can hold several refs.
 const ANCHOR = /\.([A-Za-z0-9]{1,10})(?![A-Za-z0-9])/g;
 
 // Step 2, backwards: the path chars that may precede the dot. Excludes the separators that delimit a
@@ -362,8 +362,8 @@ const DRIVE = /[A-Za-z]:$/;
 
 /** How strict the path check is. Prose is scanned blind, so it needs the extension allow-list to keep
  *  "localhost.net:4040" / "19.99:2" from rendering as dead links; a markdown href was written as a link
- *  by the model on purpose, so any plausible path shape is enough (that's the case VS Code covers and
- *  we used to drop). See the file-link entry in docs/internal/TODO.md for the measurements. */
+ *  by the model on purpose, so any plausible path shape is enough (a case we used to drop).
+ *  See the file-link entry in docs/internal/TODO.md for the measurements. */
 export type RefStrictness = 'known-ext' | 'plausible-path';
 
 /** Scan `text` for file references, growing outwards from each ".ext" anchor. Returns them in order,

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/permission-modes.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/permission-modes.ts
@@ -69,14 +69,14 @@ export const PERMISSION_ITEMS: PermissionItem[] = [
     },
 ];
 
-/** Gate optional modes like VS Code: `auto` only when the current model supports it,
+/** Gate the optional modes: `auto` only when the current model supports it,
  *  `bypassPermissions` only when the option is enabled. Before the model catalogue
  *  arrives, keep `auto` shown. */
 export function permissionItems(): PermissionItem[] {
     const value = resolveModelValue(appState.currentModel);
     const m = appState.models.find((x) => x.value === value);
     const autoOk = m ? m.supportsAutoMode : true;
-    // Two gates, like VS Code: our own VS option AND the CLI's effective settings — an org can
+    // Two gates: our own VS option AND the CLI's effective settings — an org can
     // forbid the mode via managed settings. Without the second one we would offer a mode the CLI
     // then refuses. Note the different sources: `ui.*` is a VS Option, the other is CLI state.
     const bypassOk =

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/state.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/state.ts
@@ -162,7 +162,7 @@ const _impl = new StoreImpl<AppState>({
     thinkingEnabled: false,
     inDev: false,
     fastMode: false,
-    switchModelsOnFlag: true, // default on, like VS Code (get_settings overrides)
+    switchModelsOnFlag: true, // permissive until get_settings says otherwise
     bypassPermissionsDisabled: false, // permissive until the CLI says otherwise
 
     isBusy: false,

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
@@ -141,9 +141,9 @@ export class CvApp extends LitElement {
         this._offs.push(appState.on('isBusy', (v) => (this._isBusy = v)));
         this._offs.push(appState.on('status', (v) => (this._status = v)));
         this._offs.push(appState.on('pendingPermission', (v) => (this._awaitingUser = v != null)));
-        // Global Esc-to-stop (like VS Code): interrupt generation regardless of
-        // focus. Skipped when a permission/Ask prompt is open — there Esc cancels
-        // the prompt (the banner handles it, with stopPropagation).
+        // Global Esc-to-stop: interrupt generation regardless of focus, so stopping
+        // never depends on where the caret is. Skipped when a permission/Ask prompt
+        // is open — there Esc cancels the prompt (the banner handles it, with stopPropagation).
         window.addEventListener('keydown', this._onGlobalEsc);
         // A nested Agent box toggled. Expand: fetch the full transcript (subagent_loaded
         // upserts it + sets expanded). Collapse: drop back to the last 3 here.
@@ -324,7 +324,7 @@ export class CvApp extends LitElement {
                     const parentId = data?.parentToolUseId ?? '';
                     let entryId = this._thinkingMsgs.get(parentId);
                     // A redacted_thinking block has no preceding delta → no entry yet: create a static,
-                    // text-less one here so it still shows (like VS Code's "✻ Thinking…").
+                    // text-less one here so the user still sees that the model thought.
                     if (entryId === undefined) {
                         if (!data?.redacted) {
                             return;
@@ -360,8 +360,7 @@ export class CvApp extends LitElement {
                 (data) => {
                     // A turn can fail with nothing to show for it: max_turns, budget exhausted or a
                     // refusal produce no failing tool row, so without this the stream just stops and
-                    // the user is left guessing. (VS Code only uses this text to improve a crash
-                    // message; in a chat surface a notice is the useful form.)
+                    // the user is left guessing. A visible notice is the only place this reaches them.
                     // …but a turn the user stopped is not one of those: the transcript already
                     // carries "[Request interrupted by user]", so a red notice under it would
                     // report their own decision back to them as a failure.
@@ -834,8 +833,8 @@ export class CvApp extends LitElement {
 
         // A tool_use with no matching tool_result on disk was never completed — the session
         // ended while it was open (e.g. an AskUserQuestion the user closed without answering).
-        // In replay nothing more is coming, so mark it interrupted (static red dot, like the
-        // VS Code extension) instead of leaving it 'pending' (a spinning "in progress" dot).
+        // In replay nothing more is coming, so mark it interrupted (static red dot) instead of
+        // leaving it 'pending' — a spinning "in progress" dot that would never resolve.
         for (const e of out) {
             if (e.kind === 'tool' && e.status === 'pending') {
                 e.status = 'error';
@@ -952,8 +951,7 @@ export class CvApp extends LitElement {
             const parent = this._transcript.findTool(parentId);
             if (parent) {
                 // The sub-agent's first message echoes the prompt the Agent tool was
-                // launched with — it's already shown as the Agent row's IN, so drop the
-                // duplicate (matches the VS Code extension, which renders prompt in IN only).
+                // launched with — it's already shown as the Agent row's IN, so drop the duplicate.
                 if (
                     entry.kind === 'text' &&
                     entry.role === 'user' &&

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-command-menu.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-command-menu.ts
@@ -67,7 +67,8 @@ export class CvCommandMenu extends LitElement {
         }));
     }
 
-    /** Fuse config mirrors the VS Code extension: label/aliases/id weigh more than description. */
+    /** Fuse config: label/aliases/id weigh more than description — you search for a command by
+     *  its name, and the descriptions are long enough to swamp it otherwise. */
     private _fuseSearch(commands: ChatCommand[], query: string): ChatCommand[] {
         const docs = commands.map((c) => ({
             cmd: c,

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-permission-banner.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-permission-banner.ts
@@ -45,13 +45,14 @@ interface PermissionSuggestion {
 
 const OTHER = 'Other';
 
-/** Scope destinations the "Yes, allow …" choice can cycle through, in VS Code's
- *  order (`wK` in the bundle). Clicking the scope word advances this cycle. */
+/** Scope destinations the "Yes, allow …" choice can cycle through. The order is
+ *  narrowest-first, so the least far-reaching scope is the default. Clicking the
+ *  scope word advances this cycle. */
 const SCOPE_ORDER = ['localSettings', 'userSettings', 'projectSettings', 'session'] as const;
 type Scope = (typeof SCOPE_ORDER)[number];
 
 /** Short human label for a scope, shown as the clickable suffix of the button.
- *  Matches VS Code's wording exactly. */
+ *  Says who the rule will affect, not the settings file it lands in. */
 const SCOPE_LABEL: Record<Scope, string> = {
     localSettings: 'this project (just you)',
     userSettings: 'all projects',
@@ -59,8 +60,8 @@ const SCOPE_LABEL: Record<Scope, string> = {
     session: 'this session',
 };
 
-/** Tooltip per scope — explains where the permission is persisted. Mirrors the
- *  VS Code `title` map (`JLt`), so the hint changes as the scope cycles. */
+/** Tooltip per scope — explains where the permission is persisted. Keyed by
+ *  scope so the hint follows the button as the scope cycles. */
 const SCOPE_TOOLTIP: Record<Scope, string> = {
     localSettings: 'Saves to .claude/settings.local.json (gitignored)',
     userSettings: 'Saves to ~/.claude/settings.json',
@@ -78,8 +79,8 @@ export class CvPermissionBanner extends LitElement {
         iconStyles,
         css`
             /* In-flow, sitting where the input box is (the input hides while a
-             * prompt is pending) — like VS Code, which swaps the composer for the
-             * permission request rather than overlaying the chat. */
+             * prompt is pending): swapping the composer for the request keeps the
+             * chat readable, where an overlay would cover the tool call being asked about. */
             :host {
                 display: contents;
             }
@@ -101,8 +102,8 @@ export class CvPermissionBanner extends LitElement {
                 font-weight: var(--fontWeightSemibold);
                 margin-bottom: 6px;
             }
-            /* Collapsible "Details" expander (VS Code style): the command/input is
-             * hidden by default behind a small "Details" toggle. */
+            /* Collapsible "Details" expander: the command/input is hidden by
+             * default behind a small "Details" toggle so the banner stays compact. */
             #permission-details {
                 margin-bottom: 8px;
             }
@@ -142,7 +143,7 @@ export class CvPermissionBanner extends LitElement {
                 max-height: 160px;
                 overflow-y: auto;
             }
-            /* Short single-line command shown inline (no expander), like VS Code. */
+            /* Short single-line command shown inline: an expander would cost a click for one line. */
             #permission-detail-inline {
                 font-family: var(--fontFamilyMonospace);
                 font-size: var(--fontSizeBase200);
@@ -189,7 +190,7 @@ export class CvPermissionBanner extends LitElement {
             }
             #permission-buttons {
                 display: flex;
-                /* Stacked vertically (one choice per row), like the VS Code prompt. */
+                /* Stacked vertically (one choice per row): the labels are long sentences. */
                 flex-direction: column;
                 align-items: stretch;
                 gap: 4px;
@@ -232,7 +233,7 @@ export class CvPermissionBanner extends LitElement {
                 white-space: pre-wrap;
                 overflow-y: auto;
             }
-            /* Numbered shortcut badge on each choice (1/2/3), like the VS Code prompt. */
+            /* Numbered shortcut badge on each choice (1/2/3), matching the keys handled in _onKeydown. */
             .num {
                 display: inline-block;
                 min-width: 1.1em;
@@ -294,9 +295,9 @@ export class CvPermissionBanner extends LitElement {
                 flex: 0 0 auto;
             }
             /* Question tabs: fluent-tablist stays pure (active underline is Fluent's).
-             * We colour our own slotted label span, mirroring VS Code's navTab: an
-             * unanswered question stays highlighted (full foreground + medium weight),
-             * an answered one greys out and stays grey even while active. */
+             * We colour our own slotted label span so an unanswered question stays
+             * highlighted (full foreground + medium weight), while an answered one
+             * greys out and stays grey even while active. */
             .tab-label {
                 color: var(--colorNeutralForeground1);
                 font-weight: var(--fontWeightMedium);
@@ -392,12 +393,12 @@ export class CvPermissionBanner extends LitElement {
     @state() private _other: Map<string, string> = new Map();
 
     // Scope cycle for the "Yes, allow … for {scope}" choice. Clicking the
-    // scope word cycles through SCOPE_ORDER (VS Code behaviour); the button
-    // itself confirms with the current scope. Index into SCOPE_ORDER.
+    // scope word cycles through SCOPE_ORDER; the button itself confirms with
+    // the current scope, so picking a scope never costs an extra step. Index into SCOPE_ORDER.
     @state() private _scopeIdx = 0;
     // True once the user has touched the scope cycle: the suggestion choice
-    // becomes the primary (blue) button and "Yes" drops to outline, mirroring
-    // VS Code where the focused choice is the primary one.
+    // becomes the primary (blue) button and "Yes" drops to outline, so the
+    // highlighted button is the one the user just aimed at.
     @state() private _scopeActive = false;
 
     private _offs: Array<() => void> = [];
@@ -419,7 +420,7 @@ export class CvPermissionBanner extends LitElement {
     }
 
     override updated(): void {
-        // Focus the first choice when the prompt opens, like VS Code, so Enter and the arrow keys
+        // Focus the first choice when the prompt opens, so Enter and the arrow keys
         // act on it straight away.
         if (this._pending && !this._focusedOnOpen) {
             if (this.focusFirst()) {
@@ -482,9 +483,9 @@ export class CvPermissionBanner extends LitElement {
             ),
         );
         this._offs.push(bridge.onNotification(Msg.toWebView.chat.cleared, () => this._dismiss()));
-        // Keyboard shortcuts while a prompt is open (like VS Code): Esc cancels,
-        // 1/2/3 pick a choice, Enter confirms the default. Disabled while typing
-        // in the "tell Claude what to do instead" field.
+        // Keyboard shortcuts while a prompt is open: Esc cancels, 1/2/3 pick a
+        // choice, Enter confirms the default. Disabled while typing in the
+        // "tell Claude what to do instead" field.
         document.addEventListener('keydown', this._onKeydown);
     }
 
@@ -526,7 +527,7 @@ export class CvPermissionBanner extends LitElement {
         const inDeny = this._inDenyInput() && !inCommand;
         // Up/Down cycle focus across the choices and the deny field. While editing
         // the command textarea the arrows move the caret; in a multi-line deny
-        // message they do too (VS Code).
+        // message they do too, since caret movement wins inside a text field.
         if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
             if (inCommand || (inDeny && this._denyValue().includes('\n'))) {
                 return;
@@ -539,7 +540,7 @@ export class CvPermissionBanner extends LitElement {
         if (inCommand || inDeny) {
             return;
         }
-        // Numbered actions in VS Code order: Yes, [suggestion], No, focus the
+        // Numbered actions, least-destructive first: Yes, [suggestion], No, focus the
         // deny field. The last number doesn't confirm — it jumps to the textarea.
         const actions = this._numberedActions();
         // Enter confirms the focused choice, defaulting to the first (Yes).
@@ -556,8 +557,8 @@ export class CvPermissionBanner extends LitElement {
         }
     };
 
-    /** Ordered keyboard actions (1..n), mirroring VS Code: Yes, the suggestion
-     *  (if any), No, then focus the deny field as the final number. */
+    /** Ordered keyboard actions (1..n): Yes, the suggestion (if any), No, then
+     *  focus the deny field as the final number. */
     private _numberedActions(): Array<() => void> {
         const p = this._pending;
         const suggestion = (p?.permissionSuggestions ?? [])[0];
@@ -592,7 +593,7 @@ export class CvPermissionBanner extends LitElement {
         return this._focusables().findIndex((el) => el === active);
     }
 
-    /** Move focus by `delta` across the choices, wrapping around (VS Code `ne`). */
+    /** Move focus by `delta` across the choices, wrapping around. */
     private _navFocus(delta: number): void {
         const items = this._focusables();
         if (!items.length) {
@@ -683,7 +684,7 @@ export class CvPermissionBanner extends LitElement {
 
     /** Toggle an option. Single-select clears the others and auto-advances to
      *  the next question; multi-select just flips. Picking "Other" focuses its
-     *  text field. Mirrors the VS Code AskUserQuestion component. */
+     *  text field. */
     private _toggle(q: AskQuestion, label: string): void {
         const set = new Set(this._picked.get(q.question) ?? []);
         if (q.multiSelect) {
@@ -728,7 +729,7 @@ export class CvPermissionBanner extends LitElement {
     }
 
     /** Enter in the Other field advances to the next question; Shift+Enter adds
-     *  a newline. Mirrors VS Code's Other input. */
+     *  a newline, so a multi-line answer is still possible. */
     private _onOtherKey = (e: KeyboardEvent): void => {
         e.stopPropagation();
         if (e.key !== 'Enter' || e.shiftKey) {
@@ -742,8 +743,8 @@ export class CvPermissionBanner extends LitElement {
     };
 
     /** Up/Down move focus between the options (radio or checkbox), wrapping
-     *  around — selection stays on Enter/Space. Mirrors VS Code; also stops the
-     *  arrows from scrolling the panel. */
+     *  around — selection stays on Enter/Space, so browsing never answers by
+     *  accident. Also stops the arrows from scrolling the panel. */
     private _onOptionsKey = (e: KeyboardEvent): void => {
         if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') {
             return;
@@ -836,7 +837,8 @@ export class CvPermissionBanner extends LitElement {
             return;
         }
         const msg: RespondPermissionNotification = { allowed, toolUseId: this._pending.id };
-        // If the user edited the command, allow with the patched input (like VS Code).
+        // If the user edited the command, allow with the patched input: the CLI
+        // runs updatedInput in place of the original.
         if (allowed && this._editedCommand !== null && this._pending.input) {
             msg.updatedInput = { ...(this._pending.input as object), command: this._editedCommand };
         }
@@ -851,8 +853,8 @@ export class CvPermissionBanner extends LitElement {
     private _onDeny = () => this._respond(false);
 
     /** Allow once AND apply a permission_suggestion, overriding its destination
-     *  with the currently-cycled scope (VS Code behaviour). Echoed back verbatim
-     *  as updatedPermissions. `setMode` suggestions carry no rule scope, so they
+     *  with the currently-cycled scope. Echoed back verbatim as
+     *  updatedPermissions. `setMode` suggestions carry no rule scope, so they
      *  go back unchanged. */
     private _onAllowWith(suggestion: PermissionSuggestion): void {
         if (!this._pending) {
@@ -874,7 +876,7 @@ export class CvPermissionBanner extends LitElement {
     }
 
     /** Cycle the scope word forward (localSettings → userSettings → … → session
-     *  → wrap), without confirming. Matches VS Code's clickable scope toggle. */
+     *  → wrap), without confirming: choosing a scope must not grant the tool. */
     private _cycleScope = (e: Event): void => {
         e.stopPropagation();
         this._scopeIdx = (this._scopeIdx + 1) % SCOPE_ORDER.length;
@@ -900,9 +902,9 @@ export class CvPermissionBanner extends LitElement {
         return `Yes, allow ${what}`;
     }
 
-    /** Tool detail under the title. Like VS Code: a short single-line detail
-     *  (≤250 chars, the command/path) is shown inline; a long or multi-line one
-     *  collapses into a "Details" expander so the banner stays compact. */
+    /** Tool detail under the title: a short single-line detail (≤250 chars, the
+     *  command/path) is shown inline; a long or multi-line one collapses into a
+     *  "Details" expander so the banner stays compact. */
     private _renderDetails(p: ToolPermission) {
         const input = p.input as Record<string, unknown> | undefined;
         const hasInput = input && typeof input === 'object' && Object.keys(input).length > 0;
@@ -950,9 +952,10 @@ export class CvPermissionBanner extends LitElement {
         if (p.name === 'AskUserQuestion') {
             return this._renderQuestions();
         }
-        // Like VS Code: at most THREE numbered choices — 1 Yes, 2 "allow … for
-        // this project" (the suggestions collapsed into one), 3 No. Numbers are
-        // keyboard shortcuts (handled in _onKeydown), shown as a badge per row.
+        // At most THREE numbered choices — 1 Yes, 2 "allow … for this project"
+        // (the suggestions collapsed into one), 3 No: more rows than that and the
+        // banner stops being scannable. Numbers are keyboard shortcuts (handled
+        // in _onKeydown), shown as a badge per row.
         const suggestion = (p.permissionSuggestions ?? [])[0];
         let n = 1;
         return html`
@@ -1035,8 +1038,7 @@ export class CvPermissionBanner extends LitElement {
     };
 
     /** Interactive AskUserQuestion UI: per-question tabs, radio/checkbox
-     *  options, an "Other" free-text option, and a Submit footer. Layout and
-     *  behaviour mirror the VS Code extension. */
+     *  options, an "Other" free-text option, and a Submit footer. */
     private _renderQuestions() {
         const qs = this._questions();
         if (!qs.length) {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-plugin-manager.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-plugin-manager.ts
@@ -26,7 +26,7 @@ type Tab = 'installed' | 'available' | 'marketplaces';
 // slice client-side). A search narrows the full list first, then the same cap applies.
 const AVAILABLE_LIMIT = 30;
 
-// Anthropic's official marketplace — flagged with a hippo, like VS Code.
+// Anthropic's official marketplace — flagged with a hippo to set it apart from user-added ones.
 const OFFICIAL_MARKETPLACE = 'claude-plugins-official';
 
 // Strip the CLI's leading ✔/✘ (and stray whitespace) — the message-bar icon already conveys it.
@@ -76,7 +76,7 @@ function marketplaceUrl(m: MarketplaceDto): string | null {
 
 // Resolve an available plugin's source to a browsable URL. Url sources are already the final URL
 // (git-subdir resolved host-side); a Relative "./path" is joined onto the owning marketplace's
-// repo tree (mirrors VS Code).
+// repo tree.
 function pluginUrl(p: AvailablePluginDto, marketplaces: MarketplaceDto[]): string | null {
     if (p.sourceKind === 'url') {
         return p.source;
@@ -198,7 +198,8 @@ export class CvPluginManager extends CvDialogBase {
             .card .title {
                 font-weight: var(--fontWeightSemibold);
             }
-            /* Available card head: name left, install count right (like VS Code). */
+            /* Available card head: name left, install count right — popularity is the
+             * secondary signal, so it must not push the name around. */
             .av-head {
                 display: flex;
                 align-items: baseline;
@@ -215,7 +216,8 @@ export class CvPluginManager extends CvDialogBase {
                 font-size: var(--fontSizeBase200);
                 color: var(--colorNeutralForeground3);
                 margin-top: 2px;
-                /* Full text — wrap freely, no clamp (VS Code shows the whole description). */
+                /* Full text — wrap freely, no clamp: the description is what the user
+                 * decides on, so a truncated one is worse than a taller card. */
                 overflow-wrap: anywhere;
             }
             .card .meta {
@@ -417,7 +419,7 @@ export class CvPluginManager extends CvDialogBase {
         }
     };
 
-    // Compact install counts like VS Code: 1636 → "1.6k", 404300 → "404.3k", 1_000_000 → "1m".
+    // Compact install counts so the column never wraps: 1636 → "1.6k", 404300 → "404.3k", 1_000_000 → "1m".
     private _formatInstalls(n: number): string {
         if (n >= 1_000_000) {
             return `${(n / 1_000_000).toFixed(n % 1_000_000 ? 1 : 0)}m`;
@@ -743,7 +745,7 @@ export class CvPluginManager extends CvDialogBase {
             return;
         }
         // No client-side URL validation — the CLI validates (clones the repo, checks marketplace.json)
-        // and reports failure via the op result, exactly like VS Code.
+        // and reports failure via the op result; a second rule here would only reject sources it accepts.
         this._send(Msg.fromWebView.plugins.marketplaceAdd, { source });
         this._addSource = '';
     };

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-spinner.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-spinner.ts
@@ -99,7 +99,8 @@ export function setVerbsConfig(cfg: SpinnerVerbsConfigDto | null): void {
         _activeVerbs = DEFAULT_VERBS;
         return;
     }
-    // 'replace' with an empty list falls back to defaults (matches VS Code).
+    // 'replace' with an empty list falls back to defaults: an empty verb pool would
+    // leave the spinner with no label at all.
     _activeVerbs =
         cfg.mode === 'replace'
             ? cfg.verbs.length > 0

--- a/src/Corsinvest.VisualStudio.Agents/Cli/Pane/CliPaneControl.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Cli/Pane/CliPaneControl.cs
@@ -299,8 +299,8 @@ internal class CliPaneControl : PaneControlBase, ITerminalConnection, IDisposabl
 
     private void OnProcessExited()
     {
-        // claude.exe ended (exit/Ctrl-C/crash). Auto-close the pane VS Code-style —
-        // process gone means the terminal pane goes too.
+        // claude.exe ended (exit/Ctrl-C/crash). The pane is only a view onto that process,
+        // so auto-close it: process gone means the terminal pane goes too.
 
         // Marshal off the ConPTY read thread; ClosePane → VS → Dispose (which
         // removes us from the registry).

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.Protocol.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.Protocol.cs
@@ -206,8 +206,7 @@ internal sealed partial class ClaudeClient
 
             case ClientMessages.ControlSubtype.Elicitation:
                 // An MCP server asks the user for structured input (form) or to open a URL (OAuth).
-                // We have no elicitation UI, so we decline cleanly — same as the VS Code extension,
-                // which passes no onElicitation handler and always replies {action:"decline"}. A
+                // We have no elicitation UI, so we decline cleanly with {action:"decline"}: a
                 // decline is the protocol's expected "unsupported" answer; an error would be a bug.
                 // Warn (not silent): from the user's side an MCP action silently didn't happen —
                 // this line is the only trace of why (e.g. an MCP login that never prompts).
@@ -408,8 +407,8 @@ internal sealed partial class ClaudeClient
     }
 
     /// <summary>The failure text of a `result`: the error subtypes carry `errors[]`, while a
-    /// success-subtype result that is still flagged is_error puts it in `result`. Same split
-    /// VS Code applies. Empty when the turn didn't fail.</summary>
+    /// success-subtype result that is still flagged is_error puts it in `result`. Empty when
+    /// the turn didn't fail.</summary>
     private static string ResultErrorText(JObject obj, string subtype)
     {
         if (!obj.Val("is_error", false)) { return ""; }
@@ -425,7 +424,7 @@ internal sealed partial class ClaudeClient
 
     /// <summary>Fail every in-flight control_request and forget tracked tool
     /// requests. Called when the process exits (so awaiters don't hang to their
-    /// timeout) and on Dispose. Mirrors VS Code's performCleanup.</summary>
+    /// timeout) and on Dispose.</summary>
     private void RejectPendingRequests(string reason)
     {
         foreach (var kv in _pending) { kv.Value.TrySetException(new InvalidOperationException(reason)); }

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.cs
@@ -176,8 +176,8 @@ internal sealed partial class ClaudeClient : IClaudeClient
         // NOTE: no --ide here. In stream-json mode the CLI's --ide auto-connect is
         // UI-only (REPL hook) and never runs, so it does nothing. Instead we expose
         // the IDE tools as an in-process SDK MCP server: declared in the initialize
-        // payload (sdkMcpServers) and registered via mcp_set_servers — the same flow
-        // VS Code uses for its chat. The interactive CLI pane keeps --ide + WS lockfile.
+        // payload (sdkMcpServers) and registered via mcp_set_servers. The interactive
+        // CLI pane keeps --ide + WS lockfile.
         var args = "--output-format stream-json --verbose --input-format stream-json --include-partial-messages";
         // --setting-sources: headless mode loads NO settings by default; re-enable so the user's
         // ~/.claude/settings.json permissions.allow/deny apply (else CLI asks can_use_tool for every tool).
@@ -188,8 +188,9 @@ internal sealed partial class ClaudeClient : IClaudeClient
         {
             args += $" --allowedTools mcp__{SdkMcpServerName}__*";
         }
-        // Model is NOT passed via --model. Like VS Code, we launch without a model and
-        // set it after init with a `set_model` control_request (InitializeAndPublishCatalogAsync).
+        // Model is NOT passed via --model: we launch without one and set it after init with a
+        // `set_model` control_request (InitializeAndPublishCatalogAsync), so a model change is a
+        // hot-swap on the live process instead of a respawn.
         if (!string.IsNullOrEmpty(options.ResumeSessionId)) { args += " --resume " + options.ResumeSessionId; }
 
         // Grants the capability to switch into bypassPermissions later; weakens nothing now.
@@ -236,15 +237,15 @@ internal sealed partial class ClaudeClient : IClaudeClient
         // decides whether to actually save. Best-effort: if the CLI rejects the
         // initialize, autosave simply won't fire (no crash, CLI keeps running).
         SendInitializeHooks();
-        // Like VS Code: the SDK MCP server names are declared in the initialize payload
-        // (sdkMcpServers) AND registered via mcp_set_servers — VS Code does both.
+        // The SDK MCP server names are declared in the initialize payload (sdkMcpServers) AND
+        // registered via mcp_set_servers; the CLI needs both before it will route tool calls.
         RegisterSdkMcpServer();
     }
 
     /// <summary>Register the in-process SDK MCP server so the stream-json chat can
-    /// call our IDE tools (mcp__&lt;name&gt;__*). VS Code does the same via
-    /// `mcp_set_servers` with a `type:"sdk"` server; the CLI then calls tools back
-    /// over `mcp_message` (handled by HandleMcpMessage). No-op when unset.</summary>
+    /// call our IDE tools (mcp__&lt;name&gt;__*). Sent as `mcp_set_servers` with a
+    /// `type:"sdk"` server; the CLI then calls tools back over `mcp_message`
+    /// (handled by HandleMcpMessage). No-op when unset.</summary>
     private void RegisterSdkMcpServer()
     {
         var name = SdkMcpServerName;
@@ -491,8 +492,8 @@ internal sealed partial class ClaudeClient : IClaudeClient
     public Task ApplyFlagSettingsAsync(object settings)
         => SendControlRequestAsync(ClientMessages.ControlSubtype.ApplyFlagSettings, new { settings });
 
-    /// <summary>Enable/disable extended thinking at runtime (VS Code's channel). ON = budget 31999 +
-    /// summarized display; OFF = budget 0. display is omitted when null so the CLI keeps the session mode.</summary>
+    /// <summary>Enable/disable extended thinking at runtime. ON = budget 31999 + summarized display;
+    /// OFF = budget 0. display is omitted when null so the CLI keeps the session mode.</summary>
     public Task SetMaxThinkingTokensAsync(int maxThinkingTokens, string display)
         => SendControlRequestAsync(
             ClientMessages.ControlSubtype.SetMaxThinkingTokens,
@@ -747,10 +748,9 @@ internal sealed partial class ClaudeClient : IClaudeClient
         object payload;
         if (response.Allow)
         {
-            // Match VS Code's PermissionResult: ALWAYS send updatedInput (a record,
-            // never undefined — that triggered the CLI's ZodError) and
-            // updatedPermissions (the chosen permission_suggestion for "allow for
-            // this session", or empty for a one-time allow).
+            // ALWAYS send updatedInput (a record, never undefined — that triggered the
+            // CLI's ZodError) and updatedPermissions (the chosen permission_suggestion
+            // for "allow for this session", or empty for a one-time allow).
             payload = new
             {
                 behavior = "allow",

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneEntry.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneEntry.cs
@@ -13,7 +13,7 @@ namespace Corsinvest.VisualStudio.Agents.Core.Panes;
 public sealed class PaneOptions
 {
     /// <summary>When false, the chat's IDE-context "eye" is closed: the host stops forwarding
-    /// the editor selection to this chat. Default: on (matches the VS Code extension).</summary>
+    /// the editor selection to this chat. Default: on.</summary>
     public bool SendSelection { get; set; } = true;
 }
 

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneToolbar.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneToolbar.xaml.cs
@@ -53,8 +53,8 @@ public partial class PaneToolbar : UserControl
     private bool _titleFocused;
 
     // Shown when a titleable pane has no title yet — a fresh chat, or one whose ai-title has not
-    // been generated (or written) yet. Like VS Code's "Untitled": the box stays visible and
-    // editable rather than vanishing, so there is always something to click to rename.
+    // been generated (or written) yet. The box stays visible and editable rather than vanishing,
+    // so there is always something to click to rename.
     private const string UntitledPlaceholder = "Untitled";
 
     /// <summary>Reflect the pane's current title. Hidden only when the pane doesn't support a title
@@ -103,8 +103,7 @@ public partial class PaneToolbar : UserControl
     {
         var newTitle = TitleBox.Text?.Trim();
         // Compare against what the box was showing, placeholder included: leaving "Untitled"
-        // untouched must not rename the session to "Untitled". This mirrors VS Code, which shows
-        // the placeholder as the input's value and commits only a real change against it.
+        // untouched must not rename the session to "Untitled".
         var current = string.IsNullOrWhiteSpace(_pane.SessionTitle) ? UntitledPlaceholder : _pane.SessionTitle;
         if (!string.IsNullOrEmpty(newTitle) && newTitle != current)
         {

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneWindowBase.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneWindowBase.cs
@@ -133,8 +133,8 @@ public abstract class PaneWindowBase : ToolWindowPane
     internal void Init(PaneEntry entry)
     {
         PaneControl.Init(entry);
-        // The CLI gates the in-IDE diff on diffTool==='auto' but only writes it for VS Code;
-        // ensure the key for this pane's config-dir so our diff works. Idempotent.
+        // The CLI gates the in-IDE diff on diffTool==='auto' but does not write that key for our
+        // entrypoint; ensure it for this pane's config-dir so our diff works. Idempotent.
         AgentsPackage.EnsureDiffToolAuto(entry.ClaudePaths.SettingsFile);
     }
 

--- a/src/Corsinvest.VisualStudio.Agents/Core/Plugins/PluginService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Plugins/PluginService.cs
@@ -16,8 +16,8 @@ namespace Corsinvest.VisualStudio.Agents.Core.Plugins;
 /// the output. Plugins are global (~/.claude), so no session/control-protocol is involved: the
 /// live chat process rejects plugin ops (verified: <c>list_plugins</c>/<c>install_plugin</c> as a
 /// control_request return "Unsupported control request subtype" — only <c>reload_plugins</c> is
-/// accepted). This mirrors how VS Code's extension manages plugins (spawn per action). Success is
-/// detected by exit code 0 (✔); failure by exit code 1 (✘) — the CLI never emits JSON on error.
+/// accepted), so every plugin action spawns its own process. Success is detected by exit code 0
+/// (✔); failure by exit code 1 (✘) — the CLI never emits JSON on error.
 /// Analogous to <see cref="Sessions.SessionManager"/>: a static service reading data from outside
 /// the protocol.
 /// </summary>

--- a/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.cs
@@ -20,8 +20,8 @@ namespace Corsinvest.VisualStudio.Agents.Core.Sessions;
 /// threaded through every call — a config-dir can never be silently forgotten.</summary>
 internal sealed partial class SessionManager
 {
-    // VS Code-style metadata scan: read a fixed 64 KB window from the start and
-    // from the end of the JSONL in one read each, decode once, scan the lines.
+    // Metadata scan: read a fixed 64 KB window from the start and from the end
+    // of the JSONL in one read each, decode once, scan the lines.
     // Title rows (custom-title / ai-title / last-prompt) and the freshest
     // git/version/model/permissionMode all live within these windows. Reading in
     // a single block avoids the multi-byte-UTF-8 corruption a chunked backward
@@ -335,13 +335,13 @@ internal sealed partial class SessionManager
     {
         public string NewSessionId { get; set; }
         /// <summary>Text of the forked-at message — excluded from the transcript
-        /// and handed back so the user can edit/resend it (VS Code behaviour).</summary>
+        /// and handed back so the user can edit/resend it.</summary>
         public string ExcludedPrompt { get; set; }
     }
 
     /// <summary>Forks a session into a brand-new JSONL: copies messages up to but
-    /// EXCLUDING <paramref name="resumeAtMessageUuid"/> (VS Code forks before the
-    /// clicked message and hands its text back for editing) and rewrites every uuid
+    /// EXCLUDING <paramref name="resumeAtMessageUuid"/> (the cut message's text is
+    /// handed back for editing instead of replayed) and rewrites every uuid
     /// (plus parentUuid / leafUuid / messageId) to fresh ids, so the new transcript
     /// shares no message identity with the source. Stamps the new sessionId on each
     /// line. Returns null if the source is missing or the cut point isn't found.</summary>

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeDiagnosticsTracker.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeDiagnosticsTracker.cs
@@ -14,9 +14,8 @@ using System.Threading.Tasks;
 namespace Corsinvest.VisualStudio.Agents.Ide;
 
 /// <summary>Tracks per-file diagnostics across a Claude edit: capture a baseline on PreToolUse,
-/// then on PostToolUse re-read and report only the diagnostics the edit introduced. Mirrors the
-/// VS Code extension's captureBaseline/findDiagnosticsProblems pair. Diff is essential — without it
-/// Claude would be spammed with pre-existing errors it didn't cause.</summary>
+/// then on PostToolUse re-read and report only the diagnostics the edit introduced. Diff is
+/// essential — without it Claude would be spammed with pre-existing errors it didn't cause.</summary>
 internal sealed class IdeDiagnosticsTracker
 {
     public static readonly IdeDiagnosticsTracker Instance = new();
@@ -53,8 +52,9 @@ internal sealed class IdeDiagnosticsTracker
         var before = b.Diags != null ? await b.Diags : [];
         OutputWindowLogger.Global.Debug(() => $"[diag] check start {filePath} visible={editorVisible} baseline={before.Count} items");
 
-        // The Error List refreshes after the edit lands; wait like VS Code. Visible editors settle
-        // faster (2×750ms, bail at first hit); background files get a single 1000ms wait.
+        // The Error List refreshes asynchronously after the edit lands, so it has to be given time.
+        // Visible editors settle faster (2×750ms, bail at first hit); background files get a single
+        // 1000ms wait.
         var steps = editorVisible ? new[] { 750, 750 } : new[] { 1000 };
         for (int i = 0; i < steps.Length; i++)
         {
@@ -100,7 +100,8 @@ internal sealed class IdeDiagnosticsTracker
 
     private static string Format(string filePath, List<Diagnostic> diags)
     {
-        // 1-based line/column (our LSP shape is 0-based); shape matches VS Code so Claude reads it as trained.
+        // 1-based line/column (our LSP shape is 0-based): the model expects diagnostics numbered
+        // the way an editor shows them.
         var items = diags.Select(d => new
         {
             filePath,

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeDiffViewer.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeDiffViewer.cs
@@ -29,8 +29,8 @@ internal sealed partial class IdeDiffViewer
     public static IdeDiffViewer Instance => _instance.Value;
 
     /// <summary>Diff resolution status strings — the exact wire tokens the Claude
-    /// CLI's openDiff handler expects (see the VS Code extension). FileSaved =
-    /// applied (user saved the proposal); TabClosed = closed without saving;
+    /// CLI's openDiff handler expects. FileSaved = applied (user saved the
+    /// proposal); TabClosed = closed without saving;
     /// Rejected = error / explicit reject. (2.1.169 maps TabClosed → rejected on
     /// the wire; see OpenDiffTool.)</summary>
     public const string FileSaved = "FILE_SAVED";
@@ -94,21 +94,13 @@ internal sealed partial class IdeDiffViewer
         {
             var tempPath = WriteTemp(newFileContents, Path.GetFileName(newFilePath ?? oldFilePath));
 
-            // If the original file has unsaved changes in the editor,
-            // VS's diff service compares the dirty buffer (not the
-            // on-disk content) against our proposed version — mixing
-            // user edits with Claude's edits in the diff. Mirror what
-            // the VS Code extension does: snapshot the on-disk version
-            // to a separate temp and diff against THAT. The user can
-            // still see / handle their dirty changes in the original
-            // editor pane.
             var isNewFile = !File.Exists(oldFilePath);
             var leftPath = oldFilePath;
             var leftIsTemp = false;
             if (isNewFile)
             {
                 // New file (Claude is creating it): diff the proposal against an
-                // empty left side, like the VS Code extension does.
+                // empty left side.
                 leftPath = WriteTemp("", Path.GetFileName(oldFilePath) + ".empty");
                 leftIsTemp = true;
             }

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/IMcpTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/IMcpTool.cs
@@ -17,9 +17,9 @@ namespace Corsinvest.VisualStudio.Agents.Mcp;
 /// </summary>
 internal interface IMcpTool
 {
-    /// <summary>Method name used by the CLI in <c>tools/call</c>. camelCase,
-    /// mirrors the VS Code extension's tool names so the CLI needs no
-    /// IDE-specific handling (e.g. <c>getCurrentSelection</c>, <c>openFile</c>).</summary>
+    /// <summary>Method name used by the CLI in <c>tools/call</c>. camelCase, and for the tools the
+    /// CLI special-cases it must be the name the CLI already knows, so it needs no IDE-specific
+    /// handling (e.g. <c>getCurrentSelection</c>, <c>openFile</c>).</summary>
     string Name { get; }
 
     /// <summary>Human-readable description shown in the CLI's tool catalog.

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/McpServerHost.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/McpServerHost.cs
@@ -286,7 +286,7 @@ internal sealed partial class McpServerHost
 
         WebSocketContext wsCtx;
         // MUST echo the "mcp" subprotocol or the CLI treats the upgrade as failed and aborts the
-        // TCP connection (matches the official VS Code extension behavior).
+        // TCP connection.
         try { wsCtx = await ctx.AcceptWebSocketAsync(subProtocol: "mcp"); }
         catch (Exception ex)
         {
@@ -372,9 +372,9 @@ internal sealed partial class McpServerHost
         }
     }
 
-    /// <summary>Builds a <c>selection_changed</c> notification and broadcasts it. Payload shape
-    /// mirrors the official VS Code extension so the CLI's <c>useIdeSelection</c> hook accepts it
-    /// and injects an <c>&lt;ide_selection&gt;</c> block: { text, filePath, fileUrl, selection }.</summary>
+    /// <summary>Builds a <c>selection_changed</c> notification and broadcasts it. The payload shape
+    /// is what the CLI's <c>useIdeSelection</c> hook accepts before it injects an
+    /// <c>&lt;ide_selection&gt;</c> block: { text, filePath, fileUrl, selection }.</summary>
     private void OnEditorContextChanged(EditorContext ctx)
     {
         if (ctx == null)

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Document/SaveDocumentTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Document/SaveDocumentTool.cs
@@ -16,8 +16,8 @@ internal sealed class SaveDocumentArgs
 }
 
 /// <summary>MCP tool: save an open document if it has unsaved changes, so Claude
-/// reads/edits the on-disk version the user actually sees. Mirrors the official
-/// VS Code extension's saveDocument.</summary>
+/// reads/edits the on-disk version the user actually sees. Registered under the
+/// <c>saveDocument</c> name the CLI already knows.</summary>
 internal sealed class SaveDocumentTool : McpTool<SaveDocumentArgs>
 {
     public override string Name => "document_save";

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Editor/OpenDiffTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Editor/OpenDiffTool.cs
@@ -51,9 +51,9 @@ internal sealed class OpenDiffTool : McpTool<OpenDiffArgs>
         var result = await IdeContextService.Instance.OpenDiffAsync(
             args.OldFilePath, args.NewFilePath, args.NewFileContents, args.TabName);
 
-        // Wire format mirrors the VS Code extension (2.1.169): accept →
-        // [FILE_SAVED, content]; anything else → [DIFF_REJECTED, tab_name].
-        // (2.1.169 dropped TAB_CLOSED; our viewer's TAB_CLOSED maps to reject.)
+        // Wire format the CLI accepts: accept → [FILE_SAVED, content]; anything
+        // else → [DIFF_REJECTED, tab_name]. Current CLI builds no longer act on a
+        // distinct TAB_CLOSED, so our viewer's TAB_CLOSED maps to reject.
         if (result.Status == IdeDiffViewer.FileSaved)
         {
             return new RawMcpContent(

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Ide/ExecuteCodeTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Ide/ExecuteCodeTool.cs
@@ -16,8 +16,8 @@ internal sealed class ExecuteCodeArgs
 }
 
 /// <summary>MCP tool: submit a snippet to VS's C# Interactive window.
-/// Mirrors the VS Code extension's <c>executeCode</c> (Jupyter-targeted)
-/// — same shape, IDE-appropriate backend.</summary>
+/// Registered under the <c>executeCode</c> name the CLI already knows (elsewhere
+/// Jupyter-targeted) — same shape, IDE-appropriate backend.</summary>
 internal sealed class ExecuteCodeTool : McpTool<ExecuteCodeArgs>
 {
     public override string Name => "ide_execute_code";

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Ide/GetWorkspaceFoldersTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Ide/GetWorkspaceFoldersTool.cs
@@ -9,8 +9,8 @@ using System.Threading.Tasks;
 namespace Corsinvest.VisualStudio.Agents.Mcp.Tools;
 
 /// <summary>MCP tool: returns the IDE's "workspace folders" (in our case,
-/// the single solution folder). Mirrors the VS Code extension's
-/// <c>getWorkspaceFolders</c>.</summary>
+/// the single solution folder), under the <c>getWorkspaceFolders</c> name the
+/// CLI already knows.</summary>
 internal sealed class GetWorkspaceFoldersTool : McpTool<NoArgs>
 {
     public override string Name => "ide_get_workspace_folders";

--- a/src/Corsinvest.VisualStudio.Agents/Options/AgentsChatPage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Options/AgentsChatPage.cs
@@ -10,11 +10,10 @@ using System.Runtime.InteropServices;
 namespace Corsinvest.VisualStudio.Agents.Options;
 
 /// <summary>Permission mode a new chat session starts in; maps to the CLI's
-/// <c>--permission-mode</c> (see Core/Client/PermissionMode.cs). VS Code's
-/// `initialPermissionMode` also lists `manual`, which their own docs call "an alias for
-/// 'default'" — one behaviour under two names, so it is deliberately not repeated here
-/// ("Manual" is already the label of Default). `auto` stays toolbar-only: it depends on the
-/// model supporting it, which isn't known until the catalogue arrives.</summary>
+/// <c>--permission-mode</c> (see Core/Client/PermissionMode.cs). The CLI also accepts
+/// `manual` as an alias for `default` — one behaviour under two names, so it is deliberately
+/// not repeated here ("Manual" is already the label of Default). `auto` stays toolbar-only:
+/// it depends on the model supporting it, which isn't known until the catalogue arrives.</summary>
 public enum InitialPermissionMode
 {
     /// <summary>Manual — approval required for each edit (prudent default). The name stays
@@ -128,7 +127,7 @@ public class AgentsChatPage : AgentsOptionsPage
 
     [Category("Input")]
     [DisplayName("Allow dangerously skip permissions")]
-    [Description("When enabled, the toolbar's permission menu offers \"Bypass permissions\", which never asks for approval — even for commands that can destroy data. Enabling it does not skip anything by itself: the mode still has to be selected. Takes effect on new sessions (the CLI decides at launch whether the mode can ever be entered). Off by default; mirrors VS Code's allowDangerouslySkipPermissions.")]
+    [Description("When enabled, the toolbar's permission menu offers \"Bypass permissions\", which never asks for approval — even for commands that can destroy data. Enabling it does not skip anything by itself: the mode still has to be selected. Takes effect on new sessions (the CLI decides at launch whether the mode can ever be entered). Off by default.")]
     public bool AllowDangerouslySkipPermissions { get; set; } = false;
 
     [Category("Diff")]


### PR DESCRIPTION
Comment hygiene pass, first of two. This one is about **where a comment's justification comes from**; the companion PR removes comments that carry no information at all.

## What

Comments across the codebase justified a choice by pointing at how the VS Code extension does it. Most were harmless ("like VS Code"), but some named things that are **not observable from outside that extension**:

| Kind | Examples |
|---|---|
| Minified identifiers | `` `wK` in the bundle ``, `` `JLt` ``, `` VS Code `ne` `` |
| Internal function names | `captureBaseline`/`findDiagnosticsProblems`, `performCleanup`, `navTab`, `allowDangerouslySkipPermissions`, `ultracodeAvailable`, `initialPermissionMode` |
| A version and its changelog | `(2.1.169)` and "2.1.169 dropped TAB_CLOSED" |
| Undocumented internals | `atob(...)`, `workspace.findFiles`, thinking budget, the 100-row cap, the ~13k auto-compact reserve |

An attribution is also a weak reason: it tells you someone else made this choice, not why it is right here. Each one is rewritten to stand on something we can observe and defend — **the CLI's wire contract**, the user-facing behaviour we want, or the constraint that forced the choice.

## What did not change

No engineering rationale was dropped. Where the attribution *was* the rationale, it is replaced by the real one — e.g. launching without `--model` is now justified by our own hot-swap rule (a model change must never respawn the process) instead of "Like VS Code".

Kept on purpose:

- `CLAUDE_CODE_ENTRYPOINT=claude-vscode` — the value the CLI expects, and the comments explaining why
- `.vscode` in the ignored-folder list; `vscode-jsonrpc` (a real library name)
- `cv-segmented-slider.ts` — records why we *stopped* using `--vscode-*` token names; that is our own history
- `PaneWindowBase.cs` — the CLI not writing `diffTool` for our entrypoint is real CLI behaviour, reattributed to the CLI
- `AgentsChatPage.cs` "compact, like VS Code" — user-facing orientation for people who run both editors

## Scope

Comments only, with one exception: an Options `[Description]` string that named an internal setting key in text shown to the user (`"; mirrors VS Code's allowDangerouslySkipPermissions"` → removed).

Verified mechanically rather than by eye: comments were stripped from all 35 touched files with a parser that respects string, char, verbatim (`@""`) and template literals, then diffed against `HEAD`. That `[Description]` string is the **only** difference. No instruction, expression, signature, value or literal used in logic was touched.

## Verification

- `msbuild cv4vs-agents.sln /t:Build /p:Configuration=Debug` — green, VSIX produced (only pre-existing VSTHRD010 warnings)
- `npm run typecheck` — green
- `npm run format` — no changes
