### PR TITLE
docs(comments): comment hygiene — remove redundant and wrong comments

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents.Contracts/ToWebViewDtos.cs
+++ b/src/Corsinvest.VisualStudio.Agents.Contracts/ToWebViewDtos.cs
@@ -515,8 +515,8 @@ public class VsOptionsDto
 /// options. Sent as soon as the WebView is up, before any history, so the first rows already
 /// have the working directory they need to shorten paths against.
 /// <para>The CLI's own state travels separately, on cli_state: it is not available until
-/// claude.exe has answered initialize + get_settings, seconds later, and holding this back for
-/// it was what left that first history rendering absolute paths.</para></summary>
+/// claude.exe has answered initialize + get_settings, seconds later, and this payload must not
+/// wait for it.</para></summary>
 public class InitPayloadNotification
 {
     public InitConfigDto Config { get; set; }

--- a/src/Corsinvest.VisualStudio.Agents/AgentsPackage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/AgentsPackage.cs
@@ -400,8 +400,6 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
         base.Dispose(disposing);
     }
 
-    //  IVsSolutionEvents — only the two we actually need; everything else returns S_OK.
-
     int IVsSolutionEvents.OnAfterOpenSolution(object pUnkReserved, int fNewSolution)
     {
         // Redundant with OnBeforeOpenSolution, but covers the rare load path

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.Payloads.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.Payloads.cs
@@ -48,7 +48,7 @@ internal sealed partial class WebViewBridge
             AppVersion = BuildInfo.Version,
             AppCopyright = BuildInfo.Copyright,
             PerfEnabled = dbg.EnablePerfLog,
-            // Always honour the Debug-page LogLevel setting (default None); previously DEBUG forced Trace ignoring it.
+            // The Debug-page LogLevel (default None) is honoured on every build, DEBUG included.
             LogLevel = (int)dbg.LogLevel,
         };
     }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.cs
@@ -224,9 +224,10 @@ internal sealed partial class WebViewBridge(Microsoft.Web.WebView2.Wpf.WebView2C
         }
     }
 
-    /// renderer process behind this pane. VS keeps the closed tool window's control alive, so
-    /// without this the renderer outlives the pane and the browser accumulates one per pane ever
-    /// opened. Handlers are unhooked first: they run on the controller being torn down.</summary>
+    /// <summary>Tear down the WebView2, releasing the renderer process behind this pane. VS keeps
+    /// the closed tool window's control alive, so without this the renderer outlives the pane and
+    /// the browser accumulates one per pane ever opened. Handlers are unhooked first: they run on
+    /// the controller being torn down.</summary>
     public void Dispose()
     {
         if (_disposed) { return; }
@@ -382,11 +383,9 @@ internal sealed partial class WebViewBridge(Microsoft.Web.WebView2.Wpf.WebView2C
         catch (Exception ex) { log.LogException($"WebViewBridge.SendError[{type}]", ex); }
     }
 
-    // The 5 ToWebView channels that carry request responses. In DEBUG, Send() warns if called
+    // The ToWebView channels that carry request responses. In DEBUG, Send() warns if called
     // on one of these (a case that forgot Send→SendResponse would silently time out the Promise).
-    // chat_history is now a pure response channel (the unprompted push moved to
-    // chat_history_loaded). subagent_loaded is added once its ToWebView listener is removed
-    // (its logic moves into the sendRequest .then).
+    // chat_history is a pure response channel — the unprompted push goes on chat_history_loaded.
     private static readonly System.Collections.Generic.HashSet<string> _responseChannels =
     [
         BridgeMessages.ToWebView.Chat.ImageData,

--- a/src/Corsinvest.VisualStudio.Agents/Chat/IconCacheService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/IconCacheService.cs
@@ -43,8 +43,8 @@ internal static class IconCacheService
         var key = string.IsNullOrEmpty(iconKey) ? "file" : iconKey.ToLowerInvariant();
         // Keyed by the background the PNG is rendered against (see RenderMonikerToPng), not by the
         // theme's name: that colour is what decides the glyph, so two themes sharing a background
-        // can share the cache, and one that only LOOKS dark still gets its own. Before this the
-        // cache was flat, so a dark-theme run left pale icons that stayed pale on white.
+        // can share the cache, and one that only LOOKS dark still gets its own — a flat cache would
+        // leave a dark-theme run's pale icons in place on white.
         // The light-/dark- prefix is for whoever opens the folder; the hex is what makes it correct.
         var themeBg = VSColorTheme.GetThemedColor(EnvironmentColors.ToolWindowBackgroundColorKey);
         var bucket = $"{(VsThemeReader.IsDark() ? "dark" : "light")}-{themeBg.R:x2}{themeBg.G:x2}{themeBg.B:x2}";

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
@@ -430,8 +430,8 @@ public partial class ChatPaneControl : PaneControlBase
             return;
         }
 
-        // Reload the transcript into the WebView only; do NOT call ResumeSessionAsync
-        // (a respawn isn't needed to re-render UI options, and triggered a crash).
+        // Reload the transcript into the WebView only; do NOT call ResumeSessionAsync — re-rendering
+        // UI options needs no respawn, and respawning here is not safe.
         _bridge?.Send(BridgeMessages.ToWebView.Chat.Cleared, null);
         var page = Sessions.ReadHistoryRaw(sid, SessionManager.HistoryBatchSize, -1, out _);
         SendHistoryPage(page, sid);

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/dialog-host.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/dialog-host.ts
@@ -24,8 +24,8 @@ function mount(tag: string, props?: Record<string, unknown>): void {
     const returnFocus = captureFocus();
     // Full teardown, idempotent. Both paths must deregister from the Esc stack: the `close` event
     // (the dialog's own Esc/backdrop/✕) AND closeTopDialog() calling this directly (VS eats the real
-    // Esc → ui_escape → closeTopDialog → close()). Removing the element alone left the entry on the
-    // stack, so the next Esc was swallowed by a phantom dialog and never reached the composer menus.
+    // Esc → ui_escape → closeTopDialog → close()). Removing the element without popping leaves a
+    // phantom entry that swallows the next Esc before it reaches the composer menus.
     let closed = false;
     const close = (): void => {
         if (closed) {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/exchanges.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/exchanges.ts
@@ -8,7 +8,7 @@ import type { UiEntry } from './types';
  * user message (a history page boundary) gets its own leading group.
  *
  * Pure and derived — cv-app calls this from a memoised getter instead of holding the groups as
- * state. Two writers on one structure is what let the groups and the entries drift apart.
+ * state, so the groups can never drift from the entries they are built from.
  */
 export function buildGroups(entries: readonly UiEntry[]): UiEntry[][] {
     const groups: UiEntry[][] = [];

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/file-links.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/file-links.ts
@@ -362,8 +362,8 @@ const DRIVE = /[A-Za-z]:$/;
 
 /** How strict the path check is. Prose is scanned blind, so it needs the extension allow-list to keep
  *  "localhost.net:4040" / "19.99:2" from rendering as dead links; a markdown href was written as a link
- *  by the model on purpose, so any plausible path shape is enough (a case we used to drop).
- *  See the file-link entry in docs/internal/TODO.md for the measurements. */
+ *  by the model on purpose, so any plausible path shape is enough. See the file-link entry in
+ *  docs/internal/TODO.md for the measurements. */
 export type RefStrictness = 'known-ext' | 'plausible-path';
 
 /** Scan `text` for file references, growing outwards from each ".ext" anchor. Returns them in order,

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/markdown.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/markdown.ts
@@ -48,8 +48,8 @@ renderer.link = function (token: Tokens.Link): string {
     // parses as a file ref, render a clickable file link (cv-message routes the click to VS) using
     // the LABEL text as-is. Otherwise fall back to plain text.
     // 'plausible-path', not the prose allow-list: the model wrote this AS a link, so any extension is
-    // fine (.rb/.kt/.tf … used to be dropped here). Unlike VS Code we still degrade to text when the
-    // href isn't path-shaped at all, instead of leaving a blue link that does nothing on click.
+    // fine (.rb/.kt/.tf …). Unlike VS Code we still degrade to text when the href isn't path-shaped
+    // at all, instead of leaving a blue link that does nothing on click.
     const ref = parseFileRef(href, 'plausible-path');
     if (ref) {
         const line = ref.lines[0] ?? 0;
@@ -68,8 +68,8 @@ const fileLinkExtension = {
     name: 'fileLink',
     level: 'inline' as const,
     // Where marked should jump to next — a potential index, per marked's contract. firstRefHint
-    // shares ANCHOR/BACK with the parser, so it can't drift the way a parallel hand-written regex
-    // did (that is how "#L10" in prose stayed unlinked once already).
+    // shares ANCHOR/BACK with the parser so it can't drift: a hint that misses a shape silently
+    // stops the tokenizer from ever being offered that position.
     start: firstRefHint,
     tokenizer(src: string) {
         // A file-ref only counts if it starts at the cursor (offset 0 of the remaining src). Only the

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/time.test.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/time.test.ts
@@ -11,17 +11,17 @@ const HOUR = 3600_000;
 test('formatTimeAgo: il clock e iniettabile, non e Date.now cablato', () => {
     const t = 1_000_000_000_000;
 
-    // Lo stesso timestamp letto a due momenti diversi deve dare due stringhe diverse: e quello che
-    // rende il refresh su hover una questione di stato, non di scrittura nel DOM.
+    // The same timestamp read at two different moments must give two different strings: that is
+    // what makes the refresh on hover a matter of state, not of writing into the DOM.
     const subito = formatTimeAgo(t, t + MINUTE);
     const dopo = formatTimeAgo(t, t + 3 * HOUR);
 
     assert.notEqual(subito, dopo, 'un clock piu avanti deve dare un testo diverso');
 });
 
-// Il testo esatto dipende dal locale di sistema (Intl.RelativeTimeFormat): asserire su stringhe
-// inglesi renderebbe il test verde solo sulle macchine in inglese. Quello che conta e' che unita
-// diverse diano stringhe diverse, e che il numero sia quello giusto.
+// The exact text depends on the system locale (Intl.RelativeTimeFormat): asserting on English
+// strings would make the test green only on English machines. What matters is that different
+// units give different strings, and that the number is the right one.
 test('formatTimeAgo: sceglie l unita in base alla distanza', () => {
     const t = 1_000_000_000_000;
 
@@ -36,7 +36,7 @@ test('formatTimeAgo: sceglie l unita in base alla distanza', () => {
 });
 
 test('formatTimeAgo: senza clock esplicito usa adesso', () => {
-    // Il default deve restare Date.now(): i chiamanti che non passano il clock non cambiano.
+    // The default must stay Date.now(): callers that pass no clock are unaffected.
     const esplicito = formatTimeAgo(1_000_000_000_000, 1_000_000_000_000 + 2 * MINUTE);
     const implicito = formatTimeAgo(Date.now() - 2 * MINUTE);
 

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/transcript.test.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/transcript.test.ts
@@ -119,9 +119,9 @@ test('appendChild: parent, children e items nuovi; fratelli invariati', () => {
     assert.equal(t.entries[1], sibling, 'il fratello mantiene il riferimento');
 });
 
-// Il difetto del 2026-07-31: il ring scartava un figlio mutando items in place, e il blocco
-// children del parent restava identico per ===. cv-tool-row non veniva aggiornato e i suoi
-// ChildPart puntavano a nodi rimossi.
+// If the ring dropped a child by mutating items in place, the parent's children block would stay
+// identical by ===: cv-tool-row would not be updated and its ChildParts would point at removed
+// nodes.
 test('appendChild: il ring che scarta un figlio ricrea comunque il blocco children', () => {
     const t = new Transcript();
     t.append(toolEntry(1, 'tool-1'));
@@ -154,7 +154,7 @@ test('appendChild: showAll tiene tutto e fa upsert invece di duplicare', () => {
         t.appendChild('tool-1', userEntry(i), childKey);
     }
 
-    // re-emissione dello stesso figlio: aggiorna in place, non duplica
+    // re-emitting the same child: updates in place, does not duplicate
     t.appendChild('tool-1', userEntry(3, 'aggiornato'), childKey);
 
     const p = t.entries[0] as UiToolEntry;
@@ -233,16 +233,15 @@ test('findToolByAgentId: trova la riga Agent che ha lanciato il sub-agent', () =
     assert.equal(t.findToolByAgentId('nope'), null);
 });
 
-// Il difetto del 2026-07-31 (secondo giro): "Show all" su un Agent ancora in esecuzione.
-// La fetch sostituisce children.items con l'intera cronologia, ma quei figli non erano mai
-// passati da appendChild — restano fuori dall'index. L'evento live che arriva subito dopo non
-// li trova, e l'update tocca il ramo sbagliato.
+// "Show all" on an Agent still running: the fetch replaces children.items with the whole history,
+// but those children never go through appendChild. Without a reindex they stay out of the index,
+// the live event arriving right after does not find them and the update hits the wrong branch.
 test('update: sostituire children.items indicizza i figli arrivati da fuori', () => {
     const t = new Transcript();
     t.append(toolEntry(1, 'agent'));
     t.appendChild('agent', userEntry(2), childKey);
 
-    // la fetch di "Show all": rimpiazza i 3 tenuti con la cronologia completa
+    // the "Show all" fetch: replaces the 3 kept ones with the full history
     t.update<UiToolEntry>(1, (e) => ({
         ...e,
         children: {
@@ -252,7 +251,7 @@ test('update: sostituire children.items indicizza i figli arrivati da fuori', ()
         },
     }));
 
-    // l'agent sta ancora lavorando: arriva un evento per un figlio della lista sostituita
+    // the agent is still working: an event arrives for a child of the replaced list
     assert.equal(t.find(11)?.id, 11, 'i figli sostituiti devono essere raggiungibili');
     assert.equal(
         t.update<UiUserEntry>(11, (e) => ({ ...e, text: 'aggiornato' })),

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/transcript.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/transcript.ts
@@ -25,7 +25,7 @@ function upsert(list: UiEntry[], entry: UiEntry, key: (e: UiEntry) => string): U
  * mutating method here replaces the entry it touches AND rebuilds every object on the path from
  * the root down to it — the entries array, each ancestor's `children`, `children.items`. Branches
  * that did not change keep their identity, so Lit skips them. By construction, not by convention:
- * that is what the previous `_commit` left to each caller to remember, and got wrong.
+ * no caller has to remember to re-create the path itself.
  */
 export class Transcript {
     private _entries: UiEntry[] = [];

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tools/gen-bridge.mjs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tools/gen-bridge.mjs
@@ -40,7 +40,6 @@ function parse() {
     for (const raw of lines) {
         const line = raw.trim();
 
-        // Direction class
         let m = line.match(reClassDirection);
         if (m) {
             direction = m[1] === 'FromWebView' ? 'fromWebView' : 'toWebView';
@@ -48,7 +47,7 @@ function parse() {
             continue;
         }
 
-        // Domain class — only when we're already inside a direction
+        // reClassDomain also matches a direction class, so only try it once inside one.
         if (direction && (m = line.match(reClassDomain))) {
             domain = m[1].charAt(0).toLowerCase() + m[1].slice(1);
             out[direction][domain] ||= {};
@@ -56,7 +55,6 @@ function parse() {
             continue;
         }
 
-        // Constant
         if (direction && domain && (m = line.match(reConst))) {
             const tsName = m[1].charAt(0).toLowerCase() + m[1].slice(1);
             out[direction][domain][tsName] = m[2];
@@ -70,7 +68,6 @@ function parse() {
                 depth++;
             } else if (ch === '}') {
                 depth--;
-                // Pop any scopes that closed at this depth
                 while (stack.length > 0 && stack[stack.length - 1].depth >= depth) {
                     const popped = stack.pop();
                     if (popped.kind === 'domain') { domain = null; }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/chat.css
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/chat.css
@@ -294,9 +294,8 @@ body.sticky-user .cv-exchange > cv-message[role="user"]:first-child .cv-message.
     fill: var(--colorPaletteBerryBorderActive);
     stroke: none;
 }
-/* A tool row's nested children (Agent / Skill transcript today) — indented and
- * separated by a left border to show the parent/child relationship. */
-/* No rule down the side: the indent already says "these belong to the row above". */
+/* A tool row's nested children (Agent / Skill transcript today).
+ * No rule down the side: the indent already says "these belong to the row above". */
 .cv-children {
     margin-left: 16px;
     padding-left: 8px;
@@ -367,9 +366,8 @@ body.sticky-user .cv-exchange > cv-message[role="user"]:first-child .cv-message.
 .cv-tool-row-chev.always-shown {
     opacity: 1;
 }
-/* Tool header actions — all now come from one renderHeaderActions() per renderer (error / open-diff /
- * sub-agent copy+expand), rendered in flow on the row (not an absolute overlay). This wrapper holds
- * the diff/error buttons; the tints below colour them. Buttons are .icon-btn (shared 14px style). */
+/* Tool header actions (error / open-diff / sub-agent copy+expand), in flow on the row rather than
+ * an absolute overlay. Buttons are .icon-btn (shared 14px style); the tints below colour them. */
 .cv-tool-actions {
     display: inline-flex;
     align-items: center;
@@ -699,9 +697,6 @@ cv-message:focus-within .cv-msg-actions {
     color: var(--colorNeutralForeground3);
     padding: 2px 4px;
 }
-/* A slash command's local output (<local-command-stdout>, e.g. "Set model to X"): a centered
- * berry/purple pill with hairline rules either side — same "special action" language as the
- * model-switch notice, and centered like the VS Code compact divider. stderr → red. */
 /* A slash command's own output (/config, /model, "Unknown command"…) — the CLI's raw terminal
  * text. Rendered as a preformatted monospace block (left-aligned, wraps), faithful to the terminal
  * (no markdown reinterpretation, which would break /config's aligned key=value list). A subtle left
@@ -805,8 +800,6 @@ cv-message:focus-within .cv-msg-actions {
     border: 1px solid color-mix(in srgb, var(--colorPaletteBerryBorderActive) 35%, transparent);
     white-space: nowrap;
 }
-
-/* The .cv-children / -collapsed / -more classes above belong to cv-tool-row. */
 
 /* Elapsed time on a running Agent row (the dot handles the spinner). */
 .cv-agent-time { margin-left: 4px; font-size: 11px; opacity: 0.7; }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/diff.css
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/diff.css
@@ -140,7 +140,7 @@ cv-diff-dialog fluent-dialog-body::part(title) {
     overflow: auto;
 }
 
-/*  diff2html minor overrides (colors come from diff2html's dark/light scheme) */
+/* diff2html overrides: layout and typography only — colours stay diff2html's own dark/light scheme. */
 
 .d2h-wrapper {
     font-family: var(--fontFamilyMonospace);

--- a/src/Corsinvest.VisualStudio.Agents/Cli/Pane/CliPaneControl.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Cli/Pane/CliPaneControl.cs
@@ -27,7 +27,6 @@ namespace Corsinvest.VisualStudio.Agents.Cli.Pane;
 ///   • <see cref="OnLoaded"/>     resolve workdir, spawn <c>claude --ide</c>.
 ///   • <see cref="OnUnloaded"/>   no-op (don't kill on hide; user may dock-toggle).
 ///   • <see cref="Dispose"/>      kill process, drop control.
-///   • <see cref="OnSolutionChanged"/> respawn with the new workdir.
 /// </para>
 /// </summary>
 internal class CliPaneControl : PaneControlBase, ITerminalConnection, IDisposable
@@ -63,7 +62,7 @@ internal class CliPaneControl : PaneControlBase, ITerminalConnection, IDisposabl
     private string BuildCommand(int mcpPort, string mcpAuthToken)
     {
         var baseCmd = ClaudeCliLauncher.BuildConPtyCommandLine(ide: true, mcpPort, mcpAuthToken);
-        if (string.IsNullOrEmpty(_activeSessionId)) { return baseCmd; }   // safety (shouldn't happen after Step 1)
+        if (string.IsNullOrEmpty(_activeSessionId)) { return baseCmd; }   // StartOrRestartAsync always mints an id first
         // Fresh id we minted → create it (--session-id). Existing id (picker/restore) → resume it.
         return _sessionIsNew
             ? $"{baseCmd} --session-id {_activeSessionId}"
@@ -206,9 +205,8 @@ internal class CliPaneControl : PaneControlBase, ITerminalConnection, IDisposabl
         _sessionIsNew = false;
         _log.Info($"CliPane: starting {cmd ?? "<null>"} in {Entry.WorkingDirectory}");
 
-        // claude.exe must be installed via the official npm package (see
-        // ClaudeCliLauncher for why no cmd-shim/PATH fallback). When missing,
-        // swap in the inline "not installed" panel instead of a modal dialog.
+        // claude.exe must be installed (see ClaudeInstall for why only a real .exe will do).
+        // When missing, swap in the inline "not installed" panel instead of a modal dialog.
         if (cmd == null)
         {
             _log.Warn("[cli] claude.exe not found — showing 'not installed' panel");
@@ -289,8 +287,8 @@ internal class CliPaneControl : PaneControlBase, ITerminalConnection, IDisposabl
     }
 
     /// <summary>Replace the embedded terminal with the shared "Claude Code
-    /// not installed" panel produced by <see cref="ClaudeInstall.BuildMissingPanel"/>.
-    /// The chat pane will use the same factory.</summary>
+    /// not installed" panel produced by <see cref="ClaudeInstall.BuildMissingPanel"/>
+    /// (the chat pane shows the same one).</summary>
     private void ShowMissingPanel()
     {
         ThreadHelper.ThrowIfNotOnUIThread();

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneToolbar.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneToolbar.xaml.cs
@@ -168,9 +168,6 @@ public partial class PaneToolbar : UserControl
 
     private void OnHistory_Click(object sender, RoutedEventArgs e) => ShowSessionHistory();
 
-    /// <summary>Open the session picker for this pane. Public because the chat's
-    /// "Resume conversation" command reaches it through the bridge, not just the
-    /// toolbar button — same popup either way.</summary>
     // The live session-picker popup, so Esc (which VS routes through IOleCommandTarget, never
     // reaching the popup) can dismiss it. Null when closed.
     private Popup _historyPopup;
@@ -194,6 +191,9 @@ public partial class PaneToolbar : UserControl
         return true;
     }
 
+    /// <summary>Open the session picker for this pane. Public because the chat's
+    /// "Resume conversation" command reaches it through the bridge, not just the
+    /// toolbar button — same popup either way.</summary>
     public void ShowSessionHistory()
     {
         var picker = new SessionManagerControl(ClaudePaths.ForProfile(_pane.Entry.Profile), _pane.Entry.WorkingDirectory, _pane.Entry.ActiveSessionId);

--- a/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManagerControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManagerControl.xaml.cs
@@ -80,8 +80,8 @@ public partial class SessionManagerControl : UserControl
         }
         catch
         {
+            // Swallowed: an unreadable folder shouldn't crash the picker.
             OutputWindowLogger.Global.Warn("[sessions] failed to load the session list — picker may be empty");
-            // Silent: an unreadable folder shouldn't crash the picker.
         }
         ApplyActiveFlag();
         ApplyFilter();

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/CvHeatmap.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/CvHeatmap.cs
@@ -41,7 +41,6 @@ internal sealed class CvHeatmap : StackPanel
         Children.Clear();
         if (cols == null || cols.Count == 0) { return; }
 
-        // Grid of week-columns.
         var grid = new StackPanel { Orientation = Orientation.Horizontal };
         foreach (var col in cols)
         {

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsCache.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsCache.cs
@@ -20,9 +20,8 @@ namespace Corsinvest.VisualStudio.Agents.Core.Stats;
 /// </summary>
 internal static class StatsCache
 {
-    // 7: projectCwd moved out, to project.json beside the project's own data — it was a fact about
-    // the project sitting in each profile's cache. A version that does not match rebuilds from
-    // scratch, which is how the existing caches shed the field.
+    // Bump on any shape change: a version that does not match is dropped and rebuilt from scratch,
+    // which is the only way an existing cache sheds a field.
     private const int Version = 7;
 
     /// <summary>One cached file: its aggregate + the mtime/size it was computed at.</summary>

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsTreeNode.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsTreeNode.cs
@@ -7,12 +7,12 @@ using System.Collections.Generic;
 
 namespace Corsinvest.VisualStudio.Agents.Core.Stats;
 
-/// <summary>One node of the stats navigation tree (All → Profile → Project → Session). Every node
-/// is clickable: its <see cref="Selection"/> is what BuildResponse aggregates for that level.</summary>
 /// <summary>Overrides a node's icon when its scope alone isn't enough — the "Days"/"Sessions"
 /// grouping nodes both carry the Project scope but want distinct icons.</summary>
 internal enum StatsNodeKind { Default, DaysGroup, SessionsGroup }
 
+/// <summary>One node of the stats navigation tree (All → Profile → Project → Session). Every node
+/// is clickable: its <see cref="Selection"/> is what BuildResponse aggregates for that level.</summary>
 internal sealed class StatsTreeNode
 {
     public string Label { get; set; }

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.cs
@@ -44,10 +44,8 @@ internal sealed partial class IdeContextService : IDisposable
 
     private IdeContextService() { }
 
-    //  Live selection tracking (real editor, not DTE)
-    //
-    // IWpfTextView.Selection.SelectionChanged is the only reliable signal for
-    // editor selection/caret (the DTE path didn't fire on mouse selection).
+    // Live selection tracking. IWpfTextView.Selection.SelectionChanged is the only reliable
+    // signal for editor selection/caret — DTE doesn't fire on mouse selection.
     // IVsMonitorSelection tells us when the active frame changes so we re-attach.
 
     private IVsEditorAdaptersFactoryService _editorAdapters;
@@ -506,10 +504,7 @@ internal sealed partial class IdeContextService : IDisposable
     }
 }
 
-//  DTOs
-
-/// <summary>Snapshot of the active editor state for the live badge
-/// (formerly <c>Host.EditorContext</c>).</summary>
+/// <summary>Snapshot of the active editor state for the live badge.</summary>
 internal sealed class EditorContext
 {
     public string FilePath { get; set; }

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.Inspection.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.Inspection.cs
@@ -19,7 +19,7 @@ namespace Corsinvest.VisualStudio.Agents.Ide;
 /// </summary>
 internal sealed partial class IdeDebugService
 {
-    // ---- Live inspection + stepping (require Break mode) ---------------------------
+    // Live inspection + stepping: every entry point here requires Break mode.
 
     private const string NotInBreak =
         "Debugger must be paused (break mode) for this. Poll getDebugState and wait for mode='break' " +

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeDiffViewer.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeDiffViewer.cs
@@ -130,10 +130,9 @@ internal sealed partial class IdeDiffViewer
                 rightIsTemp: false, leftIsTemp: leftIsTemp);
             if (frame == null) { return new DiffResult { Status = DiffRejected }; }
 
-            // Track the frame in the global registry so close_tab and
-            // closeAllDiffTabs can address it without caption matching
-            // (which used to take down our own panes because their
-            // caption contained "Claude Code").
+            // Track the frame in the global registry so close_tab and closeAllDiffTabs can
+            // address it by identity: matching on the caption also hits our own panes, whose
+            // caption contains "Claude Code".
             var registryKey = tabName ?? caption;
             _openFrames[registryKey] = frame;
 
@@ -355,8 +354,6 @@ internal sealed partial class IdeDiffViewer
         }
         return null;
     }
-
-    //  Helpers
 
     private IVsWindowFrame OpenComparison(
         string leftPath, string rightPath, string caption,

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.cs
@@ -51,7 +51,7 @@ internal sealed partial class IdeNavigationService
         public string Preview { get; set; } // the source line's text, trimmed
     }
 
-    // ---- Shared reflection handles, resolved once (feature-detection). Null ⇒ unsupported. ----
+    // Shared reflection handles, resolved once (feature-detection). Null ⇒ unsupported.
 
     private bool _probed;
     private bool _available;

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/JsonRpcDispatcher.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/JsonRpcDispatcher.cs
@@ -83,8 +83,6 @@ internal sealed class JsonRpcDispatcher
         }
     }
 
-    //  Method handlers
-
     private object BuildInitializeResult() => new
     {
         protocolVersion = ProtocolVersion,
@@ -159,8 +157,6 @@ internal sealed class JsonRpcDispatcher
         };
     }
 
-    //  JSON-RPC envelope helpers
-    //
     // Use SerializeObject(anonymous), not JObject.ToString(Formatting): VS loads its own
     // Newtonsoft.Json that may lack that overload and throw MissingMethodException.
 

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/McpServerHost.LockFile.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/McpServerHost.LockFile.cs
@@ -20,8 +20,6 @@ namespace Corsinvest.VisualStudio.Agents.Mcp;
 /// </summary>
 internal sealed partial class McpServerHost
 {
-    //  Lock file
-
     private void WriteLockFile(string ideFolder)
     {
         Directory.CreateDirectory(ideFolder);

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/McpServerHost.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/McpServerHost.cs
@@ -186,8 +186,6 @@ internal sealed partial class McpServerHost
         catch (Exception ex) { OutputWindowLogger.Global.LogException("Mcp.RewriteLockFile", ex); }
     }
 
-    //  Tool registry
-
     private static IEnumerable<IMcpTool> BuildToolRegistry()
     {
         // Add new tools here (order irrelevant; dispatcher is name-keyed). One file per tool under Mcp/Tools/.
@@ -242,8 +240,6 @@ internal sealed partial class McpServerHost
         yield return new Tools.SetExceptionBreakTool();
         yield return new Tools.ApplyHotReloadTool();
     }
-
-    //  Accept loop + per-client loop
 
     private async Task AcceptLoopAsync(CancellationToken ct)
     {
@@ -495,8 +491,6 @@ internal sealed partial class McpServerHost
         }
     }
 
-
-    //  Helpers
 
     private static int AllocateFreePort()
     {

--- a/src/Corsinvest.VisualStudio.Agents/Options/ProfilesControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Options/ProfilesControl.xaml.cs
@@ -163,7 +163,6 @@ public partial class ProfilesControl : UserControl
     {
         if (_loadingDetail || _selected == null) { return; }
         _selected.Name = NameBox.Text ?? "";
-        // Refresh the list item's Name display.
         ProfilesList.Items.Refresh();
         ValidateName();
         PersistProfiles();
@@ -177,10 +176,9 @@ public partial class ProfilesControl : UserControl
     }
 
     /// <summary>Name must be non-blank and unique (OrdinalIgnoreCase) among the
-    /// other profiles. Known limitation (phase 1): this only flags the problem
-    /// inline (red border/text) — it does not block Apply. UIElementDialogPage.OnApply
-    /// has no supported way to cancel the Apply/close, so a hard block would need a
-    /// bigger change (e.g. a custom modal dialog) left for a later phase.</summary>
+    /// other profiles. Only flags the problem inline (red border/text) — it does not block
+    /// Apply, because UIElementDialogPage.OnApply has no supported way to cancel the
+    /// Apply/close. AgentsProfilesPage.OnApply is what actually refuses to persist.</summary>
     private void ValidateName()
     {
         if (_selected == null)
@@ -227,8 +225,6 @@ public partial class ProfilesControl : UserControl
 
     private void OnEnvVarsLinkClick(object sender, System.Windows.Navigation.RequestNavigateEventArgs e)
     {
-        // Open the CLI's env-vars doc in the default browser so the user can look up
-        // which variables a profile can set.
         try { System.Diagnostics.Process.Start(e.Uri.AbsoluteUri); }
         catch (Exception) { /* no browser / blocked — ignore, not worth a dialog */ }
         e.Handled = true;

--- a/src/Corsinvest.VisualStudio.Agents/Utils/ClaudePaths.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Utils/ClaudePaths.cs
@@ -39,8 +39,7 @@ public sealed class ClaudePaths
 
     // Mirrors the CLI folder-naming: the CLI resolves the cwd to an absolute path, then
     // `replace(/[^a-zA-Z0-9]/g, "-")` — every non-alphanumeric char becomes '-', case PRESERVED.
-    // So C:\Users\jane.doe → C--Users-jane-doe (the dot in the username becomes a dash too; an
-    // earlier version left dots intact and lowercased, missing the folder).
+    // So C:\Users\jane.doe → C--Users-jane-doe (the dot in the username becomes a dash too).
     // Not replicated (rare on Windows): the CLI also realpath's the cwd (symlink/junction
     // canonicalization). The >200-char case IS handled, by SessionFolder rather than here.
     public static string ProjectFolderName(string workingDirectory)


### PR DESCRIPTION
Comment hygiene pass, second of two. #81 is about where a comment's justification comes from; this one removes comments that carry no information at all, and fixes the ones that were actively wrong.

Deliberately conservative: when a comment might carry information, it was kept. 31 files touched out of ~300 reviewed.

## What was removed

- Comments restating the line below them (`// Grid of week-columns.` above `new StackPanel { Orientation = Horizontal }`).
- Section labels with no content (`// IVsSolutionEvents — only the two we actually need`).
- Bug history in the past tense, where the constraint it described still binds — kept the constraint, dropped the story.

## What was actually wrong

The removals are the small part. These are the finds that justified the pass:

- **`StatsTreeNode.cs`** — two consecutive `<summary>` blocks sat before the enum. The compiler binds the *last* one, so the class's doc landed on `StatsNodeKind` and the class itself was undocumented. Both now sit on their own type; wording untouched.
- **`PaneToolbar.xaml.cs`** — the `<summary>` for `ShowSessionHistory` had drifted ~20 lines up onto the `_historyPopup` field, which already had its own comment. The field carried two contradictory descriptions in IntelliSense.
- **`chat.css`** — one comment described a centered pill the rule below never implements; another described a left border the rule deliberately omits. Both would send a reader hunting for code that isn't there.
- **`AgentsPackage.cs`** — a label claiming "only the two we actually need" carry logic; five members do.
- **`SessionManagerControl.xaml.cs`** — a catch commented "Silent:" while logging a `Warn`.

## Language

The Italian comments in `time.test.ts` and `transcript.test.ts` are now English, per the CLAUDE.md rule that applies even to files whose prose is Italian. Test names and assert messages were left alone — those are code and output, out of scope here.

## Scope

Comments only. Verified two independent ways, because each has a different blind spot:

1. **Comment-stripped diff against `HEAD`** — 29 of 31 files byte-identical. The two exceptions (`file-links.ts`, `gen-bridge.mjs`) are false positives: both contain regex literals, which the stripper cannot tell from the start of a comment, so it desyncs and leaks comment text through.
2. **Line-level check** on those two files — zero non-comment lines changed.

The one line where code and comment share a row is unchanged on the code side:

```
if (string.IsNullOrEmpty(_activeSessionId)) { return baseCmd; }   // <- comment only
```

## Verification

- Solution build (via the extension's own MCP `build_solution`) — **succeeded**, 0 failed projects, 0 errors
- `npm run test` — **24/24 pass**
- `npm run typecheck` — green
- `npm run format` — no file rewritten

## Merge order

This branch and #81 both touch `ClaudePaths.cs`, `McpServerHost.cs`, `IdeDiffViewer.cs` and `file-links.ts`. Whichever lands second will need a rebase; the conflicts are comment-text only.
