### PR TITLE
fix(chat): dismissing the rate-limit notice now keeps it dismissed

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/types.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/types.ts
@@ -440,3 +440,8 @@ export interface Notice {
     /** Stays until the host clears it (a dead CLI process) — never auto-dismissed. */
     sticky?: boolean;
 }
+
+/** Payload of `notice-dismissed`, raised only when the user clicks a notice's ✕. */
+export interface NoticeDismissedDetail {
+    key?: string;
+}

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-notice-stack.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-notice-stack.ts
@@ -11,7 +11,7 @@ import CheckmarkCircle16Filled from '@fluentui/svg-icons/icons/checkmark_circle_
 import DismissCircle16Filled from '@fluentui/svg-icons/icons/dismiss_circle_16_filled.svg';
 import Dismiss16Regular from '@fluentui/svg-icons/icons/dismiss_16_regular.svg';
 import { bridge } from '../../core/bridge';
-import type { Notice } from '../../core/types';
+import type { Notice, NoticeDismissedDetail } from '../../core/types';
 
 // Same glyph set Fluent's own message-bar uses: info outlined, the actionable severities filled so
 // they read at a glance.
@@ -159,6 +159,21 @@ export class CvNoticeStack extends LitElement {
         }
     }
 
+    /** The ✕. Kept apart from `_remove`, which also serves the auto-dismiss timer and `dismissByKey`
+     *  — neither of those is the user deciding they have read the thing. Only this one is worth
+     *  telling the caller about: one that re-pushes the same key on a schedule it doesn't control
+     *  (the CLI re-sends `rate_limit_info` every turn) has no other way to know to stop. */
+    private _dismissByUser(n: Notice): void {
+        this.dispatchEvent(
+            new CustomEvent<NoticeDismissedDetail>('notice-dismissed', {
+                detail: { key: n.key },
+                bubbles: true,
+                composed: true,
+            }),
+        );
+        this._remove(n.id);
+    }
+
     private _remove(id: string): void {
         this._clearTimer(id);
         this._queue = this._queue.filter((q) => q.id !== id);
@@ -204,7 +219,7 @@ export class CvNoticeStack extends LitElement {
                                 appearance="transparent"
                                 icon-only
                                 title="Dismiss"
-                                @click=${() => this._remove(n.id)}
+                                @click=${() => this._dismissByUser(n)}
                             >
                                 ${unsafeHTML(Dismiss16Regular)}
                             </fluent-button>

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-prompt.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-prompt.ts
@@ -18,6 +18,7 @@ import type {
     AtItemDto,
     RateLimitNotification,
     NoticeNotification,
+    NoticeDismissedDetail,
     PromptHistoryNotification,
     UserTextNotification,
     UserImageDto,
@@ -328,6 +329,16 @@ export class CvPrompt extends LitElement implements CommandHost {
     // (status:type) changes. _rateKey = the live banner's key (null if not a rate limit).
     private _dismissedRateKey: string | null = null;
     private _rateKey: string | null = null;
+
+    /** The user closed a notice by hand. Only the rate limit needs remembering: the CLI re-sends
+     *  `rate_limit_info` on every turn with the same key, so without this the banner comes straight
+     *  back on the next message. A changed key (warning → rejected) is a different condition and
+     *  shows again, which is the point. */
+    private _onNoticeDismissed = (e: CustomEvent<NoticeDismissedDetail>): void => {
+        if (e.detail?.key && e.detail.key === this._rateKey) {
+            this._dismissedRateKey = e.detail.key;
+        }
+    };
 
     @query('textarea') private _ta!: HTMLTextAreaElement;
     @query('input[data-cv-file-picker]') private _filePicker!: HTMLInputElement;
@@ -1497,7 +1508,7 @@ export class CvPrompt extends LitElement implements CommandHost {
                 @dragleave=${this._onDragLeave}
                 @drop=${this._onDrop}
             >
-                <cv-notice-stack></cv-notice-stack>
+                <cv-notice-stack @notice-dismissed=${this._onNoticeDismissed}></cv-notice-stack>
                 ${this._renderQueue()} ${this._renderChips()}
                 <textarea
                     id="input"


### PR DESCRIPTION
Close the rate-limit banner and it comes straight back on the next message. Once you are over quota the CLI re-sends `rate_limit_info` on **every** turn with the same key, so the ✕ buys you exactly one message of quiet.

## What was actually wrong

`cv-prompt` already had the guard:

```ts
if (d.key === this._dismissedRateKey) {
    return;
}
```

`_dismissedRateKey` is declared, is reset to `null` when the limit lifts, and is read on every incoming event — but **nothing ever assigns it**. The comment above it describes behaviour the code could not perform.

The reason is where the ✕ lives. It is inside `cv-notice-stack`, and it called `_remove(n.id)` directly: the row disappears from the queue and that is the end of it. The click never crossed the shadow boundary, so the component that pushed the notice had no way to find out the user had read it.

## The fix

The stack now raises `notice-dismissed` — from the ✕ **only**:

```ts
private _dismissByUser(n: Notice): void {
    this.dispatchEvent(new CustomEvent<NoticeDismissedDetail>('notice-dismissed', {
        detail: { key: n.key }, bubbles: true, composed: true,
    }));
    this._remove(n.id);
}
```

Keeping this apart from `_remove` is the point of the change. `_remove` also serves the auto-dismiss timer and `dismissByKey` (a condition clearing upstream), and neither of those is the user deciding they have read the thing — folding the event into `_remove` would make a notice that faded on its own after seven seconds count as dismissed and never return.

`cv-prompt` listens and fills in the field the guard was already waiting for. Nothing else changed: the guard and the `allowed` reset were correct all along.

## No timer

An earlier sketch had a 10–15 minute re-show window. Checked what the VS Code extension does (`dismissRateLimitWarning`, bundle 2.1.221) — it has no timer at all, and it does not need one, because the key carries the meaning:

- key is `status:rateLimitType`, so `warning:5h` → `rejected:5h` is a **different** key and shows again. That is the case where the turn will not start, and staying quiet would leave you with no explanation.
- utilization is *not* in the key, so climbing from 80% to 95% does not re-open a banner you closed.
- `status === "allowed"` clears both fields, so the next time you cross the threshold you get told again.

Their state is the same three values we already had (`currentRateLimitKey` / `dismissedRateLimitKey` / the notice itself). The only thing we were missing was the ✕ writing the second one.

## Verified

In the experimental instance, with the built bundle: clicking the ✕ emits `notice-dismissed {key: "warning:5h"}` and `_dismissedRateKey` lands on `warning:5h`. Those were the two broken links. The end-to-end suppression rides on the guard at `cv-prompt.ts:435`, which was already there and now has something to compare against.

`npm run typecheck`, `lint`, `format` and `build` all clean, before and after rebasing onto master.
