### PR TITLE
fix(chat): double-click selects the word, not the paragraph

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatWebView.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatWebView.cs
@@ -65,6 +65,18 @@ internal sealed class ChatWebView : WebView2CompositionControl
         e.Handled = true;
     }
 
+    /// <summary>Makes a double click select the word rather than the whole paragraph.
+    /// <para>WPF raises MouseDown → MouseUp → MouseDown → MouseUp → MouseDoubleClick for one double
+    /// click, and the composition control forwards both MouseDown and MouseDoubleClick through
+    /// SendMouseInput. So the browser gets three mousedown for two physical clicks, reads the third
+    /// as a triple click and selects the block. Measured on the page: the second and third arrive
+    /// with the SAME timeStamp — one click delivered twice, not an extra one invented.</para></summary>
+    protected override void OnMouseDoubleClick(MouseButtonEventArgs e)
+    {
+        // Empty on purpose, and no base call: OnMouseDown has already sent this click, with its own
+        // ClickCount, so the page still sees detail=2 and nothing needs the second delivery.
+    }
+
     // Static: the browser has ONE task manager, so one owner serves every pane. A per-pane field
     // grew a spare renderer for each chat that had opened it, all of them then listed in the very
     // window they had opened.


### PR DESCRIPTION
Double-clicking a word in the chat selected the entire paragraph. The selection was doing its job — the input was being duplicated.

## What the measurement showed

Tracing both sides of the boundary, one double click on a `<code>` element:

```
19:10:11.144 TRACE [chat#0] [input] wpf mousedown click=1 ts=485110343
19:10:11.381 TRACE [chat#0] [input] wpf mousedown click=2 ts=485110593
             [input] dom mousedown detail=1 ts=67168 on=CODE
             [input] dom mousedown detail=2 ts=67403 on=CODE
             [input] dom mousedown detail=3 ts=67403 on=CODE
```

Two on the host, three on the page. The giveaway is `ts=67403` appearing twice: `detail=2` and `detail=3` share a timestamp, so this is one click delivered twice, not a phantom click being invented somewhere. `detail=3` is the triple-click gesture, and every browser answers that by selecting the block.

## Why it happens

Not our code. `WebView2CompositionControl` renders through `Windows.UI.Composition`, so input is handed to the browser by hand instead of reaching a child HWND — and it overrides *both* `OnMouseDown` and `OnMouseDoubleClick`, each calling `SendMouseInput`. Its own spec says so in both places:

> **OnMouseDown** — "This is an event handler for WPF control's OnMouseDown event. We use CoreWebView2CompositionController.SendMouseInput to send the mouse input to our browser."
>
> **OnMouseDoubleClick** — "This is an event handler for WPF control's OnMouseDoubleClick event. We use CoreWebView2CompositionController.SendMouseInput to send the input to our browser."

(verbatim from `Microsoft.Web.WebView2.Wpf.xml` in the 1.0.3912.50 package we reference, and from the [published spec](https://github.com/MicrosoftEdge/WebView2Feedback/blob/main/specs/WPF_WebView2CompositionControl.md))

In WPF the two are not alternatives. A double click raises `MouseDown → MouseUp → MouseDown → MouseUp → MouseDoubleClick` — the second click always arrives as a MouseDown *and* as a MouseDoubleClick. Forwarding both means the browser is told about that second click twice.

## The fix

Override `OnMouseDoubleClick` and do not call base. The click still gets through via `OnMouseDown`, carrying its own `ClickCount` — the page was already reading `detail=2` from it, which is what proves the count does not depend on the second delivery.

The investigation logs are removed; what they established is in the comment on the override, which is where someone hits this next.

## Scope

Only the chat pane uses this control (the CLI pane is ConPTY), so this covers it.

## Not reported upstream

No matching issue on WebView2Feedback — searched `SendMouseInput`, `CompositionControl mouse`, duplicate/double-click variants. The known `WebView2CompositionControl` regressions (#5566, #5189, #5124, #5205) are about rendering, disposal, external drop and blur. Worth filing separately; the trace above is the evidence.

## Verification

Builds are green through CI. **The manual check in the experimental instance has not been run yet** — double-click a word in the chat and confirm it selects the word rather than the paragraph. That is the one thing this change can get wrong: if the browser's click count came from the MouseDoubleClick delivery rather than from `ClickCount` on MouseDown, dropping it would break double click entirely instead of fixing it. The `detail=2` in the trace argues against that, but it has not been observed post-fix.
