### PR TITLE
fix(chat): move the composer's left-hand tooltips off the placeholder

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-attach-menu.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-attach-menu.ts
@@ -110,9 +110,12 @@ export class CvAttachMenu extends LitElement {
             <!-- Outside the menu: inside it the tooltip would be a menu child, and fluent-menu lays
                  out only its trigger and its list. Anchored to the same id the list uses — one
                  names the anchor, the other looks the element up, and they don't collide. -->
-            <fluent-tooltip anchor="attach-tip" positioning="above-start">
-                <span class="tip-name">Add</span>
-                <span class="tip-action">A file from disk, or a path from the workspace</span>
+            <!-- positioning=before, like the slash trigger next to it: opening above would land on
+                 the placeholder, and beside the button is the only direction with nothing under it.
+                 tip-desc, not tip-action: alone, the smaller action size reads as a footnote to
+                 something that isn't there. -->
+            <fluent-tooltip anchor="attach-tip" positioning="before">
+                <span class="tip-desc">A file from disk, or a path from the workspace</span>
             </fluent-tooltip>
         `;
     }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-ide-context-badge.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-ide-context-badge.ts
@@ -11,6 +11,7 @@ import type { IdeContextNotification, SetSendSelectionNotification } from '../..
 import { bridge } from '../../core/bridge';
 import { Msg } from '../../core/bridge-messages';
 import { iconUrl } from '../../core/icon-url';
+import { displayPathUi } from '../paths';
 import { iconStyles, tooltipStyles } from '../styles/shared';
 
 /**
@@ -168,16 +169,17 @@ export class CvIdeContextBadge extends LitElement {
                 <span class="name"><bdi>${ctx.fileName}</bdi></span>
                 ${lineInfo ? html`<span class="info">${lineInfo}</span>` : nothing}
             </fluent-button>
-            <!-- The chip truncates the name, so the tooltip is where it can be read in full. -->
-            <fluent-tooltip anchor="ide-badge" positioning="above-start">
-                <span class="tip-name">${ctx.fileName}${lineInfo}</span>
-                <span class="tip-action">
-                    ${
-                        this._enabled
-                            ? 'Goes with every message — click to stop'
-                            : 'Is not sent — click to include it'
-                    }
-                </span>
+            <!-- The path, not the bare name the chip already shows: it says WHICH file, through
+                 displayPathUi so it follows "Show relative paths" like the tool rows and falls back
+                 to the full path outside the workdir. tip-desc for the second line, as on the model
+                 tooltip — tip-action's smaller size is for a third one. -->
+            <fluent-tooltip anchor="ide-badge" positioning="before">
+                <span class="tip-name">${displayPathUi(ctx.filePath)}${lineInfo}</span>
+                <!-- On one line on purpose: tooltipStyles sets white-space: pre-line, so a line
+                     break here would render as blank space inside the tooltip. -->
+                <span class="tip-desc"
+                    >${this._enabled ? 'Goes with every message — click to stop' : 'Is not sent — click to include it'}</span
+                >
             </fluent-tooltip>
         `;
     }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-slash-menu.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-slash-menu.ts
@@ -47,9 +47,14 @@ export class CvSlashMenu extends LitElement {
             >
                 ${unsafeHTML(SlashForward16Regular)}
             </fluent-button>
-            <fluent-tooltip anchor="slash-trigger" positioning="above-start">
-                <span class="tip-name">Commands</span>
-                <span class="tip-action">Every slash command, in one list</span>
+            <!-- positioning=before, not the above-start the triggers on the right use: this one
+                 sits against the textarea, and anything opening above it lands on the placeholder.
+                 There is no room on the inline-start side either, so Fluent flips it to the other
+                 side — which is the point: beside the button rather than over the text.
+                 tip-desc, not tip-action: alone, the smaller action size reads as a footnote to
+                 something that isn't there. -->
+            <fluent-tooltip anchor="slash-trigger" positioning="before">
+                <span class="tip-desc">Every slash command, in one list</span>
             </fluent-tooltip>
         `;
     }


### PR DESCRIPTION
## The problem

The `/`, `+` and file-context triggers sit against the textarea. Their tooltips open `above-start`, which puts them straight onto the placeholder you are about to type over — the one thing in the composer you might be reading when your mouse is down there.

The seven triggers on the right (`High`, `Opus`, `Auto-edit`, mic, send, context, thinking) don't have the problem: they open past the end of the line, over nothing.

## Position

`positioning=before` puts these three beside the button instead. There is no room on the inline-start side, so Fluent flips them to the other side — which is the point: beside the button rather than over the text.

The other eleven positions were tried in the running WebView:

- `above-*` — lands on the placeholder, which is the bug
- `above-end` — clears the text, but with no width to the left it breaks into a four-word column against the edge
- `below-*` — flipped back up; the composer sits on the bottom edge of the pane
- `after-*` — leaves the tooltip stranded at the far side, with no visual link to the button being pointed at

## Content

`/` and `+` carried a heading that wasn't earning its line: "Commands" over a `/` button, "Add" over a `+`. The convention in `shared.ts` has `tip-name` carry *which setting is on* — neither of these has a state, so the line existed only to be a heading.

The file chip keeps a first line, but showing the **path** instead of the file name the chip already displays. It says *which* file — two `Program.cs` from different projects were indistinguishable — and goes through `displayPathUi`, so it follows the existing "Show relative paths" option like the tool rows do, full path when the file is outside the working directory.

The remaining line moves from `tip-action` to `tip-desc`. `tip-action` is a smaller size meant for a third line under the other two; on its own it read as a footnote to something that wasn't there.

## Testing

Typecheck and lint clean (the 7 `any` warnings are pre-existing), prettier run, WebView built. Positions were tried live in the experimental instance through DevTools before being written down — that's where `above-end`, `below-start` and `after-top` were ruled out.
