### PR TITLE
perf(chat): build only the diff lines the preview can show

### DIFF
--- a/docs/chat/diff.md
+++ b/docs/chat/diff.md
@@ -6,9 +6,10 @@ edit — with the full editor.
 
 ## Inline diff
 
-Each Edit/Write tool row renders a diff: added/removed lines with configurable context
-(**Options → Chat → Diff context lines**) and an optional **Ignore whitespace**. Expand it to a
-full-screen viewer with four view modes:
+Each Edit/Write tool row renders a preview of the diff: the added/removed lines with a few lines of
+context around them, and an optional **Ignore whitespace** (**Options → Chat → Diff**). A large
+change is cut short here — expand it for a full-screen viewer with the whole diff and four view
+modes:
 
 - **Split** — side-by-side.
 - **Unified** — one column, changes interleaved.

--- a/docs/options.md
+++ b/docs/options.md
@@ -33,7 +33,6 @@ go to `%LOCALAPPDATA%` — see [Settings and data](settings-and-data.md).
 | Use Ctrl+Enter to send | bool | `false` | On: Ctrl+Enter sends, Enter = newline. Off: Enter sends, Shift+Enter = newline. |
 | Initial permission mode | `Default` / `AcceptEdits` / `Plan` | `Default` | Mode every new chat starts in (changeable per-session from the toolbar). `Default` = ask before edits. |
 | Allow dangerously skip permissions | bool | `false` | Enables the toolbar's "Bypass permissions" (never asks — even for dangerous commands). |
-| Diff — preview context lines | int | `10` | Context lines around changes in the inline diff (the expand dialog always shows the full diff). |
 | Diff — ignore whitespace | bool | `false` | Ignore leading/trailing whitespace when computing the diff. |
 | Diff — show "Open diff in Visual Studio" button | bool | `true` | Show the VS-icon button on Edit/Write rows that opens the change in VS's native diff viewer. |
 | Respect `.gitignore` | bool | `true` | Also hide `.gitignore`-matched files/folders from the `@` picker (re-read on change, cached otherwise). |

--- a/src/Corsinvest.VisualStudio.Agents.Contracts/ToWebViewDtos.cs
+++ b/src/Corsinvest.VisualStudio.Agents.Contracts/ToWebViewDtos.cs
@@ -500,7 +500,6 @@ public class VsOptionsDto
     public bool UseCtrlEnterToSend { get; set; }
     public bool CompactOutputAskAnswers { get; set; }
     public bool AllowDangerouslySkipPermissions { get; set; }
-    public int DiffContextLines { get; set; }
     public bool DiffIgnoreWhitespace { get; set; }
     public bool ShowOpenDiffInVsButton { get; set; }
     public string[] AllowedUploadExtensions { get; set; }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.Payloads.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.Payloads.cs
@@ -38,7 +38,6 @@ internal sealed partial class WebViewBridge
             UseCtrlEnterToSend = chat.UseCtrlEnterToSend,
             CompactOutputAskAnswers = chat.CompactOutputAskAnswers,
             AllowDangerouslySkipPermissions = chat.AllowDangerouslySkipPermissions,
-            DiffContextLines = chat.DiffContextLines,
             DiffIgnoreWhitespace = chat.DiffIgnoreWhitespace,
             ShowOpenDiffInVsButton = chat.ShowOpenDiffInVsButton,
             AllowedUploadExtensions = NormalizeExtensions(chat.AllowedUploadFileExtensions),

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.cs
@@ -264,6 +264,34 @@ internal sealed partial class WebViewBridge(Microsoft.Web.WebView2.Wpf.WebView2C
         catch (Exception ex) { log.LogException("WebViewBridge.SetDocumentTitle", ex); }
     }
 
+    /// <summary>Evaluate `script` in the page and return its value, or null when the WebView is
+    /// gone or the script threw. ExecuteScriptAsync hands back the result JSON-encoded, so a
+    /// string comes out quoted and escaped — this unwraps it.
+    /// <para>Deliberately NOT a bridge message: the bridge only carries WebView→host requests, and
+    /// the host→WebView direction with a reply would mean correlation and timeouts built for a
+    /// single diagnostic caller. The cost is that the script is a string, so what it names in the
+    /// page is not checked by anything — keep such callers to diagnostics, where a rename that
+    /// slips through degrades a dialog instead of breaking a feature.</para></summary>
+    public async Task<string> EvalAsync(string script)
+    {
+        if (_disposed) { return null; }
+        try
+        {
+            var core = webView.CoreWebView2;
+            if (core == null) { return null; }
+            var json = await core.ExecuteScriptAsync(script);
+            // "null" is what the page returns for undefined too — both mean "nothing to show".
+            return string.IsNullOrEmpty(json) || json == "null"
+                ? null
+                : JsonConvert.DeserializeObject<string>(json);
+        }
+        catch (Exception ex)
+        {
+            log.LogException("WebViewBridge.Eval", ex);
+            return null;
+        }
+    }
+
     /// <summary>Give the WebView2 control the native (WPF) focus, so the keyboard actually reaches
     /// the page. Without this a JS `element.focus()` only shows a blinking caret while keystrokes
     /// still go to VS — the WebView host must own the focus first. Call before posting

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
@@ -220,31 +220,39 @@ public partial class ChatPaneControl : PaneControlBase
     /// the base's shared row). What a frozen or misbehaving chat comes down to is "which process is
     /// mine" — with several panes open that is otherwise a command-line hunt in Task Manager, so
     /// the renderer is the pane's own, resolved by frame, not the browser's whole list.</summary>
-    protected override IEnumerable<(string Label, string Value)> ExtraSessionInfo
+    protected override async Task<IEnumerable<(string Label, string Value)>> ExtraSessionInfoAsync()
     {
-        get
+        var renderer = _bridge == null ? null : await WithDeadline(_bridge.RendererProcessIdAsync(), "renderer PID");
+        return
+        [
+            ("WebView PID", _bridge?.BrowserProcessId?.ToString() ?? "(not started)"),
+            ("WebView renderer", renderer?.ToString() ?? "(unknown)"),
+        ];
+    }
+
+    /// <summary>The page's own diagnostic report — CLI state as the UI sees it, context usage, and
+    /// how heavy the transcript got in DOM nodes. None of it is reachable from here: it lives in
+    /// the WebView, so the page is asked for it already formatted (`window.cv.dump()` in
+    /// ui/debug.ts — renaming that helper silently empties this section).</summary>
+    protected override async Task<IEnumerable<string>> ExtraSessionSectionsAsync()
+    {
+        if (_bridge == null) { return []; }
+        var report = await WithDeadline(_bridge.EvalAsync("window.cv ? window.cv.dump() : null"), "diagnostic");
+        return string.IsNullOrWhiteSpace(report) ? [] : [report];
+    }
+
+    /// <summary>Await `call`, giving up after two seconds. Both info-dialog round-trips go through
+    /// the browser, which delivers on the UI thread: a renderer that is busy or gone would
+    /// otherwise leave the dialog waiting on a row that is only diagnostic.</summary>
+    private async Task<T> WithDeadline<T>(Task<T> call, string what)
+    {
+        var done = await Task.WhenAny(call, Task.Delay(2000)).ConfigureAwait(true);
+        if (done != call)
         {
-            yield return ("WebView PID", _bridge?.BrowserProcessId?.ToString() ?? "(not started)");
-            // Blocking on the UI thread, with a deadline. The round-trip is in-process and
-            // normally instant, but the answer comes back through the browser — which needs this
-            // same thread to deliver it. A renderer that is busy or gone therefore hangs the IDE
-            // on a row that is only diagnostic. Two seconds, then "(unknown)": nobody opens this
-            // dialog for the renderer PID badly enough to freeze Visual Studio over it.
-            var renderer = _bridge == null
-                ? null
-                : ThreadHelper.JoinableTaskFactory.Run(async () =>
-                {
-                    var call = _bridge.RendererProcessIdAsync();
-                    var done = await Task.WhenAny(call, Task.Delay(2000)).ConfigureAwait(true);
-                    if (done != call)
-                    {
-                        _log.Warn("[chat] renderer PID timed out — WebView not answering");
-                        return null;
-                    }
-                    return await call.ConfigureAwait(true);
-                });
-            yield return ("WebView renderer", renderer?.ToString() ?? "(unknown)");
+            _log.Warn($"[chat] {what} timed out — WebView not answering");
+            return default;
         }
+        return await call.ConfigureAwait(true);
     }
 
     /// <summary>Chat-only extras for the toolbar's "More" menu — the WebView DevTools and the

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated/VsOptionsDto.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated/VsOptionsDto.ts
@@ -13,7 +13,6 @@ export interface VsOptionsDto {
     useCtrlEnterToSend: boolean;
     compactOutputAskAnswers: boolean;
     allowDangerouslySkipPermissions: boolean;
-    diffContextLines: number;
     diffIgnoreWhitespace: boolean;
     showOpenDiffInVsButton: boolean;
     allowedUploadExtensions: string[];

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/patch-clamp.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/patch-clamp.ts
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+// Unified-patch trimming. Its own module, with no imports: plain text in, plain text out,
+// so it stays testable without pulling in jsdiff and the language tables `diff.ts` needs.
+
+/**
+ * Cut a patch down to `maxLines` of hunk content, dropping whole hunks past the cap and
+ * keeping the file header. Returns `patch` unchanged when it already fits.
+ *
+ * diff2html emits one row per patch line, so an inline preview that clips with `max-height`
+ * still builds every row of a large edit: a file with many scattered changes mounts hundreds
+ * of nodes for the dozen it shows. Cutting the patch is what keeps them out of the DOM —
+ * nothing is lost, since the expand dialog re-renders from the full strings.
+ */
+export function clampPatch(patch: string, maxLines: number): string {
+    const lines = patch.split('\n');
+    const kept: string[] = [];
+    let inHunk = false;
+    let rows = 0;
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        const startsHunk = line.startsWith('@@');
+        // Everything before the first hunk is the file header: free, and diff2html needs it to
+        // name the file. From there on every line is a rendered row, `@@` included.
+        if (startsHunk) {
+            // Take a hunk only if all of it fits, so the cut never leaves a header with no rows
+            // under it — diff2html would draw an empty file block. The first one is taken
+            // whatever its size and truncated below: dropping it would render nothing at all.
+            let size = 1;
+            while (i + size < lines.length && !lines[i + size].startsWith('@@')) {
+                size++;
+            }
+            if (rows > 0 && rows + size > maxLines) {
+                break;
+            }
+            inHunk = true;
+        } else if (inHunk && rows + 1 > maxLines) {
+            break;
+        }
+        if (inHunk) {
+            rows++;
+        }
+        kept.push(line);
+    }
+    return kept.length === lines.length ? patch : `${kept.join('\n')}\n`;
+}

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/state.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/state.ts
@@ -193,7 +193,6 @@ const _impl = new StoreImpl<AppState>({
         useCtrlEnterToSend: false,
         compactOutputAskAnswers: true,
         allowDangerouslySkipPermissions: false,
-        diffContextLines: 10,
         diffIgnoreWhitespace: false,
         showOpenDiffInVsButton: true,
         allowedUploadExtensions: [],

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/package.json
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/package.json
@@ -10,11 +10,11 @@
         "build:dev": "node tools/gen-bridge.mjs && node esbuild.config.mjs --dev",
         "dev": "node tools/gen-bridge.mjs && node esbuild.config.mjs --watch",
         "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
-        "test": "node --test \"core/**/*.test.ts\" \"ui/**/*.test.ts\"",
-        "lint": "eslint \"{core,ui}/**/*.ts\"",
-        "lint:fix": "eslint --fix \"{core,ui}/**/*.ts\"",
-        "format": "prettier --write \"{core,ui}/**/*.ts\" \"*.ts\"",
-        "format:check": "prettier --check \"{core,ui}/**/*.ts\" \"*.ts\"",
+        "test": "node --test \"tests/**/*.test.ts\"",
+        "lint": "eslint \"{core,ui,tests}/**/*.ts\"",
+        "lint:fix": "eslint --fix \"{core,ui,tests}/**/*.ts\"",
+        "format": "prettier --write \"{core,ui,tests}/**/*.ts\" \"*.ts\"",
+        "format:check": "prettier --check \"{core,ui,tests}/**/*.ts\" \"*.ts\"",
         "check": "npm run typecheck && npm run lint && npm run format:check && npm run test"
     },
     "dependencies": {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/exchanges.test.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/exchanges.test.ts
@@ -3,8 +3,8 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { buildGroups } from './exchanges.ts';
-import type { UiAssistantEntry, UiUserEntry } from './types';
+import { buildGroups } from '../core/exchanges.ts';
+import type { UiAssistantEntry, UiUserEntry } from '../core/types';
 
 const user = (id: number): UiUserEntry => ({ kind: 'text', id, role: 'user', text: `u${id}` });
 const bot = (id: number): UiAssistantEntry => ({

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/patch-clamp.test.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/patch-clamp.test.ts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright (C) 2026 Corsinvest Srl
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { clampPatch } from '../core/patch-clamp.ts';
+
+/** Rows diff2html would build: the hunks, `@@` headers included, minus the trailing newline. */
+function hunkLines(patch: string): number {
+    const lines = patch.split('\n');
+    const first = lines.findIndex((l) => l.startsWith('@@'));
+    return first < 0 ? 0 : lines.length - first - 1;
+}
+
+/** A unified patch with `hunks` hunks of `perHunk` body lines each, in jsdiff's shape. */
+function patchOf(hunks: number, perHunk: number): string {
+    const out = ['Index: f.ts', '='.repeat(67), '--- f.ts', '+++ f.ts'];
+    for (let h = 0; h < hunks; h++) {
+        const at = h * 100 + 1;
+        out.push(`@@ -${at},${perHunk} +${at},${perHunk} @@`);
+        for (let i = 0; i < perHunk; i++) {
+            out.push(i === 0 ? `-old ${h}.${i}` : ` ctx ${h}.${i}`);
+        }
+    }
+    return `${out.join('\n')}\n`;
+}
+
+test('clampPatch: un patch che ci sta torna identico', () => {
+    const patch = patchOf(1, 5);
+
+    // Same reference, not just same text: a short diff must not pay a copy.
+    assert.equal(clampPatch(patch, 60), patch);
+});
+
+test('clampPatch: taglia i hunk oltre il cap', () => {
+    // Scattered edits: many hunks, which is what makes a patch long even at low context.
+    const full = patchOf(20, 7);
+    const clamped = clampPatch(full, 60);
+
+    assert.ok(hunkLines(full) > 60, 'il patch di partenza deve superare il cap');
+    assert.ok(clamped.length < full.length, 'il patch deve essere accorciato');
+    assert.ok(hunkLines(clamped) <= 60, `corpo troppo lungo: ${hunkLines(clamped)}`);
+});
+
+test('clampPatch: taglia a confine di hunk, non a meta', () => {
+    // 8 rows per hunk (@@ + 7), cap 20 → 2 whole hunks = 16; a third would reach 24.
+    const clamped = clampPatch(patchOf(20, 7), 20);
+    const hunks = clamped.split('\n').filter((l) => l.startsWith('@@')).length;
+
+    assert.equal(hunks, 2, 'deve tenere i hunk interi che ci stanno');
+    assert.equal(hunkLines(clamped), 16);
+});
+
+test('clampPatch: tiene l header del file, non solo le prime righe', () => {
+    const clamped = clampPatch(patchOf(20, 7), 10);
+
+    // Without the header diff2html has no file name and renders nothing usable.
+    assert.match(clamped, /^Index: /m);
+    assert.match(clamped, /^--- /m);
+    assert.match(clamped, /^\+\+\+ /m);
+    assert.match(clamped, /^@@ /m);
+});
+
+test('clampPatch: un solo hunk piu lungo del cap viene comunque tagliato', () => {
+    // One contiguous block of changes: there is no hunk boundary to cut at.
+    const clamped = clampPatch(patchOf(1, 200), 40);
+
+    assert.equal(hunkLines(clamped), 40, 'deve fermarsi esattamente al cap');
+});
+
+test('clampPatch: un patch senza hunk (nessuna modifica) resta intatto', () => {
+    const patch = 'Index: f.ts\n===\n--- f.ts\n+++ f.ts\n';
+
+    assert.equal(clampPatch(patch, 10), patch);
+});

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/time.test.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/time.test.ts
@@ -3,7 +3,7 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { formatTimeAgo } from './time.ts';
+import { formatTimeAgo } from '../core/time.ts';
 
 const MINUTE = 60_000;
 const HOUR = 3600_000;

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/transcript.test.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/transcript.test.ts
@@ -3,8 +3,8 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { Transcript } from './transcript.ts';
-import type { UiEntry, UiToolEntry, UiUserEntry } from './types';
+import { Transcript } from '../core/transcript.ts';
+import type { UiEntry, UiToolEntry, UiUserEntry } from '../core/types';
 
 function userEntry(id: number, text = 't'): UiUserEntry {
     return { kind: 'text', id, role: 'user', text };

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tsconfig.test.json
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tsconfig.test.json
@@ -7,8 +7,8 @@
         "allowImportingTsExtensions": true,
         "types": ["node"]
     },
-    // The base excludes *.test.ts so the app build ignores them; restate it here without that
+    // The base excludes tests so the app build ignores them; restate it here without that
     // entry, or extends would cancel the include below.
-    "include": ["core/**/*.test.ts", "ui/**/*.test.ts"],
+    "include": ["tests/**/*.test.ts"],
     "exclude": ["node_modules", "dist"]
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-diff-preview.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-diff-preview.ts
@@ -5,9 +5,26 @@
 import { LitElement, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { buildPatch } from '../../core/diff';
+import { clampPatch } from '../../core/patch-clamp';
 import { state as appState } from '../../core/state';
 import { renderDiff, SPLIT_THRESHOLD, type DiffFormat } from '../diff';
 import { observeSize } from '../resize';
+
+/** Unchanged lines kept around each change — what git and GitHub show. */
+const CONTEXT_LINES = 3;
+
+/** Rows the preview is tall enough to show. Measured: diff2html's compact row is ~20.6px. */
+const VISIBLE_ROWS = 12;
+
+/**
+ * Patch lines built at all — tied to what fits, because the box does not scroll vertically
+ * (see `_draw`: overflow-y is hidden, only the horizontal one is left to diff2html). A line
+ * past the visible ones is DOM nobody can reach; the full diff lives in the expand dialog.
+ *
+ * Not a context setting either: context is per hunk, so a file with scattered edits produces
+ * many hunks and a long patch whatever the context.
+ */
+const MAX_PATCH_LINES = VISIBLE_ROWS;
 
 /**
  * Inline diff preview for tool rows (Edit / Write / MultiEdit). Lit emits only
@@ -70,21 +87,24 @@ export class CvDiffPreview extends LitElement {
         if (!wrap) {
             return;
         }
-        const previewLines = appState.ui.diffContextLines;
-        this._patch = buildPatch(
-            this.oldString,
-            this.newString,
-            this.filePath,
-            previewLines,
-            appState.ui.diffIgnoreWhitespace,
+        // Clamp the patch, not just the height: the cap below hides rows diff2html has already
+        // built, so a large edit would sit in the DOM in full to show a dozen lines.
+        this._patch = clampPatch(
+            buildPatch(
+                this.oldString,
+                this.newString,
+                this.filePath,
+                CONTEXT_LINES,
+                appState.ui.diffIgnoreWhitespace,
+            ),
+            MAX_PATCH_LINES,
         );
         const fmt: DiffFormat =
             this.offsetWidth >= SPLIT_THRESHOLD ? 'side-by-side' : 'line-by-line';
         this._format = fmt;
-        // Height cap ~20px/row clips to the first N lines. Horizontal scroll is
-        // owned by diff2html per-pane (.d2h-file-side-diff / .d2h-file-diff);
-        // a wrap-level x-scroll would merge panes and break scroll-syncing.
-        wrap.style.maxHeight = `${previewLines * 20 + 8}px`;
+        // Horizontal scroll is owned by diff2html per-pane (.d2h-file-side-diff /
+        // .d2h-file-diff); a wrap-level x-scroll would merge panes and break scroll-syncing.
+        wrap.style.maxHeight = `${VISIBLE_ROWS * 20 + 8}px`;
         wrap.style.overflowY = 'hidden';
         wrap.style.overflowX = 'hidden';
         wrap.innerHTML = '';

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/debug.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/debug.ts
@@ -5,6 +5,7 @@
 // Diagnostic helpers on `window.cv` (always installed): cv.info() logs a
 // report to DevTools; cv.dump() returns a string for bug reports.
 
+import { consumedTokens } from '../core/ai-models';
 import { state } from '../core/state';
 
 interface MemoryInfo {
@@ -20,127 +21,369 @@ function fmtMb(bytes: number | undefined): string {
     return (bytes / 1048576).toFixed(1) + ' MB';
 }
 
+function fmtDuration(ms: number): string {
+    const s = Math.floor(ms / 1000);
+    const h = Math.floor(s / 3600);
+    const m = Math.floor((s % 3600) / 60);
+    return h > 0 ? `${h}h ${m}m` : m > 0 ? `${m}m ${s % 60}s` : `${s}s`;
+}
+
 function getMemory(): MemoryInfo | null {
-    // performance.memory is Chromium-only (WebView2 has it).
+    // performance.memory is Chromium-only (WebView2 has it). It measures the JS heap only —
+    // the DOM lives in native memory, so the node counts below are the better size signal.
     const perf = performance as Performance & { memory?: MemoryInfo };
     return perf.memory ?? null;
 }
 
+/** Walk the page, entering every shadow root. */
+function walkAll(visit: (el: Element) => void, root: ParentNode = document.body): void {
+    for (const el of root.querySelectorAll('*')) {
+        visit(el);
+        if (el.shadowRoot) {
+            walkAll(visit, el.shadowRoot);
+        }
+    }
+}
+
+/** Elements inside `el`, its own shadow root included. */
+function nodesIn(el: Element): number {
+    let n = 0;
+    const count = (): void => {
+        n++;
+    };
+    if (el.shadowRoot) {
+        walkAll(count, el.shadowRoot);
+    }
+    walkAll(count, el);
+    return n;
+}
+
+/** What a transcript row is made of, which is what decides its cost. */
+type RowKind = 'diff' | 'code' | 'table' | 'image' | 'text';
+
+function rowKind(el: Element): RowKind {
+    let kind: RowKind = 'text';
+    walkAll((e) => {
+        const t = e.localName;
+        // First match wins by weight: a diff dwarfs everything else in the same row.
+        if (t === 'cv-diff-preview') {
+            kind = 'diff';
+        } else if (kind !== 'diff' && t === 'table') {
+            kind = 'table';
+        } else if (kind === 'text' && t === 'pre') {
+            kind = 'code';
+        } else if (kind === 'text' && t === 'img') {
+            kind = 'image';
+        }
+    }, el);
+    return kind;
+}
+
+interface DomStats {
+    /** Elements in the page, shadow roots included — the number that tracks chat weight.
+     *  A plain querySelectorAll stops at each shadow boundary and misses most of them. */
+    nodes: number;
+    shadowRoots: number;
+    toolRows: number;
+    messages: number;
+    diffPreviews: number;
+    attachments: number;
+    /** Nodes per top-level row, so a heavy chat can be told from a merely long one. */
+    nodesPerRow: number;
+    heaviestRow: number;
+    /** Nodes and row count per content kind: says WHAT is costing, not just how much. */
+    byKind: Record<string, { rows: number; nodes: number; avg: number }>;
+}
+
+function domStats(): DomStats {
+    let nodes = 0;
+    let shadowRoots = 0;
+    walkAll((el) => {
+        nodes++;
+        if (el.shadowRoot) {
+            shadowRoots++;
+        }
+    });
+
+    // Top-level rows only: a nested row is already counted inside its parent.
+    const rows: Element[] = [];
+    const collect = (root: ParentNode): void => {
+        for (const el of root.querySelectorAll('*')) {
+            if (el.localName === 'cv-message' || el.localName === 'cv-tool-row') {
+                rows.push(el);
+                continue;
+            }
+            if (el.shadowRoot) {
+                collect(el.shadowRoot);
+            }
+        }
+    };
+    collect(document.body);
+
+    const byKind: DomStats['byKind'] = {};
+    let heaviest = 0;
+    let rowNodes = 0;
+    for (const el of rows) {
+        const n = nodesIn(el);
+        rowNodes += n;
+        heaviest = Math.max(heaviest, n);
+        const k = rowKind(el);
+        const acc = (byKind[k] ??= { rows: 0, nodes: 0, avg: 0 });
+        acc.rows++;
+        acc.nodes += n;
+    }
+    for (const acc of Object.values(byKind)) {
+        acc.avg = +(acc.nodes / acc.rows).toFixed(1);
+    }
+
+    return {
+        nodes,
+        shadowRoots,
+        toolRows: rows.filter((r) => r.localName === 'cv-tool-row').length,
+        messages: rows.filter((r) => r.localName === 'cv-message').length,
+        diffPreviews: document.querySelectorAll('cv-diff-preview').length,
+        attachments:
+            (
+                document.querySelector('cv-prompt') as HTMLElement | null
+            )?.shadowRoot?.querySelectorAll('#attachments cv-attach-chip').length ?? 0,
+        nodesPerRow: rows.length ? +(rowNodes / rows.length).toFixed(1) : 0,
+        heaviestRow: heaviest,
+        byKind,
+    };
+}
+
 interface Snapshot {
     app: {
+        version: string;
         theme: string;
-        permissionMode: string;
-        currentModel: string | null;
         workingDirectory: string;
-        isBusy: boolean;
+        sessionId: string;
         initialized: boolean;
+        inDev: boolean;
         logLevel: number;
         perfEnabled: boolean;
+        /** How long this page has been up. A renderer open since this morning reads its memory
+         *  numbers differently from one opened a minute ago. */
+        uptime: string;
+    };
+    /** What the CLI is running with — the first question on any "it answered wrong" report. */
+    cli: {
+        model: string | null;
+        permissionMode: string;
+        effort: string;
+        thinking: boolean;
+        ultracode: boolean;
+        fastMode: boolean;
+        isBusy: boolean;
+        status: string;
+        subagents: number;
+    };
+    /** Token usage against the window: a chat that compacted on its own explains itself here. */
+    context: {
+        window: number;
+        used: number;
+        pctOfWindow: string;
+        cacheRead: number;
+        cacheCreation: number;
     };
     options: {
         previewLines: number;
-        diffContextLines: number;
         diffIgnoreWhitespace: boolean;
         showCostAndDuration: boolean;
         showRelativePaths: boolean;
         stickyUserMessages: boolean;
+        showInlineToolErrors: boolean;
+        chatFontSize: number;
     };
     memory: { used: string; total: string; limit: string };
-    dom: {
-        toolRows: number;
-        messages: number;
-        diffPreviews: number;
-        attachments: number;
-    };
-    viewport: { width: number; height: number };
+    dom: DomStats;
+    history: { hasMore: boolean; loadingOlder: boolean; oldestOffset: number };
+    ide: { contextEnabled: boolean; hasContext: boolean };
+    viewport: { width: number; height: number; dpr: number };
 }
 
 function snapshot(): Snapshot {
     const mem = getMemory();
+    const u = state.contextUsage;
+    // The gauge's own sum, so the dialog and the ring can never disagree — note it leaves out
+    // outputTokens, which are not in the window yet when the reading is taken.
+    const used = u ? consumedTokens(u) : 0;
+    const win = state.contextWindow;
     return {
         app: {
+            version: state.ui.appVersion || '(unknown)',
             theme: state.theme,
-            permissionMode: state.permissionMode,
-            currentModel: state.currentModel,
             workingDirectory: state.workingDirectory,
-            isBusy: state.isBusy,
+            sessionId: state.currentSessionId || '(none)',
             initialized: state.initialized,
+            inDev: state.inDev,
             logLevel: state.ui.logLevel,
             perfEnabled: state.ui.perfEnabled,
+            uptime: fmtDuration(performance.now()),
+        },
+        cli: {
+            model: state.currentModel,
+            permissionMode: state.permissionMode,
+            effort: state.effortLevel,
+            thinking: state.thinkingEnabled,
+            ultracode: state.ultracodeEnabled,
+            fastMode: state.fastMode,
+            isBusy: state.isBusy,
+            status: state.status || '(idle)',
+            subagents: state.subagentTasks.length,
+        },
+        context: {
+            window: win,
+            used,
+            pctOfWindow: win ? `${((used / win) * 100).toFixed(1)}%` : 'n/a',
+            cacheRead: u?.cacheReadTokens ?? 0,
+            cacheCreation: u?.cacheCreationTokens ?? 0,
         },
         options: {
             previewLines: state.ui.previewLines,
-            diffContextLines: state.ui.diffContextLines,
             diffIgnoreWhitespace: state.ui.diffIgnoreWhitespace,
             showCostAndDuration: state.ui.showCostAndDuration,
             showRelativePaths: state.ui.showRelativePaths,
             stickyUserMessages: state.ui.stickyUserMessages,
+            showInlineToolErrors: state.ui.showInlineToolErrors,
+            chatFontSize: state.ui.chatFontSize,
         },
         memory: {
             used: fmtMb(mem?.usedJSHeapSize),
             total: fmtMb(mem?.totalJSHeapSize),
             limit: fmtMb(mem?.jsHeapSizeLimit),
         },
-        dom: {
-            toolRows: document.querySelectorAll('cv-tool-row').length,
-            messages: document.querySelectorAll('cv-message').length,
-            diffPreviews: document.querySelectorAll('cv-diff-preview').length,
-            attachments:
-                (
-                    document.querySelector('cv-prompt') as HTMLElement | null
-                )?.shadowRoot?.querySelectorAll('#attachments cv-attach-chip').length ?? 0,
+        dom: domStats(),
+        history: {
+            hasMore: state.hasMoreHistory,
+            loadingOlder: state.loadingOlder,
+            oldestOffset: state.oldestLoadedOffset,
+        },
+        ide: {
+            contextEnabled: state.ideContextEnabled,
+            hasContext: state.ideContext !== null,
         },
         viewport: {
             width: window.innerWidth,
             height: window.innerHeight,
+            dpr: window.devicePixelRatio,
         },
     };
+}
+
+/** Sections in the order they answer questions: what is running, then what it is chewing on,
+ *  then how heavy the page got. Shared by every renderer so they never drift apart. */
+function sections(s: Snapshot): [string, Record<string, unknown>][] {
+    // byKind is a table of its own, rendered separately by each caller.
+    const dom: Record<string, unknown> = { ...s.dom };
+    delete dom.byKind;
+    return [
+        ['app', s.app],
+        ['cli', s.cli],
+        ['context', s.context],
+        ['dom', dom],
+        ['memory', s.memory],
+        ['history', s.history],
+        ['ide', s.ide],
+        ['options', s.options],
+        ['viewport', s.viewport],
+    ];
+}
+
+/** Kinds sorted by weight, with each one's share of the page. */
+function kindRows(
+    s: Snapshot,
+): { kind: string; rows: number; nodes: number; avg: number; share: string }[] {
+    return Object.entries(s.dom.byKind)
+        .sort((a, b) => b[1].nodes - a[1].nodes)
+        .map(([kind, v]) => ({
+            kind,
+            rows: v.rows,
+            nodes: v.nodes,
+            avg: v.avg,
+            share: s.dom.nodes ? `${((v.nodes / s.dom.nodes) * 100).toFixed(0)}%` : '0%',
+        }));
 }
 
 /** Pretty-print the current diagnostic snapshot to the DevTools console. */
 function info(): void {
     const s = snapshot();
     console.group('%c[cv4vs] info', 'color:#3794ff;font-weight:bold');
-    console.log('app', s.app);
-    console.log('options', s.options);
-    console.log('memory', s.memory);
-    console.log('dom', s.dom);
-    console.log('viewport', s.viewport);
+    for (const [title, obj] of sections(s)) {
+        console.log(title, obj);
+    }
+    // A table beats a nested object here: the whole point is comparing kinds by weight.
+    console.table(kindRows(s));
     console.groupEnd();
 }
 
-/** Diagnostic report string for bug reports: counts/flags only, no cv-message content. */
+/** Diagnostic report as plain text — for reading in the console, where markdown pipes and
+ *  dashes are noise. Counts and flags only, never cv-message content. */
 function dump(): string {
     const s = snapshot();
-    const lines: string[] = [];
-    lines.push('=== cv4vs diagnostic ===');
-    lines.push('-- app --');
-    for (const [k, v] of Object.entries(s.app)) {
-        lines.push(`  ${k}: ${v}`);
+    const lines = ['=== cv4vs diagnostic ==='];
+    for (const [title, obj] of sections(s)) {
+        lines.push(`-- ${title} --`);
+        for (const [k, v] of Object.entries(obj)) {
+            lines.push(`  ${k}: ${v}`);
+        }
     }
-    lines.push('-- options --');
-    for (const [k, v] of Object.entries(s.options)) {
-        lines.push(`  ${k}: ${v}`);
+    lines.push('-- dom by kind --');
+    for (const r of kindRows(s)) {
+        lines.push(`  ${r.kind}: ${r.rows} rows, ${r.nodes} nodes, avg ${r.avg} (${r.share})`);
     }
-    lines.push('-- memory --');
-    lines.push(`  used:  ${s.memory.used}`);
-    lines.push(`  total: ${s.memory.total}`);
-    lines.push(`  limit: ${s.memory.limit}`);
-    lines.push('-- dom --');
-    for (const [k, v] of Object.entries(s.dom)) {
-        lines.push(`  ${k}: ${v}`);
-    }
-    lines.push('-- viewport --');
-    lines.push(`  ${s.viewport.width} x ${s.viewport.height}`);
     return lines.join('\n');
+}
+
+/** Diagnostic report as markdown — for pasting into an issue, where the tables render and a
+ *  `<details>` keeps it from burying the actual report. */
+function dumpMarkdown(): string {
+    const s = snapshot();
+    const out = ['<details>', '<summary>cv4vs diagnostic</summary>', ''];
+    for (const [title, obj] of sections(s)) {
+        out.push(`**${title}**`, '', '| | |', '|---|---|');
+        for (const [k, v] of Object.entries(obj)) {
+            out.push(`| ${k} | \`${v}\` |`);
+        }
+        out.push('');
+    }
+    const kinds = kindRows(s);
+    if (kinds.length) {
+        out.push(
+            '**dom by kind**',
+            '',
+            '| kind | rows | nodes | avg | share |',
+            '|---|---|---|---|---|',
+        );
+        for (const r of kinds) {
+            out.push(`| ${r.kind} | ${r.rows} | ${r.nodes} | ${r.avg} | ${r.share} |`);
+        }
+        out.push('');
+    }
+    out.push('</details>');
+    return out.join('\n');
 }
 
 /**
  * Install `window.cv` with the public helpers. Called once from init().
+ *
+ * `info` reads in the console, `dump` is the same report as plain text, `markdown` is the shape
+ * an issue renders. No copy helper: the pane's Info dialog already has a Copy button, and it is
+ * `dump()` that it shows — see ChatPaneControl.ExtraSessionSections, which calls it BY NAME
+ * through ExecuteScriptAsync. Renaming these silently empties that dialog's last section.
  */
 export function installDebugApi(): void {
-    (window as unknown as { cv: { info: typeof info; dump: typeof dump } }).cv = {
+    (
+        window as unknown as {
+            cv: {
+                info: typeof info;
+                dump: typeof dump;
+                markdown: typeof dumpMarkdown;
+            };
+        }
+    ).cv = {
         info,
         dump,
+        markdown: dumpMarkdown,
     };
 }

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/DevInfoDialog.xaml
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/DevInfoDialog.xaml
@@ -1,6 +1,8 @@
 <!-- Fixed size + NoResize, same as AboutDialog: a resizable dialog gets picked up and tiled
-     by window managers instead of floating over the IDE. The info text scrolls, so a fixed
-     width costs nothing. -->
+     by window managers instead of floating over the IDE. The info text scrolls, so fixed
+     bounds cost nothing.
+     Height is fixed rather than SizeToContent: the WebView's diagnostic section makes the
+     content several screens tall, and a dialog sized to it would run off the display. -->
 <vsui:DialogWindow x:Class="Corsinvest.VisualStudio.Agents.Core.Panes.DevInfoDialog"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -11,7 +13,7 @@
         xmlns:platformui="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Imaging"
         toolkit:Themes.UseVsTheme="True"
         Title="Info"
-        Width="760" SizeToContent="Height"
+        Width="760" Height="620"
         WindowStartupLocation="CenterOwner"
         ResizeMode="NoResize"
         ShowInTaskbar="False"
@@ -37,7 +39,7 @@
              AcceptsReturn="True"
              VerticalScrollBarVisibility="Auto"
              HorizontalScrollBarVisibility="Auto"
-             MinWidth="440" MinHeight="120" />
+             MinWidth="440" />
 
     <Button Grid.Row="1" x:Name="BtnCopy" Click="OnCopy_Click"
             HorizontalAlignment="Right" MinWidth="72" Margin="0,12,0,0"

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/IPaneControl.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/IPaneControl.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Corsinvest.VisualStudio.Agents.Core.Panes;
 
@@ -77,8 +78,10 @@ public interface IPaneControl
     IEnumerable<ButtonAction> MoreMenuActions { get; }
 
     /// <summary>Show this pane's session info (id, session file, workdir, CLI) for debug and bug
-    /// reports. Same dialog for both kinds — the base builds it from the pane's Entry.</summary>
-    void ShowSessionInfo();
+    /// reports. Same dialog for both kinds — the base builds it from the pane's Entry.
+    /// <para>Async because the chat's rows come back from its WebView, which answers on the UI
+    /// thread: gathering them has to yield it, not hold it.</para></summary>
+    Task ShowSessionInfoAsync();
 
     /// <summary>Real teardown when the pane's frame closes for good: drop the
     /// registry entry and release resources (CLI: kill ConPTY; Chat: dispose

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneControlBase.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneControlBase.cs
@@ -4,10 +4,12 @@
  */
 
 using Corsinvest.VisualStudio.Agents.Core.Client;
+using Microsoft.VisualStudio.Shell;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 
@@ -113,18 +115,33 @@ public abstract class PaneControlBase : UserControl, IPaneControl
     /// dialog's row is built once here rather than duplicated per kind.</summary>
     protected abstract int CliProcessId { get; }
 
-    /// <summary>Extra info rows for <see cref="ShowSessionInfo"/>, appended after the shared ones
-    /// and after the CLI PID. Chat adds the WebView2 processes; the CLI pane adds none — its
+    /// <summary>Extra info rows for <see cref="ShowSessionInfoAsync"/>, appended after the shared
+    /// ones and after the CLI PID. Chat adds the WebView2 processes; the CLI pane adds none — its
     /// process is the shared row. Kept as label/value pairs rather than formatted lines so the
     /// base owns the column alignment — a longer label added here must not leave the whole dialog
-    /// ragged.</summary>
-    protected virtual IEnumerable<(string Label, string Value)> ExtraSessionInfo => [];
+    /// ragged.
+    /// <para>Async for the same reason as <see cref="ExtraSessionSectionsAsync"/>: the chat's rows
+    /// come from WebView2, which answers on the UI thread.</para></summary>
+    protected virtual Task<IEnumerable<(string Label, string Value)>> ExtraSessionInfoAsync()
+        => Task.FromResult<IEnumerable<(string Label, string Value)>>([]);
+
+    /// <summary>Free-form sections appended below the aligned rows, each already formatted.
+    /// Separate from <see cref="ExtraSessionInfo"/> because these are not label/value: the chat's
+    /// WebView report is a block of its own with its own inner layout, and forcing it through the
+    /// column alignment above would only mangle it.
+    /// <para>Async because a pane may have to ask something that answers on the UI thread — see
+    /// the chat's, which asks its WebView. Awaited before the dialog opens, never blocked on.</para></summary>
+    protected virtual Task<IEnumerable<string>> ExtraSessionSectionsAsync()
+        => Task.FromResult<IEnumerable<string>>([]);
 
     /// <summary>Read-only session info (id, session file, workdir, CLI) for debug and bug reports.
     /// Built from <see cref="Entry"/>, which both pane kinds keep current — so the terminal gets the
     /// same dialog as the chat, with no duplicated code — plus whatever
-    /// <see cref="ExtraSessionInfo"/> adds for the kind.</summary>
-    public void ShowSessionInfo()
+    /// <see cref="ExtraSessionInfo"/> adds for the kind.
+    /// <para>Async all the way to the dialog: what the chat pane contributes comes back from the
+    /// WebView, which delivers on this very thread. Blocking on it here — even with a deadline —
+    /// deadlocks until that deadline and yields "(unknown)" rather than the answer.</para></summary>
+    public async Task ShowSessionInfoAsync()
     {
         try
         {
@@ -147,13 +164,22 @@ public abstract class PaneControlBase : UserControl, IPaneControl
                 ("CLI path", ClaudeInstall.ResolveExecutable() ?? "(not found)"),
                 ("CLI version", ClaudeInstall.Version() ?? "(unknown)"),
                 ("CLI PID", CliProcessId > 0 ? CliProcessId.ToString() : "(not running)"),
-                .. ExtraSessionInfo,
+                .. await ExtraSessionInfoAsync(),
             ];
 
             // Widest label decides the column, so an added row can't misalign the others.
             var width = rows.Max(r => r.Label.Length) + 2;
             var info = string.Join("\n", rows.Select(r => (r.Label + ":").PadRight(width) + r.Value));
 
+            var sections = (await ExtraSessionSectionsAsync())
+                .Where(s => !string.IsNullOrWhiteSpace(s))
+                .ToList();
+            if (sections.Count > 0)
+            {
+                info += "\n\n" + string.Join("\n\n", sections);
+            }
+
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
             new DevInfoDialog(info).ShowDialog();
         }
         catch (Exception ex) { OutputWindowLogger.Global.LogException("Pane.ShowSessionInfo", ex); }

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneToolbar.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneToolbar.xaml.cs
@@ -7,6 +7,7 @@ using Corsinvest.VisualStudio.Agents.Core.Sessions;
 using Corsinvest.VisualStudio.Agents.Helpers;
 using Corsinvest.VisualStudio.Agents.Options;
 using Microsoft.VisualStudio.Imaging;
+using Microsoft.VisualStudio.Shell;
 using System;
 using System.Linq;
 using System.Windows;
@@ -276,7 +277,11 @@ public partial class PaneToolbar : UserControl
         OpenContextMenu(BtnMore);
     }
 
-    private void OnMenu_Info(object sender, RoutedEventArgs e) => _pane.ShowSessionInfo();
+    // The dialog opens itself once the pane has gathered its rows — some of which come back from
+    // a WebView that answers on this thread, so the handler starts the work and returns rather
+    // than waiting on it. Failures are logged by ShowSessionInfoAsync's own catch.
+    private void OnMenu_Info(object sender, RoutedEventArgs e)
+        => _ = ThreadHelper.JoinableTaskFactory.RunAsync(() => _pane.ShowSessionInfoAsync());
 
     private void OnMenu_SessionsFolder(object sender, RoutedEventArgs e)
     {

--- a/src/Corsinvest.VisualStudio.Agents/Options/AgentsChatPage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Options/AgentsChatPage.cs
@@ -131,11 +131,6 @@ public class AgentsChatPage : AgentsOptionsPage
     public bool AllowDangerouslySkipPermissions { get; set; } = false;
 
     [Category("Diff")]
-    [DisplayName("Preview context lines")]
-    [Description("Number of context lines shown around changes in the inline diff preview. The expand dialog always shows the full diff. Default: 10.")]
-    public int DiffContextLines { get; set; } = 10;
-
-    [Category("Diff")]
     [DisplayName("Ignore whitespace")]
     [Description("Ignore leading and trailing whitespace when computing diff.")]
     public bool DiffIgnoreWhitespace { get; set; } = false;


### PR DESCRIPTION
## The problem

The inline diff preview clipped with `max-height` while diff2html had already
built one row per patch line. A large edit mounted hundreds of nodes to display
twelve — and the box has no vertical scroll, so every line past the visible ones
was DOM nobody could reach.

Measured on a day-long chat: **one diff held 1468 nodes, 20% of the entire page**.

## What changed

`clampPatch` cuts the patch before diff2html sees it, at a hunk boundary where
one fits and mid-hunk only when the first hunk alone overflows — dropping it
would render an empty file block.

| | before | after |
|---|---|---|
| heaviest row | 1468 nodes | **229** |
| diffs' share of the page | ~75% | **39%** |

Nothing is lost: the full diff was already one click away in the expand dialog.

**"Diff — preview context lines" is gone.** It fed two unrelated things at once
(jsdiff's context *and* the box height), and its default of 10 was why patches
were long to begin with — git and GitHub show 3. Three constants replace it,
each meaning one thing, with the line cap derived from what actually fits.

## Along the way

**A pre-existing deadlock.** `ShowSessionInfo` gathered the renderer PID with
`JoinableTaskFactory.Run` on the UI thread, waiting for an answer WebView2
delivers on that same thread. It never arrived — the dialog waited out the full
deadline and printed `(unknown)` every time. Now async to the caller.

**`window.cv` reports weight, not just counts.** It counted components, which
says how many and never how big; node counts are what decide whether a chat
feels slow, and `querySelectorAll` cannot see past a shadow boundary. It now
walks every root and breaks the count down by content kind — that breakdown is
how this bug was found. The pane's Info dialog appends the report, so collecting
it takes no DevTools.

Also fixed there: `context.used` summed `outputTokens`, which the gauge's own
`consumedTokens()` excludes — they are not in the window yet when the reading is
taken. It now calls that function, so the dialog and the ring cannot disagree.

## Verification

- MSBuild Debug: 0 errors
- `npm run check`: typecheck, lint, format, **30/30 tests** (6 new on `clampPatch`)
- Runtime self-check in the Exp instance: 17/18 (the one red is the checker
  looking for the gauge in the light DOM)
- Numbers above are from `cv.info()` before and after, on the same session

## Note

Test suites moved to `tests/`, so the test/lint/format globs and
`tsconfig.test.json` name one folder instead of two.
