### PR TITLE
fix(sessions): reject a sessionId that isn't a plain token before it reaches a path

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.cs
@@ -43,7 +43,19 @@ internal sealed partial class SessionManager
     // The session folder / a session .jsonl path for this instance's workdir, honouring
     // this instance's config-dir. One place each so the path construction lives in a single spot.
     private string FolderFor() => LongPath(_paths.SessionFolder(_workingDirectory));
-    private string FileFor(string sessionId) => LongPath(Path.Combine(_paths.SessionFolder(_workingDirectory), sessionId + ".jsonl"));
+
+    /// <summary>Null for an id that isn't a plain token, so a traversal never reaches Path.Combine.
+    /// <para>The id can come straight off a WebView DTO (<c>p.SessionId ?? client.SessionId</c> in
+    /// the history/image/document handlers), so <c>..\..\</c> in it would resolve out of the session
+    /// folder and hand back whatever it landed on as transcript. LongPath makes that worse: past 260
+    /// characters it prefixes <c>\\?\</c>, which tells Win32 to skip its own path normalisation.</para>
+    /// <para>Here rather than in each reader: this is the single spot the path is built, so every
+    /// caller inherits it, including ones written later. All of them test File.Exists on the result,
+    /// and File.Exists(null) is false — a rejected id degrades to "no such session".</para></summary>
+    private string FileFor(string sessionId)
+        => IsSafePathToken(sessionId)
+            ? LongPath(Path.Combine(_paths.SessionFolder(_workingDirectory), sessionId + ".jsonl"))
+            : null;
 
     /// <summary>Past 260 characters .NET Framework refuses the path outright — DirectoryNotFoundException
     /// on a file that is plainly there — and the CLI happily writes session files that long: its own


### PR DESCRIPTION
## The hole

`FileFor` built a session's `.jsonl` path straight from the id:

```csharp
LongPath(Path.Combine(_paths.SessionFolder(_workingDirectory), sessionId + ".jsonl"))
```

The id can come off a WebView DTO — the history, image and document handlers all take `p.SessionId ?? client.SessionId`. A `..\..\` in it resolved out of the session folder, and whatever file it landed on came back to the chat as transcript.

`LongPath` makes it worse rather than safer: past 260 characters it prefixes `\\?\`, which tells Win32 to skip its own path normalisation. The comment above it says as much — *"hands the path to Win32 unchecked"*.

## The fix

`IsSafePathToken` already existed (`SessionManager.Common.cs`, alphanumeric + `-_`) and was already applied in `ReadCompactSummary` and `ReadSubagentHistory`. `ReadHistoryRaw` and `ReadMessageBlock` — the two the WebView reaches — were the ones it had been left out of.

The check goes in `FileFor` rather than in each reader. That's the single place the path is built, so every caller inherits it, including ones written later. All twelve call sites test `File.Exists` on the result, and `File.Exists(null)` is false, so a rejected id degrades to "no such session" without a branch of its own.

`ReadCompactSummary` keeps its own guard: it also validates `boundaryUuid`.

## Testing

Driven through the bridge from DevTools in the experimental instance, posting `get_chat_history` with the id the WebView would normally supply:

| sessionId | result |
|---|---|
| `..\..\..\..\Windows\win` | `events: 0` |
| `../../../../etc/passwd` | `events: 0` |
| `a/b` | `events: 0` |
| `..` | `events: 0` |

No exception on any of them — the rejection is silent, as the other guarded readers already were.

The legitimate path still works: opening a session from the history picker in the same instance loaded its transcript and prompt history normally, which is the route through `ReadHistoryRaw` with a real id.

Green MSBuild.
