### PR TITLE
fix(client): every client operation reports its own failure

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Cli.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Cli.cs
@@ -77,17 +77,13 @@ internal sealed partial class WebViewMessageHandler
         // Hot-swap via set_permission_mode; every mode is supported so no respawn is
         // needed. The continuation runs off the UI thread, but bridge.Send marshals
         // CoreWebView2 access itself.
-        _ = client.SetPermissionModeAsync(newMode).ContinueWith(t =>
+        _ = client.SetPermissionModeAsync(newMode).ContinueWith(_ =>
         {
-            if (t.IsFaulted)
-            {
-                log.Warn($"!!! set_permission_mode failed: {t.Exception?.GetBaseException().Message}");
-            }
-            // Either way, tell the WebView what the mode REALLY is. The selector switched
-            // optimistically before asking, and the client only advances PermissionMode once
-            // the CLI has acked — so on failure this sends the old mode back and the UI rolls
-            // itself back. Without it the selector reads "Plan" while the CLI is still in
-            // bypass: the one lie that costs files.
+            // Failure or not — the client logs that itself — tell the WebView what the mode REALLY
+            // is. The selector switched optimistically before asking, and the client only advances
+            // PermissionMode once the CLI has acked, so on failure this sends the old mode back and
+            // the UI rolls itself back. Without it the selector reads "Plan" while the CLI is still
+            // in bypass: the one lie that costs files.
             bridge.Send(
                 BridgeMessages.ToWebView.Cli.PermissionModeChanged,
                 new Contracts.PermissionModeChangedNotification { Mode = client.PermissionMode });
@@ -97,12 +93,8 @@ internal sealed partial class WebViewMessageHandler
     private void HandleSetModel(JObject data, int? id)
     {
         var newModel = data.ToObject<Contracts.SetModelNotification>().Model;
-        _ = client.SetModelAsync(string.IsNullOrEmpty(newModel) ? null : newModel).ContinueWith(t =>
+        _ = client.SetModelAsync(string.IsNullOrEmpty(newModel) ? null : newModel).ContinueWith(_ =>
         {
-            if (t.IsFaulted)
-            {
-                log.Warn($"!!! set_model failed: {t.Exception?.GetBaseException().Message}");
-            }
             // Same rollback as the permission mode: the picker switched before asking, so echo
             // back what the client actually holds. Null means "Default", which the WebView
             // renders as such.

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Cli.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Cli.cs
@@ -65,17 +65,10 @@ internal sealed partial class WebViewMessageHandler
 
     private void HandleStop(JObject data, int? id)
     {
-        // The WebView frees itself the moment it asks (it can't wait on a wedged CLI), so a failed
-        // interrupt is invisible from the UI: it reads as stopped while the turn runs on. Nothing
-        // else observes this Task — the 10s request timeout would fault it into silence — so the
-        // log is the only place the divergence can surface.
-        _ = client.InterruptAsync().ContinueWith(t =>
-        {
-            if (t.IsFaulted)
-            {
-                log.Warn($"!!! interrupt failed: {t.Exception?.GetBaseException().Message}");
-            }
-        });
+        // Fire and forget: the WebView frees itself the moment it asks, since it can't wait on a
+        // wedged CLI. InterruptAsync logs its own failure — there is nothing to roll back here,
+        // unlike the model and permission handlers below.
+        _ = client.InterruptAsync();
     }
 
     private void HandleSetPermissionMode(JObject data, int? id)

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.cs
@@ -408,39 +408,61 @@ internal sealed partial class ClaudeClient : IClaudeClient
         return Task.CompletedTask;
     }
 
-    /// <summary>Starts a new empty session in the same working directory. Kills the current process and spawns a fresh one.</summary>
-    public Task NewSessionAsync()
+    /// <summary>Starts a new empty session in the same working directory. Kills the current process and spawns a fresh one.
+    /// Logs its own failure rather than leaving it to the caller: the pane starts this and drops the
+    /// Task, and by then the transcript is already cleared — a silent failure leaves an empty pane
+    /// with no process behind it, which reads as "still loading" instead of as an error.</summary>
+    public async Task NewSessionAsync()
     {
         SessionId = null;
         KillForRespawn();
-        return StartAsync(new ClientOptions
+        try
         {
-            WorkingDirectory = WorkingDirectory,
-            InitialPermissionMode = PermissionMode,
-            // Preserved across respawn like Env: losing it would make bypass unreachable
-            // for the rest of the pane's life, with nothing to explain why.
-            AllowBypassPermissions = _lastOptions?.AllowBypassPermissions ?? false,
-            Env = _env,
-        });
+            await StartAsync(new ClientOptions
+            {
+                WorkingDirectory = WorkingDirectory,
+                InitialPermissionMode = PermissionMode,
+                // Preserved across respawn like Env: losing it would make bypass unreachable
+                // for the rest of the pane's life, with nothing to explain why.
+                AllowBypassPermissions = _lastOptions?.AllowBypassPermissions ?? false,
+                Env = _env,
+            });
+        }
+        catch (Exception ex)
+        {
+            _log.LogException("[client] new_session", ex);
+            throw;
+        }
     }
 
     /// <summary>Resumes an existing session by id. Requires respawn. The
     /// caller passes the session's own mode (read from its JSONL) so the
     /// respawned CLI runs on the SAME mode shown in the selector — not
     /// whatever the client happened to hold. Null falls back to the current.
-    /// Model is not passed: the CLI's init re-emits the session's own model on --resume.</summary>
-    public Task ResumeSessionAsync(string sessionId, string permissionMode = null)
+    /// Model is not passed: the CLI's init re-emits the session's own model on --resume.
+    /// Logs its own failure, like NewSessionAsync — and here it matters more: the caller has already
+    /// pushed the history into the WebView, so a silent failure shows the right transcript over a
+    /// process that isn't there, and looks like it worked until the first prompt goes nowhere.</summary>
+    public async Task ResumeSessionAsync(string sessionId, string permissionMode = null)
     {
         KillForRespawn();
         PermissionMode = permissionMode ?? PermissionMode;
-        return StartAsync(new ClientOptions
+        try
         {
-            WorkingDirectory = WorkingDirectory,
-            ResumeSessionId = sessionId,
-            InitialPermissionMode = PermissionMode,
-            AllowBypassPermissions = _lastOptions?.AllowBypassPermissions ?? false,
-            Env = _env,
-        });
+            await StartAsync(new ClientOptions
+            {
+                WorkingDirectory = WorkingDirectory,
+                ResumeSessionId = sessionId,
+                InitialPermissionMode = PermissionMode,
+                AllowBypassPermissions = _lastOptions?.AllowBypassPermissions ?? false,
+                Env = _env,
+            });
+        }
+        catch (Exception ex)
+        {
+            _log.LogException($"[client] resume_session {sessionId}", ex);
+            throw;
+        }
     }
 
     private void KillForRespawn() => _transport.DisposeIntentional();

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.cs
@@ -468,15 +468,38 @@ internal sealed partial class ClaudeClient : IClaudeClient
     private void KillForRespawn() => _transport.DisposeIntentional();
 
     // Hot-swap operations — these must never respawn the process.
+
+    /// <summary>Logs its own failure like the rest, so no caller has to wonder whether this one
+    /// reports for itself. The property advances only after the ack, which is what lets the caller
+    /// echo the real value back and roll an optimistic selector onto it — that echo has to stay at
+    /// the call site, where the bridge is.</summary>
     public async Task SetModelAsync(string model)
     {
-        await SendControlRequestAsync(ClientMessages.ControlSubtype.SetModel, new { model });
+        try
+        {
+            await SendControlRequestAsync(ClientMessages.ControlSubtype.SetModel, new { model });
+        }
+        catch (Exception ex)
+        {
+            _log.LogException($"[client] set_model {model ?? "(default)"}", ex);
+            throw;
+        }
         Model = model;
     }
 
+    /// <summary>Same as SetModelAsync — and the echo matters more here: a selector left reading
+    /// "Plan" while the CLI is still in bypass is the one lie that costs files.</summary>
     public async Task SetPermissionModeAsync(string mode)
     {
-        await SendControlRequestAsync(ClientMessages.ControlSubtype.SetPermissionMode, new { mode });
+        try
+        {
+            await SendControlRequestAsync(ClientMessages.ControlSubtype.SetPermissionMode, new { mode });
+        }
+        catch (Exception ex)
+        {
+            _log.LogException($"[client] set_permission_mode {mode}", ex);
+            throw;
+        }
         PermissionMode = mode;
     }
 

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.cs
@@ -480,7 +480,22 @@ internal sealed partial class ClaudeClient : IClaudeClient
         PermissionMode = mode;
     }
 
-    public Task InterruptAsync() => SendControlRequestAsync(ClientMessages.ControlSubtype.Interrupt, null);
+    /// <summary>Logs its own failure: the WebView frees itself the moment it asks (it can't wait on
+    /// a wedged CLI), so a failed interrupt is invisible from the UI — it reads as stopped while the
+    /// turn runs on. Callers fire and forget, and the 10s request timeout would fault this into
+    /// silence, so the log is the only place the divergence can surface.</summary>
+    public async Task InterruptAsync()
+    {
+        try
+        {
+            await SendControlRequestAsync(ClientMessages.ControlSubtype.Interrupt, null);
+        }
+        catch (Exception ex)
+        {
+            _log.LogException("[client] interrupt", ex);
+            throw;
+        }
+    }
 
     /// <summary>Structured /usage data: session cost + claude.ai plan rate-limit
     /// windows. Experimental in the SDK (shape may change) — returned raw so the
@@ -516,12 +531,26 @@ internal sealed partial class ClaudeClient : IClaudeClient
 
     /// <summary>Enable/disable extended thinking at runtime. ON = budget 31999 + summarized display;
     /// OFF = budget 0. display is omitted when null so the CLI keeps the session mode.</summary>
-    public Task SetMaxThinkingTokensAsync(int maxThinkingTokens, string display)
-        => SendControlRequestAsync(
-            ClientMessages.ControlSubtype.SetMaxThinkingTokens,
-            display == null
-                ? (object)new { max_thinking_tokens = maxThinkingTokens }
-                : new { max_thinking_tokens = maxThinkingTokens, thinking_display = display });
+    /// <summary>Logs its own failure, like the other fire-and-forget hot-swaps: the caller drops the
+    /// Task, and unlike the model and permission selectors there is no echo back to roll the UI
+    /// onto what the CLI really holds — the toggle would simply keep showing a setting that never
+    /// took.</summary>
+    public async Task SetMaxThinkingTokensAsync(int maxThinkingTokens, string display)
+    {
+        try
+        {
+            await SendControlRequestAsync(
+                ClientMessages.ControlSubtype.SetMaxThinkingTokens,
+                display == null
+                    ? (object)new { max_thinking_tokens = maxThinkingTokens }
+                    : new { max_thinking_tokens = maxThinkingTokens, thinking_display = display });
+        }
+        catch (Exception ex)
+        {
+            _log.LogException("[client] set_max_thinking_tokens", ex);
+            throw;
+        }
+    }
 
     public async Task<JObject> GetSettingsAsync()
     {


### PR DESCRIPTION
Ask the client to do something and it now reports its own failure. Before this, whether an operation left a trace depended on which method you happened to call, and two of them left none at all.

## The one that could actually cost you

`ChatPaneControl` starts both session respawns and drops the Task:

```csharp
_ = _client?.NewSessionAsync();
_ = _client.ResumeSessionAsync(sessionId, mode);
```

`_ =` discards it, so an exception is captured by the Task and observed by nobody — no log, no UI, no crash. It behaves like an empty `catch {}`, except there is no `catch` in the source to notice while reading.

Both methods clear the UI *before* launching the respawn. `NewSession` sends `Cleared` and then respawns, so a failure leaves an empty pane with no process behind it — indistinguishable from one still loading. `LoadSession` is worse, because it pushes the history into the WebView first:

```
Cleared
SendHistoryPage(page, sessionId)     ← the transcript IS on screen
_ = _client.ResumeSessionAsync(…)    ← fails silently
```

The right transcript over a client that doesn't exist. It looks like it worked until the first prompt goes nowhere, minutes later, with nothing written down about why. These two also carry more weight than the rest: a failed `set_model` leaves the old model and a working chat, while these respawn the process and are the only way to open a session — there is no partial degradation, there is nothing behind the pane.

`set_max_thinking_tokens` had the same bare `_ =` and was missed when the above was first written up. Nothing echoes back there either, so a failure leaves the toggle showing a setting that never took.

## Where the logging went, and why

Into the methods. Each was a bare `return SendControlRequestAsync(...)` or `return StartAsync(...)`, so this is one place per operation instead of one per call site; the message can name the session id, the model, the mode; and a future caller that also drops the Task is covered without having to remember.

Not in `StartAsync` or `SendControlRequestAsync` themselves — their other callers await and already propagate, and they would have logged the same failure twice.

`interrupt` already had a faulted handler, but it was doing nothing else, so it moved too — along with the reason it needs one: the WebView frees itself the moment it asks (it can't wait on a wedged CLI), so a failed interrupt reads as stopped while the turn runs on, and the 10s request timeout would fault it into silence.

`set_model` and `set_permission_mode` were the interesting case. Their continuation does two unrelated things — write the log, and echo the real value back so the optimistic selector can roll onto it — and only the second needs to be at the call site, since `ClaudeClient` has no bridge to send through. Splitting them leaves the echo alone there, which is what that continuation was always for. The properties still advance only after the ack, which is what makes the rollback work: a failed swap leaves `Model`/`PermissionMode` on the old value and the echo carries it back. Without that, the selector reads "Plan" while the CLI is still in bypass — the one lie that costs files.

Everything still throws after logging. This adds the record; it does not swallow.

## Checked

MSBuild Debug green after each commit — 0 errors, no new CS warnings, VSIX produced.

Not verified: the failure paths themselves. Making a respawn or a control request fail on demand means killing the CLI mid-flight, and I haven't staged that. The changes are a log plus a rethrow around unmodified calls, so the risk sits in the signature changes (`Task` → `async Task`, same public shape) rather than in the logic.
