### PR TITLE
fix(mcp): a build through the tools no longer freezes the IDE

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.Operations.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.Operations.cs
@@ -66,10 +66,39 @@ internal sealed partial class IdeContextService
 
     //  Build (MCP buildSolution / buildProject)
 
-    /// <summary>Build the whole solution (projectName null) or a single project, synchronously,
-    /// then report success plus the Error List down to <paramref name="severity"/>. The DTE build is
-    /// blocking, so run it on a background-safe path: switch to the UI thread, kick the build, wait
-    /// via SolutionBuild.BuildState polling.</summary>
+    /// <summary>Wait for a build/clean kicked with WaitFor…=false, yielding the UI thread between
+    /// polls.
+    ///
+    /// The blocking overloads (WaitForBuildToFinish: true) are a synchronous COM call that never
+    /// pumps: called from the UI thread — which every DTE access has to be — they freeze the whole
+    /// IDE for the length of the build. Ctrl+Shift+B doesn't, which is what gives it away as a
+    /// defect rather than a constraint. The tool still can't return until the build ends (it owes
+    /// the caller LastBuildInfo plus the Error List); what changes is that the user no longer waits
+    /// with it.
+    ///
+    /// The await is what does the work: leaving the UI thread lets VS pump again, and
+    /// SwitchToMainThreadAsync takes it back for the next read of BuildState, which is itself a DTE
+    /// call. 200ms is short enough to not add a visible tail to a fast build and long enough to cost
+    /// nothing on a long one.</summary>
+    private static async Task WaitForBuildAsync(SolutionBuild sb)
+    {
+        // Poll at least once before testing: BuildState can still read vsBuildStateDone on the first
+        // look after kicking off, and exiting here would report the PREVIOUS build's LastBuildInfo
+        // as this one's result.
+        do
+        {
+            await Task.Delay(BuildPollMs);
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+        }
+        while (sb.BuildState == vsBuildState.vsBuildStateInProgress);
+    }
+
+    private const int BuildPollMs = 200;
+
+    /// <summary>Build the whole solution (projectName null) or a single project, then report success
+    /// plus the Error List down to <paramref name="severity"/>. Kicks the build without waiting and
+    /// polls SolutionBuild.BuildState, so the IDE stays live while it runs — see
+    /// <see cref="WaitForBuildAsync"/>.</summary>
     public async Task<BuildResult> BuildAsync(string projectName, string severity = "error")
     {
         await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
@@ -83,7 +112,7 @@ internal sealed partial class IdeContextService
         {
             if (string.IsNullOrEmpty(projectName))
             {
-                sb.Build(WaitForBuildToFinish: true);
+                sb.Build(WaitForBuildToFinish: false);
             }
             else
             {
@@ -95,8 +124,10 @@ internal sealed partial class IdeContextService
                 {
                     return new BuildResult { Ok = false, Message = $"Project not found: {projectName}" };
                 }
-                sb.BuildProject(config, proj.UniqueName, WaitForBuildToFinish: true);
+                sb.BuildProject(config, proj.UniqueName, WaitForBuildToFinish: false);
             }
+
+            await WaitForBuildAsync(sb);
 
             // LastBuildInfo = number of projects that FAILED (0 = success).
             var failed = sb.LastBuildInfo;
@@ -124,9 +155,9 @@ internal sealed partial class IdeContextService
         }
     }
 
-    /// <summary>Clean the solution (delete bin/obj outputs) and wait for it.
-    /// No error collection: unlike a build, a clean produces no diagnostics —
-    /// <c>LastBuildInfo</c> is the only outcome there is.</summary>
+    /// <summary>Clean the solution (delete bin/obj outputs) and wait for it, polling like
+    /// <see cref="BuildAsync"/> so the IDE stays live. No error collection: unlike a build, a clean
+    /// produces no diagnostics — <c>LastBuildInfo</c> is the only outcome there is.</summary>
     public async Task<BuildResult> CleanAsync()
     {
         await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
@@ -138,7 +169,8 @@ internal sealed partial class IdeContextService
         }
         try
         {
-            sb.Clean(WaitForCleanToFinish: true);
+            sb.Clean(WaitForCleanToFinish: false);
+            await WaitForBuildAsync(sb);
             var failed = sb.LastBuildInfo;
             return new BuildResult
             {


### PR DESCRIPTION
Asking the agent to build the solution froze Visual Studio for as long as the build ran — no editing, no scrolling, not even a redraw. `Ctrl+Shift+B` does the same build without any of that, and that comparison is what gives it away as a defect rather than something inherent to DTE.

## Cause

`WaitForBuildToFinish: true` is a synchronous COM call that never pumps messages. Every DTE access has to happen on the UI thread, so waiting there stops the message loop outright:

```csharp
await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();   // :75 — required for DTE
…
sb.Build(WaitForBuildToFinish: true);                               // :86 — and now nothing pumps
```

The doc comment above the method already described the fix — *"wait via SolutionBuild.BuildState polling"* — it had simply never been written. Comment and code disagreed, and the comment was right.

## Fix

Kick the build without waiting, then poll `BuildState`, leaving the UI thread between polls. The `await` is what does the work: releasing the thread lets VS pump again, and `SwitchToMainThreadAsync` takes it back for the next read, which is itself a DTE call.

**Nothing changes for the caller.** The tool still cannot return before the build ends — it owes it `LastBuildInfo` and the Error List. What changes is that the user no longer waits alongside it.

One detail worth the second look: the loop is a `do…while`, not a `while`. Right after kicking a build, `BuildState` can still read `vsBuildStateDone`; testing before the first delay would let the loop exit immediately and report the **previous** build's `LastBuildInfo` as this one's result — a wrong answer that looks perfectly plausible.

All three call sites, since fixing one would leave the other two freezing: the solution build (`:86`), the single-project build (`:98`) and the clean (`:141`). They now share one `WaitForBuildAsync` helper, so the poll only has to be corrected in one place if it ever needs adjusting.

## Considered and dropped

**An Options toggle for sync/async.** The two behaviours are indistinguishable from outside — the call returns when the build ends either way — and nobody would pick the one that freezes their IDE. A real option would be fire-and-forget, where the tool returns immediately and the build is followed elsewhere, but that is a different feature.

## Scope: this was the only place

Checked across `Ide/` and `Mcp/` for `WaitFor*`, `.Wait()`, `GetAwaiter().GetResult()`, `.Result` and `Thread.Sleep`: of 51 MCP tools these three were the only ones holding the UI thread for any length of time. The others take it because VS's model requires it, but for instant operations — reading the Error List, the debugger, symbols.

The debugger was already right, and deliberately so: `dbg.Go(false)` in `IdeDebugService.cs:95`, commented *"false = don't block waiting for break/end"* — the same choice the build was missing.

## Checked

MSBuild Debug green — 0 errors, no new CS warnings, VSIX produced.

**Not verified, and it matters here:** the freeze is only visible by eye, so the real gate is running `build_solution` in the Experimental instance and trying to scroll the editor while it runs. I haven't done that. Two things I would watch there:

- an unattended edge in `BuildState`, if a build somehow finishes inside the first 200ms
- a user starting a build by hand while the tool is polling — both would then be watching the same `BuildState`, and the tool would report on whichever finished

One thing I did not chase: `Debug.Restart` and `Debug.StartWithoutDebugging` trigger an implicit build when the project is stale. From reading the code `ExecuteCommand` returns once the command is queued, so it should not block — but the only way to be sure is the same scroll test, with a pending edit.
