### PR TITLE
fix(ide): three catches on user-facing paths stop swallowing

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Helpers.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Helpers.cs
@@ -135,7 +135,13 @@ internal sealed partial class WebViewMessageHandler
             frame?.Show();
             return frame != null;
         }
-        catch { return false; }
+        catch (Exception ex)
+        {
+            // The other half of a file-link click, next to FindFileByNameUnderRoot: the path was
+            // resolved and the open still failed. All the user sees is a link that does nothing.
+            OutputWindowLogger.Global.LogException($"WebView.TryOpenInVs({filePath})", ex);
+            return false;
+        }
     }
     private static string SanitizeFileName(string name)
     {
@@ -326,11 +332,20 @@ internal sealed partial class WebViewMessageHandler
                         stack.Push(sub);
                     }
                 }
+                // Per-directory and deliberately silent: a folder we can't read is the normal shape
+                // of a walk over a whole tree, and logging one line per skipped directory would
+                // bury the entries that mean something.
                 catch (System.UnauthorizedAccessException) { }
                 catch (System.IO.IOException) { }
             }
         }
-        catch (System.Exception) { }
+        catch (System.Exception ex)
+        {
+            // The outer one is a different matter: it catches whatever the walk itself failed on,
+            // and the caller only sees a file-link that doesn't open. Without this there is nothing
+            // to read afterwards.
+            OutputWindowLogger.Global.LogException($"WebView.FindFileByNameUnderRoot({name})", ex);
+        }
         return null;
     }
 }

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.Common.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.Common.cs
@@ -5,6 +5,7 @@
 
 using EnvDTE;
 using Microsoft.VisualStudio.Shell;
+using System;
 
 namespace Corsinvest.VisualStudio.Agents.Ide;
 
@@ -36,7 +37,15 @@ internal sealed partial class IdeDebugService
             var line = doc?.Selection is TextSelection sel ? sel.ActivePoint.Line : 0;
             return (file, line);
         }
-        catch { return (null, 0); }
+        catch (Exception ex)
+        {
+            // Not a per-item probe: this is where the debugger stopped, and it feeds StepAsync and
+            // GetCallStackAsync. Degrading to (null, 0) reads as "no location" — the same answer a
+            // session with no active document gives — so without this the COM failure behind it
+            // would leave nothing to read.
+            OutputWindowLogger.Global.LogException("IdeDebugService.CurrentLocation", ex);
+            return (null, 0);
+        }
     }
 
     private static string SafeModule(StackFrame sf)


### PR DESCRIPTION
```csharp
catch { return (null, 0); }
```

Three things happen at once here: the exception is discarded, the function returns something that looks like a legitimate answer, and the caller has no way to tell "there was nothing to find" from "something went wrong". The failure becomes indistinguishable from the ordinary case.

Nobody notices while writing it. It costs whoever hits it months later — a degraded result, and no way to find out why short of attaching a debugger to the IDE and reproducing.

## The three

**`CurrentLocation()`** (`IdeDebugService.Common.cs:39`) is where the debugger stopped, and it feeds `StepAsync` and `GetCallStackAsync`. Degrading to `(null, 0)` reads exactly like a session with no active document, so a `COMException` from `ActiveDocument` disappeared into "I don't know where I am" — and you'd go looking at PDBs and symbol loading instead.

**`FindFileByNameUnderRoot`'s outer catch** (`WebViewMessageHandler.Helpers.cs:333`) sits next to two per-directory ones and looks like a third of the same kind, but it is outside the loop and catches everything the walk itself failed on. The user sees a file-link that doesn't open.

**`TryOpenInVs`** (`:138`) is the other half of that same click: the path resolved, and the open still failed. Its neighbour three lines up already called `LogException`; this one didn't.

None of them changes what it returns. The degraded value stays; only the trace is added.

## The silent ones that stay silent

The two per-directory catches in the walk (`UnauthorizedAccessException`, `IOException`) keep swallowing and now carry a comment saying why: a folder we can't read is the normal shape of a walk over a whole tree, and a line per skipped directory would bury the entries that mean something.

That comment is the actual fix for those two. They were correct already — but with nothing written down, a chosen silence and a forgotten one look identical, which is how the outer catch three lines below passed for one of them.

## Scope: checked, not assumed

Searched the codebase for both shapes (bare `catch {}` and typed-without-log). Of roughly twenty swallowing catches, these were the only ones on a user-facing path. The rest are correct and stay:

- **Per-item Roslyn reflection probes** (`IdeNavigationService.Search.cs`, `.Symbols.cs`, `OffsetToLine`, `FileOffsetToLineCol`) — one symbol at a time, discarded by `.Where(s => s != null)`. A line each would bury a search returning hundreds. This is the case CLAUDE.md explicitly exempts.
- **Feature detection** (`BuildEmptyStringSet`, `BuildEmptyDocumentList`) — `null` is the expected answer, not a failure.
- **Parsers and formatters** (a malformed JSONL line in `SessionManager.History.cs:501`, `PathHelpers.cs:70`, `VsThemeReader.cs:24`) — the default *is* the semantics.

So the convention was already being followed nearly everywhere. What was missing was the comment on the deliberate silences, which is what let three real ones blend in.

## Checked

MSBuild Debug green — 0 errors, no new CS warnings, VSIX produced.

Not verified: the failure paths themselves. Forcing a `COMException` out of `ActiveDocument`, or making `OpenDocument` fail, isn't something I staged. These are a log plus an unchanged return around untouched logic, so the risk is in the added `using System;` and the string interpolation, not in behaviour.
