### PR TITLE
feat(chat): drop the messages the CLI retracts

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents.Contracts/BridgeGenerationSpec.cs
+++ b/src/Corsinvest.VisualStudio.Agents.Contracts/BridgeGenerationSpec.cs
@@ -83,6 +83,7 @@ public class BridgeGenerationSpec : GenerationSpec
             .Member(x => nameof(x.ParentToolUseId)).Null()
             .Member(x => nameof(x.Usage)).Null();
         AddInterface<ExchangeEndedNotification>().Member(x => nameof(x.Usage)).Null();
+        AddInterface<EvictMessagesNotification>();
         AddInterface<IdeContextNotification>();
         AddInterface<CliErrorNotification>();
         AddInterface<UserImageDto>()

--- a/src/Corsinvest.VisualStudio.Agents.Contracts/ToWebViewDtos.cs
+++ b/src/Corsinvest.VisualStudio.Agents.Contracts/ToWebViewDtos.cs
@@ -488,10 +488,29 @@ public class AssistantTextNotification
 {
     public string Text { get; set; }
     public string ParentToolUseId { get; set; }
+    // The message's wire uuid, so an entry can be addressed after the fact. Every block of one
+    // assistant message carries the same one — the CLI derives per-block uuids for its own
+    // retraction lists, but what reaches us here is the message's. Always present: the CLI writes
+    // it unconditionally on both assistant lanes and SDKAssistantMessage.uuid is non-optional.
+    // The permission banner's synthetic message is the one caller that passes none, and it only
+    // ever emits tool_use blocks — never the text block this rides on.
+    public string Uuid { get; set; }
     public ContextUsageDto Usage { get; set; }
     // Message time (epoch ms) from the .jsonl record / live event; null when absent. The WebView
     // shows it as "x ago" with an absolute date/time tooltip.
     public long? Timestamp { get; set; }
+}
+
+/// <summary>Messages the CLI retracted (chat_evict_messages): they were delivered to us but are no
+/// longer part of the conversation, so the model does not have them. Leaving them on screen is what
+/// makes the transcript diverge from the model's context — the user reads a partial answer and
+/// reasons about it, while the model never saw it.
+///
+/// Matching is by uuid equality and nothing else, which is what makes it safe to apply blind: a
+/// uuid naming nothing on screen removes nothing.</summary>
+public class EvictMessagesNotification
+{
+    public string[] Uuids { get; set; }
 }
 
 /// <summary>Spinner-verb override config (nested in the init ui payload). mode is the

--- a/src/Corsinvest.VisualStudio.Agents/Chat/ContentBlockTranslator.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/ContentBlockTranslator.cs
@@ -87,7 +87,8 @@ internal static class ContentBlockTranslator
                                      JObject usage = null,
                                      bool needsPermission = false,
                                      JArray permissionSuggestions = null,
-                                     long? timestamp = null)
+                                     long? timestamp = null,
+                                     string uuid = null)
     {
         // JToken for a uniform Emit* signature (HistoryReplay passes the raw content to both). The
         // assistant content is always a block array in practice; a bare string never occurs, so just
@@ -118,6 +119,8 @@ internal static class ContentBlockTranslator
                 {
                     Text = item.Val("text", ""),
                     ParentToolUseId = parentToolUseId,
+                    // Same uuid on every block of the message: it names the message, not the block.
+                    Uuid = uuid,
                     Usage = !firstEmitted ? usagePayload : null,
                     Timestamp = timestamp,
                 });

--- a/src/Corsinvest.VisualStudio.Agents/Chat/HistoryReplay.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/HistoryReplay.cs
@@ -55,7 +55,12 @@ internal static class HistoryReplay
             var tsMs = msg.ValTimestampMs("timestamp");
             if (role == "assistant")
             {
-                ContentBlockTranslator.EmitAssistant(content, Collect, parentToolUseId, msg["usage"] as JObject, timestamp: tsMs);
+                ContentBlockTranslator.EmitAssistant(content,
+                                                     Collect,
+                                                     parentToolUseId,
+                                                     msg["usage"] as JObject,
+                                                     timestamp: tsMs,
+                                                     uuid: uuid);
             }
             else // user (and tool_result-carrying user lines)
             {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/BridgeMessages.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/BridgeMessages.cs
@@ -156,6 +156,10 @@ internal static class BridgeMessages
             public const string ToolResult = "chat_tool_result";
             public const string ExchangeEnded = "chat_exchange_ended";
             public const string Compacted = "chat_compacted";
+            /// <summary>Notification: drop these messages from the transcript — the CLI retracted
+            /// them (refusal fallback), so the model no longer has them. Idempotent: uuids that
+            /// name nothing on screen are a no-op.</summary>
+            public const string EvictMessages = "chat_evict_messages";
             public const string Status = "chat_status";
             public const string ImageData = "chat_image_data";
             public const string SlashCommands = "chat_slash_commands";

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.ClientEvents.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.ClientEvents.cs
@@ -257,7 +257,20 @@ public partial class ChatPaneControl
             // Do NOT push the reply's `model` to the selector: sub-agents run on a different
             // model and would flip the selection. The selector reflects only the user's explicit
             // choice (set_model) plus init/history.
-            ContentBlockTranslator.EmitAssistant(e.Content, (t, d) => _bridge.Send(t, d), e.ParentToolUseId, e.Usage, timestamp: e.Timestamp);
+            // Evict BEFORE emitting: this message replaces those, so dropping them first keeps the
+            // replacement from appearing under the text it supersedes.
+            if (e.Supersedes is { Length: > 0 })
+            {
+                _log.Debug(() => $"[chat] assistant supersedes {e.Supersedes.Length} message(s)");
+                _bridge.Send(BridgeMessages.ToWebView.Chat.EvictMessages,
+                             new Contracts.EvictMessagesNotification { Uuids = e.Supersedes });
+            }
+            ContentBlockTranslator.EmitAssistant(e.Content,
+                                                 (t, d) => _bridge.Send(t, d),
+                                                 e.ParentToolUseId,
+                                                 e.Usage,
+                                                 timestamp: e.Timestamp,
+                                                 uuid: e.Uuid);
         });
 
     private void OnUserMessage(object sender, UserMessageEventArgs e)
@@ -549,6 +562,25 @@ public partial class ChatPaneControl
                     EstimatedTokens = obj.Val("estimated_tokens", -1),
                     ParentToolUseId = obj.Val("parent_tool_use_id"),
                 });
+            }
+            else if (subtype == ClientMessages.SystemSubtype.ModelRefusalFallback)
+            {
+                // The refused partial was already delivered to us and is now retracted: drop it,
+                // else the user goes on reading (and replying to) text the model never saw. Warn,
+                // not Debug: text disappears from the chat under the user's eyes, so "the chat lost
+                // a piece" needs an answer that is there without turning the log level up first.
+                var uuids = (obj["retracted_message_uuids"] as JArray)?
+                    .Select(t => t?.ToString())
+                    .Where(s => !string.IsNullOrEmpty(s))
+                    .Distinct(StringComparer.Ordinal)
+                    .ToArray() ?? [];
+                _log.Warn($"[chat] model_refusal_fallback {obj.Val("original_model")} → " +
+                          $"{obj.Val("fallback_model")}, retracting {uuids.Length} message(s)");
+                if (uuids.Length > 0)
+                {
+                    _bridge.Send(BridgeMessages.ToWebView.Chat.EvictMessages,
+                                 new Contracts.EvictMessagesNotification { Uuids = uuids });
+                }
             }
             else if (subtype == ClientMessages.SystemSubtype.BackgroundTasksChanged)
             {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/bridge-messages.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/bridge-messages.ts
@@ -94,6 +94,7 @@ export const Msg = {
             toolResult: 'chat_tool_result',
             exchangeEnded: 'chat_exchange_ended',
             compacted: 'chat_compacted',
+            evictMessages: 'chat_evict_messages',
             status: 'chat_status',
             imageData: 'chat_image_data',
             slashCommands: 'chat_slash_commands',

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated/AssistantTextNotification.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated/AssistantTextNotification.ts
@@ -8,6 +8,7 @@ import { ContextUsageDto } from './ContextUsageDto';
 export interface AssistantTextNotification {
     text: string;
     parentToolUseId: string | null;
+    uuid: string;
     usage: ContextUsageDto | null;
     timestamp?: number;
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated/EvictMessagesNotification.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated/EvictMessagesNotification.ts
@@ -1,0 +1,8 @@
+/**
+ * This is a TypeGen auto-generated file.
+ * Any changes made to this file can be lost when this file is regenerated.
+ */
+
+export interface EvictMessagesNotification {
+    uuids: string[];
+}

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/transcript.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/transcript.ts
@@ -32,6 +32,27 @@ export class Transcript {
     /** id → path, so find/update are O(1) instead of walking the tree on every event. */
     private _index = new Map<number, EntryPath>();
 
+    /**
+     * Called with the ids that just left the tree, subtrees included.
+     *
+     * Entries used to be add-only, so anything keyed on an id outside this class stayed valid for
+     * as long as the session did. Retraction broke that: an id can now disappear mid-session, and a
+     * key left behind means either events written into an entry that is gone or a Map that never
+     * shrinks. Rather than expect every caller to remember the cleanup, the removal announces
+     * itself — this class still knows nothing about who listens or what they keyed.
+     */
+    onRemoved?: (ids: readonly number[]) => void;
+
+    /**
+     * Called when every id in the tree stops being valid at once — a session switch or a history
+     * page swapped in.
+     *
+     * Separate from onRemoved rather than passing the whole id list: the listener only ever wants
+     * to drop everything, so walking the tree to hand it an array it would immediately ignore buys
+     * nothing. Two callbacks, two meanings — some ids died, or all of them did.
+     */
+    onCleared?: () => void;
+
     get entries(): readonly UiEntry[] {
         return this._entries;
     }
@@ -49,6 +70,76 @@ export class Transcript {
     clear(): void {
         this._entries = [];
         this._index.clear();
+        this.onCleared?.();
+    }
+
+    /**
+     * Drop the top-level entries whose `uuid` is in `uuids`, returning how many went. Used when the
+     * CLI retracts messages it had already delivered (refusal fallback): they are no longer part of
+     * the conversation, and leaving them on screen makes what the user reads diverge from what the
+     * model knows.
+     *
+     * Matching is uuid equality and nothing else, so it is safe to apply blind: a uuid naming
+     * nothing removes nothing, and calling it twice with the same list is the same as calling it
+     * once. That is the contract the CLI relies on — the per-message `supersedes` and the
+     * end-of-turn `retracted_message_uuids` overlap on purpose.
+     *
+     * At every depth, not just the top: a uuid names a MESSAGE, not a position, and a sub-agent's
+     * reply is as retracted as a main-thread one. Two entries sharing a uuid are the same message
+     * written twice (measured: the .jsonl does that on ~0.1% of assistant lines, identical on every
+     * other field), so taking both is right rather than over-eager.
+     */
+    removeByUuid(uuids: readonly string[]): number {
+        if (uuids.length === 0) {
+            return 0;
+        }
+        const drop = new Set(uuids);
+        const doomed: UiEntry[] = [];
+        const prune = (list: readonly UiEntry[]): UiEntry[] | null => {
+            let changed = false;
+            const kept: UiEntry[] = [];
+            for (const e of list) {
+                if ('uuid' in e && typeof e.uuid === 'string' && drop.has(e.uuid)) {
+                    doomed.push(e);
+                    changed = true;
+                    continue;
+                }
+                // Rebuild the parent only when a descendant actually went, so an untouched branch
+                // keeps its identity and Lit skips it.
+                if (e.kind === 'tool' && e.children) {
+                    const kids = prune(e.children.items);
+                    if (kids) {
+                        kept.push({ ...e, children: { ...e.children, items: kids } });
+                        changed = true;
+                        continue;
+                    }
+                }
+                kept.push(e);
+            }
+            return changed ? kept : null;
+        };
+        const next = prune(this._entries);
+        if (!next || doomed.length === 0) {
+            return 0;
+        }
+        this._entries = next;
+        // Rebuild rather than unset the removed ids: a dropped entry takes its whole subtree with
+        // it, and those children are indexed too.
+        this._reindex();
+        // Report the subtrees, not just the roots: whoever keyed something on a nested row is as
+        // stranded as whoever keyed it on the message that contained it.
+        const gone: number[] = [];
+        const collect = (list: readonly UiEntry[]): void => {
+            for (const e of list) {
+                gone.push(e.id);
+                if (e.kind === 'tool' && e.children?.items.length) {
+                    collect(e.children.items);
+                }
+            }
+        };
+        collect(doomed);
+        this.onRemoved?.(gone);
+        return doomed.length;
     }
 
     /**
@@ -134,6 +225,11 @@ export class Transcript {
     /** Swap the whole transcript (a history page load). The index is rebuilt from scratch: one
      *  that outlives its entries would resolve an id to a path that leads nowhere. */
     replaceAll(entries: UiEntry[]): void {
+        // Deliberately does NOT fire onCleared, unlike clear(). The caller builds the replacement
+        // entries before handing them over, and building them is what refills the id-keyed maps for
+        // the replayed turns — an invalidation at this point would wipe what the replay had just
+        // written. The history listener drops the old ids before it starts replaying, which is the
+        // only moment where "these ids are dead" and "these ids are being written" don't overlap.
         this._entries = entries;
         this._reindex();
     }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/types.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/types.ts
@@ -80,6 +80,7 @@ export type { SubagentUsageDto } from './generated/SubagentUsageDto';
 /** Context compaction (`chat_compacted`, header-only: uuid/trigger/preTokens) and CLI process
  *  exit (`cli_exited`). Generated from C# by TypeGen — re-exported here. */
 export type { CompactedNotification } from './generated/CompactedNotification';
+export type { EvictMessagesNotification } from './generated/EvictMessagesNotification';
 export type { StatusNotification } from './generated/StatusNotification';
 export type { CliExitedNotification } from './generated/CliExitedNotification';
 
@@ -330,6 +331,9 @@ export interface UiUserEntry extends UiEntryBase {
 export interface UiAssistantEntry extends UiEntryBase {
     role: 'assistant';
     streaming?: boolean;
+    /** The message's wire uuid — what lets an entry be addressed after it has been rendered.
+     *  Absent on a synthetic message (the permission banner's) and on older .jsonl lines. */
+    uuid?: string;
 }
 
 /** A thinking block: the model's reasoning, live-only (never persisted). `streaming` true while

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/transcript.test.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/transcript.test.ts
@@ -4,7 +4,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { Transcript } from '../core/transcript.ts';
-import type { UiEntry, UiToolEntry, UiUserEntry } from '../core/types';
+import type { UiAssistantEntry, UiEntry, UiToolEntry, UiUserEntry } from '../core/types';
 
 function userEntry(id: number, text = 't'): UiUserEntry {
     return { kind: 'text', id, role: 'user', text };
@@ -273,4 +273,120 @@ test('appendChild annidato: l index risolve un figlio di figlio', () => {
         true,
         'update deve raggiungere un figlio di secondo livello',
     );
+});
+
+function assistantEntry(id: number, uuid?: string): UiAssistantEntry {
+    return { kind: 'text', id, role: 'assistant', text: 'a', uuid };
+}
+
+test('removeByUuid: toglie solo le entry nominate', () => {
+    const t = new Transcript();
+    t.append(assistantEntry(1, 'u1'));
+    t.append(assistantEntry(2, 'u2'));
+    t.append(assistantEntry(3, 'u3'));
+
+    assert.equal(t.removeByUuid(['u2']), 1);
+    assert.deepEqual(
+        t.entries.map((e) => e.id),
+        [1, 3],
+    );
+});
+
+test('removeByUuid: uuid sconosciuti sono un no-op, e ripeterlo non cambia nulla', () => {
+    const t = new Transcript();
+    t.append(assistantEntry(1, 'u1'));
+    const before = t.entries;
+
+    assert.equal(t.removeByUuid(['mai-visto']), 0, 'un uuid ignoto non rimuove niente');
+    assert.equal(t.entries, before, 'senza rimozioni l array non viene ricreato');
+
+    assert.equal(t.removeByUuid(['u1']), 1);
+    assert.equal(t.removeByUuid(['u1']), 0, 'la seconda volta non ha piu niente da togliere');
+});
+
+test('removeByUuid: una entry senza uuid non viene mai toccata', () => {
+    const t = new Transcript();
+    t.append(assistantEntry(1));
+    t.append(userEntry(2));
+
+    assert.equal(t.removeByUuid(['u1', 'u2']), 0);
+    assert.equal(t.entries.length, 2);
+});
+
+test('removeByUuid: rimuovere una entry non scolla le altre dall index', () => {
+    const t = new Transcript();
+    t.append(assistantEntry(1, 'u1'));
+    t.append(toolEntry(2, 'outer'));
+    t.appendChild('outer', userEntry(3), childKey);
+
+    assert.equal(t.removeByUuid(['u1']), 1);
+    // La rimozione ricostruisce l index: se lo facesse a meta, i figli della entry SOPRAVVISSUTA
+    // resterebbero indicizzati sul percorso vecchio e un evento per loro finirebbe altrove.
+    assert.equal(t.find(3)?.id, 3, 'il figlio di una entry rimasta deve ancora risolvere');
+    assert.equal(t.findTool('outer')?.id, 2);
+});
+
+test('removeByUuid: onRemoved riceve anche i figli della entry rimossa', () => {
+    const t = new Transcript();
+    const seen: number[][] = [];
+    t.onRemoved = (ids) => seen.push([...ids]);
+
+    t.append(assistantEntry(1, 'u1'));
+    t.append(toolEntry(2, 'outer'));
+    t.appendChild('outer', userEntry(3), childKey);
+
+    t.removeByUuid(['u1']);
+    assert.deepEqual(seen, [[1]], 'una entry senza figli riporta solo se stessa');
+
+    // Chi ha messo in mappa l id di una riga annidata resta appeso quanto chi ha messo il padre:
+    // l evento deve nominare l intero sottoalbero, non la sola radice.
+    seen.length = 0;
+    const t2 = new Transcript();
+    t2.onRemoved = (ids) => seen.push([...ids]);
+    t2.append({ ...toolEntry(10, 'root'), uuid: 'ur' } as unknown as UiEntry);
+    t2.appendChild('root', toolEntry(11, 'mid'), childKey);
+    t2.appendChild('mid', userEntry(12), childKey);
+
+    t2.removeByUuid(['ur']);
+    assert.deepEqual(seen, [[10, 11, 12]]);
+});
+
+test('removeByUuid: senza rimozioni onRemoved non scatta', () => {
+    const t = new Transcript();
+    let calls = 0;
+    t.onRemoved = () => calls++;
+    t.append(assistantEntry(1, 'u1'));
+
+    t.removeByUuid(['altro']);
+    assert.equal(calls, 0);
+});
+
+test('removeByUuid: raggiunge anche una entry annidata in un sub-agent', () => {
+    const t = new Transcript();
+    const removed: number[][] = [];
+    t.onRemoved = (ids) => removed.push([...ids]);
+
+    t.append(toolEntry(1, 'agent'));
+    t.appendChild('agent', assistantEntry(2, 'dentro'), childKey);
+    t.appendChild('agent', userEntry(3), childKey);
+
+    assert.equal(t.removeByUuid(['dentro']), 1);
+    assert.equal(t.find(2), null, 'la entry annidata deve sparire');
+    assert.equal(t.find(3)?.id, 3, 'i fratelli restano');
+    assert.equal(t.findTool('agent')?.id, 1, 'il parent resta');
+    assert.deepEqual(removed, [[2]]);
+});
+
+test('removeByUuid: un ramo senza rimozioni mantiene la sua identita', () => {
+    const t = new Transcript();
+    t.append(assistantEntry(1, 'u1'));
+    t.append(toolEntry(2, 'intatto'));
+    t.appendChild('intatto', userEntry(3), childKey);
+    const before = t.entries[1];
+
+    t.removeByUuid(['u1']);
+
+    // Se il prune ricreasse anche i rami non toccati, Lit rirenderizzerebbe l intero sottoalbero
+    // del sub-agent a ogni retraction.
+    assert.equal(t.entries[0], before, 'il ramo non toccato mantiene il riferimento');
 });

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
@@ -47,6 +47,7 @@ import type {
     SubagentProgressNotification,
     SubagentEndedNotification,
     CompactedNotification,
+    EvictMessagesNotification,
     StatusNotification,
     ToolResultNotification,
     ModelChangedNotification,
@@ -138,12 +139,49 @@ export class CvApp extends LitElement {
         this._rev++;
     }
 
+    /**
+     * Forget ids the transcript has dropped — wired to its onRemoved, so a removal cannot land
+     * without this running.
+     *
+     * Three maps here are keyed on entry ids, and none of them belongs in Transcript: they track
+     * what is still streaming and what a turn cost, none of which is about the shape of the tree.
+     * What they do share is that an id leaving the tree strands them — deltas written into an entry
+     * that is gone, or a Map that never shrinks. The clears at session switch and history push
+     * cover the wholesale case; this is the piecemeal one.
+     */
+    private _dropRemovedIds(ids: readonly number[]): void {
+        const gone = new Set(ids);
+        for (const [parentId, id] of [...this._streamingMsgs]) {
+            if (gone.has(id)) {
+                this._streamingMsgs.delete(parentId);
+            }
+        }
+        for (const [parentId, id] of [...this._thinkingMsgs]) {
+            if (gone.has(id)) {
+                this._thinkingMsgs.delete(parentId);
+            }
+        }
+        for (const id of gone) {
+            this._turnMetrics.delete(id);
+        }
+    }
+
+    /** Same three maps, for when the whole tree goes (transcript's onCleared). */
+    private _dropAllIds(): void {
+        this._streamingMsgs.clear();
+        this._thinkingMsgs.clear();
+        this._turnMetrics.clear();
+    }
+
     override createRenderRoot() {
         return this;
     }
 
     override connectedCallback(): void {
         super.connectedCallback();
+        // Wired here rather than at the field: the initializer runs before `this` is usable.
+        this._transcript.onRemoved = (ids) => this._dropRemovedIds(ids);
+        this._transcript.onCleared = () => this._dropAllIds();
         this._offs.push(appState.on('isBusy', (v) => (this._isBusy = v)));
         this._offs.push(appState.on('status', (v) => (this._status = v)));
         this._offs.push(appState.on('pendingPermission', (v) => (this._awaitingUser = v != null)));
@@ -242,6 +280,9 @@ export class CvApp extends LitElement {
                                 // The final assistant notification carries the message time;
                                 // live fallback = now.
                                 timestamp: data?.timestamp ?? Date.now(),
+                                // Only this final notification names the message — the deltas that
+                                // built the entry carry no uuid, so it lands here or nowhere.
+                                uuid: data?.uuid ?? e.uuid,
                             })),
                         );
                         entryId = streamingId;
@@ -426,10 +467,8 @@ export class CvApp extends LitElement {
                 // Abort in-flight requests for the old session so their Promises reject
                 // instead of resolving against the new session (or hanging until timeout).
                 bridge.rejectAllPending('session changed');
+                // clear() fires onCleared, which drops everything keyed on the old entry ids.
                 this._mutate(() => this._transcript.clear());
-                this._streamingMsgs.clear();
-                this._thinkingMsgs.clear();
-                this._turnMetrics.clear();
                 // The rendered markdown belonged to the entries just dropped; keeping it would let
                 // a dead session's messages hold the cache slots the new one needs.
                 clearMarkdownCache();
@@ -454,6 +493,22 @@ export class CvApp extends LitElement {
                 this._appendEntry(CvApp.buildCompactEntry(data));
                 queueMicrotask(() => this._scrollToBottom());
             }),
+        );
+
+        this._offs.push(
+            bridge.onNotification<EvictMessagesNotification>(
+                Msg.toWebView.chat.evictMessages,
+                (data) => {
+                    // The CLI retracted these: they reached us, but the model does not have them.
+                    // Leaving them up is what makes the transcript diverge from the model's context.
+                    const uuids = data?.uuids ?? [];
+                    if (uuids.length === 0) {
+                        return;
+                    }
+                    // The maps keyed on entry ids are cleaned by the transcript's onRemoved.
+                    this._mutate(() => this._transcript.removeByUuid(uuids));
+                },
+            ),
         );
 
         this._offs.push(
@@ -571,10 +626,11 @@ export class CvApp extends LitElement {
                 Msg.toWebView.chat.historyLoaded,
                 (data) => {
                     const events = data?.events ?? [];
-                    // Before the replay, not after: _applyHistoryPage refills this from the events
-                    // it is about to build, so clearing it afterwards would drop what it just wrote.
-                    // A history push REPLACES the tree, so the ids it was keyed on are gone.
-                    this._turnMetrics.clear();
+                    // Before the replay, not after: a history push replaces the tree, so the ids
+                    // these were keyed on are gone — but building the replacement is what refills
+                    // them for the replayed turns, and clearing afterwards would drop that. This is
+                    // why replaceAll leaves onCleared alone and the drop happens here instead.
+                    this._dropAllIds();
                     const out = this._applyHistoryPage(data, events);
 
                     // Seed the gauge from the last assistant_text event carrying usage.
@@ -605,10 +661,6 @@ export class CvApp extends LitElement {
 
                     appState.loadingOlder = false;
                     this._mutate(() => this._transcript.replaceAll(out));
-                    // Both, like chat_cleared: the entries these named are not in the tree any
-                    // more, so a delta arriving for one would update nothing and look dropped.
-                    this._streamingMsgs.clear();
-                    this._thinkingMsgs.clear();
                     // Land at the bottom. Re-jump for several frames because async-rendered
                     // children (markdown, diff2html, lazy images) keep growing scrollHeight.
                     void this.updateComplete.then(() => {
@@ -1190,6 +1242,7 @@ export class CvApp extends LitElement {
             role: 'assistant',
             text: d.text ?? '',
             timestamp: d.timestamp ?? undefined,
+            uuid: d.uuid ?? undefined,
         };
     }
 

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.Protocol.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.Protocol.cs
@@ -316,6 +316,11 @@ internal sealed partial class ClaudeClient
             Content = m["content"],
             Usage = m["usage"] as JObject,
             Uuid = obj.Val("uuid"),
+            // Wrapper-level like uuid, not inside `message`.
+            Supersedes = (obj["supersedes"] as JArray)?
+                .Select(t => t?.ToString())
+                .Where(s => !string.IsNullOrEmpty(s))
+                .ToArray(),
             Timestamp = obj.ValTimestampMs("timestamp"),
             ParentToolUseId = obj.Val("parent_tool_use_id"),
         });

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClientMessages.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClientMessages.cs
@@ -46,6 +46,12 @@ internal static class ClientMessages
         public const string BackgroundTasksChanged = "background_tasks_changed";
         // Authoritative cumulative thinking-token estimate for the in-flight thinking block.
         public const string ThinkingTokens = "thinking_tokens";
+        // The model refused and the CLI fell back to another one. Carries
+        // `retracted_message_uuids`: messages already delivered to us that are no longer part of
+        // the conversation — the model never saw them, so leaving them on screen makes what the
+        // user reads diverge from what the model knows. Emitted AFTER the retraction, so it is an
+        // eviction order, not a warning.
+        public const string ModelRefusalFallback = "model_refusal_fallback";
         // A slash command's own output ("Current model: …", "Unknown command: …", "/x isn't available",
         // /config|/context usage). content = "<local-command-stdout>…</local-command-stdout>" (or -stderr).
         // The WebView renders it as a slash-result pill (parseLocalCommandOutput on the UserText text).

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/Events.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/Events.cs
@@ -54,6 +54,12 @@ public sealed class AssistantMessageEventArgs
     public JToken Content { get; set; }
     public JObject Usage { get; set; }
     public string Uuid { get; set; }
+    /// <summary>Uuids of messages this one REPLACES (refusal-fallback supersede): they were already
+    /// delivered to us and are no longer part of the conversation. Same job as the end-of-turn
+    /// `retracted_message_uuids`, arriving early and per-message; the two are idempotent with each
+    /// other, so acting on both is safe. Null when the message replaces nothing, which is nearly
+    /// always.</summary>
+    public string[] Supersedes { get; set; }
     /// <summary>Message time (epoch ms) parsed from the wire `timestamp`; null when absent.</summary>
     public long? Timestamp { get; set; }
     /// <summary>When non-null, this assistant message was emitted by a sub-agent


### PR DESCRIPTION
When the model refuses, the CLI falls back to another one and retracts the partial answer the first had already sent us. We kept showing it.

That is worse than it looks. The user reads that text, reasons about it, replies to it — and the model has no memory of ever having written it. From there on the transcript and the model's context quietly disagree, and it surfaces as "the model isn't following", which is about the hardest thing for a user to diagnose.

## The two signals

The CLI says it twice, deliberately and idempotently:

- **`supersedes`** rides the assistant message that replaces them — early, per message
- **`retracted_message_uuids`** closes the turn with the complete list

Both now reach the WebView as `chat_evict_messages` and go through the same removal, so acting on either is safe and acting on both is harmless. On the `supersedes` lane the eviction is sent *before* the replacement is emitted, so the new text never appears under the text it supersedes.

## Why matching by uuid alone

Uuid equality and nothing else, which is what makes it safe to apply blind: a uuid naming nothing removes nothing, and repeating a list changes nothing. That is the contract the overlap depends on.

Two entries sharing a uuid are the same message written twice — measured across 8 real sessions, the `.jsonl` does that on ~0.1% of assistant lines, and those pairs are identical on every other field (`agentId`, `parentToolUseId`, even the `tool_use` ids). A composite key resolved 0 of 40. So taking both is right rather than over-eager.

## Every depth, not just the top

A uuid names a **message**, not a position — a sub-agent's reply is as retracted as a main-thread one. The prune walks the tree and rebuilds only the branches that actually lost something, so an untouched sub-agent transcript keeps its identity and Lit skips re-rendering it.

## The bookkeeping that retraction broke

Three maps in `cv-app` are keyed on entry ids — what is streaming, what a turn cost. None belongs in `Transcript`: none of them is about the shape of the tree. They worked because entries were **add-only**, so an id stayed valid for a whole session. Retraction ends that: an id can now leave mid-session, and a stale key means either deltas written into an entry that is gone, or a Map that never shrinks.

Rather than ask every caller to remember the cleanup, the transcript announces it — `onRemoved` (with subtrees, since whoever keyed a nested row is as stranded as whoever keyed its parent) and `onCleared` for the wholesale case. It still knows nothing about who listens or what they keyed.

**`replaceAll` deliberately stays silent**, and the comment says so where someone would otherwise "fix" it: its caller builds the replacement entries first, and building them is what refills those maps for the replayed turns. An invalidation there would wipe what the replay had just written. The history listener drops the old ids *before* replaying instead — the only point where "these ids are dead" and "these ids are being written" don't overlap.

## Carrying the uuid down

None of the above was addressable before, because a rendered assistant message had nothing tying it to the message on the wire. The uuid was already parsed and already sat on `AssistantMessageEventArgs` — it just never travelled further. Both paths pass it now, live and history, since one alone would work until the session was reopened. The streaming branch matters too: deltas carry no uuid, so it lands with the closing notification or nowhere.

## Checked

MSBuild Debug green (0 errors, no new CS warnings). WebView: 43/43 unit tests (8 new on removal — nesting, idempotence, subtree reporting, branch identity), typecheck, lint clean, prettier.

**Verified by hand in the Experimental instance**, injecting the notification through the real bridge entry point:

- top-level removal → gone from the data and from the DOM, no manual `requestUpdate`
- repeating it, and unknown uuids → no-op, no errors
- **nested removal inside an expanded Agent** → only that child goes; the Agent row and its siblings stay
- children fetched through `get_subagent` do carry their uuid, which had been an open question
- no Lit errors in the console throughout

## Not verified

That the CLI actually emits these. Neither field appears in the SDK runtime or in the CLI source I have, though the VS Code extension implements the same handling — so the signal almost certainly exists, but "almost certainly" isn't measured. The `Warn` on the `model_refusal_fallback` branch is the probe: if a refusal ever happens, it says so in the Output window at the default log level.

Worst case if the payload differs from what we expect, the match simply finds nothing — it removes the wrong thing only if a uuid collides, which is the one thing uuids are for.
