### PR TITLE
fix(chat): open a tool's IN in a temp the editor can actually read

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents.Contracts/FromWebViewDtos.cs
+++ b/src/Corsinvest.VisualStudio.Agents.Contracts/FromWebViewDtos.cs
@@ -62,7 +62,6 @@ public class GetSuggestionsRequest
 public class ToolOutputNotification
 {
     public string ToolUseId { get; set; }
-    public string Title { get; set; }
     public string Which { get; set; }
     public string AgentId { get; set; }
     public string ToolName { get; set; }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Helpers.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Helpers.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -43,17 +43,36 @@ internal sealed partial class WebViewMessageHandler
     }
     // The static helpers below log through OutputWindowLogger, not the pane logger: a primary
     // constructor parameter isn't in scope in a static member (CS9105).
-    private static string FindToolInput(string workingDirectory, string sessionId, string toolUseId, ClaudePaths paths, string toolName = "", string agentId = null)
+
+    /// <summary>The transcript holding a tool call: the session file, or the sub-agent's own when
+    /// agentId names one. Null when anything is missing or unsafe — sessionId and agentId compose a
+    /// path and come from the WebView, so they are checked for traversal here, once, instead of at
+    /// each lookup.</summary>
+    private static string TranscriptPathFor(string workingDirectory, string sessionId, string toolUseId,
+                                            ClaudePaths paths, string agentId)
     {
         if (string.IsNullOrEmpty(sessionId) || string.IsNullOrEmpty(toolUseId)) { return null; }
-        // sessionId/agentId compose a file path and come from the WebView — reject traversal.
         if (!SessionManager.IsSafePathToken(sessionId)) { return null; }
         if (!string.IsNullOrEmpty(agentId) && !SessionManager.IsSafePathToken(agentId)) { return null; }
         var folder = paths.SessionFolder(workingDirectory);
         var path = string.IsNullOrEmpty(agentId)
             ? Path.Combine(folder, sessionId + ".jsonl")
             : Path.Combine(folder, sessionId, "subagents", $"agent-{agentId}.jsonl");
-        if (!File.Exists(path)) { return null; }
+        return File.Exists(path) ? path : null;
+    }
+
+    /// <summary>What a tool was called with: the text to show, and the file it names when it names
+    /// one. Both come off the same `input` object, so reading it twice would mean scanning the
+    /// JSONL twice. FilePath is null for the tools that write no file — Bash, Grep, most MCP.</summary>
+    private static (string Content, string FilePath) FindToolInput(string workingDirectory,
+                                                                   string sessionId,
+                                                                   string toolUseId,
+                                                                   ClaudePaths paths,
+                                                                   string toolName = "",
+                                                                   string agentId = null)
+    {
+        var path = TranscriptPathFor(workingDirectory, sessionId, toolUseId, paths, agentId);
+        if (path == null) { return default; }
         try
         {
             foreach (var line in File.ReadLines(path, System.Text.Encoding.UTF8))
@@ -68,7 +87,9 @@ internal sealed partial class WebViewMessageHandler
                     {
                         if (item.Val("type", "") == "tool_use" && item.Val("id") == toolUseId)
                         {
-                            return item["input"] is not JObject input ? null : ProjectInput(toolName, input);
+                            return item["input"] is not JObject input
+                                ? default
+                                : (ProjectInput(toolName, input), input.Val("file_path"));
                         }
                     }
                 }
@@ -76,19 +97,15 @@ internal sealed partial class WebViewMessageHandler
             }
         }
         catch (Exception ex) { OutputWindowLogger.Global.LogException("FindToolInput/Result", ex); }
-        return null;
+        return default;
     }
+    /// <summary>What the tool answered. Unlike the IN side this is always text meant for the model,
+    /// never a file: a Write reports "File created successfully at: …", a Read returns the content
+    /// with line numbers prefixed. That is why the temp it opens into stays .txt.</summary>
     private static string FindToolResult(string workingDirectory, string sessionId, string toolUseId, ClaudePaths paths, string agentId = null)
     {
-        if (string.IsNullOrEmpty(sessionId) || string.IsNullOrEmpty(toolUseId)) { return null; }
-        // sessionId/agentId compose a file path and come from the WebView — reject traversal.
-        if (!SessionManager.IsSafePathToken(sessionId)) { return null; }
-        if (!string.IsNullOrEmpty(agentId) && !SessionManager.IsSafePathToken(agentId)) { return null; }
-        var folder = paths.SessionFolder(workingDirectory);
-        var path = string.IsNullOrEmpty(agentId)
-            ? Path.Combine(folder, sessionId + ".jsonl")
-            : Path.Combine(folder, sessionId, "subagents", $"agent-{agentId}.jsonl");
-        if (!File.Exists(path)) { return null; }
+        var path = TranscriptPathFor(workingDirectory, sessionId, toolUseId, paths, agentId);
+        if (path == null) { return null; }
         try
         {
             foreach (var line in File.ReadLines(path, System.Text.Encoding.UTF8))
@@ -148,6 +165,51 @@ internal sealed partial class WebViewMessageHandler
         var invalid = Path.GetInvalidFileNameChars();
         var safe = string.Concat(name.Select(c => invalid.Contains(c) ? '_' : c)).Trim('_');
         return safe.Length > 40 ? safe.Substring(0, 40) : safe;
+    }
+
+    /// <summary>Name for the temp file a tool's IN/OUT is opened from — readable in the tab, and
+    /// carrying an extension the editor can colour.
+    ///
+    /// The temp is the right thing to open here and not a stand-in for the real file: clicking the
+    /// row's TITLE already goes to the file. Clicking the content asks a different question — what
+    /// was written in THAT turn — and the file on disk answers it wrongly three turns later, while
+    /// a temp cannot change under you.</summary>
+    private static string TempFileName(string toolName, string which, string filePath, string toolUseId)
+    {
+        // Last few chars of the tool_use_id: enough to keep two temps apart — two writes to
+        // same-named files in different folders, or the same command run twice — without turning
+        // the tab into a guid nobody can read back to a row.
+        var id = SanitizeFileName(toolUseId ?? "");
+        if (id.Length > 6) { id = id.Substring(id.Length - 6); }
+        var side = which == "in" ? "in" : "out";
+
+        // A tool that names a file gets that file's name and extension: "Modello_in_a3f21.cs" reads
+        // back to the row at a glance and the editor colours it. The whole title used to go through
+        // SanitizeFileName instead, which turned a path into "claude_[Write] C__Users_daniele_cors".
+        if (which == "in" && !string.IsNullOrEmpty(filePath))
+        {
+            var name = SanitizeFileName(Path.GetFileNameWithoutExtension(filePath));
+            var ext = Path.GetExtension(filePath);
+            if (!string.IsNullOrEmpty(name))
+            {
+                return $"{name}_{side}_{id}{(string.IsNullOrEmpty(ext) ? ".txt" : ext)}";
+            }
+        }
+
+        // A shell tool's IN is the command — script, so give it the script's extension, with
+        // PowerShell told apart from Bash: .ps1 is what VS colours, and calling it .sh on Windows
+        // highlights it as the wrong language. Its OUT is stdout, which is text and nothing else,
+        // so it stays .txt like every other result.
+        var fallbackExt = which == "in"
+            ? toolName switch
+            {
+                "PowerShell" => ".ps1",
+                "Bash" => ".sh",
+                _ => ".txt",
+            }
+            : ".txt";
+        var who = SanitizeFileName(string.IsNullOrEmpty(toolName) ? AppConstants.AppId : toolName);
+        return $"{who}_{side}_{id}{fallbackExt}";
     }
 
     /// <summary>Write a chat document / composer attachment to a temp file and open it.

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Open.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Open.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -8,6 +8,7 @@ using Corsinvest.VisualStudio.Agents.Helpers;
 using Corsinvest.VisualStudio.Agents.Options;
 using Microsoft.VisualStudio.Shell;
 using Newtonsoft.Json.Linq;
+using System;
 using System.IO;
 
 namespace Corsinvest.VisualStudio.Agents.Chat.Host;
@@ -45,43 +46,60 @@ internal sealed partial class WebViewMessageHandler
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
             var p = data.ToObject<Contracts.ToolOutputNotification>();
             var toolUseId = p.ToolUseId ?? "";
-            var title = p.Title ?? "Tool Output";
             var which = p.Which ?? "out";
             var agentId = p.AgentId;
             var toolName = p.ToolName ?? "";
             if (string.IsNullOrEmpty(toolUseId)) { return; }
-            // Read full content from the JSONL — the WebView only holds
-            // preview-capped text, so this gives the untruncated output.
-            // agentId routes lookup to the sub-agent transcript when present.
-            // But the Agent ROW itself carries an agentId (for fetching its
-            // children) while its OWN result lives in the main transcript — so
-            // fall back to the main file when the sub-agent file has no match.
+            // Read full content from the JSONL — the WebView only holds preview-capped text, so
+            // this gives the untruncated output. The fallback below is for the Agent ROW: it
+            // carries an agentId (it needs one to fetch its children) while its OWN result lives
+            // in the main transcript, so the sub-agent file has no match for it.
             var paths = PaneClaudePaths;
-            var content = which == "in"
-                            ? FindToolInput(client.WorkingDirectory, client.SessionId, toolUseId, paths, toolName, agentId)
-                            : FindToolResult(client.WorkingDirectory, client.SessionId, toolUseId, paths, agentId);
-            if (string.IsNullOrEmpty(content) && !string.IsNullOrEmpty(agentId))
+            string content = null;
+            // Only the IN side names a file. OUT for a Write is "File created successfully at: …",
+            // which is not the file and must not lend the temp its extension.
+            string filePath = null;
+            // The sub-agent transcript first when there is one, then the main file. Same call, and
+            // the agentId is what picks the file it reads.
+            foreach (var lookIn in string.IsNullOrEmpty(agentId) ? [null] : new[] { agentId, null })
             {
-                content = which == "in"
-                            ? FindToolInput(client.WorkingDirectory, client.SessionId, toolUseId, paths, toolName)
-                            : FindToolResult(client.WorkingDirectory, client.SessionId, toolUseId, paths);
+                if (which == "in")
+                {
+                    (content, filePath) = FindToolInput(client.WorkingDirectory, client.SessionId, toolUseId, paths, toolName, lookIn);
+                }
+                else
+                {
+                    content = FindToolResult(client.WorkingDirectory, client.SessionId, toolUseId, paths, lookIn);
+                }
+                if (!string.IsNullOrEmpty(content)) { break; }
             }
+
             if (string.IsNullOrEmpty(content))
             {
                 log.Debug(() => $"[open-output] no content found for tool_use_id={toolUseId}");
                 return;
             }
+
             // Strip the CLI's <tool_use_error> wrapper (protocol detail).
             // Same regex as the WebView's `_cleanResult`.
-            var m = System.Text.RegularExpressions.Regex.Match(
-                content,
-                @"<tool_use_error>([\s\S]*?)</tool_use_error>",
-                System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+            var m = System.Text.RegularExpressions.Regex.Match(content,
+                                                              @"<tool_use_error>([\s\S]*?)</tool_use_error>",
+                                                              System.Text.RegularExpressions.RegexOptions.IgnoreCase);
             if (m.Success) { content = m.Groups[1].Value.Trim(); }
-            var ext = title.StartsWith("[Bash]") || title.StartsWith("[PowerShell]") ? ".sh" : ".txt";
-            var suffix = which == "in" ? "_in" : "_out";
-            var tmpPath = Path.Combine(Path.GetTempPath(), $"claude_{SanitizeFileName(title)}{suffix}{ext}");
+            var tmpPath = Path.Combine(Path.GetTempPath(), TempFileName(toolName, which, filePath, toolUseId));
+            // Clear the flag before rewriting: a previous open left the file read-only, and
+            // WriteAllText would throw on it.
+            try
+            {
+                if (File.Exists(tmpPath)) { File.SetAttributes(tmpPath, FileAttributes.Normal); }
+            }
+            catch (Exception ex) { log.Warn($"[open-output] could not clear read-only on {tmpPath}: {ex.Message}"); }
             File.WriteAllText(tmpPath, content, System.Text.Encoding.UTF8);
+            // Read-only on purpose: this is a copy of what the tool wrote at that turn, and now that
+            // it carries the real extension it looks even more like the source file. Editing it
+            // would change nothing on disk, which is worth making obvious rather than discovering.
+            try { File.SetAttributes(tmpPath, FileAttributes.ReadOnly); }
+            catch (Exception ex) { log.Warn($"[open-output] could not mark {tmpPath} read-only: {ex.Message}"); }
             VsShellUtilities.OpenDocument(ServiceProvider.GlobalProvider, tmpPath,
                 Microsoft.VisualStudio.VSConstants.LOGVIEWID.TextView_guid, out _, out _, out var frame);
             frame?.Show();

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated/ToolOutputNotification.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated/ToolOutputNotification.ts
@@ -5,7 +5,6 @@
 
 export interface ToolOutputNotification {
     toolUseId: string;
-    title: string;
     which: string;
     agentId?: string;
     toolName?: string;

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/tool-host.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/tool-host.ts
@@ -134,19 +134,8 @@ export class BridgeToolHost implements ToolHost {
     /** Open IN/OUT in a temp file in VS. The host holds only the preview-capped
      *  text; the app fetches the full content by toolUseId. */
     openOutput(which: 'in' | 'out'): void {
-        const inp = this.input;
-        const detail =
-            String(inp.file_path ?? '') ||
-            String(inp.command ?? '') ||
-            String(inp.script ?? '') ||
-            String(inp.code ?? '') ||
-            String(inp.pattern ?? '') ||
-            String(inp.query ?? '') ||
-            String(inp.url ?? '') ||
-            this.name;
         bridge.sendNotification<ToolOutputNotification>(Msg.fromWebView.open.toolOutput, {
             toolUseId: this.toolUseId,
-            title: `[${this.name || 'Tool'}] ${detail.slice(0, 60)}`,
             which,
             agentId: this.containerAgentId,
             // Lets the host project the IN to the tool's main field (Agent→prompt,
@@ -158,7 +147,6 @@ export class BridgeToolHost implements ToolHost {
     openError(): void {
         bridge.sendNotification<ToolOutputNotification>(Msg.fromWebView.open.toolOutput, {
             toolUseId: this.toolUseId,
-            title: `[${this.name || 'Tool'}] error`,
             which: 'out',
             agentId: this.containerAgentId,
         });


### PR DESCRIPTION
Clicking the content of a `Write` on `Cliente.cs` opened this:

```
claude_[Write] C__Users_daniele_cors_in.txt
```

Flat text, no colouring, and a tab title you cannot read back to the row it came from — the whole title went through `SanitizeFileName`, so a path turned into underscores and then got cut at 40 characters.

Now:

```
Modello_in_a3f21.cs
```

## Where the extension comes from

The tool's own `file_path`. It sits in the same `input` object the host already reads out of the JSONL to get the content — `FindToolInput` was fetching it and throwing half of it away. So this costs no extra lookup and no new field on the wire: the path travels straight from the transcript, instead of being composed into a title in the WebView and parsed back out here.

The `tool_use_id` tail keeps two writes to same-named files in different folders (`A/config.json`, `B/config.json`) off each other's temp — without it the second would overwrite the first while the first is open in a tab. Six characters, not a guid: a guid is unreadable in a different way, and with three temps open you want to know which is which.

## Only the IN side gets a real extension

The OUT is always text written for the model, never a file:

- `Write` → *"File created successfully at: …"*
- `Read` → the content **with line numbers prefixed** (`formatFileLines` → `addLineNumbers` in the CLI source)

Colouring either as source would highlight something that isn't. Shell tools follow the same rule and used to break it: the command is a script and gets `.ps1` or `.sh` — told apart because calling PowerShell `.sh` on Windows highlights it as the wrong language — while stdout stays `.txt`. That last part was wrong before this change too, not a regression, but wrong.

## Read-only

It was a copy before as well, but a `.txt` named after the tool never looked like the source file. A coloured `Cliente_in.cs` does, and editing it would change nothing on disk — worth making obvious rather than discovering. The attribute is cleared before rewriting, since a second click would otherwise hit the read-only file left by the first.

## Why a temp at all, rather than the real file

Because the row's **title** already opens the real file. Clicking the content asks a different question — what was written in *that* turn — and the file on disk answers it wrongly three turns later. A temp cannot change under you. An earlier draft of this had the host compare the two and choose; that was complexity spent picking between two answers, one of which is already reachable from the title.

## Along the way

`Title` and the seven-way `detail` fallback that built it are gone from the notification — they existed to name the temp, and the name no longer comes from there.

The two lookups shared ten lines of opening (token validation, path composition, `File.Exists`), with the traversal check on WebView-supplied input duplicated across both. That is now `TranscriptPathFor`, in one place. The "sub-agent transcript first, main file second" fallback — which exists because an Agent row carries an `agentId` while its own result lives in the main transcript — is a loop over the two files rather than the same block written twice, once per direction.

## Checked

MSBuild Debug green (0 errors, no new CS warnings). WebView: typecheck, lint clean, prettier, 43/43 unit tests (unchanged — this touches no tested logic).

**Verified by hand in the Experimental instance**: a `Write` on a `.cs` and one on a `.md` open coloured and read-only under their own names; the row title still opens the real file, editable; a Bash command opens `.sh` and its output `.txt`; same for PowerShell with `.ps1`.

Not fixed here: `.sh` has no colouring in VS at all (no Bash language service), and `.ps1` depends on the PowerShell component being installed. Giving them the right extension is still correct — whoever has the component sees it — but `.txt` would have guaranteed nothing for everyone. Tried `LOGVIEWID_Primary` instead of `TextView_guid` in case VS picked a better editor for them; it changed nothing, so it stays as it was.

Left open in the internal TODO: the temps still live in `%TEMP%` and nobody cleans them. The name is now stable per tool_use, so re-clicking a row reuses its file rather than adding another, but sessions still accumulate.
