### PR TITLE
fix(chat): stop showing every stderr line as a failed session

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.ClientEvents.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.ClientEvents.cs
@@ -715,8 +715,25 @@ public partial class ChatPaneControl
             SetSessionTitle(null);
         });
 
+    /// <summary>A line the CLI wrote on stderr. It reaches the chat only if the process is gone —
+    /// a CLI that is still running is warning, not failing, and rendering that as the red banner
+    /// says the session broke when it didn't.
+    ///
+    /// Measured 2026-08-06 on an untrusted workspace: the CLI writes "Ignoring 1 permissions.allow
+    /// entry … this workspace has not been trusted", carries on, and answers the turn normally —
+    /// while we showed an error over a working chat. Node's own DeprecationWarnings came out the
+    /// same way. VS Code reads the child's stderr into a 2KB diagnostic tail and never surfaces it
+    /// (verified in the SDK's ProcessTransport), which is why the same warning is invisible there.
+    ///
+    /// Deliberately not a match on the message text: that would mean chasing the CLI's wording
+    /// release by release. Whether the process survived is the CLI's own verdict on how bad the
+    /// line was. Nothing is lost either way — every line is already logged as Warn by
+    /// NdjsonTransport, and a process that dies raises its own banner through OnProcessExited.</summary>
     private void OnClientError(object sender, string msg)
-        => Dispatcher.Invoke(() => _bridge.Send(BridgeMessages.ToWebView.Cli.Error, new Contracts.CliErrorNotification { Message = msg }));
+    {
+        if (_client?.IsRunning == true) { return; }
+        Dispatcher.Invoke(() => _bridge.Send(BridgeMessages.ToWebView.Cli.Error, new Contracts.CliErrorNotification { Message = msg }));
+    }
 
     private void OnProcessStarted(object sender, ProcessStartedEventArgs e)
         => Dispatcher.Invoke(() =>


### PR DESCRIPTION
Opening the chat on a folder that was never trusted looked like this: a red error banner, and underneath it a chat answering the turn perfectly well — `$1.4677 · 4.7s`.

The CLI had written this on stderr:

```
Ignoring 1 permissions.allow entry from .claude/settings.local.json: this workspace
has not been trusted. Run Claude Code interactively here once and accept the trust
dialog, or set projects["K:/…/webapi"].hasTrustDialogAccepted: true in
C:\Users\…\.claude.json.
```

A warning, with instructions, from a session that then worked. Alongside it: two of Node's own `DeprecationWarning` lines. Three error banners, zero errors.

## Why it happened

There was no point in the chain where anything decided a line was an error:

```
NdjsonTransport:96   ErrorLine?.Invoke(line)     ← every line
ClaudeClient:110     Error?.Invoke(this, msg)    ← no check
OnClientError        → CliErrorNotification      ← red banner
```

It was an error by construction.

## The change

```csharp
if (_client?.IsRunning == true) { return; }
```

A line reaches the chat only if the process is gone.

**Deliberately not a match on the message text.** `msg.Contains("has not been trusted")` means chasing the CLI's wording release by release, and only ever covering what we have already seen. Whether the process survived is *the CLI's own verdict* on how bad that line was — not our guess — and it holds for messages we have never seen, which is most of them.

## Nothing is lost

- Every line is already logged as `Warn` by `NdjsonTransport:95` — always written, whatever the configured log level.
- A process that dies raises its own banner through `OnProcessExited`. That also covers the edge case: a fatal line arriving while `IsRunning` is momentarily still true is dropped here, and announced there.

## What VS Code does with the same stream

Nothing visible. Their SDK reads the child's stderr into a 2 KB `stderrTail` — a diagnostic buffer, there to explain an abnormal exit — and only forwards it to `options.stderr?.()` when debug is on, a callback the extension never sets. They read it because an undrained pipe stalls the process, not to display it. Which is why the identical warning is invisible in VS Code and was a red banner here.

## What this unblocks

`--debug` and `--debug-to-stderr`, two of the five flags VS Code passes and we do not. Until now they would have filled the chat with banners. Not enabled here: that wants its own change, gated on the Trace log level, and a look at what they actually produce for our entrypoint first.

## Checked

MSBuild Debug green — 0 errors, no new CS warnings, VSIX produced.

The evidence came from `tools/cli-probe` run against a real project with `hasTrustDialogAccepted` flipped to `false`; the captured stdout/stderr is saved in `results/results-untrusted-workspace.txt` (gitignored, like the rest of that folder). Also verified in passing: neither the CLI nor VS Code writes that flag back to `true` on its own — after a session with each, the file had been rewritten with new costs and durations, and trust was still `false`.

**Not verified in the running IDE yet**: that the banner is gone and the lines still show up in the Output window under `[stderr]`. The change is one early return around an unmodified send, so the risk is in what no longer reaches the chat, not in what does.
