### PR TITLE
feat(chat): show an API failure as a failure, not as an answer

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents.Contracts/BridgeGenerationSpec.cs
+++ b/src/Corsinvest.VisualStudio.Agents.Contracts/BridgeGenerationSpec.cs
@@ -81,6 +81,8 @@ public class BridgeGenerationSpec : GenerationSpec
         // the result carried none — so it's genuinely nullable on the wire.
         AddInterface<AssistantTextNotification>()
             .Member(x => nameof(x.ParentToolUseId)).Null()
+            // Absent on every message that isn't an API failure, which is nearly all of them.
+            .Member(x => nameof(x.Error)).Null()
             .Member(x => nameof(x.Usage)).Null();
         AddInterface<ExchangeEndedNotification>().Member(x => nameof(x.Usage)).Null();
         AddInterface<EvictMessagesNotification>();

--- a/src/Corsinvest.VisualStudio.Agents.Contracts/ToWebViewDtos.cs
+++ b/src/Corsinvest.VisualStudio.Agents.Contracts/ToWebViewDtos.cs
@@ -495,6 +495,11 @@ public class AssistantTextNotification
     // The permission banner's synthetic message is the one caller that passes none, and it only
     // ever emits tool_use blocks — never the text block this rides on.
     public string Uuid { get; set; }
+    // Why the API call failed, when it did — a closed enum from the CLI (overloaded, rate_limit,
+    // authentication_failed, …). An API failure arrives as an assistant message whose TEXT is the
+    // error, so without this the chat renders it as an ordinary answer, grey dot included. Null on
+    // every normal message: the CLI omits the field rather than sending an empty one.
+    public string Error { get; set; }
     public ContextUsageDto Usage { get; set; }
     // Message time (epoch ms) from the .jsonl record / live event; null when absent. The WebView
     // shows it as "x ago" with an absolute date/time tooltip.

--- a/src/Corsinvest.VisualStudio.Agents/Chat/ContentBlockTranslator.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/ContentBlockTranslator.cs
@@ -88,7 +88,8 @@ internal static class ContentBlockTranslator
                                      bool needsPermission = false,
                                      JArray permissionSuggestions = null,
                                      long? timestamp = null,
-                                     string uuid = null)
+                                     string uuid = null,
+                                     string error = null)
     {
         // JToken for a uniform Emit* signature (HistoryReplay passes the raw content to both). The
         // assistant content is always a block array in practice; a bare string never occurs, so just
@@ -121,6 +122,7 @@ internal static class ContentBlockTranslator
                     ParentToolUseId = parentToolUseId,
                     // Same uuid on every block of the message: it names the message, not the block.
                     Uuid = uuid,
+                    Error = error,
                     Usage = !firstEmitted ? usagePayload : null,
                     Timestamp = timestamp,
                 });

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.ClientEvents.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.ClientEvents.cs
@@ -257,6 +257,14 @@ public partial class ChatPaneControl
             // Do NOT push the reply's `model` to the selector: sub-agents run on a different
             // model and would flip the selection. The selector reflects only the user's explicit
             // choice (set_model) plus init/history.
+            // Logged and nothing else for now: this frame is a failure wearing an answer's clothes
+            // (the CLI puts the error in the TEXT of a synthetic assistant), and the double
+            // rendering that follows is its own change. Warn, not Debug: the turn did not happen,
+            // and "why did it answer with an error message" deserves a line at the default level.
+            if (!string.IsNullOrEmpty(e.Error))
+            {
+                _log.Warn($"[chat] assistant frame reports an API failure: {e.Error}");
+            }
             // Evict BEFORE emitting: this message replaces those, so dropping them first keeps the
             // replacement from appearing under the text it supersedes.
             if (e.Supersedes is { Length: > 0 })
@@ -270,7 +278,8 @@ public partial class ChatPaneControl
                                                  e.ParentToolUseId,
                                                  e.Usage,
                                                  timestamp: e.Timestamp,
-                                                 uuid: e.Uuid);
+                                                 uuid: e.Uuid,
+                                                 error: e.Error);
         });
 
     private void OnUserMessage(object sender, UserMessageEventArgs e)

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated/AssistantTextNotification.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated/AssistantTextNotification.ts
@@ -9,6 +9,7 @@ export interface AssistantTextNotification {
     text: string;
     parentToolUseId: string | null;
     uuid: string;
+    error: string | null;
     usage: ContextUsageDto | null;
     timestamp?: number;
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/types.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/types.ts
@@ -334,6 +334,11 @@ export interface UiAssistantEntry extends UiEntryBase {
     /** The message's wire uuid — what lets an entry be addressed after it has been rendered.
      *  Absent on a synthetic message (the permission banner's) and on older .jsonl lines. */
     uuid?: string;
+    /** Why the API call failed, when it did (`overloaded`, `rate_limit`, …). An API failure reaches
+     *  us as an assistant message whose text IS the error, so this is what tells the two apart —
+     *  without it the turn renders as an answer, grey dot and all. Absent on a normal message, and
+     *  on history: the .jsonl keeps no such field. */
+    error?: string;
 }
 
 /** A thinking block: the model's reasoning, live-only (never persisted). `streaming` true while

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
@@ -283,6 +283,8 @@ export class CvApp extends LitElement {
                                 // Only this final notification names the message — the deltas that
                                 // built the entry carry no uuid, so it lands here or nowhere.
                                 uuid: data?.uuid ?? e.uuid,
+                                // Same: an API failure is only known once the frame arrives.
+                                error: data?.error ?? e.error,
                             })),
                         );
                         entryId = streamingId;
@@ -1243,6 +1245,7 @@ export class CvApp extends LitElement {
             text: d.text ?? '',
             timestamp: d.timestamp ?? undefined,
             uuid: d.uuid ?? undefined,
+            error: d.error ?? undefined,
         };
     }
 
@@ -1588,7 +1591,7 @@ export class CvApp extends LitElement {
             .images=${e.role === 'user' ? (e.images ?? []) : []}
             .files=${e.role === 'user' ? (e.files ?? []) : []}
             ?streaming=${e.role === 'assistant' ? !!e.streaming : false}
-            ?isError=${e.role === 'slash-result' ? e.isError : false}
+            ?isError=${e.role === 'slash-result' ? e.isError : e.role === 'assistant' && !!e.error}
             .timestamp=${
                 e.role === 'user' || e.role === 'assistant' || e.role === 'slash-result'
                     ? (e.timestamp ?? 0)

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-message.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-message.ts
@@ -415,7 +415,14 @@ export class CvMessage extends LitElement {
             }
 
             case 'assistant': {
-                const dotClass = this.streaming ? 'spinning' : 'dot-gray';
+                // Red when the API refused the turn. The frame looks like any other answer — the
+                // CLI puts the error in the TEXT of a synthetic assistant — so the grey dot would
+                // read as "answered fine". Same class the tool rows use for a failed tool.
+                const dotClass = this.streaming
+                    ? 'spinning'
+                    : this.isError
+                      ? 'dot-error'
+                      : 'dot-gray';
                 return html`
                     <div class="cv-message assistant">
                         <span class="cv-tool-row-dot ${dotClass}"></span>

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.Protocol.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.Protocol.cs
@@ -317,6 +317,7 @@ internal sealed partial class ClaudeClient
             Usage = m["usage"] as JObject,
             Uuid = obj.Val("uuid"),
             // Wrapper-level like uuid, not inside `message`.
+            Error = obj.Val("error"),
             Supersedes = (obj["supersedes"] as JArray)?
                 .Select(t => t?.ToString())
                 .Where(s => !string.IsNullOrEmpty(s))

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/Events.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/Events.cs
@@ -60,6 +60,25 @@ public sealed class AssistantMessageEventArgs
     /// other, so acting on both is safe. Null when the message replaces nothing, which is nearly
     /// always.</summary>
     public string[] Supersedes { get; set; }
+    /// <summary>Why the API call failed, when it did. An API failure doesn't arrive as an error on
+    /// the wire: the CLI fabricates a synthetic assistant whose TEXT is the error
+    /// (`utils/messages.ts:445-457`), so without this field it reads as an ordinary answer — which
+    /// is why one turn can show up twice, once as a grey-dot reply and once as the red notice the
+    /// `result` raises.
+    ///
+    /// A closed enum, not free text: `SDKAssistantMessageError` (`sdk.d.ts:2846`) is
+    /// authentication_failed | oauth_org_not_allowed | billing_error | rate_limit | overloaded |
+    /// invalid_request | model_not_found | server_error | unknown | max_output_tokens. So it says
+    /// WHICH failure, not just that there was one — a notice can name the rate limit instead of
+    /// saying "API error".
+    ///
+    /// Measured 2026-08-06 by pointing the CLI at an invalid token: the wrapper came back with
+    /// `error: "authentication_failed"`, and a normal turn carries no such field. The same frame
+    /// also had `is_api_error_message: true`, which is NOT in the SDK types (0 hits in a file that
+    /// declares everything else we use) — emitted without a contract, so not something to build on.
+    ///
+    /// Read and logged, not acted on: the double-rendering fix is a separate change.</summary>
+    public string Error { get; set; }
     /// <summary>Message time (epoch ms) parsed from the wire `timestamp`; null when absent.</summary>
     public long? Timestamp { get; set; }
     /// <summary>When non-null, this assistant message was emitted by a sub-agent


### PR DESCRIPTION
When the API refuses a turn, nothing on the wire says "error". The CLI fabricates a synthetic assistant message whose **text** is the error and sends it like any other reply — so the chat rendered it as one, grey dot and all, the same dot a finished answer gets.

The frame does carry the answer, in a field we were dropping.

## `error`, and why it is the right one

`SDKAssistantMessage.error` is a closed enum in the SDK types (`sdk.d.ts:2807`, `:2846`):

```
authentication_failed | oauth_org_not_allowed | billing_error | rate_limit
| overloaded | invalid_request | model_not_found | server_error | unknown
| max_output_tokens
```

So it says *which* failure, not merely that there was one — enough for a future notice to name the rate limit instead of saying "API error".

**Measured, not assumed.** Pointing the CLI at an invalid token brings back:

```json
{ "type":"assistant", "uuid":"…", "error":"authentication_failed",
  "request_id":"…", "is_api_error_message":true }
```
with text `Failed to authenticate. API Error: 401 Invalid bearer token`. A turn that succeeds carries neither field — the wrapper is just `type/parent_tool_use_id/session_id/uuid/timestamp/request_id`.

Note `is_api_error_message` in that frame: it arrives, but it is **absent from the SDK types** — 0 hits in a file that declares everything else we use, including the fields added in this week's work. Emitted without a contract, so not something to build on when the declared field says more.

## The dot

Three states now instead of two, using `dot-error` — the class the tool rows already use for a failed tool — and `cv-message`'s existing `isError` property rather than a parallel flag. No new CSS, no new concept: the tool row path already worked this way, it just had a DTO field to work from and the assistant didn't.

## History is untouched

The field rides the wire wrapper; the `.jsonl` keeps none. A reloaded session shows the grey dot again. That is the shape of the data rather than an oversight, and the type comment says so.

## Logged at Warn

The turn did not happen. *"Why did it answer me with an error message"* is a question that deserves a line at the default log level, not one you only get after turning Debug on.

## What this does not fix

The same failure still appears **twice** — once as this message, once as the notice the `result` raises. Suppressing the second is now trivial, since the entry before it carries `error`, but it is a separate change and the TODO entry keeps it.

## Checked

MSBuild Debug green (0 errors, no new CS warnings). WebView: typecheck, lint clean, prettier, 43/43 unit tests.

**Not verified in the running IDE**: that the dot is red on a real API failure. Those don't come on demand — which is the reason the `Warn` line exists, so the next one leaves evidence instead of being another missed occasion. The wire shape itself was verified with the probe (invalid token against the real API), and the transport is the same five-step path `uuid` took two commits ago.
