### PR TITLE
fix(client): follow the model when a refusal swaps it out

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.ClientEvents.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.ClientEvents.cs
@@ -590,6 +590,13 @@ public partial class ChatPaneControl
                     _bridge.Send(BridgeMessages.ToWebView.Chat.EvictMessages,
                                  new Contracts.EvictMessagesNotification { Uuids = uuids });
                 }
+                // The selector still shows the model the user picked, while the CLI is answering
+                // with another one — the same kind of lie as a permission mode that reads "Plan"
+                // over a session running in bypass. The client has already followed the switch
+                // (HandleSystem), so this is the same echo the model picker does after an ack:
+                // same message, same listener, nothing new on the wire.
+                _bridge.Send(BridgeMessages.ToWebView.Cli.ModelChanged,
+                             new Contracts.ModelChangedNotification { Model = _client?.Model });
             }
             else if (subtype == ClientMessages.SystemSubtype.BackgroundTasksChanged)
             {

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.Protocol.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.Protocol.cs
@@ -128,8 +128,7 @@ internal sealed partial class ClaudeClient
             case ClientMessages.Type.ControlResponse: HandleControlResponse(obj); break;
             case ClientMessages.Type.ControlRequest: HandleIncomingControlRequest(obj); break;
             case ClientMessages.Type.ControlCancelRequest: HandleCancelRequest(obj); break;
-            case ClientMessages.Type.System when obj.Val("subtype", "") == ClientMessages.SystemSubtype.Init: HandleInit(obj); break;
-            case ClientMessages.Type.System: SystemMessageReceived?.Invoke(this, obj); break;
+            case ClientMessages.Type.System: HandleSystem(obj); break;
             case ClientMessages.Type.Assistant: HandleAssistant(obj); break;
             case ClientMessages.Type.User: HandleUser(obj); break;
             case ClientMessages.Type.Result: HandleResult(obj); break;
@@ -304,6 +303,38 @@ internal sealed partial class ClaudeClient
             PermissionMode = PermissionMode,
             FastModeState = obj.Val("fast_mode_state", "off"),
         });
+    }
+
+    /// <summary>Every `system` message, sorted by subtype in one place. `init` is the client's own
+    /// business and stops here; everything else is read for the state this class owns and then
+    /// passed on — a pane shouldn't have to remember to tell the client what the client's own
+    /// model is.</summary>
+    private void HandleSystem(JObject obj)
+    {
+        switch (obj.Val("subtype", ""))
+        {
+            case ClientMessages.SystemSubtype.Init:
+                HandleInit(obj);
+                return;
+
+            // The model refused on safety grounds and the CLI switched to another one — and the
+            // swap is persistent for the session, not a one-turn detour (sdk.d.ts:3989). `Model`
+            // follows the CLI everywhere else (it only advances once `set_model` is acked, and
+            // init reads it back), so it follows here too: leaving it behind would show the old
+            // model in the selector for the rest of the session, and send the old one on the next
+            // set_model.
+            case ClientMessages.SystemSubtype.ModelRefusalFallback:
+                {
+                    var fallback = obj.Val("fallback_model");
+                    if (!string.IsNullOrEmpty(fallback) && fallback != Model)
+                    {
+                        _log.Warn($"[client] model_refusal_fallback: {Model} → {fallback}");
+                        Model = fallback;
+                    }
+                    break;
+                }
+        }
+        SystemMessageReceived?.Invoke(this, obj);
     }
 
     private void HandleAssistant(JObject obj)


### PR DESCRIPTION
When the primary model ends a turn with `stop_reason: "refusal"`, the CLI retries on a fallback model and keeps it **for the rest of the session** — `sdk.d.ts:3989` is explicit that the swap is persistent, not a one-turn detour.

We were already reading that message, to evict the retracted partial, and logging `fallback_model` without doing anything with it. So the selector kept showing the model the user picked while every answer came from another one, and the next `set_model` would have sent the old id back.

### What changed

`Model` now follows the switch. That is what `Model` does everywhere else: it advances only once the CLI acks a `set_model`, and `init` reads it back off the wire — it has always been a reflection of what the CLI is using, never a record of what was asked for. This is the same thing said by a different message.

Done in the client rather than the pane because `Model` is `private set` and should stay that way: a second consumer of the same client would otherwise read a stale value depending on whether some pane remembered to pass the news along.

The pane then echoes it to the selector through `ModelChanged` — the same message the model picker already sends after an ack, the same listener on the other side. Nothing new on the wire, no TypeScript touched.

### Drive-by

The two `case System` arms are now one `HandleSystem`. Before this the subtype selection lived in two places, a `when` clause on the outer switch and an `if` inside the handler; the next subtype the client needs to intercept would have had to pick between two mechanisms. `init` still stops at the client, everything else is read and passed on.

### Verification

MSBuild Debug green, 0 errors, no new CS warnings. The refusal path itself can't be triggered on demand — the `Warn` on that branch is what will show it firing.

### Not in scope

The "Switched to X / Why?" banner explaining the swap to the user. Still open in the internal TODO, downgraded now that the silent part is gone.
