### PR TITLE
fix(ide): stop claiming a line the selection never reached

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.cs
@@ -219,6 +219,16 @@ internal sealed partial class IdeContextService : IDisposable
             var isEmpty = sel.IsEmpty;
             var startLine = snapshot.GetLineFromPosition(sel.Start.Position.Position);
             var endLine = snapshot.GetLineFromPosition(sel.End.Position.Position);
+            // Dragging to the START of a line leaves the end offset on a line the selection holds no
+            // character of — reporting it would hand Claude one line more than was selected. Step
+            // back to the line that actually ends the selection. Guarded on a real multi-line
+            // selection so a bare caret at column 0 is left alone.
+            if (!isEmpty
+                && endLine.LineNumber > startLine.LineNumber
+                && sel.End.Position.Position == endLine.Start.Position)
+            {
+                endLine = snapshot.GetLineFromLineNumber(endLine.LineNumber - 1);
+            }
             var ctx = new EditorContext
             {
                 FilePath = filePath,
@@ -229,7 +239,9 @@ internal sealed partial class IdeContextService : IDisposable
                 StartLine = startLine.LineNumber + 1,
                 EndLine = endLine.LineNumber + 1,
                 StartColumn = sel.Start.Position.Position - startLine.Start.Position,
-                EndColumn = sel.End.Position.Position - endLine.Start.Position,
+                // Clamped to the line's end: when the line above was stepped back to, the original
+                // offset sits past it and the bare subtraction would overshoot.
+                EndColumn = Math.Max(0, Math.Min(sel.End.Position.Position, endLine.End.Position) - endLine.Start.Position),
                 SelectedText = isEmpty
                     ? string.Empty
                     : snapshot.GetText(sel.Start.Position.Position, sel.End.Position.Position - sel.Start.Position.Position),


### PR DESCRIPTION
## The bug

Drag a selection from line 5 down to the **first column of line 8** and release. Line 8 holds none
of the selected characters, but we reported the selection as spanning 5-8 — one line more than the
user highlighted. Claude then reasons about a line that was never selected.

`SelectedText` was always correct (it comes from the span), so nothing wrong ever reached the model
as *text*; only the line numbers alongside it were off.

Confirmed 2026-07-31, still present before this change. Spotted originally in
[finex7070/CodeAstrogator](https://github.com/finex7070/CodeAstrogator)
(`WebViewBridge.GetActiveSelection`), which handles the case explicitly.

## The fix

`IdeContextService.CaptureAndSchedule` derived `EndLine` straight from
`GetLineFromPosition(sel.End...)`, which answers "which line is this offset on" — correct, but the
end offset of such a selection sits at the *start* of the next line.

Step back to the line that actually ends the selection **before** building the DTO, so `EndLine` and
`EndColumn` both derive from the same line rather than disagreeing. `EndColumn` is then clamped to
that line's end, since the original offset now sits past it.

Three guards keep the cases that already worked untouched:

| Guard | Case it protects |
| --- | --- |
| `!isEmpty` | a bare caret at column 0 — not a selection |
| `endLine > startLine` | a single-line selection starting at column 0 |
| `End.Position == endLine.Start.Position` | the actual "stopped at line start" test |

## Verification

Green MSBuild (Debug). No test project, so the behaviour needs the Exp instance — the four cases,
watching the IDE-context chip (or `[ChatSelection] … line=X-Y` at Trace level):

| Selection | Expected |
| --- | --- |
| line 5 → **start of** line 8 | `5-7` — the fixed case |
| line 5 → middle of line 8 | `5-8` unchanged |
| within a single line | unchanged |
| caret, no selection, at line start | unchanged |

`SelectedText` stays correct in all four; only the numbers move.
