### PR TITLE
feat(chat): a message written mid-turn looks and lands like one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **A message written during a turn says so, and lands where it was sent.** Typing while Claude is
+  still answering has always held the message back until the turn ended, but its bubble went in at
+  once and looked exactly like a sent one — then stayed above a reply it had not prompted. Since an
+  exchange begins at each user message, that reply was also filed under the wrong question, and a
+  reopened session showed a different order from the live one, because the `.jsonl` records what was
+  actually sent. The bubble is now greyed out while it waits and drops below the running reply when
+  it goes, which is the order the session file already had. Stopping the turn takes those bubbles
+  away rather than leaving them looking sent — the model was never given them. The "N messages
+  queued" bar above the composer is gone with this: it counted what the bubbles now show, and its
+  Clear discarded the whole queue, which was never the thing anyone wanted to do.
+
 - **A turn tells you what it cost and how long it took.** The spinner counts the seconds while the
   turn runs and while it is thinking, and the cost lands on the hover-actions row when it finishes.
   An Agent row does the same for its own run — elapsed while it works, cost when it is done — in
@@ -53,6 +64,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - **Three catches on user-facing paths stopped swallowing.** A file that would not open and a
   debugger operation that failed both returned quietly, so "nothing happened" was all you got.
+
+- **A selection no longer claims a line it never reached.** Dragging to the *start* of a line leaves
+  the end offset on a line holding none of the selected characters, and it was reported anyway — so
+  selecting lines 5 to 8's first column told Claude the selection spanned 5-8, one line more than
+  was highlighted. The text was always right; only the line numbers Claude was asked to reason about
+  were off.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -240,6 +240,10 @@ See [Options → Profiles](docs/options.md#profiles).
 
 - **Multi-line prompt** with Send/Stop, Enter-to-send (or Ctrl+Enter, configurable),
   Shift+Enter for a newline.
+- **Write while it is still answering** — the message is held until the turn ends, then sent. Its
+  bubble appears straight away, greyed out so it does not read as already sent, and drops into place
+  below the reply it was waiting on, so each answer stays under the question that prompted it.
+  Stopping the turn discards what is still waiting, since the model was never given it.
 - **Slash-command palette** — a lightning button opens a unified palette; typing `/` filters. It
   lists the CLI's slash/skill commands plus built-in actions (Attach, Mention, Clear, Switch model,
   Settings, Manage plugins, Open Claude in Terminal, Help, Report a problem).

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/state.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/state.ts
@@ -52,6 +52,11 @@ interface AppState {
     initialized: boolean;
     // Active sub-agents, mirrored from cv-app's Map for cross-component access.
     subagentTasks: SubagentTask[];
+    // Uuids of messages typed while a turn was running: echoed as bubbles at once, but not handed
+    // to the CLI until that turn ends. Mirrored from cv-prompt's queue, which keeps the payloads
+    // themselves (text + attachments) since it is the one that sends them — cv-app needs only the
+    // uuids, to fade a bubble that is on screen without having been sent.
+    queuedUuids: string[];
 
     // History paging (scroll-up fetches older pages on demand):
     // - currentSessionId tags pages so out-of-order replies for a replaced session are dropped.
@@ -170,6 +175,7 @@ const _impl = new StoreImpl<AppState>({
     pendingPermission: null,
     initialized: false,
     subagentTasks: [],
+    queuedUuids: [],
 
     currentSessionId: null,
     oldestLoadedOffset: -1,

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/transcript.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/transcript.ts
@@ -143,6 +143,27 @@ export class Transcript {
     }
 
     /**
+     * Move the top-level entry with `uuid` to the end.
+     *
+     * A message typed during a turn is echoed at once but only sent when that turn ends, so its
+     * bubble sits above a reply it did not prompt — and `buildGroups` opens an exchange on every
+     * user message, so that reply is grouped under the wrong question. Moving it on dispatch also
+     * matches the order the .jsonl records, so the live view and a reopened session agree.
+     *
+     * Top level only: a user message is never nested under a tool row.
+     */
+    moveToEnd(uuid: string): boolean {
+        const i = this._entries.findIndex((e) => 'uuid' in e && e.uuid === uuid);
+        if (i < 0 || i === this._entries.length - 1) {
+            return false;
+        }
+        const moved = this._entries[i];
+        this._entries = [...this._entries.slice(0, i), ...this._entries.slice(i + 1), moved];
+        this._reindex();
+        return true;
+    }
+
+    /**
      * Replace the entry with `id` by `fn(entry)`, rebuilding every object on the path down to it.
      *
      * Returns false when the id is no longer in the tree — an async callback (a sub-agent fetch, a

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/transcript.test.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/transcript.test.ts
@@ -390,3 +390,42 @@ test('removeByUuid: un ramo senza rimozioni mantiene la sua identita', () => {
     // del sub-agent a ogni retraction.
     assert.equal(t.entries[0], before, 'il ramo non toccato mantiene il riferimento');
 });
+
+test('moveToEnd: la bolla accodata scende in fondo', () => {
+    const t = new Transcript();
+    t.append({ ...userEntry(1), uuid: 'chiesto' });
+    t.append({ ...userEntry(2, 'in coda'), uuid: 'in-coda' });
+    t.append(assistantEntry(3, 'risposta'));
+
+    assert.equal(t.moveToEnd('in-coda'), true);
+
+    // Senza lo spostamento buildGroups aprirebbe l exchange su 2 e la risposta a 1 finirebbe
+    // sotto la domanda sbagliata.
+    assert.deepEqual(
+        t.entries.map((e) => e.id),
+        [1, 3, 2],
+    );
+});
+
+test('moveToEnd: index coerente dopo lo spostamento', () => {
+    const t = new Transcript();
+    t.append({ ...userEntry(1), uuid: 'a' });
+    t.append(toolEntry(2, 'agent'));
+    t.appendChild('agent', userEntry(3), childKey);
+
+    t.moveToEnd('a');
+
+    assert.equal(t.find(1)?.id, 1, 'la entry spostata resta raggiungibile');
+    assert.equal(t.find(3)?.id, 3, 'i figli scalati di posizione restano indicizzati');
+});
+
+test('moveToEnd: uuid assente o gia in fondo non tocca nulla', () => {
+    const t = new Transcript();
+    t.append({ ...userEntry(1), uuid: 'a' });
+    t.append({ ...userEntry(2), uuid: 'b' });
+    const before = t.entries;
+
+    assert.equal(t.moveToEnd('mai-visto'), false);
+    assert.equal(t.moveToEnd('b'), false, 'gia ultima');
+    assert.equal(t.entries, before, 'nessun nuovo array, Lit non rirenderizza');
+});

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
@@ -123,6 +123,10 @@ export class CvApp extends LitElement {
      *  `result` and are live-only). A replayed turn therefore shows its tokens and nothing else. */
     private _turnMetrics = new Map<number, TurnMetrics>();
 
+    /** Uuids of bubbles echoed on submit but not yet handed to the CLI, mirrored from cv-prompt's
+     *  queue (which keeps the payloads). A Set because renderMessage asks per bubble. */
+    @state() private _queuedUuids = new Set(appState.queuedUuids);
+
     /** Derived, never stored: recomputed only when the tree changes identity. Holding the groups
      *  as state gave them two writers, and that is how they and the entries drifted apart. */
     private get _exchanges(): UiEntry[][] {
@@ -183,6 +187,7 @@ export class CvApp extends LitElement {
         this._transcript.onRemoved = (ids) => this._dropRemovedIds(ids);
         this._transcript.onCleared = () => this._dropAllIds();
         this._offs.push(appState.on('isBusy', (v) => (this._isBusy = v)));
+        this._offs.push(appState.on('queuedUuids', (v) => (this._queuedUuids = new Set(v))));
         this._offs.push(appState.on('status', (v) => (this._status = v)));
         this._offs.push(appState.on('pendingPermission', (v) => (this._awaitingUser = v != null)));
         // Global Esc-to-stop: interrupt generation regardless of focus, so stopping
@@ -198,6 +203,11 @@ export class CvApp extends LitElement {
         // User picked a model from the menu (cv-prompt) — the "Switched to X" notice
         // fires ONLY here, never for the ui_init seed or a runtime cli_model_changed.
         this.addEventListener('model-switched', this._onModelSwitched as EventListener);
+        // A queued message reached the CLI: its bubble moves down to where it was really sent (the
+        // fading comes from appState.queuedUuids, which needs no event).
+        this.addEventListener('queued-sent', this._onQueuedSent as EventListener);
+        // Stop / Clear: what never went is taken off screen rather than left looking sent.
+        this.addEventListener('queued-dropped', this._onQueuedDropped as EventListener);
 
         // Session/system notices: this stack keeps the `top` ones (a per-turn notice is picked up by
         // cv-prompt's own stack listening on the same channel).
@@ -478,6 +488,9 @@ export class CvApp extends LitElement {
                 // that clears busy — would land on nothing. Without this the spinner outlives the
                 // session that started it, with no message under it to explain what it is waiting for.
                 appState.isBusy = false;
+                // Anything queued was written for the session that just went; the isBusy above is
+                // what would otherwise flush it into the new one.
+                this.querySelector('cv-prompt')?.dropQueue();
                 appState.currentSessionId = null;
                 appState.oldestLoadedOffset = -1;
                 appState.hasMoreHistory = false;
@@ -1174,6 +1187,30 @@ export class CvApp extends LitElement {
         this._addText({ role: 'status', text: `Switched to ${modelLabel(value)}` });
     };
 
+    /**
+     * A queued message went to the CLI: move its bubble below the reply it had been sitting above,
+     * so that reply keeps the question which actually prompted it. The fading is already handled —
+     * the uuid left `appState.queuedUuids` — so only the position is left.
+     *
+     * No scroll: the user may well be reading further up, often the very reason they queued
+     * something, and the jump button already covers going back down.
+     */
+    private _onQueuedSent = (e: CustomEvent<{ uuid: string }>): void => {
+        const uuid = e.detail?.uuid;
+        if (uuid) {
+            this._mutate(() => this._transcript.moveToEnd(uuid));
+        }
+    };
+
+    /** Stop or Clear: these never reached the CLI, so the model has no idea they exist. Leaving
+     *  them on screen is the same divergence a retraction causes, from our own side. */
+    private _onQueuedDropped = (e: CustomEvent<{ uuids: string[] }>): void => {
+        const uuids = e.detail?.uuids ?? [];
+        if (uuids.length > 0) {
+            this._mutate(() => this._transcript.removeByUuid(uuids));
+        }
+    };
+
     /** Stable identity of a sub-agent child: toolUseId for tools, uuid for text. */
     private static _childKey(e: UiEntry): string {
         if (e.kind === 'tool') {
@@ -1588,6 +1625,7 @@ export class CvApp extends LitElement {
             .summary=${e.role === 'compact' ? (e.summary ?? '') : ''}
             ?loaded=${e.role === 'compact' ? !!e.loaded : false}
             .uuid=${e.role === 'compact' || e.role === 'user' ? (e.uuid ?? '') : ''}
+            ?queued=${e.role === 'user' && !!e.uuid && this._queuedUuids.has(e.uuid)}
             .images=${e.role === 'user' ? (e.images ?? []) : []}
             .files=${e.role === 'user' ? (e.files ?? []) : []}
             ?streaming=${e.role === 'assistant' ? !!e.streaming : false}

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-message.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-message.ts
@@ -41,6 +41,9 @@ export class CvMessage extends LitElement {
     // reflect: the sticky-user CSS keys off [role="user"] to pin only real user bubbles,
     // never a leading assistant/tool group that a history page split off from its user.
     @property({ reflect: true }) role: MessageRole = 'assistant';
+    // Typed during a turn and still waiting for it to end: reflected so chat.css can fade the
+    // bubble, since an unsent message that looks sent is the whole reason this exists.
+    @property({ type: Boolean, reflect: true }) queued = false;
     @property() text = '';
     // role:'compact' only — header fields (trigger/tokens) + the lazily-fetched summary,
     // shown in the expandable <details> body. `loaded` gates the fetch (cached after).

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-prompt.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-prompt.ts
@@ -283,18 +283,6 @@ export class CvPrompt extends LitElement implements CommandHost {
                 border-bottom: 1px solid var(--colorNeutralStroke2);
                 position: relative;
             }
-            /* Same band as #attachments: what is staged above the box the user is typing in. */
-            #queued {
-                display: flex;
-                align-items: center;
-                justify-content: space-between;
-                gap: 8px;
-                padding: 0 2px 6px;
-                margin-bottom: 6px;
-                border-bottom: 1px solid var(--colorNeutralStroke2);
-                color: var(--colorNeutralForeground3);
-                font-size: 11px;
-            }
         `,
     ];
 
@@ -958,7 +946,7 @@ export class CvPrompt extends LitElement implements CommandHost {
         this._echoUserMessage(payload);
         if (this._isBusy) {
             // Already running → enqueue. Drained when isBusy flips to false.
-            this._queue = [...this._queue, payload];
+            this._setQueue([...this._queue, payload]);
         } else {
             this._dispatch(payload);
         }
@@ -1103,13 +1091,65 @@ export class CvPrompt extends LitElement implements CommandHost {
         bridge.sendNotification<SendPromptNotification>(Msg.fromWebView.cli.sendPrompt, payload);
     }
 
+    /**
+     * Tell the transcript that a bubble entered the queue, or just left it. Only the queued path
+     * says anything: a message sent straight away is already both in the right place and really
+     * sent, so there is no state for it to leave.
+     *
+     * cv-app owns the transcript, so it does the fading and the move; this component knows the
+     * moments, not the tree.
+     */
+    /**
+     * Drop everything still queued and take its bubbles with it. They were echoed on submit but
+     * never reached the CLI, so leaving them would show the model messages it has never been told
+     * about — the same divergence a retraction causes, only from our side.
+     */
+    /**
+     * Replace the queue and mirror its uuids into the shared state — how cv-app knows which
+     * bubbles are on screen without having been sent.
+     *
+     * Every write goes through here, so the two cannot drift. The payloads stay with the component
+     * that sends them (text and attachments are of no use to anyone else); only the uuids, which
+     * another component does need, are published.
+     */
+    private _setQueue(queue: typeof this._queue): void {
+        this._queue = queue;
+        appState.queuedUuids = queue.map((q) => q.uuid);
+    }
+
+    /**
+     * Drop what is still queued and take its bubbles with it — on Stop, and when the session is
+     * swapped out from under it. They were echoed on submit but never reached the CLI, so leaving
+     * them on screen would show the model messages it has never been told about: the same
+     * divergence a retraction causes, from our own side.
+     */
+    dropQueue(): void {
+        if (this._queue.length === 0) {
+            return;
+        }
+        const uuids = this._queue.map((q) => q.uuid);
+        this._setQueue([]);
+        this.dispatchEvent(
+            new CustomEvent('queued-dropped', { detail: { uuids }, bubbles: true, composed: true }),
+        );
+    }
+
     private _flushQueue(): void {
         if (this._isBusy || this._queue.length === 0) {
             return;
         }
         const [next, ...rest] = this._queue;
-        this._queue = rest;
+        this._setQueue(rest);
         this._dispatch(next);
+        // The state above unfades the bubble; this says WHICH one left, so cv-app can move it below
+        // the reply it had been sitting above.
+        this.dispatchEvent(
+            new CustomEvent('queued-sent', {
+                detail: { uuid: next.uuid },
+                bubbles: true,
+                composed: true,
+            }),
+        );
     }
 
     private _addAttachment(att: Attachment): void {
@@ -1165,7 +1205,7 @@ export class CvPrompt extends LitElement implements CommandHost {
         // A builtin that resets the session is also the way out of a stuck one, so it must not
         // queue behind the very turn it is meant to clear — the CLI takes these mid-turn.
         if (this._isBusy && !RESET_COMMANDS.has(text.trim().split(/\s+/, 1)[0])) {
-            this._queue = [...this._queue, payload];
+            this._setQueue([...this._queue, payload]);
         } else {
             this._dispatch(payload);
         }
@@ -1311,7 +1351,7 @@ export class CvPrompt extends LitElement implements CommandHost {
         bridge.sendNotification(Msg.fromWebView.cli.stop, {});
         // Queued prompts were meant to follow the turn being stopped; flushing them after an
         // interrupt would send messages the user never confirmed at a CLI they just halted.
-        this._queue = [];
+        this.dropQueue();
         // Optimistic reset: free the UI now in case the CLI is wedged and
         // never sends `result`.
         appState.isBusy = false;
@@ -1444,30 +1484,6 @@ export class CvPrompt extends LitElement implements CommandHost {
         this._ta?.focus({ preventScroll: true });
     };
 
-    /** Messages typed while a turn was running, waiting for it to end. The bubble for each is
-     *  already in the transcript (the echo goes in on submit), so without this row a queued
-     *  message is indistinguishable from a sent one — the whole reason it looked like the chat
-     *  had swallowed them. */
-    private _renderQueue() {
-        const n = this._queue.length;
-        if (n === 0) {
-            return nothing;
-        }
-        return html`
-            <div id="queued" title=${this._queue.map((q) => q.text).join('\n\n')}>
-                <span>${n === 1 ? '1 message queued' : `${n} messages queued`}</span>
-                <fluent-button
-                    appearance="transparent"
-                    size="small"
-                    @click=${(): void => {
-                        this._queue = [];
-                    }}
-                    >Clear</fluent-button
-                >
-            </div>
-        `;
-    }
-
     private _renderChips() {
         if (this._attachments.length === 0) {
             return nothing;
@@ -1509,7 +1525,7 @@ export class CvPrompt extends LitElement implements CommandHost {
                 @drop=${this._onDrop}
             >
                 <cv-notice-stack @notice-dismissed=${this._onNoticeDismissed}></cv-notice-stack>
-                ${this._renderQueue()} ${this._renderChips()}
+                ${this._renderChips()}
                 <textarea
                     id="input"
                     placeholder=${

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/chat.css
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/chat.css
@@ -98,6 +98,17 @@
     margin-bottom: 10px;
     position: relative;
 }
+/* A message typed while a turn was running: the bubble is there because the user wrote it, but
+ * the CLI has not been given it yet. Faded rather than badged — in a column of full-strength
+ * bubbles a pale one reads at a glance, and the bubble already carries copy/fork actions on hover
+ * without another icon competing. The transition is what makes the hand-off legible: the bubble
+ * fills in as it drops into place. */
+cv-message[queued] {
+    opacity: 0.55;
+}
+cv-message {
+    transition: opacity 0.15s ease-in;
+}
 /* Pin only when the exchange's first message is a REAL user bubble. A history page can
  * start on a synthetic role:user line (tool_result / meta-injection) that renders as a
  * tool/other; the [role="user"] guard keeps that leading group from pinning wrongly. */


### PR DESCRIPTION
Typing while Claude is still answering has always held the message back until the turn ended. Its bubble, though, went in at once and looked exactly like a sent one — then stayed above a reply it had not prompted.

That is two lies at once:

- the bubble claims to have been delivered when the CLI has not seen it;
- because `buildGroups` opens an exchange at each user message, the running turn's reply gets filed under the **queued** question rather than the one that caused it.

Reopening the session showed a different order again, since the `.jsonl` records what was actually sent — so the live view and a replayed one disagreed.

### What changed

The bubble is **faded** while it waits, and **drops below the running reply** when it goes — which is the order the session file already had.

Fading rather than badging: in a column of full-strength bubbles a pale one reads at a glance, and the bubble already carries copy and fork on hover without a fourth thing competing.

**Stop and a session switch** take the queued bubbles away rather than leave them looking sent. They were never handed over, so leaving them would show the model messages it has no idea exist — the same divergence a retraction causes, from our own side.

The session-switch case was **already wrong before this**: the queue survived `chat.cleared`, and `isBusy` going false right after would have flushed a message written for the old session into the new one. One line, fixed here because the state made it visible.

### The bar is gone

The "N messages queued" bar above the composer existed because a queued bubble was indistinguishable from a sent one — its own comment said exactly that. The bubbles now say it themselves, so the bar counted what was already on screen, and its tooltip repeated text that is visible.

Its **Clear** discarded the *whole* queue, which was never the thing anyone wanted. Cancelling one message is worth doing properly, on the bubble itself; it is filed as its own piece of work rather than bolted on here. Stop already drops the queue for the "get me out of this" case.

### Where the state lives

`appState.queuedUuids`, right next to `subagentTasks`, which is the same shape: the owner keeps the real data — `cv-prompt` holds the payloads, because it is what sends them — and publishes only what another component needs. `cv-app` reads it the way it reads `isBusy`.

One event remains, for the move: the state says the queue changed, not *which* message left, and `moveToEnd` needs the uuid.

`moveToEnd` rebuilds the entries array rather than splicing in place — `cv-app` memoises the exchange grouping on the array's identity, and a mutation it cannot see is a mutation it will not render. No entry is copied, only the list of references.

### Verification

Typecheck clean, 46 tests green (3 new on `moveToEnd`: the move itself, index coherence after it, and no-op when the uuid is absent or already last), lint 0 errors, prettier no changes.

### Also in here

The CHANGELOG entry for #100 (the selection off-by-one), which landed after `[Unreleased]` was last written and had no entry.
