### PR TITLE
fix(chat): stop losing a permission request behind the next one

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/permission-queue.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/permission-queue.ts
@@ -1,0 +1,94 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+/**
+ * Which permission request is being answered, and which are waiting.
+ *
+ * The CLI can have several `can_use_tool` in flight at once — a turn firing parallel tools, or a
+ * sub-agent asking while the main thread does — and the client tracks them all, keyed by
+ * tool_use_id (`ClaudeClient._toolRequestIds`, a ConcurrentDictionary). The banner used to hold
+ * one: a second request overwrote the first, which then vanished from screen while the CLI still
+ * waited for an answer that could no longer be given, hanging that tool until the turn was
+ * interrupted.
+ *
+ * Kept out of the component because it is state, not rendering, and this way it can be tested
+ * without a DOM. The component owns what a request LOOKS like; this owns which one is up.
+ */
+
+/** The queue only ever needs the id — the component keeps the full request. */
+export interface Identified {
+    id: string;
+}
+
+export class PermissionQueue<T extends Identified> {
+    private _current: T | null = null;
+    private _waiting: T[] = [];
+
+    /** The request being answered, or null when nothing is pending. */
+    get current(): T | null {
+        return this._current;
+    }
+
+    /** Those still waiting, oldest first. A copy: callers must not reorder the queue by hand. */
+    get waiting(): readonly T[] {
+        return this._waiting;
+    }
+
+    get size(): number {
+        return (this._current ? 1 : 0) + this._waiting.length;
+    }
+
+    /**
+     * Take a request. Returns true when it goes straight on screen, false when it queues behind
+     * one already there — the caller uses that to decide whether to reset its per-request state.
+     *
+     * An id already known is ignored: the CLI re-sends a request whose turn was replayed, and
+     * answering the same tool_use_id twice is worse than answering it once.
+     */
+    push(req: T): boolean {
+        if (this._current?.id === req.id || this._waiting.some((q) => q.id === req.id)) {
+            return false;
+        }
+        if (this._current) {
+            this._waiting = [...this._waiting, req];
+            return false;
+        }
+        this._current = req;
+        return true;
+    }
+
+    /**
+     * The current request is answered: promote the next one, or go empty. Returns what is now on
+     * screen, null when the queue has run dry.
+     */
+    next(): T | null {
+        const [head, ...rest] = this._waiting;
+        this._waiting = rest;
+        this._current = head ?? null;
+        return this._current;
+    }
+
+    /**
+     * Drop `id` wherever it sits. Returns the request now on screen — unchanged when the dropped
+     * one was merely waiting, the promoted one when it was current, null when nothing is left.
+     *
+     * A queued request has to be droppable, not just the current one: the CLI cancels a
+     * superseded `can_use_tool` by id, and a tool_result can arrive for one nobody answered.
+     * Left in, it would surface later asking about a tool that has already run.
+     */
+    drop(id: string): T | null {
+        if (this._current?.id === id) {
+            return this.next();
+        }
+        this._waiting = this._waiting.filter((q) => q.id !== id);
+        return this._current;
+    }
+
+    /** Session gone: everything waiting belonged to it and none of it can be answered now. */
+    clear(): void {
+        this._current = null;
+        this._waiting = [];
+    }
+}

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/permission-queue.test.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/permission-queue.test.ts
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright (C) 2026 Corsinvest Srl
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { PermissionQueue } from '../core/permission-queue.ts';
+
+const req = (id: string): { id: string } => ({ id });
+
+test('push: la prima va a schermo, la seconda aspetta', () => {
+    const q = new PermissionQueue();
+
+    assert.equal(q.push(req('a')), true, 'niente a schermo -> va subito');
+    assert.equal(q.push(req('b')), false, 'una gia aperta -> aspetta');
+
+    assert.equal(q.current?.id, 'a');
+    assert.deepEqual(
+        q.waiting.map((r) => r.id),
+        ['b'],
+    );
+});
+
+test('push: la richiesta gia nota non entra due volte', () => {
+    const q = new PermissionQueue();
+    q.push(req('a'));
+    q.push(req('b'));
+
+    // Il CLI rimanda un can_use_tool quando il turno viene rigiocato: rispondere
+    // due volte allo stesso tool_use_id e' peggio che rispondere una volta sola.
+    assert.equal(q.push(req('a')), false, 'duplicato di quella a schermo');
+    assert.equal(q.push(req('b')), false, 'duplicato di una in attesa');
+    assert.equal(q.size, 2);
+});
+
+test('next: promuove in ordine di arrivo, poi svuota', () => {
+    const q = new PermissionQueue();
+    q.push(req('a'));
+    q.push(req('b'));
+    q.push(req('c'));
+
+    assert.equal(q.next()?.id, 'b');
+    assert.equal(q.next()?.id, 'c');
+    assert.equal(q.next(), null, 'coda finita');
+    assert.equal(q.size, 0);
+});
+
+test('drop: toglie quella a schermo e promuove la successiva', () => {
+    const q = new PermissionQueue();
+    q.push(req('a'));
+    q.push(req('b'));
+
+    assert.equal(q.drop('a')?.id, 'b', 'ritorna chi e finito a schermo');
+    assert.equal(q.current?.id, 'b');
+});
+
+test('drop: toglie una in attesa senza toccare quella a schermo', () => {
+    const q = new PermissionQueue();
+    q.push(req('a'));
+    q.push(req('b'));
+    q.push(req('c'));
+
+    // Il CLI annulla per id una richiesta superata: se restasse in coda,
+    // spunterebbe dopo chiedendo di un tool che ha gia girato.
+    assert.equal(q.drop('b')?.id, 'a', 'quella a schermo non cambia');
+    assert.deepEqual(
+        q.waiting.map((r) => r.id),
+        ['c'],
+    );
+});
+
+test('drop: id sconosciuto non tocca nulla', () => {
+    const q = new PermissionQueue();
+    q.push(req('a'));
+
+    assert.equal(q.drop('mai-vista')?.id, 'a');
+    assert.equal(q.size, 1);
+});
+
+test('drop: l ultima lascia la coda vuota', () => {
+    const q = new PermissionQueue();
+    q.push(req('a'));
+
+    assert.equal(q.drop('a'), null);
+    assert.equal(q.current, null);
+});
+
+test('clear: butta tutto, anche chi aspettava', () => {
+    const q = new PermissionQueue();
+    q.push(req('a'));
+    q.push(req('b'));
+
+    q.clear();
+
+    assert.equal(q.current, null);
+    assert.equal(q.size, 0);
+});
+
+test('dopo clear la coda riparte pulita', () => {
+    const q = new PermissionQueue();
+    q.push(req('a'));
+    q.clear();
+
+    // Stesso id di prima: dopo un cambio sessione non e' piu un duplicato.
+    assert.equal(q.push(req('a')), true);
+    assert.equal(q.current?.id, 'a');
+});

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
@@ -813,6 +813,8 @@ export class CvApp extends LitElement {
         this.removeEventListener('subagent-toggle', this._onChildrenToggle as EventListener);
         this.removeEventListener('compact-expand', this._onCompactExpand as EventListener);
         this.removeEventListener('model-switched', this._onModelSwitched as EventListener);
+        this.removeEventListener('queued-sent', this._onQueuedSent as EventListener);
+        this.removeEventListener('queued-dropped', this._onQueuedDropped as EventListener);
         for (const off of this._offs) {
             off();
         }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-permission-banner.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-permission-banner.ts
@@ -12,6 +12,7 @@ import { iconStyles } from '../styles/shared';
 import { bridge } from '../../core/bridge';
 import { Msg } from '../../core/bridge-messages';
 import { state as appState } from '../../core/state';
+import { PermissionQueue } from '../../core/permission-queue';
 import type {
     ToolResultNotification,
     ToolPermissionNotification,
@@ -381,6 +382,17 @@ export class CvPermissionBanner extends LitElement {
 
     @state() private _pending: ToolPermission | null = null;
 
+    /**
+     * Which request is up and which are waiting. Answered one at a time rather than stacked: each
+     * carries its own choices, its own editable command and its own scope cycle, and two of those
+     * on screen together would ask the user to track which buttons belong to which tool.
+     *
+     * Not `@state`: Lit dirty-checks by reference and this object is mutated in place. `_pending`
+     * is the rendered projection of `_queue.current`, and it IS state — every path that changes
+     * the queue assigns it, which is what triggers the render.
+     */
+    private _queue = new PermissionQueue<ToolPermission>();
+
     // Editable command text for tools that carry a `command` (Bash/PowerShell):
     // shown in a textarea, sent back as updatedInput on allow. null = not editing.
     @state() private _editedCommand: string | null = null;
@@ -454,20 +466,18 @@ export class CvPermissionBanner extends LitElement {
                         permissionSuggestions:
                             dto.permissionSuggestions as unknown as PermissionSuggestion[],
                     };
-                    // AskUserQuestion is interactive: the user answers it directly.
-                    if (data.name === 'AskUserQuestion') {
-                        this._startQuestions(data);
-                        return;
-                    }
-                    this._pending = data;
-                    appState.pendingPermission = { id: data.id, name: data.name };
+                    // AskUserQuestion is interactive — the user answers it directly rather than
+                    // allowing a tool — but it queues like everything else: it is still a
+                    // can_use_tool the CLI is waiting on, and letting it jump the queue would
+                    // strand whatever was on screen.
+                    this._enqueue(data);
                 },
             ),
         );
         this._offs.push(
             bridge.onNotification<ToolResultNotification>(Msg.toWebView.chat.toolResult, (data) => {
-                if (this._pending && data?.toolUseId === this._pending.id) {
-                    this._dismiss();
+                if (data?.toolUseId) {
+                    this._drop(data.toolUseId);
                 }
             }),
         );
@@ -476,13 +486,19 @@ export class CvPermissionBanner extends LitElement {
             bridge.onNotification<ToolPermissionCancelNotification>(
                 Msg.toWebView.chat.toolPermissionCancel,
                 (data) => {
-                    if (this._pending && data?.toolUseId === this._pending.id) {
-                        this._dismiss();
+                    if (data?.toolUseId) {
+                        this._drop(data.toolUseId);
                     }
                 },
             ),
         );
-        this._offs.push(bridge.onNotification(Msg.toWebView.chat.cleared, () => this._dismiss()));
+        // Session gone: everything waiting belonged to it, and none of it can be answered now.
+        this._offs.push(bridge.onNotification(Msg.toWebView.chat.cleared, () => this._clearAll()));
+        // The CLI died. Nothing on screen can be answered any more — there is no process left to
+        // send the answer to — and a banner asking about a tool that will never run is worse than
+        // no banner: the user clicks Yes and nothing happens. The failure itself is reported by
+        // cv-app's notice; this only takes down what can no longer be acted on.
+        this._offs.push(bridge.onNotification(Msg.toWebView.cli.exited, () => this._clearAll()));
         // Keyboard shortcuts while a prompt is open: Esc cancels, 1/2/3 pick a
         // choice, Enter confirms the default. Disabled while typing in the
         // "tell Claude what to do instead" field.
@@ -631,38 +647,64 @@ export class CvPermissionBanner extends LitElement {
         return this._activeInShadow()?.id === 'permission-command';
     }
 
-    private _dismiss(): void {
-        this._pending = null;
-        appState.pendingPermission = null;
-        this._editedCommand = null;
-        this._qIndex = 0;
-        this._picked = new Map();
-        this._other = new Map();
-        this._scopeIdx = 0;
-        this._scopeActive = false;
-        this._focusedOnOpen = false;
-        // Return focus to the composer: clearing pendingPermission re-shows the prompt,
-        // but only on the next render, so defer the focus a frame (like dialog-focus).
-        requestAnimationFrame(() =>
-            (
-                document.querySelector('cv-prompt') as { focusInput?: () => void } | null
-            )?.focusInput?.(),
-        );
+    /** Take a request: on screen if nothing is up, behind the others if something is. */
+    private _enqueue(req: ToolPermission): void {
+        if (this._queue.push(req)) {
+            this._show(req);
+        }
     }
 
-    private _startQuestions(data: ToolPermission): void {
-        const qs = data.input?.questions ?? [];
+    /** Put a request on screen, or clear the banner when given null. The per-request state belongs
+     *  to whichever is being answered, so it starts clean whether this is the first or the fifth. */
+    private _show(req: ToolPermission | null): void {
+        this._pending = req;
+        appState.pendingPermission = req ? { id: req.id, name: req.name } : null;
+        this._editedCommand = null;
+        this._qIndex = 0;
+        // An AskUserQuestion needs a slot per question up front; every other tool has none.
         const picked = new Map<string, Set<string>>();
-        for (const q of qs) {
+        for (const q of req?.input?.questions ?? []) {
             picked.set(q.question, new Set());
         }
         this._picked = picked;
         this._other = new Map();
-        this._qIndex = 0;
-        this._pending = data;
-        // Mark a pending interaction so the input box hides while the user
-        // answers (no diff/preview fields needed for questions).
-        appState.pendingPermission = { id: data.id, name: data.name };
+        this._scopeIdx = 0;
+        this._scopeActive = false;
+        this._focusedOnOpen = false;
+        // Nothing left to answer: hand the caret back to the composer. Clearing pendingPermission
+        // re-shows the prompt, but only on the next render, so defer a frame (like dialog-focus).
+        // Not done when another request took over — updated() focuses that one's first choice.
+        if (!req) {
+            requestAnimationFrame(() =>
+                (
+                    document.querySelector('cv-prompt') as { focusInput?: () => void } | null
+                )?.focusInput?.(),
+            );
+        }
+    }
+
+    /** Drop `toolUseId` wherever it is — on screen or still waiting. A queued one has to go too:
+     *  the CLI cancels a superseded request by id, and a tool_result can arrive for one nobody
+     *  answered. Left in, it would surface later asking about a tool that has already run. */
+    private _drop(toolUseId: string): void {
+        const before = this._queue.current;
+        const now = this._queue.drop(toolUseId);
+        if (now !== before) {
+            this._show(now);
+        }
+    }
+
+    /** The current request is answered or gone: show whoever was waiting, or close. Handing over
+     *  rather than closing is the point — the CLI is still holding those requests open. */
+    private _dismiss(): void {
+        this._show(this._queue.next());
+    }
+
+    /** Take down everything, current and waiting, without answering any of it. For the cases where
+     *  there is nothing left to answer TO: the session was swapped out, or the CLI died. */
+    private _clearAll(): void {
+        this._queue.clear();
+        this._show(null);
     }
 
     private _questions(): AskQuestion[] {


### PR DESCRIPTION
The banner held one request in a single field and assigned straight into it, so a second `can_use_tool` overwrote the first. The overwritten one vanished from screen **while the CLI was still waiting for an answer that could no longer be given** — and that tool hung until the turn was interrupted.

Not an edge case: a turn firing parallel tools, or several sub-agents running at once, produces exactly that.

**Verified in the Experimental instance**: four parallel agents, four requests arrived, and before this only one was answerable. After it, each is presented in turn — right command on each banner, composer returning only after the last.

### The client was never the problem

`ClaudeClient` already tracks every in-flight request keyed by tool_use_id in a `ConcurrentDictionary`, and its own comment says that keying *"keeps concurrent prompts from clobbering each other"*. Only the UI had one slot.

Same shape VS Code uses, incidentally — `permissionRequests` is an array, appended to on arrival and filtered by identity on resolve.

### What changed

Requests are answered **one at a time rather than stacked**. Each carries its own choices, its own editable command and its own scope cycle; two of those on screen together would ask the user to work out which buttons belong to which tool.

The queue lives in `core/` rather than the component because it is state, not rendering, and out there it can be tested without a DOM (9 tests). The component keeps `_pending` as the rendered projection of `queue.current`: the queue is mutated in place, which Lit cannot see, so the assignment to `_pending` is what triggers the render.

### Three latent bugs fixed along the way

**`AskUserQuestion` jumped the queue** — it had its own path into `_pending`. It is a `can_use_tool` like any other and now waits its turn.

**Dropping now works by id wherever the request sits.** A cancel from the CLI, or a `tool_result` for one nobody answered, used to be matched against the *current* request only — a queued one stayed in and would surface later asking about a tool that had already run.

**The banner now listens for `cli_exited`.** With the process gone there is nothing to answer to: the C# discards the response silently (`SendControlResponse` returns early when the transport is down), so the user clicked Yes and nothing happened. This one predates the queue.

### Also in here

Two listeners `cv-app` registered in `connectedCallback` and never took down — `queued-sent` and `queued-dropped`, from #101. They sit on `this` so they die with the component, but the file's other three are removed and these two were not; a detach/reattach would double them up.

### Verification

Typecheck clean, 55 tests green (9 new), lint 0 errors, prettier no changes, plus the four-agent run above.
