### PR TITLE
fix(mcp): make two IDE tools answer predictably

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.Operations.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.Operations.cs
@@ -79,21 +79,32 @@ internal sealed partial class IdeContextService
     /// The await is what does the work: leaving the UI thread lets VS pump again, and
     /// SwitchToMainThreadAsync takes it back for the next read of BuildState, which is itself a DTE
     /// call. 200ms is short enough to not add a visible tail to a fast build and long enough to cost
-    /// nothing on a long one.</summary>
-    private static async Task WaitForBuildAsync(SolutionBuild sb)
+    /// nothing on a long one.
+    ///
+    /// Returns false if BuildState never left vsBuildStateInProgress within the cap. Without one a
+    /// wedged build (MSBuild zombie, a target that never closes) leaves the MCP call pending
+    /// forever, and the caller has no way to tell that from a build that is merely slow.</summary>
+    private static async Task<bool> WaitForBuildAsync(SolutionBuild sb)
     {
         // Poll at least once before testing: BuildState can still read vsBuildStateDone on the first
         // look after kicking off, and exiting here would report the PREVIOUS build's LastBuildInfo
         // as this one's result.
-        do
+        for (var i = 0; i < BuildPollMaxTries; i++)
         {
             await Task.Delay(BuildPollMs);
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            if (sb.BuildState != vsBuildState.vsBuildStateInProgress) { return true; }
         }
-        while (sb.BuildState == vsBuildState.vsBuildStateInProgress);
+        return false;
     }
 
     private const int BuildPollMs = 200;
+    // 30 minutes: past any real build, short enough that a wedged one still answers.
+    private const int BuildPollMaxTries = 30 * 60 * 1000 / BuildPollMs;
+
+    private static string BuildTimedOutMessage(string verb) =>
+        $"{verb} still in progress after {BuildPollMaxTries * BuildPollMs / 60000} minutes — " +
+        "check the Output window; the IDE was left building.";
 
     /// <summary>Build the whole solution (projectName null) or a single project, then report success
     /// plus the Error List down to <paramref name="severity"/>. Kicks the build without waiting and
@@ -127,7 +138,10 @@ internal sealed partial class IdeContextService
                 sb.BuildProject(config, proj.UniqueName, WaitForBuildToFinish: false);
             }
 
-            await WaitForBuildAsync(sb);
+            if (!await WaitForBuildAsync(sb))
+            {
+                return new BuildResult { Ok = false, Message = BuildTimedOutMessage("Build") };
+            }
 
             // LastBuildInfo = number of projects that FAILED (0 = success).
             var failed = sb.LastBuildInfo;
@@ -170,7 +184,10 @@ internal sealed partial class IdeContextService
         try
         {
             sb.Clean(WaitForCleanToFinish: false);
-            await WaitForBuildAsync(sb);
+            if (!await WaitForBuildAsync(sb))
+            {
+                return new BuildResult { Ok = false, Message = BuildTimedOutMessage("Clean") };
+            }
             var failed = sb.LastBuildInfo;
             return new BuildResult
             {
@@ -449,8 +466,8 @@ internal sealed partial class IdeContextService
 
     //  Open editors (MCP getOpenEditors)
 
-    /// <summary>List of files currently open in editor tabs (text only).
-    /// Order matches VS's tab order. Each entry includes active/dirty.</summary>
+    /// <summary>List of files currently open in editor tabs (text only), sorted by path.
+    /// Each entry includes active/dirty.</summary>
     public async Task<IReadOnlyList<OpenEditor>> GetOpenEditorsAsync()
     {
         await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
@@ -487,6 +504,8 @@ internal sealed partial class IdeContextService
                 Language = lang ?? string.Empty,
             });
         }
+        // GetDocumentWindowEnum gives no ordering guarantee, so sort like every other list tool.
+        list.Sort((a, b) => string.Compare(a.FilePath, b.FilePath, StringComparison.OrdinalIgnoreCase));
         return list;
     }
 


### PR DESCRIPTION
Two MCP tools in `IdeContextService.Operations.cs` could answer in ways the caller had no way to interpret. Both surfaced in a review of the IDE tool surface.

## `editor_get_open_files` returned an unordered list

The method built its list straight from `DocumentFrames()` and returned it. `IVsUIShell.GetDocumentWindowEnum` guarantees no ordering, so two consecutive calls could come back in different orders with no tab having moved — and a model comparing them sees changes that aren't there.

Every other list method in this area already sorts: projects (`:316`), diagnostics (`:554`), breakpoints (`IdeDebugService.cs:293`), processes (`:351`). This one was the exception, not a deliberate opt-out.

Its summary also claimed `Order matches VS's tab order`, which the enumerator never promised. Sorted by path (`OrdinalIgnoreCase`), and the summary now says what the method actually does.

## `build_solution` could stay pending forever

`WaitForBuildAsync` polled `SolutionBuild.BuildState` in an unbounded `do/while`. A wedged build — MSBuild zombie, a target that never closes — leaves `vsBuildStateInProgress` set, and the loop never exits: the MCP call never returns, and nothing distinguishes that from a build that is merely slow.

The poll is now capped at 30 minutes (well past any real build) and returns `bool`. Both callers, `BuildAsync` and `CleanAsync`, turn a timeout into an ordinary failed `BuildResult` pointing at the Output window, so the caller always gets an answer. `BuildTimedOutMessage(verb)` keeps the wording shared between Build and Clean.

The 200ms interval and the poll-before-testing behaviour are unchanged — the first is deliberate (see the summary), and the second still avoids reporting the previous build's `LastBuildInfo`.

## Verification

MSBuild solution build green, 0 errors.

Runtime behaviour needs checking in the Exp instance: `editor_get_open_files` with several tabs open (sorted, stable across calls), and a normal build still reporting through unchanged. The timeout path is by nature hard to trigger deliberately.
