### PR TITLE
fix(chat): stop two failures from passing as normal state

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.Payloads.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.Payloads.cs
@@ -145,8 +145,11 @@ internal sealed partial class WebViewBridge
                     {
                         textData = System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(base64));
                     }
-                    catch
+                    catch (Exception ex)
                     {
+                        // Silence here reaches the user as an attachment Claude never sees: the chip
+                        // is on the message, the document block is empty, and nothing says why.
+                        OutputWindowLogger.Global.Warn($"[chat] attachment '{name}': base64 decode failed, sent empty — {ex.Message}");
                         textData = "";
                     }
                     blocks.Add(new JObject

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-plugin-manager.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-plugin-manager.ts
@@ -385,8 +385,11 @@ export class CvPluginManager extends CvDialogBase {
             this._installed = plugins.installed ?? [];
             this._available = plugins.available ?? [];
             this._marketplaces = markets.marketplaces ?? [];
-        } catch {
-            /* leave lists as-is; the op message area shows errors */
+        } catch (e) {
+            // _onOpResult never runs for this path (connectedCallback, not an op), so without
+            // filling the banner here a failed fetch reads exactly like "you have no plugins".
+            this._opError = true;
+            this._opMessage = `Could not load plugins: ${e instanceof Error ? e.message : String(e)}`;
         } finally {
             this._busy = false;
         }


### PR DESCRIPTION
Two `catch` blocks returned a default on a user-facing path without logging or surfacing anything. The project's convention is explicit about this — *"A catch returning a default on a user-facing path must `LogException` or `Warn` — never swallow"* — and in both cases the silence made a failure look like an ordinary, correct state.

## An attachment that decodes badly is sent empty

`WebViewBridge.Payloads.cs:148`

`Convert.FromBase64String` throws on malformed base64 (truncated payload, corruption on the JS side). The catch was bare, so the file went to the CLI as a `document` block with `""` for content.

What the user sees: the attachment chip on their message, and Claude answering as if no file had been attached. What the Output window holds: nothing. There is no way to tell this from a model that simply ignored the file.

Now warns with the file name and the underlying reason. The empty-string fallback stays — the block still has to be well-formed — but the failure is no longer invisible.

## A failed plugin fetch reads as "you have no plugins"

`cv-plugin-manager.ts:388`

The catch was commented *"leave lists as-is; the op message area shows errors"*. That is true for plugin operations, which go through `_onOpResult` — but `_loadAll()` runs from `connectedCallback`, and nothing on that path ever fills `_opMessage`/`_opError`.

So a bridge timeout on `fetchPlugins()`/`fetchMarketplaces()` rendered as *"No plugins installed."* and *"No marketplaces configured."* — exactly what a user with no plugins sees.

Now sets `_opError`/`_opMessage`, which the dialog already renders at `:465-470`. No new UI.

## Verification

`npm run typecheck` clean, `npm run format:check` clean.

The C# side needs an MSBuild run; the WebView side needs a look in the Exp instance. Neither failure is easy to trigger deliberately — the plugin one can be forced by opening the dialog with the host unable to answer.
