### PR TITLE
refactor(chat): use the shared icon-button styles that already existed

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-copy-btn.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-copy-btn.ts
@@ -7,7 +7,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import Copy16Regular from '@fluentui/svg-icons/icons/copy_16_regular.svg';
 import Checkmark16Regular from '@fluentui/svg-icons/icons/checkmark_16_regular.svg';
-import { iconStyles } from '../styles/shared';
+import { iconStyles, iconButtonStyles } from '../styles/shared';
 
 /**
  * Reusable copy-to-clipboard icon button (wraps `<fluent-button>`, shows a
@@ -24,37 +24,10 @@ import { iconStyles } from '../styles/shared';
 export class CvCopyBtn extends LitElement {
     static override styles = [
         iconStyles,
+        iconButtonStyles,
         css`
             :host {
                 display: contents;
-            }
-            /* Small icon-action button: compact, theme-aware, keyboard-focusable. A bare <button>
-               (not fluent-button) so it can be this small without violating the fluent-pure rule —
-               the shared icon-action standard. Callers still position it via ::part(button). */
-            .icon-btn {
-                display: inline-flex;
-                align-items: center;
-                justify-content: center;
-                padding: 3px;
-                border: 0;
-                border-radius: var(--borderRadiusSmall);
-                background: transparent;
-                color: inherit;
-                cursor: pointer;
-                opacity: 0.75;
-            }
-            .icon-btn:hover {
-                background: color-mix(in srgb, var(--colorNeutralForeground1) 10%, transparent);
-                opacity: 1;
-            }
-            .icon-btn:focus-visible {
-                outline: 1px solid var(--colorStrokeFocus2, currentColor);
-                outline-offset: 1px;
-            }
-            .icon-btn svg {
-                width: 14px;
-                height: 14px;
-                display: block;
             }
             /* Copied state: tint the checkmark green for a clearer "done" signal. */
             .icon-btn.copied svg {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-speak-btn.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-speak-btn.ts
@@ -7,7 +7,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import Speaker216Regular from '@fluentui/svg-icons/icons/speaker_2_16_regular.svg';
 import Pause16Regular from '@fluentui/svg-icons/icons/pause_16_regular.svg';
-import { iconStyles } from '../styles/shared';
+import { iconStyles, iconButtonStyles } from '../styles/shared';
 import { renderMarkdown } from '../../core/markdown';
 
 // Web Speech synthesis is a single global engine — only one utterance plays at a time. Track which
@@ -47,34 +47,10 @@ function toSpeech(md: string): string {
 export class CvSpeakBtn extends LitElement {
     static override styles = [
         iconStyles,
+        iconButtonStyles,
         css`
             :host {
                 display: contents;
-            }
-            .icon-btn {
-                display: inline-flex;
-                align-items: center;
-                justify-content: center;
-                padding: 3px;
-                border: 0;
-                border-radius: var(--borderRadiusSmall);
-                background: transparent;
-                color: inherit;
-                cursor: pointer;
-                opacity: 0.75;
-            }
-            .icon-btn:hover {
-                background: color-mix(in srgb, var(--colorNeutralForeground1) 10%, transparent);
-                opacity: 1;
-            }
-            .icon-btn:focus-visible {
-                outline: 1px solid var(--colorStrokeFocus2, currentColor);
-                outline-offset: 1px;
-            }
-            .icon-btn svg {
-                width: 14px;
-                height: 14px;
-                display: block;
             }
             /* Speaking: a tinted pause icon — click to pause (the speaker icon returns; click resumes). */
             .icon-btn.speaking svg {


### PR DESCRIPTION
`iconButtonStyles` in `ui/styles/shared.ts` was written to be shared — its own doc comment calls it *"the Shadow-DOM twin of `.icon-btn` in chat.css"* — but a grep over `WebViewSrc` returns **zero imports**. The only other hits are comments pointing at it.

Meanwhile the two Shadow-DOM components that needed exactly that block had each written their own copy.

## The copies had already drifted

| | glyph size | base colour | hover colour | `:active` |
| --- | --- | --- | --- | --- |
| `iconButtonStyles` | `var(--cv-icon-btn-size, 14px)` | `Foreground2` | → `Foreground1` | yes |
| `cv-copy-btn` | `14px` | `inherit` | — | no |
| `cv-speak-btn` | `14px` | `inherit` | — | no |

So an icon-button tweak — hover tint, density — meant editing up to four places by hand, two of which silently disagreed with the source they were supposed to mirror.

Both components now compose `iconButtonStyles` and keep only what is genuinely theirs: the green checkmark in `.copied`, the brand tint in `.speaking`. Net −51 lines.

## One consequence, deliberately left open

Copy and Speak now follow `shared.ts`; Fork and the tool-header actions still follow `chat.css:637`, which uses `color: inherit`. Those disagree, and `cv-message.ts:184-196` renders Copy and Fork **in the same actions row** — so two adjacent buttons no longer match.

The disagreement is older than this PR; it was just invisible while the copies existed, because `cv-copy-btn` had cloned `chat.css` rather than the shared source. `chat.css:651` already claims *"Kept in step with iconButtonStyles (shared.ts)"*, which was not true.

It is recorded in the internal TODO with both ways to settle it — align `shared.ts` down to `inherit`, or align `chat.css` up to `Foreground2` — alongside the larger open question of moving every icon button to `fluent-button`, which would remove both definitions and make the choice moot. Settling it here would have meant changing the look of Fork and the tool actions inside a PR about removing duplication.

## Verification

`npm run typecheck` clean, `npm run format:check` clean, `npm test` 55/55.

The rendering difference above is expected and visible; it wants a look in the Exp instance in both light and dark themes.
