### PR TITLE
fix(chat): keep the IDE-context tooltip inside the pane

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-ide-context-badge.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-ide-context-badge.ts
@@ -173,7 +173,7 @@ export class CvIdeContextBadge extends LitElement {
                  displayPathUi so it follows "Show relative paths" like the tool rows and falls back
                  to the full path outside the workdir. tip-desc for the second line, as on the model
                  tooltip — tip-action's smaller size is for a third one. -->
-            <fluent-tooltip anchor="ide-badge" positioning="before">
+            <fluent-tooltip anchor="ide-badge" positioning="after">
                 <span class="tip-name">${displayPathUi(ctx.filePath)}${lineInfo}</span>
                 <!-- On one line on purpose: tooltipStyles sets white-space: pre-line, so a line
                      break here would render as blank space inside the tooltip. -->

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/shared.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/shared.ts
@@ -101,12 +101,16 @@ export const tooltipStyles = css`
     fluent-tooltip {
         padding: 6px 8px;
         max-width: 320px;
+        box-sizing: border-box;
         /* Lets a plain string with newlines break where it says to, so a tooltip with two or three
            lines doesn't need an element per line. */
         white-space: pre-line;
     }
     .tip-name {
         font-weight: var(--fontWeightSemibold);
+        /* A file path has no spaces to break at, so without this one long path sets the tooltip's
+           width and max-width can only clip it. */
+        overflow-wrap: anywhere;
     }
     .tip-desc {
         color: var(--colorNeutralForeground2);


### PR DESCRIPTION
The IDE-context badge sits at the left end of the composer toolbar, and its tooltip opened with `positioning="before"` — towards the left edge, where there is no room. With a deep path it ran past the edge and covered the textarea and the toolbar buttons, and the **start** of the path — the part that says where the file lives — was the first thing to go.

## The fix

**`cv-ide-context-badge.ts:176`** — `positioning="after"`. The tooltip opens to the right of the badge, into the pane rather than out of it.

**`ui/styles/shared.ts`** — `overflow-wrap: anywhere` on `.tip-name`, plus `box-sizing: border-box`. A file path has no spaces to break at, so without the wrap rule the text itself sets the tooltip's width and `max-width` can only clip it. It lives in `tooltipStyles`, so the ten components sharing it get the same treatment.

## Two fixes that looked right and weren't

Both were tried against the running pane and dropped. Worth recording, since both are the obvious thing to reach for:

**`positioning="above-end"`** — what the internal notes suggested, on the grounds that six of nine tooltips already use it. But the toolbar sits *below* the textarea: anything opening upwards covers the writing area whatever side it is anchored to. It would only have moved the problem to the right, over the buttons.

**`max-width: min(320px, calc(100vw - 24px))`** — this made it visibly worse. With `before` still in place, Fluent squeezed the tooltip into the space left of the badge, which is nearly none: the result was a column one word wide. `100vw` is the width of the WebView, not the room in front of the tooltip.

## Not covered

`cv-segmented.ts:80` and `cv-stats-dialog.ts:327` carry their own `fluent-tooltip` rules and don't import `tooltipStyles`, so the wrap rule doesn't reach them. That's fine — they show short labels and a card, not paths.

## Verification

Confirmed by looking at the running pane with a deep path open in VS, before and after.

Worth noting for anyone testing a tooltip from the console: `getBoundingClientRect()` on a closed tooltip returns all zeros, and synthetic `mouseover`/`pointerenter` events don't open a `fluent-tooltip` — it uses the internal popover logic. Injecting CSS into the shadow root and looking is the only approach that works.

`npm run typecheck`, `format:check` and `npm test` (55/55) all clean.
