### PR TITLE
chore(chat): drop three class names nothing styles

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-diff-dialog.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-diff-dialog.ts
@@ -147,13 +147,7 @@ export class CvDiffDialog extends CvDialogBase {
             <fluent-dialog type="modal" aria-label="Diff viewer" @toggle=${this._onDialogToggle}>
                 <fluent-dialog-body>
                     <span slot="title" class="cv-diff-dialog-title" title=${fullPath}>
-                        <img
-                            class="cv-diff-dialog-icon"
-                            src=${iconUrl(name)}
-                            width="16"
-                            height="16"
-                            alt=""
-                        />
+                        <img src=${iconUrl(name)} width="16" height="16" alt="" />
                         <span class="cv-diff-dialog-name">${name}</span>
                     </span>
 

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-stats-dialog.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-stats-dialog.ts
@@ -798,7 +798,6 @@ export class CvStatsDialog extends CvDialogBase {
                             })}
                         </div>
                     </div>
-                    <div class="chart-xaxis-pad"></div>
                     <div class="chart-xaxis">
                         ${keys.map((k, ki) => html`<span class="chart-xtick">${ki % xStep === 0 ? formatDay(k) : ''}</span>`)}
                     </div>

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/base.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/base.ts
@@ -387,7 +387,7 @@ export abstract class ToolRenderer {
                                   style="cursor:pointer"
                                   @click=${() => this.host.openOutput('out')}
                               >
-                                  <span class="cv-tool-body-label cv-tool-body-label-out"
+                                  <span class="cv-tool-body-label"
                                       >${this.host.status === 'error' ? 'ERR' : 'OUT'}</span
                                   >
                                   <div class="cv-tool-body-cell">


### PR DESCRIPTION
Three class names in the WebView templates have no matching rule anywhere — not in `ui/styles/*.css`, not in any component's `static styles`. They are removed.

| Class | Where | What it was for |
| --- | --- | --- |
| `cv-diff-dialog-icon` | `cv-diff-dialog.ts:151` | the file-type icon in the diff dialog's title |
| `chart-xaxis-pad` | `cv-stats-dialog.ts:801` | an empty `<div>` above the stats chart's x-axis |
| `cv-tool-body-label-out` | `base.ts:390` | distinguishing the OUT cell's label from IN |

None of them changed anything on screen, which is why they went unnoticed:

- The diff dialog's title row is a flex with `align-items: center` and `gap: 6px`, so the icon's placement already comes from the parent and its size from the `width`/`height` attributes. Its sibling `.cv-diff-dialog-name` does have a rule (`diff.css:113`) — so this was an omission, not a pattern.
- `chart-xaxis-pad` was an empty `<div>`, presumably meant to reserve vertical space. With no rule it has no height, so it reserved nothing.
- `cv-tool-body-label-out` was meant to make the OUT label differ from the IN one. `.cv-tool-body-label` carries the entire style; the modifier never did anything.

The cost of leaving them is small but real: a class with no rule tells the next reader that the element has styling of its own, and sends them looking for it.

## On the audit

This came out of checking, in both directions, whether every class used is defined and every rule defined is used, across all 104 files.

The reverse direction — rules nothing uses — **came up clean**. Everything that looked orphaned (`cv-todo-done`, `no-row-click`, `always-shown`, `cv-tool-wrap`, `dot-done`, …) turned out to be reached through a class name built in a variable or a template literal:

```ts
const cls = t.status === 'completed' ? 'cv-todo-done' : 'cv-todo-pending';
const wrapCls = `cv-tool-wrap${clickable ? '' : ' no-row-click'}`;
```

That is how this codebase assigns most of its classes, so a plain text search finds the definition and misses the use. Every candidate was checked by hand before being ruled out — worth saying, because the same scan run unattended would report a few dozen false positives.

## Verification

`npm run typecheck`, `format:check`, `npm run build` and `npm test` (55/55) all clean.

Worth a look in the experimental instance at the two visible spots — the diff dialog's title row and the stats chart's x-axis — to confirm nothing shifted.
