### PR TITLE
perf(chat): scroll once per streaming delta, not three times

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
@@ -331,7 +331,7 @@ export class CvApp extends LitElement {
                         const atBottom = this._isNearBottom();
                         this._mutate(() => this._transcript.appendText(streamingId, delta));
                         if (atBottom) {
-                            queueMicrotask(() => this._scrollToBottom('instant'));
+                            queueMicrotask(() => this._scrollToBottomNow());
                         }
                     }
                 },
@@ -676,18 +676,9 @@ export class CvApp extends LitElement {
 
                     appState.loadingOlder = false;
                     this._mutate(() => this._transcript.replaceAll(out));
-                    // Land at the bottom. Re-jump for several frames because async-rendered
-                    // children (markdown, diff2html, lazy images) keep growing scrollHeight.
-                    void this.updateComplete.then(() => {
-                        let frames = 0;
-                        const tick = (): void => {
-                            this._scrollToBottom('instant');
-                            if (++frames < 10) {
-                                requestAnimationFrame(tick);
-                            }
-                        };
-                        requestAnimationFrame(tick);
-                    });
+                    // Land at the bottom, sustained for a few frames: a whole page of transcript
+                    // just went in, and images (the one thing rendered async) settle after it.
+                    this._scrollToBottom('instant', 6);
                 },
             ),
         );
@@ -1519,23 +1510,51 @@ export class CvApp extends LitElement {
         });
     }
 
-    private _scrollToBottom(behavior: ScrollBehavior = 'smooth'): void {
-        // Wait for Lit to flush the DOM before measuring scrollHeight — scrolling
-        // in a microtask (pre-render) lands short, leaving the last lines cut off.
-        // A second pass after a frame absorbs async layout (markdown, images,
-        // highlight) that keeps growing scrollHeight just after the first paint.
-        const jump = (b: ScrollBehavior) => {
-            const el = this._messagesEl;
-            if (el) {
-                el.scrollTo({ top: el.scrollHeight, behavior: b });
-            }
-        };
+    /** One jump, once Lit has flushed. For the streaming path, which lands here on every delta:
+     *  the transcript grows by a few lines at a time and there is nothing to chase, so the
+     *  catch-up passes below would triple the work for the same result. */
+    private _scrollToBottomNow(): void {
+        void this.updateComplete.then(() => this._jumpToBottom('instant'));
+    }
+
+    private _jumpToBottom(behavior: ScrollBehavior): void {
+        const el = this._messagesEl;
+        if (el) {
+            el.scrollTo({ top: el.scrollHeight, behavior });
+        }
+    }
+
+    /**
+     * Land at the bottom after content the browser is still sizing.
+     *
+     * Wait for Lit to flush the DOM before measuring scrollHeight — scrolling in a microtask
+     * (pre-render) lands short, leaving the last lines cut off. The two catch-up passes absorb
+     * what keeps growing after the first paint: that is images (cv-message awaits fetchChatImage),
+     * NOT markdown or diff2html — both are synchronous and already final when Lit is done.
+     *
+     * `sustainFrames` keeps re-landing for that many frames, for callers that just swapped in a
+     * whole page of transcript. Loading it in the caller instead multiplied these three passes by
+     * the frame count.
+     */
+    private _scrollToBottom(behavior: ScrollBehavior = 'smooth', sustainFrames = 0): void {
         void this.updateComplete.then(() => {
             // First pass honours the requested behaviour; the catch-up passes are
             // instant so they don't fight the smooth animation.
-            jump(behavior);
-            requestAnimationFrame(() => jump('instant'));
-            setTimeout(() => jump('instant'), 120);
+            this._jumpToBottom(behavior);
+            requestAnimationFrame(() => this._jumpToBottom('instant'));
+            setTimeout(() => this._jumpToBottom('instant'), 120);
+
+            let left = sustainFrames;
+            const tick = (): void => {
+                if (left-- <= 0) {
+                    return;
+                }
+                this._jumpToBottom('instant');
+                requestAnimationFrame(tick);
+            };
+            if (left > 0) {
+                requestAnimationFrame(tick);
+            }
         });
     }
 


### PR DESCRIPTION
`_scrollToBottom` never scrolled once. It scheduled **three** passes — one after `updateComplete`, one on `requestAnimationFrame`, one on a 120ms timeout — and nine call sites shared it regardless of what they were scrolling for.

## The path that pays for it

`cv-app.ts:334` is the streaming handler: it lands here on **every assistant delta**. A long answer therefore paid three scrolls and a timer per fragment, on the same path that is already rendering markdown incrementally.

It now calls `_scrollToBottomNow()` — a single jump. The transcript grows by a few lines at a time while streaming; there is nothing to chase.

The `_isNearBottom()` gate above it is unchanged, so auto-follow still only happens when the user is already at the bottom.

## The multiplication on history load

`cv-app.ts:681` ran its own 10-frame `requestAnimationFrame` loop calling `_scrollToBottom('instant')`. Ten intended jumps were thirty, plus ten overlapping 120ms timers — the last firing well after the page went still.

That loop is now a `sustainFrames` argument on the function itself, so the three passes happen once and the sustain is a plain frame counter.

| | before | after |
| --- | ---: | ---: |
| per streaming delta | 3 scrolls + 1 timer | **1 scroll** |
| history load | 30 scrolls + 10 timers | **9 scrolls + 1 timer** |

The seven remaining callers keep `_scrollToBottom` with its default — for a new message or a tool result, the catch-up passes are what they were written for.

## A comment that was wrong

Both sites justified the passes with *"async-rendered children (markdown, diff2html, lazy images) keep growing scrollHeight"*.

Markdown and diff2html are **synchronous**: `markdown.ts:161` calls `marked.parse(..., { async: false })` and `renderDiff` (`ui/diff.ts:90`) is a plain call. Both are already their final height once Lit is done. Images are the only thing that settles afterwards (`cv-message.ts:303`, `await fetchChatImage`). The comments now say that, since the wrong reason is what would justify keeping the extra passes everywhere.

## Verification

`npm run typecheck`, `lint` (0 errors), `format:check`, `build` and `npm test` (55/55) all clean.

**Not yet checked in the running pane** — this is scroll behaviour, so a green build proves little. Worth trying:

- a long streamed answer follows the bottom smoothly, no stutter
- scrolling up mid-stream to read does not yank you back down
- reopening a long session with images lands at the bottom, not part-way

That last one is what `sustainFrames = 6` covers, and the number is as arbitrary as the 10 it replaces — nobody measured either. If a session with images lands short, it wants raising.
