### PR TITLE
feat(chat): keep the spinner up for the whole turn

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
@@ -1690,7 +1690,7 @@ export class CvApp extends LitElement {
                 }
                 ${this._exchanges.map((group) => this.renderExchange(group))}
                 ${
-                    this._isBusy && this._streamingMsgs.size === 0 && !this._awaitingUser
+                    this._isBusy && !this._awaitingUser
                         ? html`<cv-spinner .status=${this._status}></cv-spinner>`
                         : nothing
                 }


### PR DESCRIPTION
The spinner vanished as soon as the first assistant delta arrived. The reasoning was that text appearing is itself the sign of activity — but it says work *happened*, not that more is coming. Between two blocks, or while a tool runs mid-answer, the transcript sits there looking finished.

```diff
- this._isBusy && this._streamingMsgs.size === 0 && !this._awaitingUser
+ this._isBusy && !this._awaitingUser
```

What remains is what the VS Code extension uses — its webview gates on `busy.value && !permissionRequests.value.length`. A pending permission still hides it: there the turn is waiting on the user, not on Claude, and the banner already says so.

## Known limit

Our `cv-spinner` is the last child of the scroller, in normal flow — unlike VS Code's `spinnerRow`, which sits in the composer block, outside the scroll area. So while auto-follow keeps you at the bottom the spinner stays in view, but scrolling up to re-read mid-answer leaves it behind.

Anchoring it (`position: sticky`, the way `#jump-to-bottom` already does it in the same scroller) was deliberately left out: it is a separate change, and worth making only if the plain version turns out to be annoying in daily use.

## Verification

`npm run typecheck`, `format:check` and `build` clean. Tried in the running pane on a long streamed answer: the spinner stays under the text for the whole turn and clears at the end.
