### PR TITLE
perf(chat): stop re-parsing settled markdown on every delta

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/markdown-split.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/markdown-split.ts
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+// Where growing markdown can be cut. Kept out of markdown.ts, which pulls in DOMPurify and so
+// needs a DOM: this is string arithmetic and stays testable under plain node --test.
+
+/**
+ * Offset of the last point in `text` that later text cannot change the meaning of — a blank line
+ * outside a fenced block. Markdown separates blocks there, so everything before it is settled and
+ * can be rendered once instead of on every delta.
+ *
+ * Returns 0 when there is no such point (a single growing paragraph, or nothing but a settled
+ * prefix), which tells the caller to render the whole thing. Deliberately conservative: cutting
+ * inside a construct would break the render, so a missed opportunity is the safe failure.
+ *
+ * Fence tracking matches closeOpenMarkdown — a line *starting* with ``` flips the state, so fences
+ * appearing as content don't throw off the count.
+ */
+export function stableMarkdownSplit(text: string): number {
+    const lines = text.split('\n');
+    let inFence = false;
+    let cut = 0;
+    let pos = 0;
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        if (/^\s*```/.test(line)) {
+            inFence = !inFence;
+        } else if (!inFence && i > 0 && line.trim() === '') {
+            // Everything up to and including this blank line is final.
+            cut = pos + line.length + 1;
+        }
+        pos += line.length + 1;
+    }
+    // Never hand back the whole text: the tail after the last blank line is still growing, and the
+    // caller needs something left to re-render.
+    return cut >= text.length ? 0 : cut;
+}

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/markdown-split.test.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/markdown-split.test.ts
@@ -1,0 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { stableMarkdownSplit } from '../core/markdown-split.ts';
+
+test('split: taglia dopo una riga vuota', () => {
+    const t = 'primo paragrafo\n\nsecondo in corso';
+    const cut = stableMarkdownSplit(t);
+    assert.equal(t.slice(0, cut), 'primo paragrafo\n\n');
+});
+
+test('split: non taglia dentro un code block aperto', () => {
+    const t = 'testo\n\n```ts\nconst a = 1;\n\nconst b = 2;';
+    const cut = stableMarkdownSplit(t);
+    // Il solo punto sicuro e' la riga vuota PRIMA della fence.
+    assert.equal(t.slice(0, cut), 'testo\n\n');
+});
+
+test('split: riprende dopo una fence chiusa', () => {
+    const t = 'testo\n\n```ts\nconst a = 1;\n```\n\ncoda in corso';
+    const cut = stableMarkdownSplit(t);
+    assert.equal(t.slice(0, cut), 'testo\n\n```ts\nconst a = 1;\n```\n\n');
+});
+
+test('split: senza righe vuote non taglia', () => {
+    assert.equal(stableMarkdownSplit('un solo paragrafo che cresce'), 0);
+});
+
+test('split: testo vuoto', () => {
+    assert.equal(stableMarkdownSplit(''), 0);
+});
+
+test('split: mai oltre la fine del testo', () => {
+    const t = 'paragrafo\n\n';
+    assert.equal(stableMarkdownSplit(t), 0);
+});
+
+test('split: una fence che contiene backtick non sfasa il conteggio', () => {
+    const t = 'a\n\n```md\nesempio con ``` dentro\n```\n\nb in corso';
+    const cut = stableMarkdownSplit(t);
+    assert.ok(cut > 0);
+    // Il taglio non cade mai a meta' del blocco: il prefisso ha fence bilanciate.
+    const fences = (t.slice(0, cut).match(/^\s*```/gm) ?? []).length;
+    assert.equal(fences % 2, 0);
+});
+
+test('split: il prefisso e sempre un confine di riga', () => {
+    const t = 'uno\n\ndue\n\ntre in corso';
+    const cut = stableMarkdownSplit(t);
+    assert.ok(cut === 0 || t[cut - 1] === '\n');
+});

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-message.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-message.ts
@@ -9,6 +9,7 @@ import BranchFork16Regular from '@fluentui/svg-icons/icons/branch_fork_16_regula
 import './cv-copy-btn';
 import './cv-attach-chip';
 import { renderMarkdown, renderMarkdownStreaming } from '../../core/markdown';
+import { stableMarkdownSplit } from '../../core/markdown-split';
 import { escapeHtml } from '../../core/html';
 import { bridge } from '../../core/bridge';
 import { Msg } from '../../core/bridge-messages';
@@ -78,6 +79,41 @@ export class CvMessage extends LitElement {
     private _streamText = '';
     private _streamAt = 0;
     private _streamTimer?: ReturnType<typeof setTimeout>;
+    // Markdown before the last blank line: settled, so it is rendered once and kept. Only the tail
+    // after it is re-rendered per pass, which is what stops the cost growing with the answer.
+    private _stableHtml = '';
+    private _stableUpTo = 0;
+    // The exact text the stable HTML was built from: if the incoming text stops starting with it,
+    // this is not the same message growing and the prefix has to go.
+    private _stablePrefix = '';
+
+    /**
+     * Render the growing text without re-parsing what is already settled.
+     *
+     * Markdown before the last blank line cannot be changed by what comes after, so it is parsed
+     * once and appended to `_stableHtml`; each pass then only parses the tail. Without this the
+     * cost climbs with the answer — measured 2.5ms per pass over the first third of a 22k-char
+     * reply against 8.2ms over the last.
+     *
+     * The stable prefix is dropped whenever the text stops extending what we saw (a re-render from
+     * history, or the text being replaced), so a stale prefix can never survive into a new message.
+     */
+    private _renderIncremental(): string {
+        if (!this.text.startsWith(this._stablePrefix)) {
+            this._stableHtml = '';
+            this._stableUpTo = 0;
+            this._stablePrefix = '';
+        }
+        const cut = stableMarkdownSplit(this.text);
+        if (cut > this._stableUpTo) {
+            this._stableHtml += renderMarkdown(this.text.slice(this._stableUpTo, cut));
+            this._stableUpTo = cut;
+            this._stablePrefix = this.text.slice(0, cut);
+        }
+        return this._stableUpTo === 0
+            ? renderMarkdownStreaming(this.text)
+            : this._stableHtml + renderMarkdownStreaming(this.text.slice(this._stableUpTo));
+    }
 
     /** Throttled streaming markdown: returns cached HTML unless enough time has
      *  passed (or the text shrank/reset), scheduling a trailing refresh so the
@@ -88,7 +124,7 @@ export class CvMessage extends LitElement {
         }
         const due = now - this._streamAt >= CvMessage.STREAM_MD_MS;
         if (due || this._streamHtml === '') {
-            this._streamHtml = renderMarkdownStreaming(this.text);
+            this._streamHtml = this._renderIncremental();
             this._streamText = this.text;
             this._streamAt = now;
             if (this._streamTimer) {


### PR DESCRIPTION
Streaming re-ran the whole `marked` → `DOMPurify` pipeline over the **entire accumulated text** every time a delta arrived. Adding 180 characters to a 20k answer meant parsing all 20k again, so the cost of a single pass grew with the answer.

## Measured, before and after

Same 22,296-character reply, probe on `_streamingMarkdown`:

| | before | after |
| --- | ---: | ---: |
| cost per pass, first third | 2.5ms | **1.5ms** |
| cost per pass, last third | 8.2ms | **1.5ms** |
| median | 5.9ms | 1.1ms |
| p90 | 9.1ms | 3.2ms |
| **total** | **697ms** | **203ms** |
| chars re-parsed per pass (median) | 22,296 | **436** |

The number that matters is first-third against last-third. It used to triple over the course of an answer; it is now flat. The old shape was quadratic in the length of the reply — n passes over text of length n — so the saving grows with longer answers, well past the 71% seen here.

## How

Markdown before a blank line **outside a fenced block** cannot be changed by what comes after it. That prefix is parsed once into `_stableHtml`; each pass then parses only the tail.

`stableMarkdownSplit` finds the cut. It tracks fences exactly as `closeOpenMarkdown` already does — a line *starting* with ``` flips the state, so fences appearing as content don't throw off the count — and returns 0 when there is no safe place to cut, which falls back to rendering the whole thing. Cutting inside a construct would visibly break the render, so a missed opportunity is the deliberate failure mode.

It lives in `core/markdown-split.ts` rather than `markdown.ts`: that module imports DOMPurify and needs a DOM, while this is string arithmetic that `node --test` can cover directly.

## Safety

The kept prefix is discarded whenever the incoming text stops starting with the text it was built from — a re-render from history, a replaced message — so a stale prefix cannot survive into a different message. And the end of a turn still renders the complete text through the ordinary non-streaming path, so any drift corrects itself when the message closes.

## Verification

8 new tests covering the cut logic: after a blank line, inside an open fence, after a closed one, a fence containing backticks, no blank lines at all, empty text, never past the end, always on a line boundary. Full suite 63/63.

`typecheck`, `lint` (0 errors), `format:check`, `build` clean.

Checked in the running pane on a long answer with code blocks, tables and nested lists — output matches what the non-incremental path produced.
