### PR TITLE
fix(chat): attaching a file works the same way three ways in

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents.Contracts/BridgeGenerationSpec.cs
+++ b/src/Corsinvest.VisualStudio.Agents.Contracts/BridgeGenerationSpec.cs
@@ -197,6 +197,7 @@ public class BridgeGenerationSpec : GenerationSpec
         AddInterface<SetModelNotification>();
         AddInterface<ForkNotification>().Member(x => nameof(x.SessionId)).Optional();
         AddInterface<ExternalUrlNotification>();
+        AddInterface<OpenOptionsNotification>().Member(x => nameof(x.Page)).Optional();
 
         // Plugin-manager requests. Scope is omitted by the WebView (host defaults to "user").
         AddInterface<PluginInstallNotification>().Member(x => nameof(x.Scope)).Optional();

--- a/src/Corsinvest.VisualStudio.Agents.Contracts/BridgeGenerationSpec.cs
+++ b/src/Corsinvest.VisualStudio.Agents.Contracts/BridgeGenerationSpec.cs
@@ -68,6 +68,8 @@ public class BridgeGenerationSpec : GenerationSpec
         AddInterface<ModelChangedNotification>();
         AddInterface<PermissionModeChangedNotification>();
         AddInterface<SetComposerNotification>();
+        AddInterface<FilesDroppedNotification>();
+        AddInterface<DroppedFile>();
         AddInterface<PromptHistoryNotification>();
         AddInterface<SlashCommandsNotification>();
         AddInterface<AssistantTextDeltaNotification>().Member(x => nameof(x.ParentToolUseId)).Null();

--- a/src/Corsinvest.VisualStudio.Agents.Contracts/FromWebViewDtos.cs
+++ b/src/Corsinvest.VisualStudio.Agents.Contracts/FromWebViewDtos.cs
@@ -191,3 +191,12 @@ public class ExternalUrlNotification
 {
     public string Url { get; set; }
 }
+
+/// <summary>Open the extension's Options (open_options).</summary>
+public class OpenOptionsNotification
+{
+    /// <summary>Which page: "general" (the default when absent), "chat", "debug" or "profiles".
+    /// A notice that names a setting can then open the page that setting lives on, instead of
+    /// spelling out the path to it.</summary>
+    public string Page { get; set; }
+}

--- a/src/Corsinvest.VisualStudio.Agents.Contracts/ToWebViewDtos.cs
+++ b/src/Corsinvest.VisualStudio.Agents.Contracts/ToWebViewDtos.cs
@@ -408,6 +408,23 @@ public class HostKeyNotification
     public bool Alt { get; set; }
 }
 
+/// <summary>Files dropped on the pane, already read (ui_files_dropped). Same root cause as
+/// <see cref="HostKeyNotification"/>: with no window of its own the browser never sees the drop, so
+/// WPF claims it before Visual Studio opens the file in an editor.</summary>
+public class FilesDroppedNotification
+{
+    public DroppedFile[] Files { get; set; } = [];
+}
+
+public class DroppedFile
+{
+    public string Name { get; set; } = "";
+    public string Base64 { get; set; } = "";
+    /// <summary>Carried because a File built in script has no type of its own, and both the chip
+    /// and the CLI block shape are chosen from it.</summary>
+    public string MediaType { get; set; } = "";
+}
+
 /// <summary>The ↑/↓ prompt history for a session (chat_prompt_history). The WebView
 /// keeps prompts; sessionId gates stale updates (only apply if it matches).</summary>
 public class PromptHistoryNotification

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/BridgeMessages.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/BridgeMessages.cs
@@ -207,6 +207,8 @@ internal static class BridgeMessages
             /// <summary>A key the composition control dropped, claimed by the pane and forwarded
             /// for the page to act on. See <c>HostKeyNotification</c>.</summary>
             public const string HostKey = "ui_host_key";
+            /// <summary>See <c>FilesDroppedNotification</c>.</summary>
+            public const string FilesDropped = "ui_files_dropped";
         }
 
         /// <summary>Plugin-manager results + the global "plugins changed" broadcast.</summary>

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.Payloads.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.Payloads.cs
@@ -95,22 +95,15 @@ internal sealed partial class WebViewBridge
         {
             foreach (var att in attachments)
             {
-                // The webview always sends base64; we decide the block shape by
-                // extension here (single source of truth). Images → image block;
-                // .pdf → pdf document; everything else → text document (decoded).
+                // The webview sends base64 plus the browser's media type, and only extensions the
+                // user allowed get this far — so the type alone picks the block: image, text
+                // (decoded back to characters), or a document carrying its own media type.
                 var name = att.Val("name", "");
                 var base64 = att.Val("base64", "");
-                var ext = Path.GetExtension(name).ToLowerInvariant();
+                var mediaType = att.Val("mediaType", "");
 
-                if (ext is ".png" or ".jpg" or ".jpeg" or ".gif" or ".webp")
+                if (mediaType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
                 {
-                    var mediaType = ext switch
-                    {
-                        ".jpg" or ".jpeg" => "image/jpeg",
-                        ".gif" => "image/gif",
-                        ".webp" => "image/webp",
-                        _ => "image/png",
-                    };
                     blocks.Add(new JObject
                     {
                         ["type"] = "image",
@@ -122,24 +115,9 @@ internal sealed partial class WebViewBridge
                         }
                     });
                 }
-                else if (ext == ".pdf")
+                else if (mediaType.StartsWith("text/", StringComparison.OrdinalIgnoreCase))
                 {
-                    blocks.Add(new JObject
-                    {
-                        ["type"] = "document",
-                        ["source"] = new JObject
-                        {
-                            ["type"] = "base64",
-                            ["media_type"] = "application/pdf",
-                            ["data"] = base64
-                        },
-                        ["title"] = name
-                    });
-                }
-                else
-                {
-                    // Text-like file: the CLI expects a plain text block, so decode the
-                    // base64 back to UTF-8 rather than attaching it as binary data.
+                    // Text arrives base64 like everything else; the CLI wants the characters.
                     string textData;
                     try
                     {
@@ -158,8 +136,22 @@ internal sealed partial class WebViewBridge
                         ["source"] = new JObject
                         {
                             ["type"] = "text",
-                            ["media_type"] = "text/plain",
+                            ["media_type"] = mediaType,
                             ["data"] = textData
+                        },
+                        ["title"] = name
+                    });
+                }
+                else
+                {
+                    blocks.Add(new JObject
+                    {
+                        ["type"] = "document",
+                        ["source"] = new JObject
+                        {
+                            ["type"] = "base64",
+                            ["media_type"] = mediaType,
+                            ["data"] = base64
                         },
                         ["title"] = name
                     });

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Open.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Open.cs
@@ -125,7 +125,14 @@ internal sealed partial class WebViewMessageHandler
 
     private void HandleOptions(JObject data, int? id)
     {
-        AgentsPackage.Instance?.ShowOptionPage(typeof(AgentsGeneralPage));
+        var page = data.ToObject<Contracts.OpenOptionsNotification>().Page ?? "";
+        AgentsPackage.Instance?.ShowOptionPage(page.ToLowerInvariant() switch
+        {
+            "chat" => typeof(AgentsChatPage),
+            "debug" => typeof(AgentsDebugPage),
+            "profiles" => typeof(AgentsProfilesPage),
+            _ => typeof(AgentsGeneralPage),
+        });
     }
 
     private void HandleCliTerminal(JObject data, int? id)

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
@@ -319,6 +319,7 @@ public partial class ChatPaneControl : PaneControlBase
         Loaded += OnLoaded;
         Unloaded += OnUnloaded;
         WebView.HostKeyPressed += OnHostKeyPressed;
+        WebView.HostFilesDropped += OnHostFilesDropped;
         // Clicking into the chat is the user answering the attention notice, so take it down.
         // Composition rendering is what makes this possible: the control lives in the WPF tree,
         // so mouse events reach us. The HwndHost version had to be told from JS instead.
@@ -335,6 +336,37 @@ public partial class ChatPaneControl : PaneControlBase
     /// bridge is up — there is nothing focused to act on yet.</summary>
     private void OnHostKeyPressed(Contracts.HostKeyNotification key)
         => _bridge?.Send(BridgeMessages.ToWebView.Ui.HostKey, key);
+
+    /// <summary>WPF hands over paths, so the bytes are read here; the page then applies the upload
+    /// allow-list, which is why the host has no copy of it.</summary>
+    private void OnHostFilesDropped(string[] paths)
+    {
+        if (_bridge == null) { return; }
+        var files = new List<Contracts.DroppedFile>();
+        foreach (var path in paths)
+        {
+            try
+            {
+                // A dropped folder: skip it rather than fail the whole drop.
+                if (!System.IO.File.Exists(path)) { continue; }
+                files.Add(new Contracts.DroppedFile
+                {
+                    Name = System.IO.Path.GetFileName(path),
+                    Base64 = Convert.ToBase64String(System.IO.File.ReadAllBytes(path)),
+                    MediaType = Helpers.MimeTypes.Of(path),
+                });
+            }
+            catch (Exception ex)
+            {
+                _log.Warn($"[chat] dropped file '{path}' could not be read — {ex.Message}");
+            }
+        }
+        if (files.Count > 0)
+        {
+            _bridge.Send(BridgeMessages.ToWebView.Ui.FilesDropped,
+                         new Contracts.FilesDroppedNotification { Files = files.ToArray() });
+        }
+    }
 
     private void OnLoaded(object sender, RoutedEventArgs e)
         => ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
@@ -378,6 +410,7 @@ public partial class ChatPaneControl : PaneControlBase
         VSColorTheme.ThemeChanged -= OnVsThemeChanged;
         AgentsOptions.Applied -= OnOptionsApplied;
         WebView.HostKeyPressed -= OnHostKeyPressed;
+        WebView.HostFilesDropped -= OnHostFilesDropped;
         WebView.PreviewMouseDown -= OnWebViewClicked;
         IdeContextService.Instance.ContextChanged -= OnEditorContextChanged;
         // EnsureClient hooked this on the IdeContextService singleton; without the unhook the

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatWebView.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatWebView.cs
@@ -29,6 +29,34 @@ internal sealed class ChatWebView : WebView2CompositionControl
     /// <summary>Raised for a claimed key, in the shape the page expects.</summary>
     internal event Action<HostKeyNotification> HostKeyPressed;
 
+    internal event Action<string[]> HostFilesDropped;
+
+    // public, not internal: XAML instantiates this by x:Name and needs a public default ctor.
+    public ChatWebView()
+    {
+        AllowDrop = true;
+    }
+
+    // Preview, and Handled either way, or the drop tunnels on to VS and opens the file in an editor.
+    // Handing it to the browser instead is not an option: the .NET wrapper exposes only DragLeave of
+    // ICoreWebView2CompositionController3.
+    protected override void OnPreviewDragOver(System.Windows.DragEventArgs e)
+    {
+        e.Effects = e.Data.GetDataPresent(System.Windows.DataFormats.FileDrop)
+            ? System.Windows.DragDropEffects.Copy
+            : System.Windows.DragDropEffects.None;
+        e.Handled = true;
+    }
+
+    protected override void OnPreviewDrop(System.Windows.DragEventArgs e)
+    {
+        if (e.Data.GetData(System.Windows.DataFormats.FileDrop) is string[] paths && paths.Length > 0)
+        {
+            HostFilesDropped?.Invoke(paths);
+        }
+        e.Handled = true;
+    }
+
     // Only keys verified as dropped. A key that already reaches the browser must stay out: claiming
     // it sets Handled and would take it away from the page, breaking what works today (arrows,
     // PageUp/PageDown and Ctrl+Left/Right all arrive fine). Esc and Ctrl+F are out for another

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/bridge-messages.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/bridge-messages.ts
@@ -120,6 +120,7 @@ export const Msg = {
             setComposer: 'ui_set_composer',
             escape: 'ui_escape',
             hostKey: 'ui_host_key',
+            filesDropped: 'ui_files_dropped',
         },
         plugins: {
             listResult: 'plugins_list_result',

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated/DroppedFile.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated/DroppedFile.ts
@@ -1,0 +1,10 @@
+/**
+ * This is a TypeGen auto-generated file.
+ * Any changes made to this file can be lost when this file is regenerated.
+ */
+
+export interface DroppedFile {
+    name: string;
+    base64: string;
+    mediaType: string;
+}

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated/FilesDroppedNotification.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated/FilesDroppedNotification.ts
@@ -1,0 +1,10 @@
+/**
+ * This is a TypeGen auto-generated file.
+ * Any changes made to this file can be lost when this file is regenerated.
+ */
+
+import { DroppedFile } from './DroppedFile';
+
+export interface FilesDroppedNotification {
+    files: DroppedFile[];
+}

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated/OpenOptionsNotification.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated/OpenOptionsNotification.ts
@@ -1,0 +1,8 @@
+/**
+ * This is a TypeGen auto-generated file.
+ * Any changes made to this file can be lost when this file is regenerated.
+ */
+
+export interface OpenOptionsNotification {
+    page?: string;
+}

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/types.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/types.ts
@@ -216,6 +216,7 @@ export type { SetPermissionModeNotification } from './generated/SetPermissionMod
 export type { SetModelNotification } from './generated/SetModelNotification';
 export type { ForkNotification } from './generated/ForkNotification';
 export type { ExternalUrlNotification } from './generated/ExternalUrlNotification';
+export type { OpenOptionsNotification } from './generated/OpenOptionsNotification';
 
 /** Global signal that a permission prompt is active (cv-prompt reads its
  *  presence to disable sending). The banner itself holds the full request
@@ -457,6 +458,8 @@ export interface Notice {
     /** Optional action button: label + the fromWebView bridge message its click sends. */
     actionLabel?: string;
     actionMessage?: string;
+    /** Payload for that message, when it takes one (which Options page to open). */
+    actionPayload?: Record<string, unknown>;
     /** Stays until the host clears it (a dead CLI process) — never auto-dismissed. */
     sticky?: boolean;
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/types.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/types.ts
@@ -141,6 +141,9 @@ export type { SetComposerNotification } from './generated/SetComposerNotificatio
 /** A key the host claimed for us (`ui_host_key`). Generated from C# by TypeGen. */
 export type { HostKeyNotification } from './generated/HostKeyNotification';
 
+/** Files the host claimed and read for us (`ui_files_dropped`). Generated from C# by TypeGen. */
+export type { FilesDroppedNotification } from './generated/FilesDroppedNotification';
+
 /** Prompt history, slash-command catalogue, streamed text delta, tool-progress tick,
  *  CLI-started notice. Generated from C# by TypeGen — re-exported here. */
 export type { PromptHistoryNotification } from './generated/PromptHistoryNotification';

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-notice-stack.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-notice-stack.ts
@@ -155,7 +155,7 @@ export class CvNoticeStack extends LitElement {
      *  leaves the row up — the host clears it when the condition resolves. */
     private _runAction(n: Notice): void {
         if (n.actionMessage) {
-            bridge.sendNotification(n.actionMessage, {});
+            bridge.sendNotification(n.actionMessage, n.actionPayload ?? {});
         }
     }
 
@@ -207,7 +207,6 @@ export class CvNoticeStack extends LitElement {
                                 n.actionLabel && n.actionMessage
                                     ? html`<fluent-button
                                           slot="actions"
-                                          appearance="transparent"
                                           size="small"
                                           @click=${() => this._runAction(n)}
                                           >${n.actionLabel}</fluent-button

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-prompt.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-prompt.ts
@@ -27,6 +27,7 @@ import type {
     SetPermissionModeNotification,
     SetModelNotification,
     ExternalUrlNotification,
+    OpenOptionsNotification,
     PermissionMode,
 } from '../../core/types';
 import { GetSuggestionsReq } from '../../core/request-types';
@@ -67,19 +68,14 @@ function isAllowedUpload(file: File): boolean {
     return !!ext && (appState.ui.allowedUploadExtensions ?? []).includes(ext);
 }
 
-/** Wording for files whose extension isn't in the upload allowlist. Tells the
- *  user the extension can be added in Options — but only text/image/PDF files
- *  are usable (Claude can't read arbitrary binaries). */
+/** Wording for files whose extension isn't in the upload allowlist. The Options path it used to
+ *  spell out is now the action button's job. */
 function unsupportedMessage(names: string[]): string {
     const list = names.join(', ');
     return (
         `<strong>Unsupported file types:</strong> ${list}. ` +
-        'Supported types: images (PNG, JPG, GIF, WebP), text files, and PDFs. ' +
-        'If this is a text, image or PDF file, add its extension under ' +
-        '<em>Options → Claude Code → Chat → Allowed upload file extensions</em>. ' +
-        'Binary files (archives, executables, Office documents) cannot be read — ' +
-        'reference them instead by absolute path in your prompt (using @ for paths ' +
-        'inside your working directory).'
+        'Add the extension to allow it, or reference the file by absolute path in your prompt ' +
+        '(@ for paths inside your working directory).'
     );
 }
 
@@ -1178,6 +1174,9 @@ export class CvPrompt extends LitElement implements CommandHost {
                 severity: 'error',
                 message: unsupportedMessage(rejected),
                 key: 'upload-rejected',
+                actionLabel: 'Open settings',
+                actionMessage: Msg.fromWebView.open.options,
+                actionPayload: { page: 'chat' },
             });
         }
     }
@@ -1266,7 +1265,7 @@ export class CvPrompt extends LitElement implements CommandHost {
 
     /** Open the extension's Tools → Options page. */
     openOptions(): void {
-        bridge.sendNotification(Msg.fromWebView.open.options, {});
+        bridge.sendNotification<OpenOptionsNotification>(Msg.fromWebView.open.options, {});
     }
 
     /** Open a fresh interactive CLI pane (host runs PaneLauncher.OpenNew(Cli)). */

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-prompt.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-prompt.ts
@@ -1324,24 +1324,18 @@ export class CvPrompt extends LitElement implements CommandHost {
         }
     };
 
+    /** kind, not an image/ mime: a pasted PDF then meets the same allow-list as drop and the
+     *  picker, which either takes it or says why — instead of vanishing. */
     private _onPaste = (e: ClipboardEvent): void => {
-        const items = e.clipboardData?.items;
-        if (!items) {
-            return;
+        const files = Array.from(e.clipboardData?.items ?? [])
+            .filter((i) => i.kind === 'file')
+            .map((i) => i.getAsFile())
+            .filter((f): f is File => f !== null);
+        if (files.length === 0) {
+            return; // plain text: leave the paste to the browser
         }
-        let consumed = false;
-        for (const item of items) {
-            if (item.type.startsWith('image/')) {
-                consumed = true;
-                const file = item.getAsFile();
-                if (file) {
-                    void this._readFiles([file]);
-                }
-            }
-        }
-        if (consumed) {
-            e.preventDefault();
-        }
+        e.preventDefault();
+        void this._readFiles(files);
     };
 
     /** Stop the turn: interrupt the CLI, drop anything queued behind it, free the UI.

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-prompt.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-prompt.ts
@@ -1182,6 +1182,11 @@ export class CvPrompt extends LitElement implements CommandHost {
         }
     }
 
+    /** Public because the drop is caught in WPF, not here (ui_files_dropped). */
+    async addDroppedFiles(files: File[]): Promise<void> {
+        await this._readFiles(files);
+    }
+
     private _onPickFile = (): void => {
         this._filePicker?.click();
     };

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/init.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/init.ts
@@ -15,6 +15,7 @@ import { setExtraLinkableExtensions } from '../core/file-links';
 import type {
     CliStateNotification,
     HostKeyNotification,
+    FilesDroppedNotification,
     InitPayloadNotification,
     ModelsNotification,
     PermissionMode,
@@ -149,6 +150,21 @@ function wireBridgeHandlers(): void {
     bridge.onNotification<HostKeyNotification>(Msg.toWebView.ui.hostKey, (data) => {
         if (data?.key) {
             applyHostKey(data);
+        }
+    });
+
+    // Rebuilt as File objects so the composer attaches them through its own path — allow-list and
+    // rejection notice stay in one place.
+    bridge.onNotification<FilesDroppedNotification>(Msg.toWebView.ui.filesDropped, (data) => {
+        const files = (data?.files ?? []).map((f) => {
+            const bin = atob(f.base64);
+            const bytes = Uint8Array.from(bin, (c) => c.charCodeAt(0));
+            return new File([bytes], f.name, { type: f.mediaType });
+        });
+        if (files.length > 0) {
+            const input = document.querySelector('cv-prompt') as
+                import('./components/cv-prompt').CvPrompt | null;
+            void input?.addDroppedFiles(files);
         }
     });
 

--- a/src/Corsinvest.VisualStudio.Agents/Corsinvest.VisualStudio.Agents.csproj
+++ b/src/Corsinvest.VisualStudio.Agents/Corsinvest.VisualStudio.Agents.csproj
@@ -313,6 +313,7 @@
     <Compile Include="Helpers\StringHelpers.cs" />
     <Compile Include="Helpers\ShellHelpers.cs" />
     <Compile Include="Helpers\VsReflection.cs" />
+    <Compile Include="Helpers\MimeTypes.cs" />
     <Compile Include="Helpers\Win32Focus.cs" />
     <Compile Include="Helpers\WindowChrome.cs" />
     <Compile Include="Chat\VsThemeReader.cs" />

--- a/src/Corsinvest.VisualStudio.Agents/Helpers/MimeTypes.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Helpers/MimeTypes.cs
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Corsinvest.VisualStudio.Agents.Helpers;
+
+/// <summary>The media type Windows itself reports for a file, so no mime list of our own.</summary>
+internal static class MimeTypes
+{
+    [DllImport("urlmon.dll", CharSet = CharSet.Unicode, ExactSpelling = true)]
+    private static extern int FindMimeFromData(IntPtr pBC, string pwzUrl, IntPtr pBuffer, int cbSize,
+                                               string pwzMimeProposed, int dwMimeFlags, out IntPtr ppwzMimeOut, int dwReserved);
+
+    /// <summary>Not the registry: it has no entry for .cs and maps .ts to video/vnd.dlna.mpeg-tts.
+    /// A failed HRESULT (.md, .razor) means "", as the browser reports for a type it cannot name
+    /// either.</summary>
+    internal static string Of(string path)
+    {
+        var mime = IntPtr.Zero;
+        try
+        {
+            return FindMimeFromData(IntPtr.Zero, path, IntPtr.Zero, 0, null, 0, out mime, 0) != 0
+                    ? ""
+                    : Marshal.PtrToStringUni(mime) ?? "";
+        }
+        catch (Exception ex)
+        {
+            // A throw would climb into the caller's WPF drop handler and take the pane with it.
+            OutputWindowLogger.Global.Warn($"[mime] media type for '{path}' — {ex.Message}");
+            return "";
+        }
+        finally
+        {
+            // Allocated by the callee.
+            if (mime != IntPtr.Zero) { Marshal.FreeCoTaskMem(mime); }
+        }
+    }
+}

--- a/src/Corsinvest.VisualStudio.Agents/Options/AgentsChatPage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Options/AgentsChatPage.cs
@@ -83,11 +83,12 @@ public class AgentsChatPage : AgentsOptionsPage
 
     [Category("Files")]
     [DisplayName("Allowed upload file extensions")]
-    [Description("Extensions accepted when uploading/dropping files into the chat. Images (.png/.jpg/.gif/.webp) are sent as images, .pdf as a PDF document, everything else as text. Anything not listed is rejected with a notice. One entry per line, with or without the leading dot. Click `…` to edit.")]
+    [Description("Extensions accepted when uploading/dropping files into the chat. Images (.png/.jpg/.gif/.webp) are sent as images, .pdf as a PDF document, everything else as text — video files are listed so they can be attached, but Claude cannot watch them and only sees the file name. Anything not listed is rejected with a notice. One entry per line, with or without the leading dot. Click `…` to edit.")]
     [Editor("System.Windows.Forms.Design.StringArrayEditor, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", typeof(UITypeEditor))]
     public string[] AllowedUploadFileExtensions { get; set; } =
     [
         ".png", ".jpg", ".jpeg", ".gif", ".webp", ".pdf",
+        ".mp4", ".mov", ".webm", ".mkv", ".avi", ".m4v", ".wmv",
         ".html", ".htm", ".xhtml", ".xml", ".svg", ".css", ".scss", ".sass", ".less",
         ".vue", ".svelte", ".astro", ".razor", ".cshtml", ".xaml",
         ".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".mts", ".cts",


### PR DESCRIPTION
Attaching a file to the composer worked in one way out of three, and the two that failed did so silently.

**Dragging** a file onto the pane handed it to Visual Studio, which opened it in an editor — the composer never saw it. Composition rendering leaves the browser no window of its own, so nothing routes the drop to the page: the same root cause that already made Home/End need forwarding. WPF claims the drop in the Preview pass now, before it tunnels on to VS, and passes the paths to the pane; the pane reads the bytes and pushes them over the bridge, and the page rebuilds them as `File` objects and feeds them to the composer's own attach path, so the allow-list and its rejection notice stay in one place. Handing the drop to the browser instead isn't available: of `ICoreWebView2CompositionController3` the .NET wrapper exposes only `DragLeave`.

**Pasting** anything that wasn't an image did nothing at all — no attachment, no message. `_onPaste` only looked at `image/*`, so a `.txt` or a `.pdf` — extensions that are *allowed* — vanished with no way to tell why. It now collects every `item.kind === 'file'` and hands them to the same reader, which already knows what to accept and what to refuse out loud.

**What we sent the CLI** was picked by extension: a lookup that knew about images and PDFs and treated the rest as text, which is how a 1.4 MB video became 44% U+FFFD in the transcript. The media type each attachment already carries decides it instead — `image/` goes as an image, `text/` as decoded text, everything else as a document with its own type. No list of our own, no filtering either: only allowed files ever reach that code.

Dropped files get their type from Windows via `FindMimeFromData`, because a `File` built in script has none, and both the chip and the block shape are chosen from it. The registry alone would not do: no entry for `.cs`, and `.ts` mapped to `video/vnd.dlna.mpeg-tts`.

Video extensions join the defaults — Claude can't watch them, but attaching one and having it named beats a silent refusal.

Last, the notice that refuses a file. It recited *"add its extension under Options → Claude Code → Chat → Allowed upload file extensions"* — four levels to walk by hand, in a bar with room for a button — and claimed binary files cannot be read, which stopped being true above: what gets rejected is the extension, not the bytes. Shorter text, and an **Open settings** button beside it. The stack could already render one, it just had nothing to send: its action carried a fixed empty payload and `open_options` always opened the General page. Notices carry an `actionPayload` now, and `open_options` takes an optional page, so a notice can land where its setting lives. Absent, it still opens General, which is what `/settings` wants.

### Verified in the experimental instance

- Drop an image → thumbnail, and the lightbox opens on it
- Drop a `.cs` → arrives as text, not base64
- Paste a non-image → attaches, or is refused with a reason
- Refused file → **Open settings** lands on the **Chat** page, not General

### Notes

- No test project: the gate is a green MSBuild plus the manual pass above. WebView `typecheck`, `lint` and `format` are clean.
- `Helpers/MimeTypes.cs` is new, so it is registered by hand in the `.csproj` `<Compile>` list.
