### PR TITLE
fix(chat): count the tokens an attachment actually costs

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/helpers/actions-row.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/helpers/actions-row.ts
@@ -20,12 +20,16 @@ export interface TurnMetrics {
     usage: ContextUsageDto | null;
 }
 
-/** "$0.3260 · ↑ 2 ↓ 84 tok · 3.2s". The figures carry `.v`, the $ ↑ ↓ tok s markers around them
+/** "$0.3260 · ↑ 1.2k ↓ 84 tok · 3.2s". The figures carry `.v`, the $ ↑ ↓ tok s markers around them
  *  don't: at this size everything at one weight reads as a single grey run with no way in, so the
  *  numbers are what the eye should land on and the markers only say which is which.
  *
  *  Cache reads are deliberately left out of the input count: they are context replayed, not tokens
  *  this turn spent, and counting them puts a five-figure number next to an answer that cost two.
+ *  Cache CREATION is the opposite and is counted: it is content entering the context for the first
+ *  time here — an attachment, a freshly read file — billed above the base input rate. Left out, a
+ *  turn that pushed 540k tokens of video into the cache reported `↑ 2`, which is what `input_tokens`
+ *  alone is once caching takes the rest.
  *  Every part is dropped when zero rather than shown as "0" — a replayed turn has its token counts
  *  but no cost or duration (those ride `result`, which the JSONL has no line for), so it renders
  *  the tokens alone instead of "$0 · … · 0.0s". */
@@ -34,7 +38,7 @@ function formatMetrics(m: TurnMetrics) {
     if (m.costUsd) {
         parts.push(html`$<span class="v">${m.costUsd.toFixed(4)}</span>`);
     }
-    const inTok = m.usage?.inputTokens ?? 0;
+    const inTok = (m.usage?.inputTokens ?? 0) + (m.usage?.cacheCreationTokens ?? 0);
     const outTok = m.usage?.outputTokens ?? 0;
     if (inTok || outTok) {
         parts.push(


### PR DESCRIPTION
A turn that pushed a 540k-token video into the context reported **`↑ 2`**. So did every other turn of that session — 21 of them, adding up to `↑ 40` against a real 2.19M.

`input_tokens` alone is what is left *after* prompt caching takes the rest, so it measures the uncached tail and almost nothing else. Cache creation is where the content actually lands — an attachment, a freshly read file, anything entering the context for the first time — and it is billed **above** the base input rate, not below it. It belongs in the figure.

Cache reads stay out, which is what the comment above the function already argued: they are context replayed from earlier turns, so counting them reports the same five-figure number on every turn regardless of what that turn did.

### Measured on a real session

`75580c0f`, 21 turns, two video attachments:

| Turn | Before | After |
|---|---|---|
| 1 (video) | ↑ 2 | **↑ 541k** |
| 2–3 | ↑ 2 | ↑ 542k |
| 4–7 | ↑ 2 | ↑ 84 – 315 |
| 8–12 | ↑ 2 | ↑ 1.0k – 1.4k |
| 15 (video) | ↑ 2 | **↑ 550k** |
| **session** | **↑ 40** | **↑ 2.19M** |

Both directions matter: the heavy turns surface, and the light ones stay light. Summing cache reads as well would have reported ~568k on the turn that spent 84, and 12M for the session — the same context counted 21 times.

### Notes

- One line changed, plus the comment that now explains why creation is in and reads are out.
- WebView `typecheck`, `build` and `format` are clean.
- Verified in the experimental instance.
