### PR TITLE
refactor(chat): let Fluent draw the icon buttons

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-attach-menu.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-attach-menu.ts
@@ -10,17 +10,22 @@ import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import Add16Regular from '@fluentui/svg-icons/icons/add_16_regular.svg';
 import ArrowUpload16Regular from '@fluentui/svg-icons/icons/arrow_upload_16_regular.svg';
 import DocumentText16Regular from '@fluentui/svg-icons/icons/document_text_16_regular.svg';
-import { iconStyles, tooltipStyles } from '../styles/shared';
+import { iconStyles, iconTriggerStyles, tooltipStyles } from '../styles/shared';
 
 /**
  * Attach-actions button in the input toolbar, built on `<fluent-menu>`.
  * No "Add active file": cv-ide-context-badge covers it and the host
  * auto-injects the file path / selection into every prompt. Shadow DOM.
+ *
+ * No accent colour on the trigger: in this row colour means state (the gauge's bands, the mic
+ * while recording, send when there is something to send), and a permanently green plus says
+ * nothing while competing with the ones that do.
  */
 @customElement('cv-attach-menu')
 export class CvAttachMenu extends LitElement {
     static override styles = [
         iconStyles,
+        iconTriggerStyles,
         tooltipStyles,
         css`
             :host {
@@ -48,14 +53,6 @@ export class CvAttachMenu extends LitElement {
                 display: inline-flex;
                 align-items: center;
                 justify-content: center;
-            }
-            /* Fluent's own button, cut to the row's density: even size="small" is padded for a
-               control standing alone. No accent colour — in this row colour means state (the
-               gauge's bands, the mic while recording, send when there is something to send), and
-               a permanently green plus says nothing while competing with the ones that do. */
-            .trigger {
-                padding: 3px;
-                min-width: 0;
             }
             /* Wraps the glyph so it can be the tooltip's anchor while the button stays the menu's.
                A real box (not display:contents) — an anchor has to be laid out to be anchored to. */

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-copy-btn.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-copy-btn.ts
@@ -7,30 +7,27 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import Copy16Regular from '@fluentui/svg-icons/icons/copy_16_regular.svg';
 import Checkmark16Regular from '@fluentui/svg-icons/icons/checkmark_16_regular.svg';
-import { iconStyles, iconButtonStyles } from '../styles/shared';
+import { iconStyles, iconTriggerStyles } from '../styles/shared';
 
 /**
- * Reusable copy-to-clipboard icon button (wraps `<fluent-button>`, shows a
- * checkmark for ~1.2s after click). Text comes from `text`, lazily from a
- * sibling `<pre>` (`frompre`) / previous element (`fromprev`), or `getBlob`
- * for binary payloads written as a `ClipboardItem` (pasteable as a real image).
+ * Reusable copy-to-clipboard icon button (a `<fluent-button>`, shows a checkmark
+ * for ~1.2s after click). Text comes from `text`, lazily from a sibling `<pre>`
+ * (`frompre`) / previous element (`fromprev`), or `getBlob` for binary payloads
+ * written as a `ClipboardItem` (pasteable as a real image).
  *
- * Shadow DOM + static styles. The host is `display:contents` (no layout box —
- * the inner button participates in the parent flex/grid). Callers that need to
- * position the button (absolute hover-reveal over a <pre>/patch) reach it via
+ * Callers that position it (the hover-reveal over a <pre>/patch) reach the button via
  * `::part(button)` — the shadow boundary blocks plain descendant selectors.
  */
 @customElement('cv-copy-btn')
 export class CvCopyBtn extends LitElement {
     static override styles = [
         iconStyles,
-        iconButtonStyles,
+        iconTriggerStyles,
         css`
             :host {
                 display: contents;
             }
-            /* Copied state: tint the checkmark green for a clearer "done" signal. */
-            .icon-btn.copied svg {
+            .trigger.copied svg {
                 color: var(--colorPaletteGreenForeground1);
                 fill: var(--colorPaletteGreenForeground1);
             }
@@ -77,14 +74,18 @@ export class CvCopyBtn extends LitElement {
 
     override render() {
         return html`
-            <button
+            <fluent-button
                 part="button"
-                class="icon-btn ${this._copied ? 'copied' : ''}"
+                class="trigger ${this._copied ? 'copied' : ''}"
+                appearance="subtle"
+                shape="rounded"
+                size="small"
+                icon-only
                 title=${this._copied ? 'Copied' : this.title}
                 @click=${this._onClick}
             >
                 ${unsafeHTML(this._copied ? Checkmark16Regular : Copy16Regular)}
-            </button>
+            </fluent-button>
         `;
     }
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-message.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-message.ts
@@ -211,7 +211,7 @@ export class CvMessage extends LitElement {
     /**
      * Bottom hover actions row (user messages): Copy + Fork (only with a uuid, i.e. replayed from
      * JSONL history — live messages have none) + "x ago" timestamp. Inline — cv-copy-btn is the
-     * shared icon button; Fork is a bare .icon-btn (styled in chat.css). Expand is NOT here: long
+     * shared icon button; Fork is a plain .trigger (styled in chat.css). Expand is NOT here: long
      * messages get an always-visible "Show more" button on the fade instead (see the user render).
      */
     private _renderActions() {
@@ -221,13 +221,17 @@ export class CvMessage extends LitElement {
             <cv-copy-btn .text=${copyText} title="Copy message"></cv-copy-btn>
             ${
                 showFork
-                    ? html`<button
-                          class="icon-btn"
+                    ? html`<fluent-button
+                          class="trigger"
+                          appearance="subtle"
+                          shape="rounded"
+                          size="small"
+                          icon-only
                           title="Fork conversation from here"
                           @click=${this._onFork}
                       >
                           ${unsafeHTML(BranchFork16Regular)}
-                      </button>`
+                      </fluent-button>`
                     : nothing
             }
             ${

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-mic-button.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-mic-button.ts
@@ -6,7 +6,7 @@ import { LitElement, html, css, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import Mic16Regular from '@fluentui/svg-icons/icons/mic_16_regular.svg';
-import { iconStyles, tooltipStyles } from '../styles/shared';
+import { iconStyles, iconTriggerStyles, tooltipStyles } from '../styles/shared';
 
 /**
  * Mic button using Web Speech API. Fires a `transcript` CustomEvent with
@@ -18,14 +18,9 @@ import { iconStyles, tooltipStyles } from '../styles/shared';
 export class CvMicButton extends LitElement {
     static override styles = [
         iconStyles,
+        iconTriggerStyles,
         tooltipStyles,
         css`
-            /* Fluent's own button, cut to the row's density: even size="small" is padded for a
-               control standing alone. */
-            .trigger {
-                padding: 3px;
-                min-width: 0;
-            }
             /* While recording: red button that pulses, reads as "stop". The colour is set on the
                host, over the subtle appearance — this state is the one thing Fluent has no
                variant for. */

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-slash-menu.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-slash-menu.ts
@@ -2,11 +2,11 @@
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
-import { LitElement, html, css } from 'lit';
+import { LitElement, html } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import SlashForward16Regular from '@fluentui/svg-icons/icons/slash_forward_16_regular.svg';
-import { iconStyles, tooltipStyles } from '../styles/shared';
+import { iconStyles, iconTriggerStyles, tooltipStyles } from '../styles/shared';
 
 /**
  * Slash button in the input toolbar. Opens the unified command palette
@@ -16,19 +16,7 @@ import { iconStyles, tooltipStyles } from '../styles/shared';
  */
 @customElement('cv-slash-menu')
 export class CvSlashMenu extends LitElement {
-    static override styles = [
-        iconStyles,
-        tooltipStyles,
-        css`
-            /* Fluent's own button, cut to the row's density: even size="small" is padded for a
-               control standing alone. No accent colour — see cv-attach-menu: in this row colour
-               means state, and this button has none. */
-            .trigger {
-                padding: 3px;
-                min-width: 0;
-            }
-        `,
-    ];
+    static override styles = [iconStyles, iconTriggerStyles, tooltipStyles];
 
     private _onClick = (): void => {
         this.dispatchEvent(new CustomEvent('open-commands', { bubbles: true, composed: true }));
@@ -47,12 +35,8 @@ export class CvSlashMenu extends LitElement {
             >
                 ${unsafeHTML(SlashForward16Regular)}
             </fluent-button>
-            <!-- positioning=before, not the above-start the triggers on the right use: this one
-                 sits against the textarea, and anything opening above it lands on the placeholder.
-                 There is no room on the inline-start side either, so Fluent flips it to the other
-                 side — which is the point: beside the button rather than over the text.
-                 tip-desc, not tip-action: alone, the smaller action size reads as a footnote to
-                 something that isn't there. -->
+            <!-- positioning=before, not above-start: this trigger sits against the textarea, and
+                 anything opening above it lands on the placeholder. -->
             <fluent-tooltip anchor="slash-trigger" positioning="before">
                 <span class="tip-desc">Every slash command, in one list</span>
             </fluent-tooltip>

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-speak-btn.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-speak-btn.ts
@@ -7,7 +7,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import Speaker216Regular from '@fluentui/svg-icons/icons/speaker_2_16_regular.svg';
 import Pause16Regular from '@fluentui/svg-icons/icons/pause_16_regular.svg';
-import { iconStyles, iconButtonStyles } from '../styles/shared';
+import { iconStyles, iconTriggerStyles } from '../styles/shared';
 import { renderMarkdown } from '../../core/markdown';
 
 // Web Speech synthesis is a single global engine — only one utterance plays at a time. Track which
@@ -47,13 +47,12 @@ function toSpeech(md: string): string {
 export class CvSpeakBtn extends LitElement {
     static override styles = [
         iconStyles,
-        iconButtonStyles,
+        iconTriggerStyles,
         css`
             :host {
                 display: contents;
             }
-            /* Speaking: a tinted pause icon — click to pause (the speaker icon returns; click resumes). */
-            .icon-btn.speaking svg {
+            .trigger.speaking svg {
                 color: var(--colorBrandForeground1);
                 fill: var(--colorBrandForeground1);
             }
@@ -123,14 +122,18 @@ export class CvSpeakBtn extends LitElement {
         }
         const speaking = this._state === 'speaking';
         return html`
-            <button
+            <fluent-button
                 part="button"
-                class="icon-btn ${speaking ? 'speaking' : ''}"
+                class="trigger ${speaking ? 'speaking' : ''}"
+                appearance="subtle"
+                shape="rounded"
+                size="small"
+                icon-only
                 title=${speaking ? 'Pause' : this._state === 'paused' ? 'Resume' : this.title}
                 @click=${this._onClick}
             >
                 ${unsafeHTML(speaking ? Pause16Regular : Speaker216Regular)}
-            </button>
+            </fluent-button>
         `;
     }
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-tool-row.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-tool-row.ts
@@ -156,13 +156,17 @@ export class CvToolRow extends LitElement implements ToolRowState {
             return nothing;
         }
         return html`
-            <button
-                class="icon-btn"
+            <fluent-button
+                class="trigger"
+                appearance="subtle"
+                shape="rounded"
+                size="small"
+                icon-only
                 title=${this.showAll ? 'Reduce' : 'Show all'}
                 @click=${this._onToggleShowAll}
             >
                 ${unsafeHTML(this.showAll ? ArrowCollapseAll16Regular : ArrowExpandAll16Regular)}
-            </button>
+            </fluent-button>
         `;
     }
 

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/base.css
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/base.css
@@ -79,12 +79,12 @@ fluent-link svg[fill='none'],
 fluent-option svg[fill='none'] {
     fill: none;
 }
-/* Fluent's small icon-only button scales its glyph to 20px; pin it to the nominal 16px
- * so the action icons read as one size (shadow-DOM components do the same via iconStyles).
+/* Fluent's small icon-only button scales its glyph to 20px; pin it to 14, the size every action
+ * icon in the chat is drawn at (shadow-DOM components do the same via iconStyles).
  * Only icon-only buttons — labelled ones keep their sizing. */
 fluent-button[icon-only] svg {
-    width: 16px;
-    height: 16px;
+    width: 14px;
+    height: 14px;
 }
 
 

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/chat.css
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/chat.css
@@ -299,7 +299,7 @@ body.sticky-user .cv-exchange > cv-message[role="user"]:first-child .cv-message.
 }
 /* "Open diff in Visual Studio" icon: tinted purple to echo the slash-cmd band
  * ("special action" colour). The SVG is a solid fill (reads well at 14px), so tint
- * the fill; clear the generic .icon-btn `fill: currentColor` on this one. */
+ * the fill; clear the generic `fill: currentColor` on this one. */
 .cv-tool-actions-vs svg,
 .cv-tool-actions-vs svg path {
     fill: var(--colorPaletteBerryBorderActive);
@@ -378,7 +378,7 @@ body.sticky-user .cv-exchange > cv-message[role="user"]:first-child .cv-message.
     opacity: 1;
 }
 /* Tool header actions (error / open-diff / sub-agent copy+expand), in flow on the row rather than
- * an absolute overlay. Buttons are .icon-btn (shared 14px style); the tints below colour them. */
+ * an absolute overlay. Buttons are .trigger fluent-buttons; the tints below colour them. */
 .cv-tool-actions {
     display: inline-flex;
     align-items: center;
@@ -630,41 +630,11 @@ cv-message:hover .cv-msg-actions,
 cv-message:focus-within .cv-msg-actions {
     opacity: 1;
 }
-/* Small icon-action button — the shared light-DOM twin of cv-copy-btn's .icon-btn (Shadow-scoped).
- * Used across the chat light DOM: message rows (Fork) and tool header actions (error/open-diff/
- * expand/copy). Compact (14px glyph), theme-aware, keyboard-focusable — a bare <button>, not a
- * fluent-button (fluent-pure rule + it can't get this small). */
-.icon-btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
+/* Light-DOM twin of iconTriggerStyles (shared.ts), for the chat's own fluent-buttons: message rows
+ * (Fork) and tool header actions (chevron/error/open-diff/expand). */
+.trigger {
     padding: 3px;
-    border: 0;
-    border-radius: var(--borderRadiusSmall);
-    background: transparent;
-    color: inherit;
-    cursor: pointer;
-    opacity: 0.75;
-}
-/* NOT --colorSubtleBackgroundHover: in the light theme that token is #f5f5f5, three points of
- * luminance off the #ffffff behind it — the hover is there and invisible. Mixing the foreground
- * inverts with the theme by construction. Kept in step with iconButtonStyles (shared.ts). */
-.icon-btn:hover {
-    background: color-mix(in srgb, var(--colorNeutralForeground1) 10%, transparent);
-    opacity: 1;
-}
-.icon-btn:active {
-    background: color-mix(in srgb, var(--colorNeutralForeground1) 16%, transparent);
-}
-.icon-btn:focus-visible {
-    outline: 1px solid var(--colorStrokeFocus2, currentColor);
-    outline-offset: 1px;
-}
-.icon-btn svg {
-    width: 14px;
-    height: 14px;
-    display: block;
-    fill: currentColor;
+    min-width: 0;
 }
 /* The response row (inline: copy + timestamp) lives at the end of the exchange (a whole answer),
  * so it reveals on hovering anywhere in the exchange, not a single bubble. */

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/shared.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/shared.ts
@@ -19,66 +19,19 @@ export const iconStyles = css`
         fill: none;
     }
     /* Fluent's small icon-only button scales its glyph to 20px; pin it to 14, the size every
-     * action icon in the chat is drawn at (see iconButtonStyles), so the two kinds of button
-     * read as one set. Only icon-only buttons — labelled ones keep theirs. */
+     * action icon in the chat is drawn at. Only icon-only buttons — labelled ones keep theirs. */
     fluent-button[icon-only] svg {
         width: 14px;
         height: 14px;
     }
 `;
 
-/**
- * Shared icon-action button — the Shadow-DOM twin of `.icon-btn` in chat.css, which the light DOM
- * uses for the same thing. A bare `<button>`, not a fluent-button: Fluent sizes a standalone
- * control, and cutting it down to an icon's own size means overriding its tokens, which the
- * fluent-pure rule forbids. Owning the element instead keeps that rule intact.
- *
- * Glyph size comes from `--cv-icon-btn-size` (default 14px, the density of an action inside the
- * transcript); a component can raise it where the icon has to carry more.
- *
- * Icon-only buttons. A control with a word instead of a glyph is a `fluent-button` with
- * `shape="circular"` — Fluent's own pill, so its hover and focus come with it (see
- * cv-model-selector).
- */
-export const iconButtonStyles = css`
-    .icon-btn {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
+/** Icon-only `<fluent-button>` cut to the app's density — even `size="small"` is padded for a
+ *  control standing on its own. Layout only, so the rest still comes from Fluent. */
+export const iconTriggerStyles = css`
+    .trigger {
         padding: 3px;
-        border: 0;
-        border-radius: var(--borderRadiusSmall);
-        background: transparent;
-        /* Foreground2, not the inherited Foreground1: these sit beside the message they act on and
-           should not compete with it. Full strength on hover, below. */
-        color: var(--colorNeutralForeground2);
-        cursor: pointer;
-        opacity: 0.75;
-    }
-    .icon-btn:hover,
-    .icon-btn:focus-visible {
-        color: var(--colorNeutralForeground1);
-    }
-    /* NOT --colorSubtleBackgroundHover: in the light theme that token is #f5f5f5, three points of
-       luminance off the #ffffff behind it — the hover is there and invisible. Mixing the foreground
-       inverts with the theme by construction, so the tint reads on either. Same as the IDE-context
-       chip beside these buttons. */
-    .icon-btn:hover {
-        background: color-mix(in srgb, var(--colorNeutralForeground1) 10%, transparent);
-        opacity: 1;
-    }
-    .icon-btn:active {
-        background: color-mix(in srgb, var(--colorNeutralForeground1) 16%, transparent);
-    }
-    .icon-btn:focus-visible {
-        outline: 1px solid var(--colorStrokeFocus2, currentColor);
-        outline-offset: 1px;
-    }
-    .icon-btn svg {
-        width: var(--cv-icon-btn-size, 14px);
-        height: var(--cv-icon-btn-size, 14px);
-        display: block;
-        fill: currentColor;
+        min-width: 0;
     }
 `;
 

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/base.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/base.ts
@@ -202,10 +202,14 @@ export abstract class ToolRenderer {
                     ${this.renderHeaderActions()}
                     ${
                         opts.chevron
-                            ? html`<button
-                                  class="icon-btn cv-tool-row-chev ${opts.open ? 'expanded' : ''} ${
+                            ? html`<fluent-button
+                                  class="trigger cv-tool-row-chev ${opts.open ? 'expanded' : ''} ${
                                       opts.chevronAlwaysShown ? 'always-shown' : ''
                                   }"
+                                  appearance="subtle"
+                                  shape="rounded"
+                                  size="small"
+                                  icon-only
                                   title=${opts.open ? 'Collapse' : 'Expand'}
                                   @click=${(e: Event) => {
                                       e.stopPropagation();
@@ -213,7 +217,7 @@ export abstract class ToolRenderer {
                                   }}
                               >
                                   ${unsafeHTML(ChevronDown16Regular)}
-                              </button>`
+                              </fluent-button>`
                             : nothing
                     }
                 </div>
@@ -461,8 +465,12 @@ export abstract class ToolRenderer {
     /** The "show error details in VS" icon button. */
     protected errorButton(): TemplateResult {
         return html`<div class="cv-tool-actions">
-            <button
-                class="icon-btn cv-tool-actions-error"
+            <fluent-button
+                class="trigger cv-tool-actions-error"
+                appearance="subtle"
+                shape="rounded"
+                size="small"
+                icon-only
                 title="Show error details"
                 @click=${(e: Event) => {
                     e.stopPropagation();
@@ -470,7 +478,7 @@ export abstract class ToolRenderer {
                 }}
             >
                 ${unsafeHTML(ErrorCircle16Regular)}
-            </button>
+            </fluent-button>
         </div>`;
     }
 
@@ -483,8 +491,12 @@ export abstract class ToolRenderer {
         return html`<div class="cv-tool-actions">
             ${
                 this.host.status === 'error'
-                    ? html`<button
-                          class="icon-btn cv-tool-actions-error"
+                    ? html`<fluent-button
+                          class="trigger cv-tool-actions-error"
+                          appearance="subtle"
+                          shape="rounded"
+                          size="small"
+                          icon-only
                           title="Show error details"
                           @click=${(e: Event) => {
                               e.stopPropagation();
@@ -492,13 +504,17 @@ export abstract class ToolRenderer {
                           }}
                       >
                           ${unsafeHTML(ErrorCircle16Regular)}
-                      </button>`
+                      </fluent-button>`
                     : nothing
             }
             ${
                 appState.ui.showOpenDiffInVsButton
-                    ? html`<button
-                          class="icon-btn cv-tool-actions-vs"
+                    ? html`<fluent-button
+                          class="trigger cv-tool-actions-vs"
+                          appearance="subtle"
+                          shape="rounded"
+                          size="small"
+                          icon-only
                           title="Open diff in Visual Studio"
                           @click=${(e: Event) => {
                               e.stopPropagation();
@@ -506,7 +522,7 @@ export abstract class ToolRenderer {
                           }}
                       >
                           ${unsafeHTML(VisualStudioIcon)}
-                      </button>`
+                      </fluent-button>`
                     : nothing
             }
         </div>`;


### PR DESCRIPTION
The chat had two kinds of icon button. Three were `fluent-button`s; the other nine were bare `<button>`s carrying ~90 lines of hand-written CSS in **two copies** — one for Shadow DOM (`iconButtonStyles`), one for the light DOM (`.icon-btn` in `chat.css`) — that had to be kept in step by eye.

They no longer were. The shadow copy had moved to `Foreground2` with a hover step; the light one still said `color: inherit`. Copy and Fork sit next to each other in the same actions row, so the drift was on screen.

### The reason for owning the element no longer holds

It was written down in `shared.ts`: Fluent sizes a standalone control, and cutting it down to an icon's own size means overriding its tokens, which the fluent-pure rule forbids.

The proof that this is no longer true was already in the tree. The composer's own triggers get there with `padding: 3px; min-width: 0` — layout, which the rule allows — plus a rule pinning the slotted glyph to 14px. Nothing Fluent owns is touched. Verified in the experimental instance before converting the rest.

### What changed

| | Before | After |
|---|---|---|
| Copy, Speak | `<button>` + `iconButtonStyles` | `fluent-button` + `iconTriggerStyles` |
| Fork, chevron, error, open-in-VS, expand | `<button>` + `.icon-btn` | `fluent-button` + `.trigger` |
| attach (+), slash (/), mic | already Fluent, `.trigger` copied ×3 | `iconTriggerStyles` |

Hover, focus, active and disabled now come from Fluent instead of from CSS we maintain. Both copies are gone, replaced by four lines of layout in two places. **−170 / +97.**

The four `::part(button)` call sites that position Copy over a `<pre>` or a patch keep working — the part is whatever element it names.

One thing fixed on the way: the twin rules pinning the glyph never agreed on a size. `base.css` said 16px, `shared.ts` said 14. Both say 14 now, which is what the chat's actions were already drawn at.

### Verified in the experimental instance

- Copy and Speak: hover in **both themes**, click (green check / blue pause), and over a `<pre>`, a patch and a tool body
- Chevron: hidden until row hover, rotates 180° when open
- Error (red) and open-in-VS (purple) keep their forced SVG fill
- Fork beside Copy — one look now, which was the point

### Notes

- Closes the drift the follow-up TODO entry describes: there is nothing left to keep in step.
- WebView `typecheck`, `build` and `format` are clean.
