### PR TITLE
refactor(chat): the two time badges carry their own styling

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-diff-preview.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-diff-preview.ts
@@ -43,6 +43,7 @@ export class CvDiffPreview extends LitElement {
     private _format: DiffFormat | null = null;
     private _unobserve?: () => void;
 
+    // Light DOM, same reason as cv-diff-dialog: diff2html markup needs the global CSS.
     override createRenderRoot() {
         return this;
     }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-elapsed.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-elapsed.ts
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
-import { LitElement, html } from 'lit';
+import { LitElement, html, css } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { formatDuration } from '../helpers/format';
 
@@ -22,12 +22,19 @@ import { formatDuration } from '../helpers/format';
  * Owning the timer here is also what makes re-rendering cheap enough to be an option at all:
  * `requestUpdate` on the tool row would rebuild the whole row — body, IN/OUT, highlighted code,
  * nested children — sixty times a minute for a number. Here it re-renders one span.
- *
- * Light DOM: the badge is styled by the chat's global stylesheet, which cannot reach into a shadow
- * root.
  */
 @customElement('cv-elapsed')
 export class CvElapsed extends LitElement {
+    // On :host: the margin separates the badge from its sibling in the row, so it belongs to the
+    // element as a whole rather than to the span inside it.
+    static override styles = css`
+        :host {
+            margin-left: 4px;
+            font-size: 11px;
+            opacity: 0.7;
+        }
+    `;
+
     /** Epoch ms the sub-agent started. 0 renders nothing and keeps the timer off.
      *
      *  There is deliberately no fallback to the task's own `usage.durationMs`: that is the total the
@@ -40,10 +47,6 @@ export class CvElapsed extends LitElement {
     @state() private _now = Date.now();
 
     private _timer = 0;
-
-    override createRenderRoot() {
-        return this;
-    }
 
     override connectedCallback() {
         super.connectedCallback();
@@ -80,9 +83,7 @@ export class CvElapsed extends LitElement {
         if (this.startedAt <= 0) {
             return html``;
         }
-        return html`<span class="cv-agent-time"
-            >${formatDuration(this._now - this.startedAt)}</span
-        >`;
+        return html`<span>${formatDuration(this._now - this.startedAt)}</span>`;
     }
 }
 

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-time-ago.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-time-ago.ts
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
-import { LitElement, html } from 'lit';
+import { LitElement, html, css } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { formatAbsolute, formatTimeAgo } from '../helpers/format';
 
@@ -19,28 +19,30 @@ import { formatAbsolute, formatTimeAgo } from '../helpers/format';
  * The previous version wrote `textContent` onto the span holding the `${...}` binding, which
  * destroyed that ChildPart's markers — after which every later render of the whole chat threw
  * `Cannot set properties of null (setting 'data')` and the pane stopped updating entirely.
- *
- * Light DOM: `.cv-ts` is styled by the chat's global stylesheet, and the hover-reveal `opacity`
- * lives on the parent row.
  */
 @customElement('cv-time-ago')
 export class CvTimeAgo extends LitElement {
+    // On :host, not the span: font-size and color inherit, so they reach the text either way, and
+    // the hover-reveal opacity on the row above applies to the whole subtree, shadow included.
+    static override styles = css`
+        :host {
+            font-size: 0.82em;
+            color: var(--colorNeutralForeground3);
+            cursor: default;
+        }
+    `;
+
     /** Epoch ms of the message. 0 renders nothing. */
     @property({ type: Number }) ms = 0;
 
     /** The clock the stamp was last computed against. Bumping it is what re-renders the text. */
     @state() private _now = Date.now();
 
-    override createRenderRoot() {
-        return this;
-    }
-
     override render() {
         if (!this.ms) {
             return html``;
         }
         return html`<span
-            class="cv-ts"
             title=${formatAbsolute(this.ms)}
             @mouseenter=${() => {
                 this._now = Date.now();

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/chat.css
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/chat.css
@@ -673,12 +673,6 @@ cv-message:focus-within .cv-msg-actions {
     color: var(--colorNeutralForeground2);
     font-weight: 600;
 }
-/* Relative "x ago" timestamp next to the copy button (both the user and response rows). */
-.cv-ts {
-    font-size: 0.82em;
-    color: var(--colorNeutralForeground3);
-    cursor: default;
-}
 /* Status messages — a whole assistant turn that is ONLY italic text (e.g.
  * "*Thinking…*"): small and greyed. The `:has` must match a message whose
  * entire body is a single italic paragraph, NOT any message that merely
@@ -800,6 +794,8 @@ cv-message:focus-within .cv-msg-actions {
 }
 
 /* Elapsed time on a running Agent row (the dot handles the spinner). */
+/* The finished Agent's totals, which take the running clock's place in the row — cv-elapsed carries
+ * the same three properties on its own :host. */
 .cv-agent-time { margin-left: 4px; font-size: 11px; opacity: 0.7; }
 /* A finished Agent's totals reveal on hover, unlike the running clock next to them: several
  * sub-agents in a row put near-identical figures one under the other, and read as a wall of


### PR DESCRIPTION
`cv-time-ago` and `cv-elapsed` rendered into the light DOM for one reason: three CSS properties each, sitting in `chat.css`. Moving those onto `:host` costs nothing and takes both components off the global sheet.

Both work through the shadow boundary:

- `font-size` and `color` **inherit**, so they reach the text regardless of where it is rendered, and `0.82em` stays relative to what the row already sets.
- The hover-reveal `opacity` the old comment worried about lives on the actions row, a level above. `opacity` applies to the whole subtree — shadow included.
- `margin-left` goes on `:host` rather than the inner span: it separates the badge from its sibling, so it belongs to the element as a whole.

### `.cv-agent-time` stays

`cv-elapsed` is not its only user. When a sub-agent finishes, its totals (`12.4s · 3.2k tok · 5 tools`) take the running clock's place in the row and share the class to match it — that span is rendered by `AgentRenderer`, in `cv-tool-row`'s light DOM.

So the rule stays in `chat.css` and now says who it belongs to. The two get those three properties from different places and have to stay in step, which is worth a line.

### Also

Documents why `cv-diff-preview` is light DOM: diff2html markup needs the global CSS, the same reason `cv-diff-dialog` already gave. Of the eleven light-DOM components it was the only one with no stated reason — the kind of gap that gets "cleaned up" into a broken diff later.

### Not yet verified in the experimental instance

The build is clean and the reasoning above is checked against the CSS, but this has **not** been looked at in Exp yet. Three things to confirm:

1. The "x ago" stamp: same size and grey, tooltip with the absolute date on hover, text recomputed when the pointer arrives.
2. A running Agent's clock: still ticking every second, same gap from the text on its left.
3. **The finished Agent's totals**: they replace the clock in the same spot, and now get their styling from `chat.css` while the clock gets it from `:host`. A mismatch would show as a jump at the moment the agent finishes — this is the one worth looking at.
