### PR TITLE
feat(panes): name the open panes by their session

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneControlBase.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneControlBase.cs
@@ -103,6 +103,8 @@ public abstract class PaneControlBase : UserControl, IPaneControl
     {
         if (string.Equals(_sessionTitle, value, StringComparison.Ordinal)) { return; }
         _sessionTitle = value;
+        // The menus that list panes hold entries, never the control.
+        Entry.SessionTitle = value;
         SessionTitleChanged?.Invoke(this, EventArgs.Empty);
     }
 

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneEntry.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneEntry.cs
@@ -69,6 +69,21 @@ public sealed class PaneEntry
     /// <summary>Id of the session currently attached (null = fresh). Drives the History picker's ✓.</summary>
     public string ActiveSessionId { get; internal set; }
 
+    /// <summary>Display title of that session (custom &gt; ai &gt; last prompt). Null until one is
+    /// known, and always null for a CLI pane.</summary>
+    public string SessionTitle { get; internal set; }
+
+    /// <summary>"Chat 3 (Default) — Fix the drag and drop", for the two menus that list open panes.
+    /// The number stays: two panes can sit on the same session, and it is what the docked tab
+    /// shows.</summary>
+    public string MenuLabel(int maxTitleChars = 48)
+    {
+        var title = SessionTitle?.Trim();
+        if (string.IsNullOrEmpty(title)) { return Title; }
+        if (title.Length > maxTitleChars) { title = title.Substring(0, maxTitleChars - 1) + "…"; }
+        return $"{Title} — {title}";
+    }
+
     /// <summary>Invoked by the toolbar ✕ to close this pane. Set by the window on register.</summary>
     internal Action CloseAction { get; set; }
 

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneToolbar.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneToolbar.xaml.cs
@@ -145,7 +145,8 @@ public partial class PaneToolbar : UserControl
             var captured = entry;
             var item = new MenuItem
             {
-                Header = entry.Title,
+                // Doubled underscores stay visible: WPF reads a single one as the access key.
+                Header = entry.MenuLabel().Replace("_", "__"),
                 Icon = new CrispImage
                 {
                     Width = 16,

--- a/src/Corsinvest.VisualStudio.Agents/Menu/ActiveSessionsMenuCommand.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Menu/ActiveSessionsMenuCommand.cs
@@ -68,7 +68,7 @@ internal sealed class ActiveSessionsMenuCommand : OleMenuCommand
         {
             cmd.Enabled = true;
             cmd.Visible = true;
-            cmd.Text = items[index].Title;
+            cmd.Text = items[index].MenuLabel();
         }
         else
         {


### PR DESCRIPTION
Both menus that list open panes showed **"Chat 3 (Default)"** — a number and a profile, identical for every chat on the same profile. With three open, picking the right one meant opening them.

The View menu was the odder of the two. Its own summary says the docked tab caption is stuck at "Chat 1"/"Chat 2" because VS derives it from the window name, and that this submenu is *"the only place their full titles are visible together"*. It listed the same number the tab does.

Now:

```
Chat 3 (Default) — Lanciare 3 agent paralleli con sub-agent ricorsivi
```

### Where the title lives

On `PaneEntry`, next to `ActiveSessionId` — same session, same place, same `internal set`. Both menus hold entries, never the controls that carry the live value, so anything else would mean reaching from the registry back to a pane.

`PaneControlBase.SetSessionTitle` mirrors it there. That is the one guarded setter the value passes through, so the title cannot be updated without the entry following — and it is already called with `null` on a new chat and on a session switch, so a title never outlives its session.

### Staying fresh

Neither menu caches. The toolbar one does `Items.Clear()` and rebuilds on click; the View one is a `DynamicItemStart` range VS re-queries. Both read `PaneEntry.MenuLabel()` at that moment, so a rename or a session switch shows up with nothing subscribing to anything.

### Details

- **The number stays in front.** Two panes can sit on the same session, and it is what the docked tab calls them.
- **Titles are cut at 48 chars.** They come from the last prompt when nothing better exists, so they can be a whole sentence.
- **The WPF menu doubles underscores**, the VS one does not. `MenuItem.Header` reads a single `_` as the access-key marker and eats it: a session called `build_solution` would render as `buildsolution`. `cmd.Text` has no such rule, so the escape sits at the one call site that needs it rather than inside `MenuLabel()`.

### Verify

Two chats with different titles → compare **View → Active sessions** with the toolbar's panes menu; they should agree. Then switch session on one pane and reopen both.
