### PR TITLE
build: generate the VSIX version instead of repeating it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,9 +36,9 @@ jobs:
       - name: Install TypeGen
         run: dotnet tool install -g dotnet-typegen
 
-      # Version in Directory.Build.props is the single source of truth (VsixVersion is derived from
-      # it), and a Release build already fails if the manifest or AssemblyInfo disagree. The tag is
-      # the one thing nothing checks -- and the Marketplace rejects an upload whose version was
+      # Version in Directory.Build.props is the single source of truth: VsixVersion derives from it,
+      # and both the manifest and AssemblyInfo are generated, so nothing can disagree. The tag is
+      # the one thing outside that chain -- and the Marketplace rejects an upload whose version was
       # already published, so a mismatch found here is the cheap version of that failure.
       - name: Extract and validate version
         id: version

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,13 +3,14 @@
   <!--
     Single source of truth for the product version.
 
-    Bump it here and nowhere else. Two places must agree with it and neither is generated:
-      - src/Corsinvest.VisualStudio.Agents/Properties/AssemblyInfo.cs (legacy project, hand-written)
-      - src/Corsinvest.VisualStudio.Agents/source.extension.vsixmanifest (<Identity Version>)
-    The Release build checks both and fails if they drifted — see Directory.Build.targets.
+    Bump it here and nowhere else — everything downstream is generated:
+      - the assembly version attributes, by GenerateVersionAssemblyInfo
+      - <Identity Version> in source.extension.vsixmanifest, which holds the token
+        |%CurrentProject%;GetVsixVersion| and is resolved at build time
+    Both targets live in Directory.Build.targets.
 
-    The Marketplace rejects an upload whose version was already published, so a mismatch caught
-    at build time is the cheap version of that failure.
+    Worth keeping that way: the Marketplace rejects an upload whose version was already
+    published, and it only says so after you have built and tagged.
   -->
   <PropertyGroup>
     <!--

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -41,29 +41,15 @@
   </Target>
 
   <!--
-    The manifest still repeats the version, and nothing can generate it: <Identity Version> is read
-    by the VSIX build itself. Check it rather than trust it — the Marketplace rejects an upload
-    whose version was already published, and it only says so after you have built and tagged.
+    Feeds the manifest its version instead of repeating it. source.extension.vsixmanifest says
+      <Identity Version="|%CurrentProject%;GetVsixVersion|" …>
+    and DetokenizeVsixManifestFile (Microsoft.VsSDK.targets) calls this target while writing the
+    resolved manifest to obj\ — the file under src\ keeps the token and is never rewritten, so a
+    build leaves the working tree clean.
 
-    Release only: noise while iterating in Debug.
+    VsixVersion, not Version: an Identity version is digits only, so a preview suffix must never
+    reach it.
   -->
-  <Target Name="VerifyManifestVersion"
-          BeforeTargets="Build"
-          Condition="'$(Configuration)' == 'Release' AND '$(MSBuildProjectName)' == 'Corsinvest.VisualStudio.Agents'">
-
-    <PropertyGroup>
-      <_ManifestPath>$(MSBuildProjectDirectory)\source.extension.vsixmanifest</_ManifestPath>
-      <!-- Matching a literal substring is unreliable: the manifest carries several Version="..."
-           attributes for the VS installation targets, so only the one on <Identity> counts. -->
-      <_ManifestVersion>$([System.Text.RegularExpressions.Regex]::Match($([System.IO.File]::ReadAllText($(_ManifestPath))), 'Identity[^&gt;]*?Version="([^"]+)"').Groups[1].Value)</_ManifestVersion>
-    </PropertyGroup>
-
-    <!-- The numeric version: a VSIX Identity Version is digits only, so a preview suffix never
-         reaches it. -->
-    <Error Condition="'$(_ManifestVersion)' != '$(VsixVersion)'"
-           Text="Version mismatch: Directory.Build.props derives $(VsixVersion) from Version $(Version), source.extension.vsixmanifest says '$(_ManifestVersion)'. Make them agree before shipping." />
-
-    <Message Importance="high" Text="Version check: $(Version) — manifest carries $(VsixVersion)." />
-  </Target>
+  <Target Name="GetVsixVersion" Outputs="$(VsixVersion)" />
 
 </Project>

--- a/src/Corsinvest.VisualStudio.Agents/source.extension.vsixmanifest
+++ b/src/Corsinvest.VisualStudio.Agents/source.extension.vsixmanifest
@@ -2,7 +2,7 @@
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011"
                  xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="Corsinvest.VisualStudio.Agents" Version="1.2.0" Language="en-US"
+    <Identity Id="Corsinvest.VisualStudio.Agents" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US"
               Publisher="Corsinvest Srl" />
     <DisplayName>cv4vs Agents</DisplayName>
     <Description xml:space="preserve">Claude Code inside Visual Studio — agentic coding with a rich chat pane and an interactive terminal, wired into the editor, solution and debugger through an in-process MCP server.</Description>


### PR DESCRIPTION
Bumping a version meant editing two files: `<Version>` in `Directory.Build.props` and
`<Identity Version>` in `source.extension.vsixmanifest`. `VerifyManifestVersion` guarded the
pair, but only in Release — in Debug a drift was invisible.

The manifest now carries a token and the number is generated.

## What changed

**`source.extension.vsixmanifest`**

```xml
<Identity Id="Corsinvest.VisualStudio.Agents" Version="|%CurrentProject%;GetVsixVersion|" … />
```

**`Directory.Build.targets`** — `VerifyManifestVersion` (25 lines) replaced by:

```xml
<Target Name="GetVsixVersion" Outputs="$(VsixVersion)" />
```

`VsixVersion`, not `Version`: an Identity version is digits only, so a preview suffix never
reaches it. The target has no body — it exists to give the detokenizer a name it can call,
because the manifest does not expand `$(…)` in that position.

**`Directory.Build.props`** — comment only; it still said the manifest could not be generated.

## The premise that was wrong

The removed comment read *"nothing can generate it: `<Identity Version>` is read by the VSIX
build itself"*. VSSDK has a target named `DetokenizeVsixManifestFile` (`Microsoft.VsSDK.targets`)
for exactly this, and the [schema reference][ref] documents the same form on `Identity Version`.

It writes the resolved manifest to `obj\`; the file under `src\` keeps the token and is never
rewritten, so a build leaves the working tree clean.

[ref]: https://learn.microsoft.com/en-us/visualstudio/extensibility/vsix-extension-schema-2-0-reference?view=vs-2022#placeholder-syntax-for-extension-manifests

## Verification

Not just a green build — the version was made to move:

1. deleted `obj\{Debug,Release}\extension.vsixmanifest`
2. set `<Version>` to `9.9.9`, built → regenerated manifest **and** the `.vsix` in `bin\Debug`
   both read `9.9.9`
3. restored `1.2.0`, built → both read `1.2.0`

Working tree after the builds: the three files of this PR, nothing else.

## Not verified

How the VS manifest designer renders a token in the `Version` field. The manifest already
carries `|%CurrentProject%;PkgdefProjectOutputGroup|`, so tokens as such are fine, but `Version`
is a typed attribute and may validate differently. Reverting is a one-line change if it does.

`obj\Release\extension.vsixmanifest` is stale from 2026-08-01 and still reads `1.1.1`; it is
regenerated on the first Release build.
