### PR TITLE
chore(webview): take the in-range dependency patches

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/package-lock.json
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/package-lock.json
@@ -35,9 +35,9 @@
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
-            "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+            "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -52,9 +52,9 @@
             }
         },
         "node_modules/@esbuild/android-arm": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
-            "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+            "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
             "cpu": [
                 "arm"
             ],
@@ -69,9 +69,9 @@
             }
         },
         "node_modules/@esbuild/android-arm64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
-            "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+            "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
             "cpu": [
                 "arm64"
             ],
@@ -86,9 +86,9 @@
             }
         },
         "node_modules/@esbuild/android-x64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
-            "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+            "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
             "cpu": [
                 "x64"
             ],
@@ -103,9 +103,9 @@
             }
         },
         "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
-            "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+            "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
             "cpu": [
                 "arm64"
             ],
@@ -120,9 +120,9 @@
             }
         },
         "node_modules/@esbuild/darwin-x64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
-            "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+            "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
             "cpu": [
                 "x64"
             ],
@@ -137,9 +137,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
-            "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+            "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
             "cpu": [
                 "arm64"
             ],
@@ -154,9 +154,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
-            "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+            "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
             "cpu": [
                 "x64"
             ],
@@ -171,9 +171,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
-            "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+            "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
             "cpu": [
                 "arm"
             ],
@@ -188,9 +188,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
-            "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+            "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
             "cpu": [
                 "arm64"
             ],
@@ -205,9 +205,9 @@
             }
         },
         "node_modules/@esbuild/linux-ia32": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
-            "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+            "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
             "cpu": [
                 "ia32"
             ],
@@ -222,9 +222,9 @@
             }
         },
         "node_modules/@esbuild/linux-loong64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
-            "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+            "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
             "cpu": [
                 "loong64"
             ],
@@ -239,9 +239,9 @@
             }
         },
         "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
-            "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+            "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
             "cpu": [
                 "mips64el"
             ],
@@ -256,9 +256,9 @@
             }
         },
         "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
-            "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+            "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -273,9 +273,9 @@
             }
         },
         "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
-            "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+            "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
             "cpu": [
                 "riscv64"
             ],
@@ -290,9 +290,9 @@
             }
         },
         "node_modules/@esbuild/linux-s390x": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
-            "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+            "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
             "cpu": [
                 "s390x"
             ],
@@ -307,9 +307,9 @@
             }
         },
         "node_modules/@esbuild/linux-x64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
-            "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+            "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
             "cpu": [
                 "x64"
             ],
@@ -324,9 +324,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-arm64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
-            "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+            "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
             "cpu": [
                 "arm64"
             ],
@@ -341,9 +341,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
-            "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+            "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
             "cpu": [
                 "x64"
             ],
@@ -358,9 +358,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-arm64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
-            "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+            "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
             "cpu": [
                 "arm64"
             ],
@@ -375,9 +375,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
-            "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+            "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
             "cpu": [
                 "x64"
             ],
@@ -392,9 +392,9 @@
             }
         },
         "node_modules/@esbuild/openharmony-arm64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
-            "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+            "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
             "cpu": [
                 "arm64"
             ],
@@ -409,9 +409,9 @@
             }
         },
         "node_modules/@esbuild/sunos-x64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
-            "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+            "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
             "cpu": [
                 "x64"
             ],
@@ -426,9 +426,9 @@
             }
         },
         "node_modules/@esbuild/win32-arm64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
-            "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+            "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
             "cpu": [
                 "arm64"
             ],
@@ -443,9 +443,9 @@
             }
         },
         "node_modules/@esbuild/win32-ia32": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
-            "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+            "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
             "cpu": [
                 "ia32"
             ],
@@ -460,9 +460,9 @@
             }
         },
         "node_modules/@esbuild/win32-x64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
-            "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+            "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
             "cpu": [
                 "x64"
             ],
@@ -477,9 +477,9 @@
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
-            "version": "4.9.1",
-            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
-            "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+            "version": "4.10.1",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+            "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -592,9 +592,9 @@
             }
         },
         "node_modules/@fluentui/svg-icons": {
-            "version": "1.1.333",
-            "resolved": "https://registry.npmjs.org/@fluentui/svg-icons/-/svg-icons-1.1.333.tgz",
-            "integrity": "sha512-uSFMDQq25/sVgHvD9KhP+c1rZrHWqIA0OZkofu9Ii3Q5b72DqLgqOreABHbPD67U5XfsFc4iPlZzWEl1849Obg==",
+            "version": "1.1.335",
+            "resolved": "https://registry.npmjs.org/@fluentui/svg-icons/-/svg-icons-1.1.335.tgz",
+            "integrity": "sha512-4nSBXLpj2F/E27ug+oPuxTEV/CzkSFWUCB2AHK9dJikr06w1Rln6c52+Pfayym6DHkxoOrOu64ImLGwPZd8Ung==",
             "license": "MIT"
         },
         "node_modules/@fluentui/tokens": {
@@ -690,9 +690,9 @@
             }
         },
         "node_modules/@lit-labs/ssr-dom-shim": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
-            "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz",
+            "integrity": "sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@lit/reactive-element": {
@@ -705,15 +705,15 @@
             }
         },
         "node_modules/@microsoft/fast-element": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-3.0.1.tgz",
-            "integrity": "sha512-euVlL8v7EAnkYD9gf6xhnY+XgzCkD0hHwC0MVsUVyhnKfGGhrNyBeD5kYnBOCcJ9afL2jTQoOA+oOpLEty3s+A==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-3.0.2.tgz",
+            "integrity": "sha512-eNCfcReRuPXyHOB9fwISEIz7BtCFstbZ6SEWrpcsSkVTQ4CCqr0pBYb9RTPbdqLY86Bt2cnEihDaX4zsKCgwpg==",
             "license": "MIT"
         },
         "node_modules/@microsoft/focusgroup-polyfill": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@microsoft/focusgroup-polyfill/-/focusgroup-polyfill-1.5.0.tgz",
-            "integrity": "sha512-2tw+AISULD5xhP+wIqUheej5wZbwiuPaqjuCa8A8jLdq2ikklZBIvSDLLa6j7zbDbtV5BXnrYgSuyW1Bj5JA4A==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/focusgroup-polyfill/-/focusgroup-polyfill-1.6.0.tgz",
+            "integrity": "sha512-SlJO8FKrdFdSEXtNTNPTlCeqyqbpyLf6suYHTK7G8WYXZf8/BWK0ucERiPgrUIpNewfQjV82BahSOW/p8YNJ1A==",
             "license": "MIT",
             "peer": true
         },
@@ -730,9 +730,9 @@
             }
         },
         "node_modules/@swc/helpers": {
-            "version": "0.5.21",
-            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
-            "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+            "version": "0.5.23",
+            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+            "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.8.0"
@@ -793,17 +793,17 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.65.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
-            "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
+            "version": "8.66.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.66.0.tgz",
+            "integrity": "sha512-p088eaGrzYz1s+7cov0aMOCkNGTJlVxF4jgubf28c8L0Cv9Rloj8YBHnv4hXLq6IIEE1AsjNWavO+k+8kP2Y0A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.12.2",
-                "@typescript-eslint/scope-manager": "8.65.0",
-                "@typescript-eslint/type-utils": "8.65.0",
-                "@typescript-eslint/utils": "8.65.0",
-                "@typescript-eslint/visitor-keys": "8.65.0",
+                "@typescript-eslint/scope-manager": "8.66.0",
+                "@typescript-eslint/type-utils": "8.66.0",
+                "@typescript-eslint/utils": "8.66.0",
+                "@typescript-eslint/visitor-keys": "8.66.0",
                 "ignore": "^7.0.5",
                 "natural-compare": "^1.4.0",
                 "ts-api-utils": "^2.5.0"
@@ -816,32 +816,22 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.65.0",
+                "@typescript-eslint/parser": "^8.66.0",
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "typescript": ">=4.8.4 <6.1.0"
             }
         },
-        "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-            "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 4"
-            }
-        },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.65.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
-            "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
+            "version": "8.66.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.66.0.tgz",
+            "integrity": "sha512-X6ypGChaWYk6PBtUg2BwuTZEFFcHJAtGTVJ9/lCTOufhZ4i9fNolQNnktq+kkMCwMj7V8Svsq7+TxSDslmhE0g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.65.0",
-                "@typescript-eslint/types": "8.65.0",
-                "@typescript-eslint/typescript-estree": "8.65.0",
-                "@typescript-eslint/visitor-keys": "8.65.0",
+                "@typescript-eslint/scope-manager": "8.66.0",
+                "@typescript-eslint/types": "8.66.0",
+                "@typescript-eslint/typescript-estree": "8.66.0",
+                "@typescript-eslint/visitor-keys": "8.66.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -857,14 +847,14 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.65.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
-            "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
+            "version": "8.66.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.66.0.tgz",
+            "integrity": "sha512-7MthGPTt4BP69lSryqpqq8HQqxuzynssckL/jyDyk3+TNMQ3y2jFWkptCrktWvBrP+EH787Nl5N5Qpw7WZg+5g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.65.0",
-                "@typescript-eslint/types": "^8.65.0",
+                "@typescript-eslint/tsconfig-utils": "^8.66.0",
+                "@typescript-eslint/types": "^8.66.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -879,14 +869,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.65.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
-            "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
+            "version": "8.66.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.66.0.tgz",
+            "integrity": "sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.65.0",
-                "@typescript-eslint/visitor-keys": "8.65.0"
+                "@typescript-eslint/types": "8.66.0",
+                "@typescript-eslint/visitor-keys": "8.66.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -897,9 +887,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.65.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
-            "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
+            "version": "8.66.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.66.0.tgz",
+            "integrity": "sha512-9D5gLYZG4rOjcoag8MQ/fWI8WqA9wcPDyOGyWtWFhvM1lHRbliqUSPIY5J3zqCU1tvSwzXxnnjhQhz5Ne7mJ4g==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -914,15 +904,15 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.65.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
-            "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
+            "version": "8.66.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.66.0.tgz",
+            "integrity": "sha512-LG2dWfjZQQp0ADtAu/EWJVayefGL2UEZ3CDeI44D9v3rXB/WYUqE/jpO28KrEKul5AySrmI+Zh1v6v+xW2U9+g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.65.0",
-                "@typescript-eslint/typescript-estree": "8.65.0",
-                "@typescript-eslint/utils": "8.65.0",
+                "@typescript-eslint/types": "8.66.0",
+                "@typescript-eslint/typescript-estree": "8.66.0",
+                "@typescript-eslint/utils": "8.66.0",
                 "debug": "^4.4.3",
                 "ts-api-utils": "^2.5.0"
             },
@@ -939,9 +929,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.65.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
-            "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
+            "version": "8.66.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.66.0.tgz",
+            "integrity": "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -953,16 +943,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.65.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
-            "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
+            "version": "8.66.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.66.0.tgz",
+            "integrity": "sha512-8/x4INiiQb10jGgXYD7116/zQ+OL84ZIFn0za68wwFHCanT/VLbBEroWht8RV8fn0/ZCAoazHLQgwUC0UQcDfg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.65.0",
-                "@typescript-eslint/tsconfig-utils": "8.65.0",
-                "@typescript-eslint/types": "8.65.0",
-                "@typescript-eslint/visitor-keys": "8.65.0",
+                "@typescript-eslint/project-service": "8.66.0",
+                "@typescript-eslint/tsconfig-utils": "8.66.0",
+                "@typescript-eslint/types": "8.66.0",
+                "@typescript-eslint/visitor-keys": "8.66.0",
                 "debug": "^4.4.3",
                 "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
@@ -981,16 +971,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.65.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
-            "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
+            "version": "8.66.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.66.0.tgz",
+            "integrity": "sha512-jasearZPolBw5NJNYGMwxzHMF83niVWmMU1VdHzG1CyfI2VS7f7nZltnKtHcg20hW+7Uo5GfK4MeDPoU3qI8EA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.65.0",
-                "@typescript-eslint/types": "8.65.0",
-                "@typescript-eslint/typescript-estree": "8.65.0"
+                "@typescript-eslint/scope-manager": "8.66.0",
+                "@typescript-eslint/types": "8.66.0",
+                "@typescript-eslint/typescript-estree": "8.66.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1005,13 +995,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.65.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
-            "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
+            "version": "8.66.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.66.0.tgz",
+            "integrity": "sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.65.0",
+                "@typescript-eslint/types": "8.66.0",
                 "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
@@ -1042,9 +1032,9 @@
             "license": "ISC"
         },
         "node_modules/acorn": {
-            "version": "8.17.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
-            "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+            "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -1081,20 +1071,7 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
-        "node_modules/brace-expansion": {
-            "version": "5.0.8",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-            "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^4.0.2"
-            },
-            "engines": {
-                "node": "20 || >=22"
-            }
-        },
-        "node_modules/brace-expansion/node_modules/balanced-match": {
+        "node_modules/balanced-match": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
             "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
@@ -1102,6 +1079,19 @@
             "license": "MIT",
             "engines": {
                 "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/brace-expansion": {
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "20 || >=22"
             }
         },
         "node_modules/cross-spawn": {
@@ -1179,18 +1169,18 @@
             }
         },
         "node_modules/dompurify": {
-            "version": "3.4.12",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-            "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+            "version": "3.4.13",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+            "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
             "license": "(MPL-2.0 OR Apache-2.0)",
             "optionalDependencies": {
                 "@types/trusted-types": "^2.0.7"
             }
         },
         "node_modules/esbuild": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
-            "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+            "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
@@ -1201,32 +1191,32 @@
                 "node": ">=18"
             },
             "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.28.1",
-                "@esbuild/android-arm": "0.28.1",
-                "@esbuild/android-arm64": "0.28.1",
-                "@esbuild/android-x64": "0.28.1",
-                "@esbuild/darwin-arm64": "0.28.1",
-                "@esbuild/darwin-x64": "0.28.1",
-                "@esbuild/freebsd-arm64": "0.28.1",
-                "@esbuild/freebsd-x64": "0.28.1",
-                "@esbuild/linux-arm": "0.28.1",
-                "@esbuild/linux-arm64": "0.28.1",
-                "@esbuild/linux-ia32": "0.28.1",
-                "@esbuild/linux-loong64": "0.28.1",
-                "@esbuild/linux-mips64el": "0.28.1",
-                "@esbuild/linux-ppc64": "0.28.1",
-                "@esbuild/linux-riscv64": "0.28.1",
-                "@esbuild/linux-s390x": "0.28.1",
-                "@esbuild/linux-x64": "0.28.1",
-                "@esbuild/netbsd-arm64": "0.28.1",
-                "@esbuild/netbsd-x64": "0.28.1",
-                "@esbuild/openbsd-arm64": "0.28.1",
-                "@esbuild/openbsd-x64": "0.28.1",
-                "@esbuild/openharmony-arm64": "0.28.1",
-                "@esbuild/sunos-x64": "0.28.1",
-                "@esbuild/win32-arm64": "0.28.1",
-                "@esbuild/win32-ia32": "0.28.1",
-                "@esbuild/win32-x64": "0.28.1"
+                "@esbuild/aix-ppc64": "0.28.2",
+                "@esbuild/android-arm": "0.28.2",
+                "@esbuild/android-arm64": "0.28.2",
+                "@esbuild/android-x64": "0.28.2",
+                "@esbuild/darwin-arm64": "0.28.2",
+                "@esbuild/darwin-x64": "0.28.2",
+                "@esbuild/freebsd-arm64": "0.28.2",
+                "@esbuild/freebsd-x64": "0.28.2",
+                "@esbuild/linux-arm": "0.28.2",
+                "@esbuild/linux-arm64": "0.28.2",
+                "@esbuild/linux-ia32": "0.28.2",
+                "@esbuild/linux-loong64": "0.28.2",
+                "@esbuild/linux-mips64el": "0.28.2",
+                "@esbuild/linux-ppc64": "0.28.2",
+                "@esbuild/linux-riscv64": "0.28.2",
+                "@esbuild/linux-s390x": "0.28.2",
+                "@esbuild/linux-x64": "0.28.2",
+                "@esbuild/netbsd-arm64": "0.28.2",
+                "@esbuild/netbsd-x64": "0.28.2",
+                "@esbuild/openbsd-arm64": "0.28.2",
+                "@esbuild/openbsd-x64": "0.28.2",
+                "@esbuild/openharmony-arm64": "0.28.2",
+                "@esbuild/sunos-x64": "0.28.2",
+                "@esbuild/win32-arm64": "0.28.2",
+                "@esbuild/win32-ia32": "0.28.2",
+                "@esbuild/win32-x64": "0.28.2"
             }
         },
         "node_modules/escape-string-regexp": {
@@ -1243,9 +1233,9 @@
             }
         },
         "node_modules/eslint": {
-            "version": "10.8.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
-            "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
+            "version": "10.8.1",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.1.tgz",
+            "integrity": "sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==",
             "dev": true,
             "license": "MIT",
             "workspaces": [
@@ -1360,6 +1350,16 @@
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/eslint/node_modules/ignore": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+            "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
             }
         },
         "node_modules/espree": {
@@ -1523,9 +1523,9 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.3.tgz",
-            "integrity": "sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==",
+            "version": "3.4.4",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+            "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
             "dev": true,
             "license": "ISC"
         },
@@ -1565,9 +1565,9 @@
             }
         },
         "node_modules/ignore": {
-            "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-            "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+            "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1682,9 +1682,9 @@
             }
         },
         "node_modules/lit-html": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
-            "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.3.tgz",
+            "integrity": "sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@types/trusted-types": "^2.0.2"
@@ -1707,9 +1707,9 @@
             }
         },
         "node_modules/marked": {
-            "version": "18.0.7",
-            "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.7.tgz",
-            "integrity": "sha512-iDVQ5ldaiKXn6b2JroX5kgRfmwgqolW7NpaEzTl1k/2Zh1njIEN9yniyLV/mOvWwtsE8OGgkjsCYvijuPk1dtA==",
+            "version": "18.0.9",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.9.tgz",
+            "integrity": "sha512-/Sa4qiiHZxf0/FQdBBowr9q4r10krCwMvpK48FUBdXdUXScDxiQGR9zCPrFgRVR5LU3iySOiIjy09ZQvADir1w==",
             "license": "MIT",
             "bin": {
                 "marked": "bin/marked.js"
@@ -1719,13 +1719,13 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "10.2.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+            "version": "10.2.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+            "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^5.0.5"
+                "brace-expansion": "^5.0.8"
             },
             "engines": {
                 "node": "18 || 20 || >=22"
@@ -1982,16 +1982,16 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.65.0",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
-            "integrity": "sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==",
+            "version": "8.66.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.66.0.tgz",
+            "integrity": "sha512-QlEbBPz/RuJ1XUHj29nm3t0F/O/cSlEnntozqPOYHnnTGAXFamnMBu5i9Vn6vhUPHGAjR+Vl+5J8vPN/BMUrJw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.65.0",
-                "@typescript-eslint/parser": "8.65.0",
-                "@typescript-eslint/typescript-estree": "8.65.0",
-                "@typescript-eslint/utils": "8.65.0"
+                "@typescript-eslint/eslint-plugin": "8.66.0",
+                "@typescript-eslint/parser": "8.66.0",
+                "@typescript-eslint/typescript-estree": "8.66.0",
+                "@typescript-eslint/utils": "8.66.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"


### PR DESCRIPTION
`npm update`, so `package.json` is untouched and only the lockfile moves.

| Package | From → to |
|---|---|
| `@fluentui/svg-icons` | 1.1.333 → 1.1.335 |
| `@microsoft/fast-element` | 3.0.1 → 3.0.2 |
| `dompurify` | 3.4.12 → 3.4.13 |
| `esbuild` | 0.28.1 → 0.28.2 |
| `eslint` | 10.8.0 → 10.8.1 |
| `marked` | 18.0.7 → 18.0.9 |
| `@typescript-eslint/*`, `typescript-eslint` | 8.65.0 → 8.66.0 |

### Left alone, and why

- **`@fluentui/web-components` 3.0.2 → 3.0.3.** Pinned without a caret, so the version is a decision rather than a range — and the nine icon buttons that moved onto `fluent-button` in #114 are exactly what a Fluent bump would touch. Worth its own change, where it can be looked at.
- **`typescript` 6.0.3 → 7.0.2.** Still blocked by `typescript-eslint`, which does not support TS7 below 7.1; this repo is on 8.66.
- **`@types/node` 24 → 26.** Two majors for types only `node --test` consumes.

### Verified

`npm run check` — typecheck, lint, format:check and 63 tests, all passing. Bundle builds under esbuild 0.28.2.

`npm audit`: 0 vulnerabilities.
