### PR TITLE
release: 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-08-10
+
+The debugger is reachable: the agent can look inside an object, move up the call stack, and say
+which thread it is talking about. Navigation stops lying — searching the solution for a symbol
+never worked at all, and go-to-definition gave up at the edge of your own code. Files can be
+dragged onto the chat, and every tool now says what to reach for around it.
+
 ### Added
 
 - **Seven new debug tools, and the ones around them answer better.** `debug_expand` opens a value

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,7 +18,7 @@
       AssemblyInformationalVersion carries so a preview build can say it is one at runtime. Ship a
       stable release by dropping the suffix.
     -->
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
 
     <!--
       The same version without the suffix, for the places that take digits only: the VSIX Identity


### PR DESCRIPTION
Cuts **1.3.0** — forty-five commits since `v1.2.0` (2026-08-05).

Two files: `Directory.Build.props` and the `[Unreleased]` heading. The version has lived in one place since #118, so `VsixVersion`, the VSIX `Identity`, and `AssemblyInformationalVersion` all follow from it.

### Why minor, not patch

The release adds capability rather than only repairing it: seven debug tools, file attachments by drag and paste, and workspace symbol search that works for the first time. Backwards-compatible additions, so `1.2.0` → `1.3.0`.

### Coverage check

Every commit in the range was read against the changelog. Thirty-four entries cover the user-visible work; the seven that have none are `chore`/`refactor`/`build` with nothing to show a user:

| Commit | Why it has no entry |
|---|---|
| #118 generate the VSIX version | build plumbing — this release is its first use |
| #120 dependency patches | `package-lock.json` only |
| #115 time badges to Shadow DOM | CSS moved into the components, rendering unchanged |
| #114, #105 icon-button styles | same |
| #108 drop three class names | nothing styled them |
| #99 docs catch-up | documentation |

### Highlights

**Debugging.** `debug_expand` opens a value into its members — one call where it used to take an evaluate per field. `debug_select_frame` reaches a caller's variables, which were simply out of scope with no way to say so. `debug_list_threads` / `debug_select_thread` / `debug_freeze_thread` name the thread everything else reads. And five tools stopped reporting the state they were leaving rather than the one they reached.

**Navigation.** `nav_search_workspace_symbols` answered `supported=false` on every call in every language — the service was there, looked up under a name Roslyn had renamed. `nav_go_to_definition` answered "No definition found" for anything in a referenced assembly, which is wrong rather than incomplete; it now follows through to the decompiled declaration and says whether you are reading rebuilt IL or real source.

**Chat.** Files dragged onto the pane reached Visual Studio instead of the composer, and pasting anything that was not an image did nothing at all, silently. A turn now shows what it cost and how long it took, a retracted message leaves the chat, and an API failure looks like a failure instead of an answer.

### After merging

Tag `v1.3.0` on master to trigger the release workflow, which uploads the package with `docs/marketplace-overview.md` as the listing text.
