### PR TITLE
Ask Claude about the code you are looking at, from the right-click menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,11 @@ own.
 - **[It knows what you're looking at](#ide-integration)** — the file open in the editor (and your
   selection) rides along with the prompt, shown as a chip you can click to jump back to it. One
   toggle turns the sharing off when you'd rather it didn't.
+- **Ask from the editor** — right-click code and the **cv4vs Agents** submenu offers Explain,
+  Review, Find bugs, Write tests, Simplify. The prompt lands in the composer rather than being
+  sent, so you can add the half line that matters; the file and selection travel with it, so the
+  prompt itself is just the instruction. The list is yours to edit in Options → Editor prompts —
+  title, text, and whether the entry needs a selection to be enabled.
 - **Jump between panes** — a toolbar list of every open pane, Chat and CLI together, each with its
   title and kind. Docked panes hide each other behind tabs; this is how you find the one you want.
 - **[Sub-agent panel](docs/chat/sub-agents.md)** — a chip shows how many sub-agents are running; click it

--- a/docs/options.md
+++ b/docs/options.md
@@ -90,3 +90,26 @@ pane per provider, switchable without touching your system environment.
 - [OpenRouter](https://openrouter.ai/blog/tutorials/claude-code-openrouter/) — multi-provider gateway
 - [Ollama](https://docs.ollama.com/api/anthropic-compatibility) — local open-source models
 - [Complete alternative models guide](https://github.com/Alorse/cc-compatible-models) — comprehensive provider list
+
+## Editor prompts
+
+Not a settings table but an editor: the entries offered when you right-click code, under
+**cv4vs Agents**. Picking one writes it into a chat pane's composer — it is not sent, so you can
+add the half line that matters before it goes.
+
+| Column | Meaning |
+|---|---|
+| Title | What the menu item reads. |
+| Prompt | What reaches the composer. The instruction alone: the file and selection travel with it through the IDE context, and Claude reads the symbol itself with the `nav_*` tools, so pasting code in here only duplicates what the pane already sends. |
+| Needs selection | Greys the entry out when nothing is selected, the way Copilot greys "Optimize selection". Leave it off for prompts that read fine against the whole file. |
+
+Rows appear in the menu in the order listed, so the one you reach for most belongs at the top;
+**Restore defaults** puts back the prompts the extension ships with.
+
+Which pane receives: the last one you worked in, brought to the front. With none open, one is
+opened. If the IDE-context eye was shut, it is re-opened with the prompt — asking about this code
+with nothing saying which file it is would reach the CLI as a question about nothing.
+
+Like profiles, these are **not** in the VS settings store: they live in `editor-prompts.json` so
+the menu can be built without opening the Options page first — see
+[Settings and data](settings-and-data.md).

--- a/docs/settings-and-data.md
+++ b/docs/settings-and-data.md
@@ -17,6 +17,7 @@ Uninstalling the extension leaves both trees behind — see [Removing everything
 | What | Where |
 |---|---|
 | Environment profiles | `%LOCALAPPDATA%\Corsinvest\cv4vs-agents\profiles.json` |
+| Editor context-menu prompts | `%LOCALAPPDATA%\Corsinvest\cv4vs-agents\editor-prompts.json` |
 | Open panes per solution | `…\cv4vs-agents\data\projects\<project-hash>\workspace.json` |
 | Usage stats cache | `…\<project-hash>\<config-id>\stats-cache.json` |
 
@@ -29,8 +30,9 @@ The Options pages (**Tools → Options → cv4vs Agents**) are VS `DialogPage`s,
 to point at: Visual Studio persists them in its own settings store, per VS instance. They apply on
 **OK/Apply**, never on a keystroke, and they don't travel with the solution or a copied folder.
 
-The **Profiles** page is the exception: it edits `profiles.json` (below) instead, so the
-launcher menu can read profiles without first materialising the Options page.
+**Profiles** and **Editor prompts** are the exceptions: they edit `profiles.json` and
+`editor-prompts.json` (below) instead, so the launcher menu and the editor context menu can be
+built without first materialising the Options page.
 
 ## Our data folder
 
@@ -38,6 +40,7 @@ Root: `%LOCALAPPDATA%\Corsinvest\cv4vs-agents\`
 
 ```
 profiles.json                       environment profiles (name, enabled, env vars)
+editor-prompts.json                 editor context-menu prompts (title, prompt, needs-selection)
 WebView2/                           WebView2 user-data (chat UI cache/storage)
 icons/                              file-type icons rasterised from VS KnownMonikers
 data/projects/<project-hash>/

--- a/src/Corsinvest.VisualStudio.Agents.Contracts/ToWebViewDtos.cs
+++ b/src/Corsinvest.VisualStudio.Agents.Contracts/ToWebViewDtos.cs
@@ -390,6 +390,11 @@ public class GetCompactSummaryResponse
 public class SetComposerNotification
 {
     public string Text { get; set; }
+
+    /// <summary>Turn the IDE-context eye back on with the text: a prompt picked from the editor
+    /// context menu is about the file it was picked in, and asking about this code outranks the
+    /// session's standing preference.</summary>
+    public bool EnableIdeContext { get; set; }
 }
 
 /// <summary>A keystroke the host claimed on the WebView's behalf (ui_host_key).

--- a/src/Corsinvest.VisualStudio.Agents/AgentsPackage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/AgentsPackage.cs
@@ -338,6 +338,7 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
         OutputWindowLogger.EnsurePaneOnUIThread();
         await ProfilesMenuCommand.InitializeAsync(this);
         await ActiveSessionsMenuCommand.InitializeAsync(this);
+        await Editor.EditorPromptsMenuCommand.InitializeAsync(this);
         await GlobalMenuCommands.InitializeAsync(this);
         // Lazy MCP lifecycle: server runs only while >=1 session is open,
         // driven by PaneRegistry's 0->1 / ->0 transitions.

--- a/src/Corsinvest.VisualStudio.Agents/AgentsPackage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/AgentsPackage.cs
@@ -47,6 +47,7 @@ namespace Corsinvest.VisualStudio.Agents;
 [ProvideOptionPage(typeof(AgentsChatPage), AppConstants.AppName, "Chat", 0, 0, true)]
 [ProvideOptionPage(typeof(AgentsDebugPage), AppConstants.AppName, "Debug", 0, 0, true)]
 [ProvideOptionPage(typeof(AgentsProfilesPage), AppConstants.AppName, "Profiles", 0, 0, true)]
+[ProvideOptionPage(typeof(AgentsEditorPromptsPage), AppConstants.AppName, "Editor prompts", 0, 0, true)]
 // Statistics: a dashboard over StatsService, with no file behind it — a tool window, not a
 // document. Single-instance, and NOT Transient: unlike the chat/CLI panes it holds no session and
 // no working directory, so there is nothing to go stale when a solution closes.

--- a/src/Corsinvest.VisualStudio.Agents/AgentsPackage.vsct
+++ b/src/Corsinvest.VisualStudio.Agents/AgentsPackage.vsct
@@ -58,6 +58,17 @@
         </Strings>
       </Menu>
 
+      <!-- Editor context menu: the prompts, one submenu deep so right-clicking code doesn't grow
+           five entries. Same shape as Copilot's "Copilot actions" submenu. -->
+      <Menu guid="guidAgentsCommandSet" id="EditorPromptsSubMenu" priority="0x0100" type="Menu">
+        <Parent guid="guidAgentsCommandSet" id="EditorContextGroup"/>
+        <Icon guid="guidImages" id="bmpPic1"/>
+        <CommandFlag>IconAndText</CommandFlag>
+        <Strings>
+          <ButtonText>cv4vs Agents</ButtonText>
+        </Strings>
+      </Menu>
+
       <!-- Help &amp; Feedback: docs first (it answers without bothering anyone), contact after. -->
       <Menu guid="guidAgentsCommandSet" id="HelpSubMenu" priority="0x0100" type="Menu">
         <Parent guid="guidAgentsCommandSet" id="HelpGroup"/>
@@ -107,6 +118,17 @@
       <Group guid="guidAgentsCommandSet" id="DeveloperGroup" priority="0x0100">
         <Parent guid="guidAgentsCommandSet" id="DeveloperSubMenu"/>
       </Group>
+      <!-- Anchors our submenu in the code window's context menu. The only thing this extension
+           puts inside the editor: everything else hangs off the View menu.
+           Low priority so it lands at the top, where Copilot puts its own actions — the point of
+           the entry is to be reached without hunting through twenty items. -->
+      <Group guid="guidAgentsCommandSet" id="EditorContextGroup" priority="0x0050">
+        <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_CODEWIN"/>
+      </Group>
+      <!-- The dynamic prompt entries inside it. -->
+      <Group guid="guidAgentsCommandSet" id="EditorPromptsGroup" priority="0x0100">
+        <Parent guid="guidAgentsCommandSet" id="EditorPromptsSubMenu"/>
+      </Group>
       <Group guid="guidAgentsCommandSet" id="HelpDocsGroup" priority="0x0100">
         <Parent guid="guidAgentsCommandSet" id="HelpSubMenu"/>
       </Group>
@@ -144,6 +166,18 @@
         <CommandFlag>TextChanges</CommandFlag>
         <Strings>
           <ButtonText>Session</ButtonText>
+        </Strings>
+      </Button>
+
+      <!-- Dynamic range inside the editor submenu: one item per configured prompt, seeded by
+           DynamicItemStart. No <Icon>, for the same reason as the two ranges above. -->
+      <Button guid="guidAgentsCommandSet" id="EditorPromptCommandId" priority="0x0100" type="Button">
+        <Parent guid="guidAgentsCommandSet" id="EditorPromptsGroup"/>
+        <CommandFlag>DynamicItemStart</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <CommandFlag>TextChanges</CommandFlag>
+        <Strings>
+          <ButtonText>Prompt</ButtonText>
         </Strings>
       </Button>
 
@@ -243,6 +277,9 @@
       <IDSymbol name="ActiveSessionsAnchorGroup" value="0x104A" />
       <IDSymbol name="DeveloperSubMenu" value="0x1075" />
       <IDSymbol name="DeveloperGroup" value="0x1076" />
+      <IDSymbol name="EditorContextGroup" value="0x1077" />
+      <IDSymbol name="EditorPromptsSubMenu" value="0x1078" />
+      <IDSymbol name="EditorPromptsGroup" value="0x1079" />
       <IDSymbol name="HelpDocsGroup" value="0x1080" />
       <IDSymbol name="HelpContactGroup" value="0x1090" />
       <!-- Must match PackageIds.cs — a mismatch is silent: the entry just never appears. -->
@@ -262,6 +299,8 @@
       <!-- Seed of the open-panes dynamic range. Its own 0x03xx block: the range grows with the
            number of open panes and must not run into the fixed ids above. -->
       <IDSymbol name="ActiveSessionCommandId" value="0x0300" />
+      <!-- Seed of the editor-prompt range. Its own 0x04xx block: the panes range above grows too. -->
+      <IDSymbol name="EditorPromptCommandId" value="0x0400" />
     </GuidSymbol>
     <GuidSymbol name="guidImages" value="{c3d4e5f6-a7b8-9012-defa-bc1234567890}">
       <IDSymbol name="bmpPic1" value="1" />

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.cs
@@ -301,6 +301,16 @@ internal sealed partial class WebViewBridge(Microsoft.Web.WebView2.Wpf.WebView2C
     public void FocusWebView()
     {
         if (_disposed) { return; }
+        if (webView.IsKeyboardFocused)
+        {
+            // Already ours as far as WPF is concerned, which on a pane that has just opened is the
+            // problem: rendering through Windows.UI.Composition, this control hands the focus to
+            // its WebView2 controller from OnGotFocus — and WPF doesn't raise that for a control
+            // that already has it. Focused while the controller was still being created, the
+            // browser side never heard: document.hasFocus() stays false and the keys go elsewhere.
+            // Dropping the focus and taking it back raises the event with the controller in place.
+            System.Windows.Input.Keyboard.ClearFocus();
+        }
         webView.Focus();
     }
 

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
@@ -389,6 +389,7 @@ public partial class ChatPaneControl : PaneControlBase
             SendTheme();
             // Re-push the caption: RegisterInstance runs before VS wires IVsWindowFrame, so the earlier set can no-op.
             RepushCaption();
+            Entry.SetComposerAction = text => SetComposerText(text, withIdeContext: true);
 
             AgentsOptions.Applied += OnOptionsApplied;
             VSColorTheme.ThemeChanged += OnVsThemeChanged;
@@ -554,13 +555,30 @@ public partial class ChatPaneControl : PaneControlBase
             Env = Entry.Profile.Env,
         });
 
-        // Forked pane: drop the forked-at message into the composer for editing/resend.
-        // (Transcript + title were already seeded above by ApplyResumedSession.)
-        if (restoreState && !string.IsNullOrEmpty(_startupPrompt))
+        // A fork's forked-at message, or a prompt from the editor context menu. Not gated on
+        // restoreState: the context menu opens a fresh pane, with a prompt but no session — which
+        // is also what tells the two apart, a fork always brings the session it forked.
+        if (!string.IsNullOrEmpty(_startupPrompt))
         {
-            _bridge.Send(BridgeMessages.ToWebView.Ui.SetComposer, new Contracts.SetComposerNotification { Text = _startupPrompt });
+            SetComposerText(_startupPrompt, withIdeContext: !restoreState);
         }
     }
+
+    /// <summary>Writes text into the composer. <paramref name="withIdeContext"/> also re-opens the
+    /// IDE-context eye: a prompt picked from the editor context menu is about the file it came
+    /// from, and with the eye shut the CLI is never told which file that is.</summary>
+    private void SetComposerText(string text, bool withIdeContext = false)
+        => Dispatcher.Invoke(() =>
+        {
+            if (withIdeContext && Entry != null && !Entry.Options.SendSelection)
+            {
+                Entry.Options.SendSelection = true;
+                Ide.IdeContextService.Instance.ForceEmitCurrentContext();
+            }
+            _bridge?.Send(
+                BridgeMessages.ToWebView.Ui.SetComposer,
+                new Contracts.SetComposerNotification { Text = text, EnableIdeContext = withIdeContext });
+        });
 
     /// <summary>Creates the single ClaudeClient instance on demand (once per tool window lifetime).</summary>
     private void EnsureClient()

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated/SetComposerNotification.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated/SetComposerNotification.ts
@@ -5,4 +5,5 @@
 
 export interface SetComposerNotification {
     text: string;
+    enableIdeContext: boolean;
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/init.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/init.ts
@@ -141,6 +141,10 @@ function wireBridgeHandlers(): void {
 
     // Forked pane: pre-fill the composer with the forked-at message text.
     bridge.onNotification<SetComposerNotification>(Msg.toWebView.ui.setComposer, (data) => {
+        // The host re-opened the eye; mirror it so the badge shows what the CLI is being sent.
+        if (data?.enableIdeContext) {
+            state.ideContextEnabled = true;
+        }
         const input = document.querySelector('cv-prompt') as
             import('./components/cv-prompt').CvPrompt | null;
         input?.setComposerText(data?.text ?? '');

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneEntry.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneEntry.cs
@@ -97,6 +97,10 @@ public sealed class PaneEntry
     /// VS routes Esc through IOleCommandTarget, so it never reaches the popup on its own.</summary>
     internal Func<bool> DismissHistoryAction { get; set; }
 
+    /// <summary>Writes text into this pane's composer, for the editor context menu. Chat panes
+    /// only — the CLI pane has no composer of ours to fill.</summary>
+    internal Action<string> SetComposerAction { get; set; }
+
     /// <summary>The single-source display title, used by BOTH the pane caption and the toolbar's
     /// open-panes list: e.g. "Chat 3 (Claude)". Computed once in the ctor (all inputs immutable).
     /// Profile.Name is always non-empty — ProfileStore.Load(forEdit:false) filters out blank-named profiles,

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneLauncher.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneLauncher.cs
@@ -187,6 +187,12 @@ internal static class PaneLauncher
                             cliPane.LoadSession(resumeSessionId);
                         }
                     }
+                    else if (pane is ChatPaneWindow freshChat && !string.IsNullOrEmpty(initialPrompt))
+                    {
+                        // A prompt with no session to start from — the editor context menu. Both
+                        // branches above need one, so without this the prompt would be dropped.
+                        freshChat.SetStartupSession(null, initialPrompt);
+                    }
                     if (pane.Frame is IVsWindowFrame frame) { ErrorHandler.ThrowOnFailure(frame.Show()); }
 
                     // Focus a fresh CLI terminal so the user can type immediately (FocusInput is on

--- a/src/Corsinvest.VisualStudio.Agents/Corsinvest.VisualStudio.Agents.csproj
+++ b/src/Corsinvest.VisualStudio.Agents/Corsinvest.VisualStudio.Agents.csproj
@@ -280,6 +280,8 @@
     <Compile Include="Menu\ActiveSessionsMenuCommand.cs" />
     <Compile Include="Menu\ProfilesMenuCommand.cs" />
     <Compile Include="Menu\GlobalMenuCommands.cs" />
+    <Compile Include="Editor\EditorPrompt.cs" />
+    <Compile Include="Editor\EditorPromptsMenuCommand.cs" />
     <Compile Include="Core\Panes\PaneLauncher.cs" />
     <Compile Include="AgentsPackage.cs" />
     <Compile Include="Core\Sessions\SessionInfo.cs" />

--- a/src/Corsinvest.VisualStudio.Agents/Corsinvest.VisualStudio.Agents.csproj
+++ b/src/Corsinvest.VisualStudio.Agents/Corsinvest.VisualStudio.Agents.csproj
@@ -281,6 +281,7 @@
     <Compile Include="Menu\ProfilesMenuCommand.cs" />
     <Compile Include="Menu\GlobalMenuCommands.cs" />
     <Compile Include="Editor\EditorPrompt.cs" />
+    <Compile Include="Editor\EditorPromptStore.cs" />
     <Compile Include="Editor\EditorPromptsMenuCommand.cs" />
     <Compile Include="Core\Panes\PaneLauncher.cs" />
     <Compile Include="AgentsPackage.cs" />
@@ -316,6 +317,12 @@
     </Compile>
     <Compile Include="Options\ProfilesControl.xaml.cs">
       <DependentUpon>ProfilesControl.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Options\AgentsEditorPromptsPage.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Include="Options\EditorPromptsControl.xaml.cs">
+      <DependentUpon>EditorPromptsControl.xaml</DependentUpon>
     </Compile>
     <Compile Include="Chat\IconCacheService.cs" />
     <Compile Include="Helpers\OutputWindowLogger.cs" />
@@ -385,6 +392,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Options\ProfilesControl.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Options\EditorPromptsControl.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/src/Corsinvest.VisualStudio.Agents/Editor/EditorPrompt.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Editor/EditorPrompt.cs
@@ -1,0 +1,55 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using System.Collections.Generic;
+
+namespace Corsinvest.VisualStudio.Agents.Editor;
+
+internal sealed class EditorPrompt
+{
+    public string Title { get; set; }
+
+    /// <summary>The instruction alone — no code in it: the selection reaches the CLI on its own,
+    /// through the IDE context the pane already sends.</summary>
+    public string Prompt { get; set; }
+
+    /// <summary>Greyed out without a selection, the way Copilot greys "Optimize selection".</summary>
+    public bool RequiresSelection { get; set; }
+}
+
+/// <summary>The context-menu prompts. Hard-coded for now; an editor for them comes later, and
+/// <see cref="Options.AgentsProfilesPage"/> is the precedent for a list-shaped Options page.</summary>
+internal static class EditorPrompts
+{
+    public static IReadOnlyList<EditorPrompt> Items { get; } =
+    [
+        new EditorPrompt
+        {
+            Title = "Explain",
+            Prompt = "Explain what this code does.",
+        },
+        new EditorPrompt
+        {
+            Title = "Review",
+            Prompt = "Review this code and point out what you would change, and why.",
+        },
+        new EditorPrompt
+        {
+            Title = "Find bugs",
+            Prompt = "Look for bugs in this code. Say so plainly if you find none.",
+        },
+        new EditorPrompt
+        {
+            Title = "Write tests",
+            Prompt = "Write tests for this code, following the ones already in this project.",
+        },
+        new EditorPrompt
+        {
+            Title = "Simplify",
+            Prompt = "Simplify this code without changing what it does.",
+            RequiresSelection = true,
+        },
+    ];
+}

--- a/src/Corsinvest.VisualStudio.Agents/Editor/EditorPrompt.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Editor/EditorPrompt.cs
@@ -3,11 +3,10 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
-using System.Collections.Generic;
-
 namespace Corsinvest.VisualStudio.Agents.Editor;
 
-internal sealed class EditorPrompt
+// Public, like Profile and for the same reason: the Options page that edits these is public.
+public sealed class EditorPrompt
 {
     public string Title { get; set; }
 
@@ -17,39 +16,6 @@ internal sealed class EditorPrompt
 
     /// <summary>Greyed out without a selection, the way Copilot greys "Optimize selection".</summary>
     public bool RequiresSelection { get; set; }
-}
 
-/// <summary>The context-menu prompts. Hard-coded for now; an editor for them comes later, and
-/// <see cref="Options.AgentsProfilesPage"/> is the precedent for a list-shaped Options page.</summary>
-internal static class EditorPrompts
-{
-    public static IReadOnlyList<EditorPrompt> Items { get; } =
-    [
-        new EditorPrompt
-        {
-            Title = "Explain",
-            Prompt = "Explain what this code does.",
-        },
-        new EditorPrompt
-        {
-            Title = "Review",
-            Prompt = "Review this code and point out what you would change, and why.",
-        },
-        new EditorPrompt
-        {
-            Title = "Find bugs",
-            Prompt = "Look for bugs in this code. Say so plainly if you find none.",
-        },
-        new EditorPrompt
-        {
-            Title = "Write tests",
-            Prompt = "Write tests for this code, following the ones already in this project.",
-        },
-        new EditorPrompt
-        {
-            Title = "Simplify",
-            Prompt = "Simplify this code without changing what it does.",
-            RequiresSelection = true,
-        },
-    ];
+    public EditorPrompt Clone() => (EditorPrompt)MemberwiseClone();
 }

--- a/src/Corsinvest.VisualStudio.Agents/Editor/EditorPromptStore.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Editor/EditorPromptStore.cs
@@ -1,0 +1,90 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using Corsinvest.VisualStudio.Agents.Helpers;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Corsinvest.VisualStudio.Agents.Editor;
+
+/// <summary>Loads/saves the editor context menu's prompts as a plain JSON file
+/// (<see cref="AppPaths.EditorPromptsFile"/>), like <c>ProfileStore</c> and for the same reason:
+/// the menu is queried by VS long before any Options page exists. Tolerant on read — a missing or
+/// corrupt file falls back to <see cref="Defaults"/> rather than an empty menu.</summary>
+internal static class EditorPromptStore
+{
+    private static IReadOnlyList<EditorPrompt> _cache;
+
+    /// <summary>What ships with the extension, and what a missing or unreadable file falls back
+    /// to. Order is the menu order: the one you reach for most comes first.</summary>
+    public static IReadOnlyList<EditorPrompt> Defaults =>
+    [
+        new EditorPrompt { Title = "Explain", Prompt = "Explain what this code does." },
+        new EditorPrompt
+        {
+            Title = "Review",
+            Prompt = "Review this code and point out what you would change, and why.",
+        },
+        new EditorPrompt
+        {
+            Title = "Find bugs",
+            Prompt = "Look for bugs in this code. Say so plainly if you find none.",
+        },
+        new EditorPrompt
+        {
+            Title = "Write tests",
+            Prompt = "Write tests for this code, following the ones already in this project.",
+        },
+        new EditorPrompt
+        {
+            Title = "Simplify",
+            Prompt = "Simplify this code without changing what it does.",
+            RequiresSelection = true,
+        },
+    ];
+
+    /// <summary>The prompts the menu shows. Cached: VS re-queries the menu on every keystroke, and
+    /// re-reading the file each time would put disk IO on that path. Blank titles are dropped —
+    /// a nameless row in the JSON would render as an empty menu item.</summary>
+    public static IReadOnlyList<EditorPrompt> Items =>
+        _cache ??= [.. Load().Where(p => !string.IsNullOrWhiteSpace(p.Title))];
+
+    /// <summary>Exactly what is on disk, for the Options page to edit. Falls back to the defaults
+    /// when there is no file yet, so the page opens on something rather than nothing.</summary>
+    public static IReadOnlyList<EditorPrompt> Load()
+    {
+        try
+        {
+            if (!File.Exists(AppPaths.EditorPromptsFile)) { return Defaults; }
+            var json = File.ReadAllText(AppPaths.EditorPromptsFile);
+            return string.IsNullOrWhiteSpace(json)
+                ? Defaults
+                : JsonConvert.DeserializeObject<List<EditorPrompt>>(json) ?? Defaults;
+        }
+        catch (IOException)
+        {
+            OutputWindowLogger.Global.Warn("[editor] failed to read editor-prompts.json (IO) — using the defaults");
+            return Defaults;
+        }
+        catch (JsonException)
+        {
+            OutputWindowLogger.Global.Warn("[editor] editor-prompts.json is corrupt — using the defaults");
+            return Defaults;
+        }
+    }
+
+    public static void Save(IReadOnlyList<EditorPrompt> prompts)
+    {
+        Directory.CreateDirectory(AppPaths.DataFolder);
+        File.WriteAllText(
+            AppPaths.EditorPromptsFile,
+            JsonExtensions.ToIndentedString(JToken.FromObject(prompts ?? [])));
+        // The menu reads Items, which is cached for the reason given there.
+        _cache = null;
+    }
+}

--- a/src/Corsinvest.VisualStudio.Agents/Editor/EditorPromptsMenuCommand.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Editor/EditorPromptsMenuCommand.cs
@@ -41,7 +41,7 @@ internal sealed class EditorPromptsMenuCommand : OleMenuCommand
     /// which is how VS discovers how many entries to render.</summary>
     public override bool DynamicItemMatch(int cmdId)
     {
-        if (cmdId < _baseId || cmdId >= _baseId + EditorPrompts.Items.Count) { return false; }
+        if (cmdId < _baseId || cmdId >= _baseId + EditorPromptStore.Items.Count) { return false; }
         MatchedCommandId = cmdId;
         return true;
     }
@@ -49,7 +49,7 @@ internal sealed class EditorPromptsMenuCommand : OleMenuCommand
     private static void OnBeforeQueryStatus(object sender, EventArgs e)
     {
         var cmd = (EditorPromptsMenuCommand)sender;
-        var items = EditorPrompts.Items;
+        var items = EditorPromptStore.Items;
         var index = GetIndex(cmd);
 
         if (index < items.Count)
@@ -74,7 +74,7 @@ internal sealed class EditorPromptsMenuCommand : OleMenuCommand
     private static void OnInvoke(object sender, EventArgs e)
     {
         var cmd = (EditorPromptsMenuCommand)sender;
-        var items = EditorPrompts.Items;
+        var items = EditorPromptStore.Items;
         var index = GetIndex(cmd);
         cmd.MatchedCommandId = 0;
         if (index < 0 || index >= items.Count) { return; }

--- a/src/Corsinvest.VisualStudio.Agents/Editor/EditorPromptsMenuCommand.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Editor/EditorPromptsMenuCommand.cs
@@ -1,0 +1,108 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using Corsinvest.VisualStudio.Agents.Core.Panes;
+using Corsinvest.VisualStudio.Agents.Core.Profiles;
+using Corsinvest.VisualStudio.Agents.Ide;
+using Microsoft.VisualStudio.Shell;
+using System;
+using System.ComponentModel.Design;
+using System.Linq;
+using Task = System.Threading.Tasks.Task;
+
+namespace Corsinvest.VisualStudio.Agents.Editor;
+
+/// <summary>The code window's context menu: one item per configured prompt, written into a chat
+/// pane's composer. Same DynamicItemStart mechanism as
+/// <see cref="Menu.ActiveSessionsMenuCommand"/>, including its two contract quirks: a matched
+/// command records its own id, and the id is cleared afterwards.</summary>
+internal sealed class EditorPromptsMenuCommand : OleMenuCommand
+{
+    private readonly int _baseId;
+
+    private EditorPromptsMenuCommand(CommandID rootId)
+        : base(OnInvoke, changeHandler: null, OnBeforeQueryStatus, rootId)
+    {
+        _baseId = rootId.ID;
+    }
+
+    public static async Task InitializeAsync(AsyncPackage package)
+    {
+        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+        var commandService = await package.GetServiceAsync(typeof(IMenuCommandService)) as OleMenuCommandService;
+
+        var rootId = new CommandID(PackageGuids.AgentsCommandSet, PackageIds.EditorPromptCommandId);
+        commandService?.AddCommand(new EditorPromptsMenuCommand(rootId));
+    }
+
+    /// <summary>Matches the seed id plus the whole dynamic range (base..base+Count-1),
+    /// which is how VS discovers how many entries to render.</summary>
+    public override bool DynamicItemMatch(int cmdId)
+    {
+        if (cmdId < _baseId || cmdId >= _baseId + EditorPrompts.Items.Count) { return false; }
+        MatchedCommandId = cmdId;
+        return true;
+    }
+
+    private static void OnBeforeQueryStatus(object sender, EventArgs e)
+    {
+        var cmd = (EditorPromptsMenuCommand)sender;
+        var items = EditorPrompts.Items;
+        var index = GetIndex(cmd);
+
+        if (index < items.Count)
+        {
+            cmd.Visible = true;
+            cmd.Text = items[index].Title;
+            // Greyed out rather than hidden: an entry that comes and goes reads as a bug.
+            cmd.Enabled = !items[index].RequiresSelection || HasSelection();
+        }
+        else
+        {
+            cmd.Enabled = false;
+            cmd.Visible = false;
+        }
+
+        cmd.MatchedCommandId = 0;
+    }
+
+    private static bool HasSelection()
+        => IdeContextService.Instance.GetCurrentContext()?.HasSelection == true;
+
+    private static void OnInvoke(object sender, EventArgs e)
+    {
+        var cmd = (EditorPromptsMenuCommand)sender;
+        var items = EditorPrompts.Items;
+        var index = GetIndex(cmd);
+        cmd.MatchedCommandId = 0;
+        if (index < 0 || index >= items.Count) { return; }
+
+        Send(items[index].Prompt);
+    }
+
+    /// <summary>Delivers the prompt to a chat pane. With several open it goes to the last
+    /// activated — the one being worked in, where the first by SeqNo would just be the oldest —
+    /// and brings it forward, or the prompt lands in a tool window nobody is looking at.</summary>
+    private static void Send(string prompt)
+    {
+        var target = PaneRegistry.Instance.OfKind(PaneKind.Chat).LastOrDefault(e => e.SetComposerAction != null);
+        if (target == null)
+        {
+            // First profile = the native "Claude" that ProfileStore prepends.
+            var profile = ProfileStore.Load(forEdit: false).FirstOrDefault();
+            if (profile != null) { PaneLauncher.OpenNew(PaneKind.Chat, profile, initialPrompt: prompt); }
+            return;
+        }
+
+        target.ActivateAction?.Invoke();
+        target.SetComposerAction(prompt);
+    }
+
+    private static int GetIndex(EditorPromptsMenuCommand cmd)
+    {
+        var matched = cmd.MatchedCommandId;
+        return matched == 0 ? 0 : matched - cmd._baseId;
+    }
+}

--- a/src/Corsinvest.VisualStudio.Agents/Options/AgentsEditorPromptsPage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Options/AgentsEditorPromptsPage.cs
@@ -1,0 +1,76 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using Corsinvest.VisualStudio.Agents.Editor;
+using Microsoft.VisualStudio.Shell;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Windows;
+
+namespace Corsinvest.VisualStudio.Agents.Options;
+
+/// <summary>Custom Options page hosting the editor context menu's prompts. Like the profiles page,
+/// these live in a plain JSON file (<see cref="EditorPromptStore"/>) rather than the VS settings
+/// store, so the menu can read them without this page ever being opened.</summary>
+[ComVisible(true)]
+public class AgentsEditorPromptsPage : UIElementDialogPage
+{
+    private List<EditorPrompt> _prompts;
+
+    public List<EditorPrompt> Prompts
+    {
+        get => _prompts ??= [.. EditorPromptStore.Load()];
+        set => _prompts = value ?? [];
+    }
+
+    // Rebuilt each time the page is shown. Reload from disk here so the editor always reflects
+    // the current file (it can be edited by hand between visits).
+    protected override UIElement Child
+    {
+        get
+        {
+            _prompts = [.. EditorPromptStore.Load()];
+            return new EditorPromptsControl(this);
+        }
+    }
+
+    protected override void OnApply(PageApplyEventArgs e)
+    {
+        if (e.ApplyBehavior == ApplyKind.Apply && _prompts != null)
+        {
+            // Blocked rather than silently dropped: a row with no title renders as an empty menu
+            // item, and one with no prompt sends nothing.
+            if (Validate(_prompts, out var error))
+            {
+                EditorPromptStore.Save(_prompts);
+            }
+            else
+            {
+                MessageBox.Show(error, "Editor prompts", MessageBoxButton.OK, MessageBoxImage.Warning);
+                e.ApplyBehavior = ApplyKind.Cancel;
+                return;
+            }
+        }
+        base.OnApply(e);
+        if (e.ApplyBehavior == ApplyKind.Apply) { AgentsOptions.RaiseApplied(); }
+    }
+
+    private static bool Validate(List<EditorPrompt> prompts, out string error)
+    {
+        if (prompts.Any(p => string.IsNullOrWhiteSpace(p.Title)))
+        {
+            error = "A prompt has no title. Give every prompt a title before saving.";
+            return false;
+        }
+        if (prompts.Any(p => string.IsNullOrWhiteSpace(p.Prompt)))
+        {
+            error = "A prompt has no text. Write what to ask, or remove the row.";
+            return false;
+        }
+        error = null;
+        return true;
+    }
+}

--- a/src/Corsinvest.VisualStudio.Agents/Options/EditorPromptsControl.xaml
+++ b/src/Corsinvest.VisualStudio.Agents/Options/EditorPromptsControl.xaml
@@ -1,0 +1,51 @@
+<UserControl x:Class="Corsinvest.VisualStudio.Agents.Options.EditorPromptsControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"
+             xmlns:catalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog">
+  <Grid Margin="8">
+    <Grid.RowDefinitions>
+      <RowDefinition Height="Auto" />
+      <RowDefinition Height="*" />
+      <RowDefinition Height="Auto" />
+    </Grid.RowDefinitions>
+
+    <TextBlock Grid.Row="0" TextWrapping="Wrap" Margin="0,0,0,6"
+               Text="Prompts offered when you right-click code, under &quot;cv4vs Agents&quot;. Picking one writes it into a chat pane's composer — the file and selection are sent with it, so the prompt is the instruction alone. Rows appear in the menu in this order." />
+
+    <!-- One grid, not the master/detail the profiles page needs: three fields per row fit in it. -->
+    <DataGrid Grid.Row="1" x:Name="PromptsGrid"
+              AutoGenerateColumns="False"
+              CanUserAddRows="False"
+              CanUserDeleteRows="True"
+              HeadersVisibility="Column">
+      <DataGrid.Columns>
+        <DataGridTextColumn Header="Title" Width="160"
+                            Binding="{Binding Title, UpdateSourceTrigger=PropertyChanged}" />
+        <DataGridTextColumn Header="Prompt" Width="*"
+                            Binding="{Binding Prompt, UpdateSourceTrigger=PropertyChanged}" />
+        <DataGridCheckBoxColumn Header="Needs selection" Width="Auto"
+                                Binding="{Binding RequiresSelection, UpdateSourceTrigger=PropertyChanged}" />
+      </DataGrid.Columns>
+    </DataGrid>
+
+    <DockPanel Grid.Row="2" Margin="0,6,0,0" LastChildFill="False">
+      <Button x:Name="AddPrompt" DockPanel.Dock="Left" Padding="6,2" Click="OnAddClick" ToolTip="Add prompt">
+        <imaging:CrispImage Width="16" Height="16" Moniker="{x:Static catalog:KnownMonikers.Add}" />
+      </Button>
+      <Button x:Name="RemovePrompt" DockPanel.Dock="Left" Padding="6,2" Margin="6,0,0,0" Click="OnRemoveClick" ToolTip="Delete selected prompt">
+        <imaging:CrispImage Width="16" Height="16" Moniker="{x:Static catalog:KnownMonikers.DeleteListItem}" />
+      </Button>
+      <Button x:Name="RestoreDefaults" DockPanel.Dock="Left" Padding="6,2" Margin="12,0,0,0" Click="OnRestoreDefaultsClick" ToolTip="Replace the list with the prompts the extension ships with">
+        <imaging:CrispImage Width="16" Height="16" Moniker="{x:Static catalog:KnownMonikers.Refresh}" />
+      </Button>
+
+      <Button x:Name="MoveDown" DockPanel.Dock="Right" Padding="6,2" Click="OnMoveDownClick" ToolTip="Move down">
+        <imaging:CrispImage Width="16" Height="16" Moniker="{x:Static catalog:KnownMonikers.MoveDown}" />
+      </Button>
+      <Button x:Name="MoveUp" DockPanel.Dock="Right" Padding="6,2" Margin="0,0,6,0" Click="OnMoveUpClick" ToolTip="Move up">
+        <imaging:CrispImage Width="16" Height="16" Moniker="{x:Static catalog:KnownMonikers.MoveUp}" />
+      </Button>
+    </DockPanel>
+  </Grid>
+</UserControl>

--- a/src/Corsinvest.VisualStudio.Agents/Options/EditorPromptsControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Options/EditorPromptsControl.xaml.cs
@@ -1,0 +1,77 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using Corsinvest.VisualStudio.Agents.Editor;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace Corsinvest.VisualStudio.Agents.Options;
+
+/// <summary>Editor for the context menu's prompts, hosted by <see cref="AgentsEditorPromptsPage"/>.
+/// Edits an ObservableCollection and writes it back to the page's list on every change, so Apply
+/// finds the current state — the page owns persistence, this owns the UI.</summary>
+public partial class EditorPromptsControl : UserControl
+{
+    private readonly AgentsEditorPromptsPage _page;
+    private readonly ObservableCollection<EditorPrompt> _items;
+
+    public EditorPromptsControl(AgentsEditorPromptsPage page)
+    {
+        InitializeComponent();
+        _page = page;
+        _items = [.. page.Prompts];
+        _items.CollectionChanged += (_, __) => Commit();
+        PromptsGrid.ItemsSource = _items;
+    }
+
+    /// <summary>Push the edited list back to the page. The grid edits the EditorPrompt objects in
+    /// place, so this only has to keep the page's list in the same order as the grid.</summary>
+    private void Commit() => _page.Prompts = [.. _items];
+
+    private void OnAddClick(object sender, RoutedEventArgs e)
+    {
+        var added = new EditorPrompt { Title = "New prompt", Prompt = "" };
+        _items.Add(added);
+        PromptsGrid.SelectedItem = added;
+        PromptsGrid.ScrollIntoView(added);
+    }
+
+    private void OnRemoveClick(object sender, RoutedEventArgs e)
+    {
+        if (PromptsGrid.SelectedItem is EditorPrompt sel) { _items.Remove(sel); }
+    }
+
+    private void OnRestoreDefaultsClick(object sender, RoutedEventArgs e)
+    {
+        if (MessageBox.Show(
+                "Replace the list with the prompts the extension ships with? Your own are lost.",
+                "Editor prompts",
+                MessageBoxButton.OKCancel,
+                MessageBoxImage.Warning) != MessageBoxResult.OK)
+        {
+            return;
+        }
+        _items.Clear();
+        foreach (var p in EditorPromptStore.Defaults) { _items.Add(p); }
+    }
+
+    private void OnMoveUpClick(object sender, RoutedEventArgs e) => Move(-1);
+
+    private void OnMoveDownClick(object sender, RoutedEventArgs e) => Move(+1);
+
+    /// <summary>Reorder the selected row. The list order IS the menu order, so this is how the
+    /// prompt you reach for most gets to the top.</summary>
+    private void Move(int delta)
+    {
+        if (PromptsGrid.SelectedItem is not EditorPrompt sel) { return; }
+        var from = _items.IndexOf(sel);
+        var to = from + delta;
+        if (from < 0 || to < 0 || to >= _items.Count) { return; }
+        _items.Move(from, to);
+        PromptsGrid.SelectedItem = sel;
+    }
+}

--- a/src/Corsinvest.VisualStudio.Agents/PackageGuids.cs
+++ b/src/Corsinvest.VisualStudio.Agents/PackageGuids.cs
@@ -38,4 +38,8 @@ internal static class PackageIds
     // Seeds the dynamic open-panes range, which grows with the number of open panes — its own
     // 0x0300 block, clear of the fixed ids above.
     public const int ActiveSessionCommandId = 0x0300;
+
+    // Seeds the editor context menu's prompt range, which grows with the configured prompts —
+    // 0x0400, clear of the panes range that grows under it.
+    public const int EditorPromptCommandId = 0x0400;
 }

--- a/src/Corsinvest.VisualStudio.Agents/Utils/AppPaths.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Utils/AppPaths.cs
@@ -21,6 +21,10 @@ internal static class AppPaths
     /// so the menu/launch can read profiles without materializing the Options page first.</summary>
     public static readonly string ProfilesFile = Path.Combine(DataFolder, "profiles.json");
 
+    /// <summary>The editor context menu's prompts, next to the profiles and for the same reason:
+    /// the menu is queried constantly by VS, long before any Options page exists.</summary>
+    public static readonly string EditorPromptsFile = Path.Combine(DataFolder, "editor-prompts.json");
+
     /// <summary>
     /// Cache folder for file-type icons rasterised from VS KnownMonikers. The
     /// WebView serves these via the `cv4vs-icons.local` virtual host, generated


### PR DESCRIPTION
Right-click code and ask about it, without leaving the editor to go explain where you are.

## The menu

**cv4vs Agents ▸** in the code window's context menu, at the top, with the prompts you configure:
Explain, Review, Find bugs, Write tests, Simplify out of the box.

Picking one **writes into the composer** rather than sending — the canned text is generic, and
nine times out of ten you want to add half a line before it goes. The prompt itself is just the
instruction: the file and selection travel with it through the IDE context, and Claude reads the
symbol with the `nav_*` tools, so pasting code into the prompt would only duplicate what the pane
already sends.

An entry that needs a selection is **greyed out** rather than hidden when there is none, the way
Copilot greys "Optimize selection" — one that comes and goes reads as a bug.

## Configurable, in Options → Editor prompts

A grid of title / prompt / needs-selection, reorderable (the list order is the menu order) with a
Restore defaults. They live in `editor-prompts.json` next to `profiles.json`, not in the VS
settings store, for the same reason profiles don't: VS queries the menu long before any Options
page exists. Cached for the same reason, since it re-queries on every keystroke.

## Which pane receives

The last one you worked in, brought to the front — the first by `SeqNo` would just be the oldest,
and a prompt landing in a hidden tool window looks like nothing happened. With none open, one is
opened rather than the prompt dropped; that path needed a branch of its own in `PaneLauncher`,
where both existing ones require a session id and a prompt without one never reached the pane.

If the IDE-context eye was shut, it is **re-opened with the prompt**: asking about this code, with
nothing telling the CLI which file it is, would arrive as a question about nothing.

## Not a CodeLens, not an inline chat

Both were considered and written up in the internal notes. The pane is already docked next to the
code, so a chat inside the editor would be a worse copy of the one we have — no history, no tools,
no diff. And Copilot, which has no shortage of resources, uses a context menu too rather than a
CodeLens. Reading the decompiled CodeLens2GPT settled the two open questions about the CodeLens
route (`[ContentType("code")]` is language-agnostic; the callback service is one-way and needs a
named pipe for the return trip) — it is deferred, not ruled out, and would now be a second trigger
on the same `Send`.

## Also here: the composer finally gets the keyboard

A separate commit, and a bug that predates this branch. Opening a chat left the composer looking
focused while the keystrokes went to Visual Studio — only on the first open; switching to a live
pane always worked.

The page was not at fault: at `webview_ready` everything is mounted, the DOM focus lands on
`cv-prompt`, and WPF reports the control as keyboard-focused. But `document.hasFocus()` stays
false, because `WebView2CompositionControl` renders through `Windows.UI.Composition` rather than a
child HWND: nothing propagates the focus for it, so it hands it to its own controller from
`OnGotFocus` — which WPF does not raise for a control that already holds the focus. The control is
focused while the controller is still being created (`EnsureCoreWebView2Async` takes 1.5-1.8s,
measured), so the browser side never hears. Dropping the focus and taking it back raises the event
with the controller in place.

## Testing

Green MSBuild. Driven by hand in the Exp instance: the submenu and its position, entries greyed
without a selection, delivery to an existing pane and to one that has to be opened, with several
panes open, and the focus on a freshly opened chat.

The diagnosis for the focus bug came from the wire, not from reading: a probe reporting what the
page had at `ready` (everything), `document.activeElement` (`CV-PROMPT`), `document.hasFocus()`
(false), and WPF's own view of the keyboard focus (ours).
