### PR TITLE
fix(mcp): find built-in output panes by GUID, not by localised name

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeOutputService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeOutputService.cs
@@ -4,7 +4,9 @@
  */
 
 using EnvDTE;
+using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -34,9 +36,54 @@ internal sealed class IdeOutputService
 
     private static OutputWindow GetOutputWindow()
     {
+        ThreadHelper.ThrowIfNotOnUIThread();
         var dte = Package.GetGlobalService(typeof(DTE)) as DTE;
-        var win = dte?.Windows?.Item(Constants.vsWindowKindOutput);
+        var win = dte?.Windows?.Item(EnvDTE.Constants.vsWindowKindOutput);
         return win?.Object as OutputWindow;
+    }
+
+    /// <summary>The built-in panes, by the English name a caller would ask for. VS localises the
+    /// displayed names — on an Italian IDE the Build pane is called "Compilazione" — so matching
+    /// the name alone never finds them outside an English install. The GUIDs don't change.</summary>
+    private static readonly Dictionary<string, Guid> WellKnownPanes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["Build"] = VSConstants.OutputWindowPaneGuid.BuildOutputPane_guid,
+        ["Debug"] = VSConstants.OutputWindowPaneGuid.DebugPane_guid,
+        ["General"] = VSConstants.OutputWindowPaneGuid.GeneralPane_guid,
+        ["Build Order"] = VSConstants.OutputWindowPaneGuid.SortedBuildOutputPane_guid,
+    };
+
+    /// <summary>Resolve a built-in pane through IVsOutputWindow, which keys on the GUID rather
+    /// than the localised name and creates the pane when the Output window has never been opened
+    /// (VS builds them lazily). Returns null for panes with no stable GUID — those are found by
+    /// name. Must be called on the UI thread.</summary>
+    private static OutputWindowPane FindWellKnownPane(OutputWindow ow, string paneName)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        if (!WellKnownPanes.TryGetValue(paneName, out var guid)) { return null; }
+
+        var vsOut = Package.GetGlobalService(typeof(SVsOutputWindow)) as IVsOutputWindow;
+        if (vsOut == null) { return null; }
+
+        // GetPane fails when the pane doesn't exist yet; CreatePane materialises it without
+        // bringing the window to the front, then GetPane succeeds.
+        if (vsOut.GetPane(ref guid, out var vsPane) != VSConstants.S_OK || vsPane == null)
+        {
+            if (vsOut.CreatePane(ref guid, paneName, 1, 0) != VSConstants.S_OK) { return null; }
+            if (vsOut.GetPane(ref guid, out vsPane) != VSConstants.S_OK || vsPane == null) { return null; }
+        }
+
+        // IVsOutputWindowPane has no text accessor; re-find the same pane through the DTE
+        // collection, which does. Creating it above is what makes it appear there.
+        string localisedName = null;
+        vsPane.GetName(ref localisedName);
+        if (string.IsNullOrEmpty(localisedName)) { return null; }
+
+        foreach (OutputWindowPane p in ow.OutputWindowPanes)
+        {
+            if (string.Equals(p.Name, localisedName, StringComparison.Ordinal)) { return p; }
+        }
+        return null;
     }
 
     /// <summary>Locate a pane by name (case-insensitive) and collect the sorted list of all
@@ -45,8 +92,12 @@ internal sealed class IdeOutputService
     private static OutputWindowPane FindPane(OutputWindow ow, string paneName, out string[] allPaneNames)
     {
         ThreadHelper.ThrowIfNotOnUIThread();
+
+        // By GUID first: the built-in panes carry a localised name, so asking for "Build" only
+        // ever matches on an English IDE. This also creates the pane when it doesn't exist yet.
+        var match = string.IsNullOrWhiteSpace(paneName) ? null : FindWellKnownPane(ow, paneName);
+
         var panes = new List<string>();
-        OutputWindowPane match = null;
         foreach (OutputWindowPane p in ow.OutputWindowPanes)
         {
             panes.Add(p.Name);

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeOutputService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeOutputService.cs
@@ -108,6 +108,39 @@ internal sealed class IdeOutputService
         return match;
     }
 
+    /// <summary>Get the pane's TextDocument, the only way EnvDTE offers to read its text.
+    ///
+    /// A pane that has never been shown answers E_FAIL here: it is listed, and it holds the text
+    /// the build wrote, but the document behind it is realised together with the window. Activating
+    /// the pane realises it, so the failure is retried once that way rather than reported — the
+    /// alternative is a caller that cannot tell "no output" from "output you haven't looked at".
+    /// Activating brings the Output window forward, which is why it is done only on that branch.
+    ///
+    /// Returns null when even the retry fails. Must be called on the UI thread.</summary>
+    private static TextDocument GetTextDocument(OutputWindowPane pane)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        try
+        {
+            return pane.TextDocument;
+        }
+        catch (Exception ex)
+        {
+            OutputWindowLogger.Global.Debug(() => $"[ide] pane '{pane.Name}' has no TextDocument yet ({ex.Message}); activating and retrying");
+        }
+
+        try
+        {
+            pane.Activate();
+            return pane.TextDocument;
+        }
+        catch (Exception ex)
+        {
+            OutputWindowLogger.Global.Warn($"[ide] pane '{pane.Name}' still unreadable after activating: {ex.Message}");
+            return null;
+        }
+    }
+
     /// <summary>Read a pane by name (case-insensitive). With no name, returns the list of
     /// available pane names instead of content. tailLines caps the returned lines.</summary>
     public async Task<OutputResult> ReadAsync(string paneName, int tailLines)
@@ -132,7 +165,18 @@ internal sealed class IdeOutputService
             }
 
             // The pane text is reachable through its TextDocument: select all, read the text.
-            var td = pane.TextDocument;
+            var td = GetTextDocument(pane);
+            if (td == null)
+            {
+                return new OutputResult
+                {
+                    Ok = false,
+                    Pane = pane.Name,
+                    AvailablePanes = panes,
+                    Reason = $"The '{pane.Name}' pane exists but its text could not be read.",
+                };
+            }
+
             var sel = td.Selection;
             sel.StartOfDocument(false);
             sel.EndOfDocument(true); // extend selection to the end

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Ide/ActivateOutputTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Ide/ActivateOutputTool.cs
@@ -11,7 +11,9 @@ namespace Corsinvest.VisualStudio.Agents.Mcp.Tools;
 
 internal sealed class ActivateOutputArgs
 {
-    [Required, Description("Output pane name to bring to the foreground, e.g. 'Build', 'Debug'.")]
+    [Required, Description("Output pane name to bring to the foreground. The built-in ones — " +
+        "'Build', 'Debug', 'General', 'Build Order' — work under those English names on any " +
+        "IDE language.")]
     public string Pane { get; set; }
 }
 

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Ide/ClearOutputTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Ide/ClearOutputTool.cs
@@ -11,7 +11,8 @@ namespace Corsinvest.VisualStudio.Agents.Mcp.Tools;
 
 internal sealed class ClearOutputArgs
 {
-    [Required, Description("Output pane name to clear, e.g. 'Build', 'Debug'.")]
+    [Required, Description("Output pane name to clear. The built-in ones — 'Build', 'Debug', " +
+        "'General', 'Build Order' — work under those English names on any IDE language.")]
     public string Pane { get; set; }
 }
 

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Ide/ReadOutputTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Ide/ReadOutputTool.cs
@@ -10,7 +10,8 @@ namespace Corsinvest.VisualStudio.Agents.Mcp.Tools;
 
 internal sealed class ReadOutputArgs
 {
-    [Description("Output pane name, e.g. 'Build', 'Debug'. Omit to list the available panes.")]
+    [Description("Output pane name. The built-in ones — 'Build', 'Debug', 'General', 'Build Order' " +
+        "— work under those English names on any IDE language. Omit to list the available panes.")]
     public string Pane { get; set; }
 
     [Description("Max number of lines to return from the end of the pane (default 200).")]
@@ -24,7 +25,9 @@ internal sealed class ReadOutputTool : McpTool<ReadOutputArgs>
     public override string Name => "ide_read_output";
     public override string Description =>
         "Read text from a Visual Studio Output window pane (e.g. 'Build', 'Debug', or the " +
-        "running program's output). Omit 'pane' to list the available pane names first. " +
+        "running program's output). Omit 'pane' to list the available pane names first — note " +
+        "those come back in the IDE's language ('Compilazione' for Build on an Italian VS), but " +
+        "the built-in panes are also reachable under their English names. " +
         "'tailLines' caps how many lines are returned from the end (default 200). Useful to " +
         "see build/debug output or the debuggee's console writes that don't go through the " +
         "shell — including what a frozen thread stopped printing, which is how debug_freeze_thread " +


### PR DESCRIPTION
Asking `ide_read_output` for the `Build` pane never worked on a non-English Visual Studio.

VS localises the Output pane names — on an Italian IDE the Build pane is called **Compilazione** — and `FindPane` compared the requested name against `OutputWindowPane.Name`. `ide_read_output`, `ide_clear_output` and `ide_activate_output` all go through it, so all three answered *"no output pane named 'Build'"* along with a pane list in which `Build` was, indeed, absent. From the caller's side that is indistinguishable from a build that produced no output at all.

Observed on this repo's own IDE, which reports:

```
Compilazione, Debug, Ordine di compilazione, Test, cv4vs Agents, ...
```

## What changed

The four built-in panes are resolved through `IVsOutputWindow.GetPane`, which keys on a GUID that does not change with the IDE language:

| Requested | GUID |
|---|---|
| `Build` | `BuildOutputPane_guid` |
| `Debug` | `DebugPane_guid` |
| `General` | `GeneralPane_guid` |
| `Build Order` | `SortedBuildOutputPane_guid` |

Panes with no stable GUID — `cv4vs Agents`, `Test`, whatever an extension creates — keep the existing name match, which is now the fallback rather than the only path.

`CreatePane` runs when `GetPane` finds nothing, which also covers the case the pane does not exist yet: VS builds panes lazily, so one can be missing simply because nobody has opened the Output window. It materialises the pane *without* bringing the window to the front, so nothing pops up in the user's face.

`IVsOutputWindowPane` exposes no text accessor, so the pane is re-found in the DTE collection by its localised name to read from it.

## The second half: a pane that has never been shown

Finding the pane turned out to be only half the problem. A pane the Output window has never displayed is listed, and holds whatever the build wrote into it, but `OutputWindowPane.TextDocument` — EnvDTE's only way to read its text — answers `E_FAIL` until the pane has been realised:

```
COMException: E_FAIL
   at EnvDTE.OutputWindowPane.get_TextDocument()
   at IdeOutputService.ReadAsync()
```

`ReadAsync` caught that as a generic failure and answered `"Failed to read output window."` — which a caller cannot tell apart from a pane that is genuinely empty. The two bugs masked each other: the name never matched, so nobody ever got far enough to hit the unrealised document.

Activating the pane realises the document, so the failing branch now does that and retries the read once. Only that branch — activating brings the Output window forward, and a plain read must not move the user's windows around.

## Notes

- `availablePanes` still reports the localised names, because that is what they are. The tool descriptions now say the English names are accepted too, and give `Compilazione` as the worked example.
- One behaviour change: asking for a built-in pane now *creates* it when absent, so `ide_read_output` can return an empty pane where it previously returned "not found". Empty is the more honest answer — "not found" sent the model guessing.
- A pre-existing `ThrowIfNotOnUIThread()` was missing in `GetOutputWindow`; added, since editing the line surfaced the analyzer warning. All callers already switch to the UI thread.

## Test

`build_solution` is green, and the behaviour was checked in the experimental instance on an Italian VS 2026:

| Case | Result |
|---|---|
| `pane: "Build"` | `ok: true`, `pane: "Compilazione"` |
| `pane: "Debug"` | `ok: true`, `pane: "Debug"` |
| `pane: "Build Order"` | `ok: true`, `pane: "Ordine di compilazione"` |
| `pane: "cv4vs Agents"` (no GUID) | `ok: true` — name fallback intact |
| `pane: "PaneCheNonEsisteDavvero"` | `ok: false`, *"No output pane named…"*, nothing created |
| no pane | 13 panes, no duplicates |

All three built-in panes read **without anyone activating them first** — the log shows the retry doing it:

```
DEBUG [ide] pane 'Ordine di compilazione' has no TextDocument yet (E_FAIL); activating and retrying
```

`CreatePane` on a system GUID returns the real pane rather than a duplicate: the pane list stays at 13 with no repeated name. A pane the run had not touched (`General`) was created on demand and read fine.

After a real build, `pane: "Build"` returns the log — 367 lines of MSBuild output. On a session with no build it returns `content: ""`, which is the honest answer rather than an error.
