### PR TITLE
chore: drop comments the code already says

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/AgentsPackage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/AgentsPackage.cs
@@ -395,8 +395,8 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
             _hidePanesTimer = null;
             Mcp.McpServerHost.Instance.Stop();
             AgentsOptions.Applied -= ProfilesMenuCommand.InvalidateCache;
-            // Unadvise the selection sink (MS pattern: at package dispose). Dispose was never
-            // called anywhere, so the IVsMonitorSelection cookie leaked for the process lifetime.
+            // Unadvise the selection sink (MS pattern: at package dispose) — without it the
+            // IVsMonitorSelection cookie leaks for the process lifetime.
             Ide.IdeContextService.Instance.Dispose();
         }
         base.Dispose(disposing);

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Helpers.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Helpers.cs
@@ -184,8 +184,8 @@ internal sealed partial class WebViewMessageHandler
         var side = which == "in" ? "in" : "out";
 
         // A tool that names a file gets that file's name and extension: "Modello_in_a3f21.cs" reads
-        // back to the row at a glance and the editor colours it. The whole title used to go through
-        // SanitizeFileName instead, which turned a path into "claude_[Write] C__Users_daniele_cors".
+        // back to the row at a glance and the editor colours it. Sanitizing the whole title instead
+        // would mangle a path into something like "claude_[Write] C__Users_daniele_cors".
         if (which == "in" && !string.IsNullOrEmpty(filePath))
         {
             var name = SanitizeFileName(Path.GetFileNameWithoutExtension(filePath));

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
@@ -93,9 +93,8 @@ public partial class ChatPaneControl : PaneControlBase
     }
 
     /// <summary>Resume a past session in THIS pane: clear the transcript,
-    /// load its history into the WebView, then resume the client. (Was the old
-    /// Session.Load bridge handler — the toolbar's History dropdown now calls
-    /// this directly.) Permission mode / model reach the selector via the gate's
+    /// load its history into the WebView, then resume the client. Called directly by the
+    /// toolbar's History dropdown. Permission mode / model reach the selector via the gate's
     /// ui_init, re-armed by the respawn's fresh system/init.</summary>
     public override void LoadSession(string sessionId)
     {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/ThumbnailGenerator.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/ThumbnailGenerator.cs
@@ -52,7 +52,7 @@ internal static class ThumbnailGenerator
                 // OnLoad: decode fully within EndInit so the stream can be disposed right after.
                 source.CacheOption = BitmapCacheOption.OnLoad;
                 source.CreateOptions = BitmapCreateOptions.None;
-                source.DecodePixelWidth = DecodeWidth; // downsample at decode time
+                source.DecodePixelWidth = DecodeWidth;
                 source.StreamSource = ms;
                 source.EndInit();
             }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/bridge.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/bridge.ts
@@ -14,7 +14,7 @@ import { Msg } from './bridge-messages';
 import type { RequestType } from './request-types';
 
 // Reject a request whose response never arrives, so _pending can't leak and the caller
-// gets an error instead of an eternal spinner. Matches every production JSON-RPC client.
+// gets an error instead of an eternal spinner.
 const REQUEST_TIMEOUT_MS = 30_000;
 
 // chrome.webview is injected by WebView2 at runtime — not in lib.dom.

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/commands/base.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/commands/base.ts
@@ -37,11 +37,8 @@ export interface CommandHost {
     sendPrompt(text: string, echo?: boolean): void;
     /** Insert text at the caret in the prompt box (e.g. "@" or "/name "). */
     insertAtCaret(text: string): void;
-    /** Open the upload-from-computer file picker. */
     pickFile(): void;
-    /** Open the model selector popover. */
     openModelPicker(): void;
-    /** Open the permission-mode picker. */
     openPermissionPicker(): void;
     /** Open a URL in the system browser (help docs, issue tracker). */
     openExternalUrl(url: string): void;
@@ -53,7 +50,6 @@ export interface CommandHost {
     openSessionHistory(): void;
     /** Open a fresh chat pane (same as the toolbar "+" for Chat). */
     openChatPane(): void;
-    /** Open the Manage Plugins dialog. */
     openPluginManager(): void;
     /** Merge keys into the CLI flag-settings layer (effortLevel,
      *  alwaysThinkingEnabled, fastMode) for the Model menu controls. */
@@ -95,7 +91,6 @@ export abstract class ChatCommand {
     readonly description?: string;
     readonly aliases: readonly string[] = [];
     readonly icon?: string;
-    /** Inline control on the right of the row (toggle/slider/value). */
     readonly trailing?: CommandTrailing;
     /** On state for `trailing: 'toggle'` commands (drives the switch). */
     get checked(): boolean {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/commands/command-icons.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/commands/command-icons.ts
@@ -42,7 +42,6 @@ const COMMAND_ICONS: Readonly<Record<string, string>> = {
     loop: ArrowRepeatAll16Regular,
 };
 
-/** SVG for a CLI slash command by its bare name (e.g. "compact"), or undefined if unmapped. */
 export function iconForCommandName(name: string): string | undefined {
     return COMMAND_ICONS[name];
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/path.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/path.ts
@@ -36,9 +36,6 @@ export function relPath(
         : pathBare;
 }
 
-/**
- * Basename of a path (last segment after the final `/` or `\`).
- */
 export function fileName(path: string | undefined | null): string {
     return normPath(path).split('/').pop() ?? '';
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/state.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/state.ts
@@ -34,8 +34,7 @@ interface AppState {
     ultracodeEnabled: boolean;
     /** Extended thinking on/off (Model menu toggle). */
     thinkingEnabled: boolean;
-    /** Host built in DEBUG (developer running under VS). Gates dev-only diagnostics (e.g. raw status
-     *  on the spinner). From the init payload; false in Release. */
+    /** Host built in DEBUG (developer running under VS); false in Release. */
     inDev: boolean;
     /** Fast mode on/off (Model menu toggle). */
     fastMode: boolean;
@@ -115,12 +114,11 @@ class StoreImpl<T extends object> {
         this._data = { ...initial };
     }
 
-    /** Used by the Proxy `get` trap. */
     _read<K extends keyof T>(key: K): T[K] {
         return this._data[key];
     }
 
-    /** Used by the Proxy `set` trap. Skips work and skips notify on no-op. */
+    /** Skips work and skips notify on no-op. */
     _write<K extends keyof T>(key: K, value: T[K]): void {
         if (this._data[key] === value) {
             return;

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
@@ -1413,8 +1413,6 @@ export class CvApp extends LitElement {
         appState.subagentTasks = [...ordered, ...linked.filter((t) => !seen.has(t.taskId))];
     }
 
-    /** True when scrolled at/near the bottom. Gates stream auto-follow so
-     *  the user isn't yanked down while reading scrolled-up content. */
     /** Coalesce to one measurement per frame: a scroll fires far more often than it repaints, and
      *  reading scrollHeight on each event is a forced layout for a value that can't have changed
      *  twice in a frame. */
@@ -1446,6 +1444,8 @@ export class CvApp extends LitElement {
         }
     }
 
+    /** True when scrolled at/near the bottom. Gates stream auto-follow so
+     *  the user isn't yanked down while reading scrolled-up content. */
     private _isNearBottom(threshold = 80): boolean {
         const el = this._messagesEl;
         if (!el) {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-context-dialog.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-context-dialog.ts
@@ -384,7 +384,6 @@ export class CvContextDialog extends CvDialogBase {
         `;
     }
 
-    /** A sub-row inside an expanded section (indented label + tokens). */
     private _subRow(label: string, tokens: number): TemplateResult {
         return html`
             <div class="subrow">

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-model-list.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-model-list.ts
@@ -54,7 +54,6 @@ export class CvModelList extends LitElement {
     }
 
     override willUpdate(changed: Map<string, unknown>): void {
-        // On open, resync from app state and put the cursor on the active model.
         if (changed.has('open') && this.open) {
             this._current = appState.currentModel;
             this._models = displayModels(appState.models);

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-prompt.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-prompt.ts
@@ -1090,19 +1090,6 @@ export class CvPrompt extends LitElement implements CommandHost {
     }
 
     /**
-     * Tell the transcript that a bubble entered the queue, or just left it. Only the queued path
-     * says anything: a message sent straight away is already both in the right place and really
-     * sent, so there is no state for it to leave.
-     *
-     * cv-app owns the transcript, so it does the fading and the move; this component knows the
-     * moments, not the tree.
-     */
-    /**
-     * Drop everything still queued and take its bubbles with it. They were echoed on submit but
-     * never reached the CLI, so leaving them would show the model messages it has never been told
-     * about — the same divergence a retraction causes, only from our side.
-     */
-    /**
      * Replace the queue and mirror its uuids into the shared state — how cv-app knows which
      * bubbles are on screen without having been sent.
      *

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-tool-row.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-tool-row.ts
@@ -62,7 +62,6 @@ export class CvToolRow extends LitElement implements ToolRowState {
 
     private _unsubSubagentTasks?: () => void;
 
-    /** ToolRowState: the host reads/writes these. */
     get expanded(): boolean {
         return this._expanded;
     }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-usage-dialog.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-usage-dialog.ts
@@ -172,7 +172,6 @@ export class CvUsageDialog extends CvDialogBase {
         `;
     }
 
-    /** One attribution group (Skills / Subagents / Plugins / MCP servers). */
     private _attribution(
         title: string,
         items: UsageAttributionDto[] | null | undefined,

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.cs
@@ -590,11 +590,11 @@ internal sealed partial class ClaudeClient : IClaudeClient
         => SendControlRequestAsync(ClientMessages.ControlSubtype.ApplyFlagSettings, new { settings });
 
     /// <summary>Enable/disable extended thinking at runtime. ON = budget 31999 + summarized display;
-    /// OFF = budget 0. display is omitted when null so the CLI keeps the session mode.</summary>
-    /// <summary>Logs its own failure, like the other fire-and-forget hot-swaps: the caller drops the
+    /// OFF = budget 0. display is omitted when null so the CLI keeps the session mode.
+    /// <para>Logs its own failure, like the other fire-and-forget hot-swaps: the caller drops the
     /// Task, and unlike the model and permission selectors there is no echo back to roll the UI
     /// onto what the CLI really holds — the toggle would simply keep showing a setting that never
-    /// took.</summary>
+    /// took.</para></summary>
     public async Task SetMaxThinkingTokensAsync(int maxThinkingTokens, string display)
     {
         try

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneToolbar.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneToolbar.xaml.cs
@@ -206,7 +206,7 @@ public partial class PaneToolbar : UserControl
             StaysOpen = false,
             AllowsTransparency = true,
             Focusable = true,
-            // 1px border so the popup detaches from the pane underneath (was SessionPickerPopup's job).
+            // 1px border so the popup detaches from the pane underneath.
             Child = new Border
             {
                 Width = 480,

--- a/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.History.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.History.cs
@@ -316,8 +316,8 @@ internal sealed partial class SessionManager
                 // against rendering an empty user bubble for them.
                 if (messagesNewestFirst != null)
                 {
-                    // Heavy blocks (image/document strip, tool_result truncate) are now
-                    // handled by EmitUser during HistoryReplay — the messages travel raw.
+                    // Heavy blocks (image/document strip, tool_result truncate) are handled by
+                    // EmitUser during HistoryReplay — the messages travel raw from here.
                     // Lift the line's top-level uuid onto the message (internal replay tag,
                     // read by HistoryReplay; the message object has no native uuid).
                     var uuid = obj.Val("uuid");

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsService.cs
@@ -602,9 +602,9 @@ internal static class StatsService
             {
                 var key = RelativeKey(projectDir, file.FullName);
                 cache.TryGetValue(key, out var cached);
-                // The cwd RefreshFile also reports is no longer wanted here: the project's path is
-                // what named the folder this cache sits in, so it is known before indexing starts
-                // and recorded once, in project.json, instead of once per profile.
+                // The cwd RefreshFile also reports is discarded here: the project's path is what
+                // named the folder this cache sits in, so it is known before indexing starts and
+                // recorded once, in project.json, instead of once per profile.
                 var (entry, _) = RefreshFile(file, cached);
                 if (entry != null) { updated[key] = entry; }
             });

--- a/src/Corsinvest.VisualStudio.Agents/Helpers/VsReflection.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Helpers/VsReflection.cs
@@ -15,10 +15,9 @@ namespace Corsinvest.VisualStudio.Agents.Helpers;
 /// Late-binding helpers for VS/Roslyn types that are loaded in-process but not referenced at
 /// compile time (referencing them would pin Roslyn/VB-only assemblies — see the "multi-language"
 /// rule — or not bind at all with a partial assembly-qualified name). Centralizes the reflection
-/// idioms that were duplicated across the Ide/ services. Behavior matches the previous inline code:
-/// a missing member throws (same NullReference/exception as before); the typed overloads use a
-/// hard <c>(T)</c> cast. Callers that tolerated a missing member with <c>?.</c> keep null-checking
-/// the returned <see cref="object"/>.
+/// idioms duplicated across the Ide/ services. A missing member throws; the typed overloads use a
+/// hard <c>(T)</c> cast. Callers that tolerate a missing member must null-check the returned
+/// <see cref="object"/>.
 /// </summary>
 internal static class VsReflection
 {
@@ -51,13 +50,12 @@ internal static class VsReflection
     public static object GetProp(object obj, string name)
         => obj.GetType().GetProperty(name).GetValue(obj);
 
-    /// <summary>Typed property read with a hard (T) cast (matches the old inline casts).</summary>
+    /// <summary>Typed property read with a hard (T) cast.</summary>
     public static T GetProp<T>(object obj, string name) => (T)GetProp(obj, name);
 
-    /// <summary>Property read that tolerates a MISSING property, returning null (matches the
-    /// old <c>obj.GetType().GetProperty(name)?.GetValue(obj)</c> call-sites, incl. the
-    /// <c>GetProp(a) ?? GetProp(b)</c> "try alternate name" fallbacks). Note: a present property
-    /// whose value is null also yields null — same as before.</summary>
+    /// <summary>Property read that tolerates a MISSING property, returning null — used by the
+    /// <c>GetProp(a) ?? GetProp(b)</c> "try alternate name" fallbacks. Note: a present property
+    /// whose value is null also yields null, so the two cases are indistinguishable.</summary>
     public static object GetPropOrNull(object obj, string name)
         => obj?.GetType().GetProperty(name)?.GetValue(obj);
 
@@ -91,7 +89,7 @@ internal static class VsReflection
     }
 
     /// <summary>Field read, including non-public fields (e.g. BufferedFindUsagesContext._state).
-    /// Returns null if the field doesn't exist (matches the current <c>?.GetValue</c> call-sites).</summary>
+    /// Returns null if the field doesn't exist.</summary>
     public static object GetField(object obj, string name,
         BindingFlags flags = BindingFlags.Public | BindingFlags.Instance)
         => obj.GetType().GetField(name, flags)?.GetValue(obj);

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeDiffViewer.Listeners.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeDiffViewer.Listeners.cs
@@ -165,7 +165,6 @@ internal sealed partial class IdeDiffViewer
         void IVsInfoBarUIEvents.OnActionItemClicked(IVsInfoBarUIElement infoBarUIElement, IVsInfoBarActionItem actionItem)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
-            // ActionContext is the token we passed (_accept/_reject).
             if (ReferenceEquals(actionItem.ActionContext, _accept)) { _onAccept?.Invoke(); }
             else if (ReferenceEquals(actionItem.ActionContext, _reject)) { _onReject?.Invoke(); }
             try { infoBarUIElement.Close(); } catch { /* best effort */ }

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.Definition.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.Definition.cs
@@ -142,7 +142,6 @@ internal sealed partial class IdeNavigationService
             if (service == null) { return new NavResult { Supported = false, Reason = "This language has no navigation service." }; }
 
             // GetNavigableItemsAsync(document, position, ct) → Task<ImmutableArray<INavigableItem>>.
-            // The MethodInfo is cached (resolved in EnsureDefProbed), so invoke it directly.
             var task = (Task)_getNavigableItemsAsync.Invoke(service, [document, offset, ct]);
             await task.ConfigureAwait(false);
             var items = (IEnumerable)VsReflection.GetProp(task, "Result");

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.Rename.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.Rename.cs
@@ -110,7 +110,6 @@ internal sealed partial class IdeNavigationService
             if (service == null) { return new RenameResult { Supported = false, Reason = "This language has no rename service." }; }
 
             // 1) GetRenameInfoAsync(document, position, ct) → IInlineRenameInfo.
-            // Cached MethodInfo (resolved in the probe), so invoke it directly.
             var infoTask = (Task)_getRenameInfoAsync.Invoke(service, [document, offset, ct]);
             await infoTask.ConfigureAwait(false);
             var info = VsReflection.GetProp(infoTask, "Result");

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/McpServerHost.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/McpServerHost.cs
@@ -87,7 +87,6 @@ internal sealed partial class McpServerHost
         {
             CleanupOrphanLockFiles(ProfileIdeFolders());
 
-            // Port 0 → OS picks a free ephemeral port.
             var port = AllocateFreePort();
             _listener = new HttpListener();
             _listener.Prefixes.Add($"http://127.0.0.1:{port}/");

--- a/src/Corsinvest.VisualStudio.Agents/Menu/GlobalMenuCommands.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Menu/GlobalMenuCommands.cs
@@ -15,8 +15,8 @@ namespace Corsinvest.VisualStudio.Agents.Menu;
 
 /// <summary>
 /// The entries under View → cv4vs Agents that don't belong to any pane: settings, the data
-/// folder, the output log, docs and feedback, About. They used to live in a pane's toolbar menu,
-/// which meant opening a pane before you could reach them.
+/// folder, the output log, docs and feedback, About. On the View menu rather than a pane's
+/// toolbar, so reaching them doesn't require opening a pane first.
 /// </summary>
 internal static class GlobalMenuCommands
 {

--- a/src/Corsinvest.VisualStudio.Agents/Properties/AssemblyInfo.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Properties/AssemblyInfo.cs
@@ -20,7 +20,6 @@ using System.Windows;
 [assembly: AssemblyCopyright("© Corsinvest Srl 2026")]
 [assembly: ComVisible(false)]
 
-// No version attributes here. This is a legacy csproj, which does not generate an AssemblyInfo, so
-// they used to be written by hand and kept in step with Directory.Build.props by a build check.
-// GenerateVersionAssemblyInfo (Directory.Build.targets) emits them into obj\ instead, from Version
-// — one place to edit, nothing left to drift.
+// No version attributes here. This is a legacy csproj, which does not generate an AssemblyInfo,
+// so GenerateVersionAssemblyInfo (Directory.Build.targets) emits them into obj\ from Version —
+// one place to edit, and nothing here to drift out of step with Directory.Build.props.


### PR DESCRIPTION
A pass over every `.cs`, `.ts` and `.css` file in the extension — 309 files, ~6000 comment lines read — keeping only what the code cannot show.

## The rule applied

Read the code *without* the comment. If the same question comes back, the comment stays.

**Kept:** why something is done the non-obvious way · what an external system actually does (the CLI wire, EnvDTE/COM, WebView2, Lit/Shadow DOM, MSBuild) · traps and ordering constraints · rejected alternatives with their reason · anything resting on a probe, a measurement, a date or a version · units and invariants the type does not state.

**Removed:** restatements of the line below · doc-comments that only re-say the method name · duplicates of a comment already made nearby.

## What actually came out

Not much, and that is the finding: −70 lines across 26 files. There was no `// increment counter`, no empty section banner, no commented-out code. Almost everything removed was a single category — **narration of the code's own history**:

> "matches the previous inline code" · "used to be written by hand" · "was never called anywhere" · "(was SessionPickerPopup's job)" · "are **now** handled by EmitUser"

The reason is what the next reader needs; the chronology is what git already holds. Where a comment mixed the two, only the chronology went — `VsReflection` keeps *a missing member throws* and *hard `(T)` cast*, and loses *"same as before"*.

## Three edits fix a defect rather than remove noise

**`ClaudeClient.cs:592`** — `SetMaxThinkingTokensAsync` carried **two stacked `<summary>` elements**. That is invalid XML doc, so the second block was being dropped silently by the doc pipeline. Both halves say something real (the 31999 budget protocol detail; why a failed hot-swap cannot roll the UI back), so they are merged under one `<summary>` with the second as a `<para>` — nothing discarded.

**`cv-prompt.ts:1089`** — two orphaned doc-blocks stacked above `_setQueue`: one describing a method that no longer exists, one a verbatim copy of `dropQueue`'s own doc fourteen lines below. A reader attributes both to `_setQueue`.

**`cv-app.ts:1416`** — `_isNearBottom`'s doc had drifted onto `_queueJumpUpdate`. **Moved back, not deleted** — it states a real gating rule. Net comment count unchanged.

## Left alone, deliberately

- **SPDX headers** — untouched everywhere.
- **Generated files** — `core/generated/**` and `bridge-messages.ts`.
- **MCP `Description` strings** — those are the model-facing API, not comments.
- **All 4 CSS files** — every comment there is a rejected alternative or an external-system trap (Fluent's `max-width` override, `::part` positioning because `cv-copy-btn` is `display:contents`, why `* { margin:0 }` breaks Fluent shadow padding). Nothing qualified.
- **Everything citing a probe** — `"Verified on CLI 2.1.220"`, `"measured 2026-08-06"`, `"a 661×1385 screenshot … still opened a 769px dialog"`, `"2.5ms vs 8.2ms per pass over a 22k-char reply"`. That knowledge was paid for in probe time and is not recoverable from the code.
- **Comments that look like bug history but justify the code's existence** — `cv-time-ago` / `cv-elapsed` exist as elements *only* because writing `textContent` over a Lit ChildPart marker throws; without the note someone simplifies them and recreates the bug.

## Two follow-ups, not touched here

- **`Editor/CloseTabTool.cs:21`** claims *"Tool name is snake_case (`close_tab`) — fixed by the CLI"*, but `Name` is `editor_close_tab` and the CLI accepts it. The comment is stale, and asserting a protocol constraint the code contradicts is worse than saying nothing.
- **`IdeDiffViewer.cs:71`** has `OpenAsync`'s `<summary>` attached to the `DiffResult` DTO, which therefore carries two consecutive summaries. Deleting it would strip the `FILE_SAVED` / `TAB_CLOSED` / `DIFF_REJECTED` contract; fixing it properly means moving code, which is outside a comments-only change.

## Verification

No code changed — the only non-comment line in the diff is a trailing comment removed from an otherwise identical statement.

| Check | Result |
|---|---|
| `build_solution` | green, 0 errors |
| `npm run typecheck` | clean (both configs) |
| `npm run lint` | 0 errors (7 pre-existing `any` warnings) |
| `npm run format` | no files changed |
| SPDX / generated / MCP Descriptions | verified untouched by diff grep |
