### PR TITLE
feat(chat): copy the Remote Control link, and get out of its way

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/commands/builtin-commands.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/commands/builtin-commands.ts
@@ -109,7 +109,6 @@ export class RemoteControlCommand extends ChatCommand {
     readonly icon = REMOTE_CONTROL_ICON;
     readonly trailing: CommandTrailing = 'toggle';
     override readonly aliases = ['remote', 'rc', 'phone'];
-    readonly keepMenuOpen = true;
     get checked(): boolean {
         return appState.remoteControl.status === 'connected';
     }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-remote-card.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-remote-card.ts
@@ -8,6 +8,7 @@ import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { REMOTE_CONTROL_ICON } from '../../core/commands/builtin-commands';
 import { qrSvg } from '../helpers/qr';
 import { iconStyles } from '../styles/shared';
+import './cv-copy-btn';
 
 /**
  * The Remote Control session link, posted into the transcript when the bridge comes up — the
@@ -73,6 +74,18 @@ export class CvRemoteCard extends LitElement {
             .url {
                 overflow-wrap: anywhere;
             }
+            /* Copying beats selecting a wrapped URL by hand — the link is how you send the
+               session to someone else, which is the one thing the QR cannot do. Aligned to the
+               first line so the button stays put as the URL wraps. */
+            .link-row {
+                display: flex;
+                align-items: flex-start;
+                gap: 4px;
+            }
+            /* cv-copy-btn is display:contents, so the flex item is the button inside its shadow. */
+            .link-row cv-copy-btn::part(button) {
+                flex-shrink: 0;
+            }
         `,
     ];
 
@@ -91,13 +104,16 @@ export class CvRemoteCard extends LitElement {
                         <span>Remote Control is active</span>
                     </div>
                     <div class="hint">Scan to continue in the Claude app, or open the link.</div>
-                    <fluent-link
-                        class="url"
-                        href=${this.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        >${this.url}</fluent-link
-                    >
+                    <div class="link-row">
+                        <fluent-link
+                            class="url"
+                            href=${this.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            >${this.url}</fluent-link
+                        >
+                        <cv-copy-btn .text=${this.url} title="Copy link"></cv-copy-btn>
+                    </div>
                     <div class="hint">It ends when this session restarts.</div>
                 </div>
             </div>


### PR DESCRIPTION
Two small things about the Remote Control card, both about getting the link out of the window and into someone else's hands.

## Copy button on the link

The card posts a QR and the session URL. The QR covers the phone — but sending the link *to someone else*, by mail or chat or to another machine, is the one thing it cannot do, and that meant selecting a URL that wraps across three lines on purpose (`.url` sets `overflow-wrap: anywhere`). Selecting all of it by hand is awkward.

A `cv-copy-btn` now sits next to it, reusing the same component as the diff dialog and the lightbox — `.text` takes the URL directly, so there is no DOM-reading variant involved.

Two details in the CSS:

- `align-items: flex-start` on the row, so the button stays on the first line as the URL wraps under it rather than drifting to the vertical centre of three lines.
- `flex-shrink: 0` goes through **`::part(button)`**. `cv-copy-btn` is `display: contents`, so the flex item is the `<fluent-button>` inside its shadow root, not the custom element — a rule on the element itself would do nothing.

The component is already a `<fluent-button>`, so the `fluent-link href="#"` double-trigger problem (the navigation interceptor firing alongside `@click`) does not apply here.

## The menu no longer stays open

`RemoteControlCommand` dropped `keepMenuOpen`.

The other toggles — Thinking, Fast mode, Switch-on-flag, Effort — keep the menu up because they act in place and you may well want to set several in a row. Remote Control is different in kind: it posts a card into the transcript, and the menu left open was sitting exactly on top of the QR you had just asked for.

## Not done, deliberately

An "ended" echo when the session stops was considered and dropped. The chip disappears from the toolbar, and a stale link simply does nothing when opened — a second transcript entry to say so is noise for a cost that is one click to discover. If someone does get confused by an old link later, it can be added then.

## Verification

`typecheck`, `lint` (0 errors, 7 pre-existing `any` warnings), `format` (no changes) and `build` all clean. Checked in the running chat: the button copies, shows its checkmark, and the menu closes onto the card.
