### PR TITLE
feat(mcp): read and switch the solution configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ own.
 
 - **[Two panes](#two-panes-one-extension)** — a rich WebView2 chat and a real terminal (ConPTY),
   both multi-instance and dockable side by side, each on its own session.
-- **[50+ MCP tools](docs/mcp-tools.md)** — Visual Studio's own navigation, references, rename,
+- **[60+ MCP tools](docs/mcp-tools.md)** — Visual Studio's own navigation, references, rename,
   diagnostics, build and the **live debugger** (breakpoints, stepping, locals, evaluate) handed to
   the agent. Not text search over source: the IDE's semantic, running view of your program.
 - **[Review changes in VS's own diff](docs/chat/diff.md)** — every Edit/Write shows as an inline diff,
@@ -429,7 +429,7 @@ among them — are saved as plain JSON under `%LOCALAPPDATA%`. See
 
 ## MCP tools (the IDE, exposed to Claude)
 
-An in-process MCP server hands the agent Visual Studio's own view of your code — **50+ tools** across
+An in-process MCP server hands the agent Visual Studio's own view of your code — **60+ tools** across
 navigation, editing, build, the live debugger and IDE state — with nothing to configure. They are
 language-agnostic by design: wired through Roslyn language services or language-agnostic VS/DTE
 APIs, never a C#/VB-only path. There is no list of supported languages — whatever your Visual

--- a/docs/marketplace-overview.md
+++ b/docs/marketplace-overview.md
@@ -15,7 +15,7 @@
 drive the IDE itself: build the solution, read the errors, step the debugger, follow references
 through the symbol graph, run the tests.
 
-**50+ MCP tools**, in process — so the agent reads the live state Visual Studio already
+**60+ MCP tools**, in process — so the agent reads the live state Visual Studio already
 holds, not the files on disk.
 
 Visual Studio **2022 and 2026**. Free, GPL-3.0.

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -5,7 +5,7 @@ Visual Studio's own understanding of your code to the agent: navigation, referen
 diagnostics, build and the live debugger. Not a text search over source files — the IDE's semantic,
 running view of your program.
 
-The 50+ tools below are exposed automatically; there is nothing to configure. They are prefixed
+The 61 tools below are exposed automatically; there is nothing to configure. They are prefixed
 `mcp__vs__` on the wire, and appear in the CLI's `/mcp` listing.
 
 **Language-agnostic by design.** Tools are wired through Roslyn's per-document language services
@@ -69,15 +69,17 @@ and it accepts assignments.
 | `document_run_cleanup` | Run the IDE's Code Cleanup on a file (Ctrl+K, Ctrl+E): formatting plus the fixers of the user's default cleanup profile. Richer than document_format, but the extra fixers are language-dependent (C#/VB get the most). The file must live inside the open solution's folder; success=false otherwise. |
 | `document_save` | Save an open file if it has unsaved changes. Returns saved=true if a save happened, false if the file wasn't open or was already saved — the two are not told apart here, document_check_dirty separates them beforehand. Needed after document_format or document_organize_imports, which change the buffer and leave it unsaved. |
 
-## Build (5)
+## Build (7)
 
 | Tool | What it does |
 |---|---|
 | `build_cancel` | Stop the build currently running in the IDE and wait for it to actually stop. Reports ok=true once the IDE is free again — including when nothing was running, since that is the state you asked for; ok=false means the build is still going and the message says why. Use it when build_solution or build_clean reported a timeout (the build was left running), or when a build started outside the chat is in the way. A cancelled build leaves partial outputs, so run build_clean before trusting the next one. |
 | `build_clean` | Clean the entire solution: delete the build outputs (bin/obj) of every project. Blocks until the clean ends. Use it when a build result looks stale, then call build_solution to rebuild — cleaning on its own produces no diagnostics. |
-| `build_project` | Build a single project (by name) in the active configuration and return whether it succeeded plus what the Error List holds (file, line, description, severity). Blocks until done. Reports errors only unless severity says otherwise; the message says how many items were left out. The name is a project name, not a path — ide_get_project_structure lists them. build_solution builds everything instead. |
+| `build_get_configuration` | Get the solution's active configuration — the one build_solution and build_project compile — plus every configuration that can be asked for ('Debug\|Any CPU', 'Release\|Any CPU', …). Takes no arguments and changes nothing. Use it to check what a build will produce, or to see the valid names before build_set_configuration, which is what actually switches it. |
+| `build_project` | Build a single project (by name) in the active configuration and return whether it succeeded plus what the Error List holds (file, line, description, severity). Blocks until done. Reports errors only unless severity says otherwise; the message says how many items were left out, and 'configuration' says which one it built — build_set_configuration changes it. The name is a project name, not a path — ide_get_project_structure lists them. build_solution builds everything instead. |
+| `build_set_configuration` | Switch the solution's active configuration (Debug, Release, …) — the one build_solution and build_project compile and debug_start launches. Pass 'Debug' or 'Release', or the full 'Release\|Any CPU' when a name has several platforms; returns ok plus the resolved configuration, or ok=false with the available ones if the name doesn't match. This is a change to the user's IDE and it persists: the toolbar dropdown moves and their next manual build follows it, so switch only when asked, and say so. build_get_configuration reads the current one, and the valid names, without changing anything. |
 | `build_set_startup_project` | Set the solution's startup project — the one debug_start (F5) launches. Pass the project name; returns ok plus the resolved startup project, or ok=false with the list of available projects if the name doesn't match. |
-| `build_solution` | Build the entire solution and return whether it succeeded plus what the Error List holds (file, line, description, severity). Blocks until the build ends. Reports errors only unless severity says otherwise; the message says how many items were left out. Prefer this to a dotnet build in the shell: it goes through the open IDE, so there is no path to resolve and no clash with a debug session. build_project builds one project instead, and ide_read_output has the raw log when the Error List is not enough. |
+| `build_solution` | Build the entire solution and return whether it succeeded plus what the Error List holds (file, line, description, severity). Blocks until the build ends. Reports errors only unless severity says otherwise; the message says how many items were left out. Prefer this to a dotnet build in the shell: it goes through the open IDE, so there is no path to resolve and no clash with a debug session. Builds whichever configuration the IDE has active and reports it back as 'configuration' — build_set_configuration changes it. build_project builds one project instead, and ide_read_output has the raw log when the Error List is not enough. |
 
 ## Debug (27)
 

--- a/src/Corsinvest.VisualStudio.Agents/Corsinvest.VisualStudio.Agents.csproj
+++ b/src/Corsinvest.VisualStudio.Agents/Corsinvest.VisualStudio.Agents.csproj
@@ -164,6 +164,8 @@
     <Compile Include="Mcp\Tools\Build\CleanSolutionTool.cs" />
     <Compile Include="Mcp\Tools\Build\CancelBuildTool.cs" />
     <Compile Include="Mcp\Tools\Build\SetStartupProjectTool.cs" />
+    <Compile Include="Mcp\Tools\Build\SetConfigurationTool.cs" />
+    <Compile Include="Mcp\Tools\Build\GetConfigurationTool.cs" />
     <Compile Include="Mcp\Tools\Ide\GetProjectStructureTool.cs" />
     <Compile Include="Mcp\Tools\Nav\GoToDefinitionTool.cs" />
     <Compile Include="Mcp\Tools\Nav\FindReferencesTool.cs" />

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.Operations.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.Operations.cs
@@ -164,6 +164,7 @@ internal sealed partial class IdeContextService
                 FailedProjects = failed,
                 Errors = errors,
                 Message = message,
+                Configuration = ActiveConfigurationName(sb),
             };
         }
         catch (Exception ex)
@@ -360,6 +361,116 @@ internal sealed partial class IdeContextService
         }
         dte.Solution.SolutionBuild.StartupProjects = match.UniqueName;
         return (true, match.Name, null);
+    }
+
+    /// <summary>Switch the active solution configuration (Debug, Release, …), the one an
+    /// argument-less build compiles. Accepts either the bare name ("Release") or the name with its
+    /// platform ("Release|Any CPU"); the bare form matches the first platform offered for it.
+    ///
+    /// This changes the IDE for the user, not just for the call: the toolbar dropdown moves and
+    /// stays moved, and their next manual build follows it. That is why it is a tool of its own
+    /// rather than an argument on build_solution — a build that quietly flipped the configuration
+    /// and left it there would be a side effect nobody asked for.</summary>
+    public async Task<(bool Ok, string Configuration, string Reason)> SetConfigurationAsync(string configuration)
+    {
+        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+        var dte = Package.GetGlobalService(typeof(DTE)) as DTE;
+        var sb = dte?.Solution?.SolutionBuild;
+        if (sb == null) { return (false, null, "No solution open."); }
+
+        try
+        {
+            var names = CollectConfigurations(sb, configuration, out var match);
+            if (match == null)
+            {
+                return (false, null, "Configuration not found. Available: " + string.Join(", ", names));
+            }
+
+            match.Activate();
+            return (true, ActiveConfigurationName(sb), null);
+        }
+        catch (Exception ex)
+        {
+            OutputWindowLogger.Global.LogException("Ide.SetConfigurationAsync", ex);
+            return (false, null, $"Could not switch configuration: {ex.Message}");
+        }
+    }
+
+    /// <summary>Report the active solution configuration and the ones that can be asked for.
+    /// Reading this through a build would mean compiling the solution to learn a setting, and
+    /// finding out what exists at all would mean sending a wrong name and reading the error.</summary>
+    public async Task<(bool Ok, string Configuration, string[] Available, string Reason)> GetConfigurationAsync()
+    {
+        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+        var dte = Package.GetGlobalService(typeof(DTE)) as DTE;
+        var sb = dte?.Solution?.SolutionBuild;
+        if (sb == null) { return (false, null, [], "No solution open."); }
+
+        try
+        {
+            var names = CollectConfigurations(sb, null, out _);
+            return (true, ActiveConfigurationName(sb), [.. names], null);
+        }
+        catch (Exception ex)
+        {
+            OutputWindowLogger.Global.LogException("Ide.GetConfigurationAsync", ex);
+            return (false, null, [], $"Could not read the configuration: {ex.Message}");
+        }
+    }
+
+    /// <summary>The solution's configurations as sorted "name|platform" strings, and — when
+    /// <paramref name="wanted"/> is given — the one matching it, by full form or by bare name.
+    ///
+    /// The set is not a tidying-up: SolutionConfigurations repeats a configuration once per
+    /// project that defines it, so a three-project solution offers "Debug|Any CPU" three times.
+    /// Must be called on the UI thread.</summary>
+    private static SortedSet<string> CollectConfigurations(SolutionBuild sb, string wanted, out SolutionConfiguration match)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        var names = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+        match = null;
+        foreach (SolutionConfiguration c in sb.SolutionConfigurations)
+        {
+            // A configuration is (name, platform); SolutionContexts carries the platform, so the
+            // display form is built here rather than read off a single property.
+            var platform = PlatformOf(c);
+            var full = string.IsNullOrEmpty(platform) ? c.Name : $"{c.Name}|{platform}";
+            names.Add(full);
+            if (match == null && !string.IsNullOrEmpty(wanted)
+                && (string.Equals(full, wanted, StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(c.Name, wanted, StringComparison.OrdinalIgnoreCase)))
+            {
+                match = c;
+            }
+        }
+        return names;
+    }
+
+    /// <summary>The platform of a solution configuration, read from its first project context —
+    /// SolutionConfiguration exposes no platform of its own. Empty when it has no projects.</summary>
+    private static string PlatformOf(SolutionConfiguration c)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        try
+        {
+            foreach (SolutionContext sc in c.SolutionContexts) { return sc.PlatformName ?? ""; }
+        }
+        catch (Exception ex)
+        {
+            OutputWindowLogger.Global.Warn($"[ide] could not read the platform of configuration '{c.Name}': {ex.Message}");
+        }
+        return "";
+    }
+
+    /// <summary>Active solution configuration as "name|platform", for reporting what a build
+    /// actually compiled. Null when there is no solution or the IDE won't say.</summary>
+    private static string ActiveConfigurationName(SolutionBuild sb)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        var active = sb?.ActiveConfiguration;
+        if (active == null) { return null; }
+        var platform = PlatformOf(active);
+        return string.IsNullOrEmpty(platform) ? active.Name : $"{active.Name}|{platform}";
     }
 
     // Walks the same solution-folder graph as CollectProject, so it carries the same cycle guard.

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.cs
@@ -684,6 +684,10 @@ internal sealed class BuildResult
     public int FailedProjects { get; set; }
     public string Message { get; set; }
 
+    /// <summary>Solution configuration the build ran under ("Debug|Any CPU"), so the caller can
+    /// tell which one it got — it is the IDE's active one, which the caller did not choose.</summary>
+    public string Configuration { get; set; }
+
     /// <summary>Errors, plus warnings and info when the caller asked for them — one list, each
     /// entry saying what it is, the way ide_get_diagnostics reports the same Error List.</summary>
     public List<BuildError> Errors { get; set; } = [];

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/McpServerHost.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/McpServerHost.cs
@@ -210,6 +210,8 @@ internal sealed partial class McpServerHost
         yield return new Tools.CleanSolutionTool();
         yield return new Tools.CancelBuildTool();
         yield return new Tools.SetStartupProjectTool();
+        yield return new Tools.SetConfigurationTool();
+        yield return new Tools.GetConfigurationTool();
         yield return new Tools.GetProjectStructureTool();
         yield return new Tools.GoToDefinitionTool();
         yield return new Tools.FindReferencesTool();

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Build/BuildProjectTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Build/BuildProjectTool.cs
@@ -29,7 +29,8 @@ internal sealed class BuildProjectTool : McpTool<BuildProjectArgs>
         "Build a single project (by name) in the active configuration and return whether it " +
         "succeeded plus what the Error List holds (file, line, description, severity). Blocks " +
         "until done. Reports errors only unless severity says otherwise; the message says how " +
-        "many items were left out. The name is a project name, not a path — " +
+        "many items were left out, and 'configuration' says which one it built — " +
+        "build_set_configuration changes it. The name is a project name, not a path — " +
         "ide_get_project_structure lists them. build_solution builds everything instead.";
 
     public override bool Idempotent => true;
@@ -41,6 +42,7 @@ internal sealed class BuildProjectTool : McpTool<BuildProjectArgs>
         {
             ok = r.Ok,
             failedProjects = r.FailedProjects,
+            configuration = r.Configuration,
             message = r.Message,
             errors = r.Errors
         };

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Build/BuildSolutionTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Build/BuildSolutionTool.cs
@@ -27,8 +27,10 @@ internal sealed class BuildSolutionTool : McpTool<BuildSolutionArgs>
         "(file, line, description, severity). Blocks until the build ends. Reports errors only " +
         "unless severity says otherwise; the message says how many items were left out. Prefer " +
         "this to a dotnet build in the shell: it goes through the open IDE, so there is no path to " +
-        "resolve and no clash with a debug session. build_project builds one project instead, and " +
-        "ide_read_output has the raw log when the Error List is not enough.";
+        "resolve and no clash with a debug session. Builds whichever configuration the IDE has " +
+        "active and reports it back as 'configuration' — build_set_configuration changes it. " +
+        "build_project builds one project instead, and ide_read_output has the raw log when the " +
+        "Error List is not enough.";
 
     public override bool Idempotent => true;
 
@@ -41,6 +43,7 @@ internal sealed class BuildSolutionTool : McpTool<BuildSolutionArgs>
         {
             ok = r.Ok,
             failedProjects = r.FailedProjects,
+            configuration = r.Configuration,
             message = r.Message,
             errors = r.Errors
         };

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Build/GetConfigurationTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Build/GetConfigurationTool.cs
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using Corsinvest.VisualStudio.Agents.Ide;
+using System.Threading.Tasks;
+
+namespace Corsinvest.VisualStudio.Agents.Mcp.Tools;
+
+/// <summary>MCP tool: report the active solution configuration and the ones available, so the
+/// caller can check or choose one without building the solution to find out.</summary>
+internal sealed class GetConfigurationTool : McpTool<NoArgs>
+{
+    public override string Name => "build_get_configuration";
+    public override string Description =>
+        "Get the solution's active configuration — the one build_solution and build_project " +
+        "compile — plus every configuration that can be asked for ('Debug|Any CPU', " +
+        "'Release|Any CPU', …). Takes no arguments and changes nothing. Use it to check what a " +
+        "build will produce, or to see the valid names before build_set_configuration, which is " +
+        "what actually switches it.";
+
+    public override bool ReadOnly => true;
+    public override bool Idempotent => true;
+
+    protected override async Task<object> InvokeAsync(NoArgs args)
+    {
+        var r = await IdeContextService.Instance.GetConfigurationAsync();
+        return new { ok = r.Ok, configuration = r.Configuration, available = r.Available, reason = r.Reason };
+    }
+}

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Build/SetConfigurationTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Build/SetConfigurationTool.cs
@@ -1,0 +1,45 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using Corsinvest.VisualStudio.Agents.Ide;
+using Newtonsoft.Json;
+using System.ComponentModel.DataAnnotations;
+using System.Threading.Tasks;
+
+namespace Corsinvest.VisualStudio.Agents.Mcp.Tools;
+
+internal sealed class SetConfigurationArgs
+{
+    [Required]
+    [Description("Solution configuration to activate, e.g. 'Debug' or 'Release'. The platform may " +
+                 "be included as 'Release|Any CPU'; without it the first platform offered for that " +
+                 "name is used.")]
+    public string Configuration { get; set; }
+}
+
+/// <summary>MCP tool: switch the active solution configuration. Separate from build_solution
+/// because it changes the IDE for the user and leaves it changed — a build must not have that
+/// as a side effect.</summary>
+internal sealed class SetConfigurationTool : McpTool<SetConfigurationArgs>
+{
+    public override string Name => "build_set_configuration";
+    public override string Description =>
+        "Switch the solution's active configuration (Debug, Release, …) — the one build_solution " +
+        "and build_project compile and debug_start launches. Pass 'Debug' or 'Release', or the " +
+        "full 'Release|Any CPU' when a name has several platforms; returns ok plus the resolved " +
+        "configuration, or ok=false with the available ones if the name doesn't match. This is a " +
+        "change to the user's IDE and it persists: the toolbar dropdown moves and their next " +
+        "manual build follows it, so switch only when asked, and say so. build_get_configuration " +
+        "reads the current one, and the valid names, without changing anything.";
+
+    public override bool Destructive => true;
+    public override bool Idempotent => true;
+
+    protected override async Task<object> InvokeAsync(SetConfigurationArgs args)
+    {
+        var r = await IdeContextService.Instance.SetConfigurationAsync(args.Configuration);
+        return new { ok = r.Ok, configuration = r.Configuration, reason = r.Reason };
+    }
+}


### PR DESCRIPTION
A build went through whichever configuration the IDE happened to have active, and nothing in the exchange said which one. With the toolbar on Release and the caller assuming Debug, there was no way to tell — the errors come back the same shape either way.

## Three changes

**`build_solution` and `build_project` report the configuration they built.**

```json
{ "ok": true, "configuration": "Debug|Any CPU", "failedProjects": 0, … }
```

**`build_get_configuration`** — new, read-only, no arguments. Returns the active configuration *and* the names that can be asked for:

```json
{ "ok": true, "configuration": "Debug|Any CPU", "available": ["Debug|Any CPU", "Release|Any CPU"] }
```

This is the gap that made the tool worth adding. Before it, checking a setting meant **compiling the whole solution** to read one field, and finding out what configurations existed at all meant sending a wrong name and reading the error message — a failure used as a lookup.

**`build_set_configuration`** — switches it. Takes the bare name (`Release`) or the name with its platform (`Release|Any CPU`); the bare form picks the first platform offered for that name, and a name matching nothing comes back with the ones that do.

## Why switching is its own tool

It changes the IDE and leaves it changed: the toolbar dropdown moves, and the user's next manual build follows it. As an argument on `build_solution` that would be a side effect nobody asked for — and `build_solution` is marked idempotent, which it would no longer be.

So the switch is `Destructive`, and its description says plainly that the change persists, that it should only happen when asked, and that `build_get_configuration` is how to look without touching.

## Two details of the EnvDTE shape

**`SolutionConfiguration` has no platform of its own.** It comes off the first `SolutionContext`, so the `name|platform` form is assembled rather than read.

**`SolutionConfigurations` repeats a configuration once per project that defines it.** This solution has three projects, so the first version of the tool offered:

```
Available: Debug|Any CPU, Debug|Any CPU, Debug|Any CPU, Release|Any CPU, Release|Any CPU, Release|Any CPU
```

Six entries for two real choices. The list is now a `SortedSet` — the caller wants the choices, not the multiplicity.

Both tools go through one `CollectConfigurations`, so the names offered are by construction the names accepted. Two copies of that enumeration would eventually disagree, and the disagreement would show up as a valid name being rejected.

## Test

Checked in the experimental instance on this solution:

| Step | Result |
|---|---|
| `build_get_configuration` | `Debug\|Any CPU`, available = 2 entries, no duplicates |
| `build_set_configuration("Release")` | `ok`, resolves to `Release\|Any CPU` |
| `build_get_configuration` | follows the switch — **no build run** |
| `build_set_configuration("Debug")` | back to `Debug\|Any CPU` |
| `build_solution` | reports `configuration` matching the active one |
| `build_set_configuration("NonEsisteQuesta")` | `ok=false`, lists exactly the two real configurations |
| `build_set_configuration("Debug\|Any CPU")` | name-with-platform form resolves |

`build_solution` is green. Docs updated: `mcp-tools.md` (61 tools, Build 6 → 7, the new entry), README and the marketplace listing to `60+`.
