### PR TITLE
chore: write down the C# formatting conventions, and fix what disagreed

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,8 +9,10 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 
 [*.cs]
-# Require accessibility modifiers (private, public, etc.)
-dotnet_style_require_accessibility_modifiers = always:error
+# Require accessibility modifiers (private, public, etc.) — except on interface members, where
+# public is implied and writing it is noise. `always` flagged 76 of them across the three
+# interfaces as errors.
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:error
 
 # Braces on new lines (Allman style)
 csharp_new_line_before_open_brace = all
@@ -23,6 +25,19 @@ csharp_new_line_between_query_expression_clauses = true
 
 # Braces always required
 csharp_prefer_braces = true:error
+
+# File-scoped namespaces (205 of the 253 declarations; the block ones are XAML code-behind).
+csharp_style_namespace_declarations = file_scoped:suggestion
+
+# usings sit above the namespace and are sorted as one alphabetical run — System included, not
+# hoisted to the top. Stating it keeps Remove-and-Sort (Ctrl+R, Ctrl+G) from reordering whatever
+# file someone happens to touch.
+csharp_using_directive_placement = outside_namespace:silent
+dotnet_sort_system_directives_first = false
+dotnet_separate_import_directive_groups = false
+
+# var where the right-hand side already names the type: 279 of them, no exceptions.
+csharp_style_var_when_type_is_apparent = true:suggestion
 
 [*.{js,ts,css,html}]
 indent_size = 2

--- a/src/Corsinvest.VisualStudio.Agents/AgentsPackage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/AgentsPackage.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/FileSuggestions.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/FileSuggestions.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.Payloads.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.Payloads.cs
@@ -7,7 +7,6 @@ using Corsinvest.VisualStudio.Agents.Helpers;
 using Corsinvest.VisualStudio.Agents.Options;
 using Newtonsoft.Json.Linq;
 using System;
-using System.IO;
 
 namespace Corsinvest.VisualStudio.Agents.Chat.Host;
 

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Chat.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Chat.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Cli.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Cli.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Misc.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Misc.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Chat/IconCacheService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/IconCacheService.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatWebView.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatWebView.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Chat/ThumbnailGenerator.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/ThumbnailGenerator.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Cli/Pane/CliPaneControl.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Cli/Pane/CliPaneControl.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.Protocol.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.Protocol.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeInstall.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeInstall.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClientMessages.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClientMessages.cs
@@ -73,7 +73,7 @@ internal static class ClientMessages
         public const string SetPermissionMode = "set_permission_mode";
         public const string SetMaxThinkingTokens = "set_max_thinking_tokens";
         public const string Interrupt = "interrupt";
-        public const string GetUsage= "get_usage";
+        public const string GetUsage = "get_usage";
         public const string GetContextUsage = "get_context_usage";
         public const string RewindFiles = "rewind_files";
         public const string CancelAsyncMessage = "cancel_async_message";

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/NdjsonTransport.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/NdjsonTransport.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Context/ContextProbe.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Context/ContextProbe.cs
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using Corsinvest.VisualStudio.Agents.Contracts;
 using Corsinvest.VisualStudio.Agents.Core.Client;
 using Corsinvest.VisualStudio.Agents.Core.Profiles;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Corsinvest.VisualStudio.Agents.Core.Context;
 

--- a/src/Corsinvest.VisualStudio.Agents/Core/Context/ContextProbe.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Context/ContextProbe.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Context/ContextUsageControl.Render.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Context/ContextUsageControl.Render.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Context/ContextUsageControl.Render.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Context/ContextUsageControl.Render.cs
@@ -166,7 +166,10 @@ public partial class ContextUsageControl
         var name = new StackPanel { Orientation = Orientation.Horizontal };
         name.Children.Add(new Rectangle
         {
-            Width = 10, Height = 10, RadiusX = 2, RadiusY = 2,
+            Width = 10,
+            Height = 10,
+            RadiusX = 2,
+            RadiusY = 2,
             Fill = CvContextPalette.BrushFor(c.Name),
             Margin = new Thickness(0, 0, 8, 0),
             VerticalAlignment = VerticalAlignment.Center,

--- a/src/Corsinvest.VisualStudio.Agents/Core/Context/ContextUsageControl.Render.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Context/ContextUsageControl.Render.cs
@@ -3,6 +3,11 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
+using Corsinvest.VisualStudio.Agents.Contracts;
+using Corsinvest.VisualStudio.Agents.Core.Controls;
+using Corsinvest.VisualStudio.Agents.Core.Stats;
+using Microsoft.VisualStudio.PlatformUI;
+using Microsoft.VisualStudio.Shell;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,11 +15,6 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Documents;
 using System.Windows.Shapes;
-using Corsinvest.VisualStudio.Agents.Contracts;
-using Corsinvest.VisualStudio.Agents.Core.Controls;
-using Corsinvest.VisualStudio.Agents.Core.Stats;
-using Microsoft.VisualStudio.PlatformUI;
-using Microsoft.VisualStudio.Shell;
 
 namespace Corsinvest.VisualStudio.Agents.Core.Context;
 

--- a/src/Corsinvest.VisualStudio.Agents/Core/Context/ContextUsageControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Context/ContextUsageControl.xaml.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Context/ContextUsageControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Context/ContextUsageControl.xaml.cs
@@ -3,16 +3,16 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
+using Corsinvest.VisualStudio.Agents.Contracts;
+using Corsinvest.VisualStudio.Agents.Core.Profiles;
+using Corsinvest.VisualStudio.Agents.Core.Stats;
+using Microsoft.VisualStudio.Shell;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Windows;
 using System.Windows.Controls;
-using Corsinvest.VisualStudio.Agents.Contracts;
-using Corsinvest.VisualStudio.Agents.Core.Profiles;
-using Corsinvest.VisualStudio.Agents.Core.Stats;
-using Microsoft.VisualStudio.Shell;
 
 namespace Corsinvest.VisualStudio.Agents.Core.Context;
 

--- a/src/Corsinvest.VisualStudio.Agents/Core/Context/ContextWindow.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Context/ContextWindow.cs
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
-using System;
-using System.Runtime.InteropServices;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using System;
+using System.Runtime.InteropServices;
 
 namespace Corsinvest.VisualStudio.Agents.Core.Context;
 

--- a/src/Corsinvest.VisualStudio.Agents/Core/Context/ContextWindow.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Context/ContextWindow.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Context/CvMemoryMap.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Context/CvMemoryMap.cs
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
+using Corsinvest.VisualStudio.Agents.Contracts;
+using Corsinvest.VisualStudio.Agents.Core.Stats;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Shapes;
-using Corsinvest.VisualStudio.Agents.Contracts;
-using Corsinvest.VisualStudio.Agents.Core.Stats;
 
 namespace Corsinvest.VisualStudio.Agents.Core.Context;
 

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneAttentionInfoBar.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneAttentionInfoBar.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneAttentionService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneAttentionService.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneControlBase.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneControlBase.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneLauncher.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneLauncher.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneRegistry.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneRegistry.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneToolbar.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneToolbar.xaml.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneWindowBase.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneWindowBase.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Plugins/PluginService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Plugins/PluginService.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Profiles/ProfileStore.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Profiles/ProfileStore.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.Common.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.Common.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.History.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.History.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManagerControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManagerControl.xaml.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/CvBarChart.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/CvBarChart.cs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
+using Microsoft.VisualStudio.PlatformUI;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -11,7 +12,6 @@ using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Media;
 using System.Windows.Shapes;
-using Microsoft.VisualStudio.PlatformUI;
 
 namespace Corsinvest.VisualStudio.Agents.Core.Stats;
 

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/ModelRow.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/ModelRow.cs
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
-using System.Windows.Media;
 using Corsinvest.VisualStudio.Agents.Contracts;
+using System.Windows.Media;
 
 namespace Corsinvest.VisualStudio.Agents.Core.Stats;
 

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/ScopeIconConverter.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/ScopeIconConverter.cs
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
+using Microsoft.VisualStudio.Imaging;
+using Microsoft.VisualStudio.Imaging.Interop;
 using System;
 using System.Globalization;
 using System.Windows.Data;
-using Microsoft.VisualStudio.Imaging;
-using Microsoft.VisualStudio.Imaging.Interop;
 
 namespace Corsinvest.VisualStudio.Agents.Core.Stats;
 

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatisticsControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatisticsControl.xaml.cs
@@ -3,15 +3,15 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
+using Corsinvest.VisualStudio.Agents.Contracts;
+using Corsinvest.VisualStudio.Agents.Core.Profiles;
+using Microsoft.VisualStudio.Shell;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using Corsinvest.VisualStudio.Agents.Contracts;
-using Corsinvest.VisualStudio.Agents.Core.Profiles;
-using Microsoft.VisualStudio.Shell;
 
 namespace Corsinvest.VisualStudio.Agents.Core.Stats;
 

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatisticsControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatisticsControl.xaml.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatisticsWindow.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatisticsWindow.cs
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
+using Microsoft.VisualStudio.Shell;
 using System;
 using System.Runtime.InteropServices;
-using Microsoft.VisualStudio.Shell;
 
 namespace Corsinvest.VisualStudio.Agents.Core.Stats;
 

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatisticsWindow.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatisticsWindow.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsAggregator.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsAggregator.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsCache.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsCache.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsChart.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsChart.cs
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
+using Corsinvest.VisualStudio.Agents.Contracts;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using Corsinvest.VisualStudio.Agents.Contracts;
 
 namespace Corsinvest.VisualStudio.Agents.Core.Stats;
 

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsService.cs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
+using Corsinvest.VisualStudio.Agents.Core.Profiles;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -10,7 +11,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using Corsinvest.VisualStudio.Agents.Core.Profiles;
 
 namespace Corsinvest.VisualStudio.Agents.Core.Stats;
 

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsService.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsTooltip.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsTooltip.cs
@@ -48,7 +48,10 @@ internal static class StatsTooltip
 
             var dot = new Rectangle
             {
-                Width = 9, Height = 9, RadiusX = 2, RadiusY = 2,
+                Width = 9,
+                Height = 9,
+                RadiusX = 2,
+                RadiusY = 2,
                 Margin = new Thickness(0, 0, 6, 0),
                 VerticalAlignment = VerticalAlignment.Center,
                 Fill = FrozenBrush(StatsPalette.ColorAt(seg.ColorIndex)),

--- a/src/Corsinvest.VisualStudio.Agents/Core/Usage/UsageControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Usage/UsageControl.xaml.cs
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
+using Corsinvest.VisualStudio.Agents.Contracts;
+using Corsinvest.VisualStudio.Agents.Core.Profiles;
+using Microsoft.VisualStudio.Shell;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,9 +13,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using Corsinvest.VisualStudio.Agents.Contracts;
-using Corsinvest.VisualStudio.Agents.Core.Profiles;
-using Microsoft.VisualStudio.Shell;
 
 namespace Corsinvest.VisualStudio.Agents.Core.Usage;
 

--- a/src/Corsinvest.VisualStudio.Agents/Core/Usage/UsageControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Usage/UsageControl.xaml.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Usage/UsageMapper.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Usage/UsageMapper.cs
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
+using Corsinvest.VisualStudio.Agents.Contracts;
+using Corsinvest.VisualStudio.Agents.Helpers;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using Corsinvest.VisualStudio.Agents.Contracts;
-using Corsinvest.VisualStudio.Agents.Helpers;
-using Newtonsoft.Json.Linq;
 
 namespace Corsinvest.VisualStudio.Agents.Core.Usage;
 

--- a/src/Corsinvest.VisualStudio.Agents/Core/Usage/UsageProbe.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Usage/UsageProbe.cs
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using Corsinvest.VisualStudio.Agents.Contracts;
 using Corsinvest.VisualStudio.Agents.Core.Client;
 using Corsinvest.VisualStudio.Agents.Core.Profiles;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Corsinvest.VisualStudio.Agents.Core.Usage;
 

--- a/src/Corsinvest.VisualStudio.Agents/Core/Usage/UsageProbe.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Usage/UsageProbe.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Usage/UsageWindow.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Usage/UsageWindow.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Core/Usage/UsageWindow.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Usage/UsageWindow.cs
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
-using System;
-using System.Runtime.InteropServices;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using System;
+using System.Runtime.InteropServices;
 
 namespace Corsinvest.VisualStudio.Agents.Core.Usage;
 

--- a/src/Corsinvest.VisualStudio.Agents/Core/Workspace/WorkspaceStore.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Workspace/WorkspaceStore.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Helpers/ShellHelpers.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Helpers/ShellHelpers.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Helpers/Win32Focus.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Helpers/Win32Focus.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Helpers/WindowChrome.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Helpers/WindowChrome.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.Operations.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.Operations.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.Inspection.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.Inspection.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.cs
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
-using Corsinvest.VisualStudio.Agents.Helpers;
 using EnvDTE;
 using Microsoft.VisualStudio.Shell;
 using System;

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeDiagnosticsTracker.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeDiagnosticsTracker.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeDiffViewer.Listeners.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeDiffViewer.Listeners.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeDiffViewer.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeDiffViewer.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.Definition.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.Definition.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.References.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.References.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.Rename.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.Rename.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.Symbols.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.Symbols.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeOutputService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeOutputService.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/JsonRpcDispatcher.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/JsonRpcDispatcher.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/McpServerHost.LockFile.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/McpServerHost.LockFile.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/McpServerHost.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/McpServerHost.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Build/BuildSolutionTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Build/BuildSolutionTool.cs
@@ -4,7 +4,6 @@
  */
 
 using Corsinvest.VisualStudio.Agents.Ide;
-using System.ComponentModel.DataAnnotations;
 using System.Threading.Tasks;
 
 namespace Corsinvest.VisualStudio.Agents.Mcp.Tools;

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/GetDebugLocalsTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/GetDebugLocalsTool.cs
@@ -4,7 +4,6 @@
  */
 
 using Corsinvest.VisualStudio.Agents.Ide;
-using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Threading.Tasks;
 

--- a/src/Corsinvest.VisualStudio.Agents/Menu/GlobalMenuCommands.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Menu/GlobalMenuCommands.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */

--- a/src/Corsinvest.VisualStudio.Agents/Options/EditorPromptsControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Options/EditorPromptsControl.xaml.cs
@@ -5,7 +5,6 @@
 
 using Corsinvest.VisualStudio.Agents.Editor;
 using System.Collections.ObjectModel;
-using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 


### PR DESCRIPTION
`.editorconfig` stated the brace style and little else, so the rest of the C# formatting rested on Visual Studio's defaults — which are not the same as this code's habits. Anyone with a different editor, or a Remove-and-Sort on a file they were only passing through, would drift.

Three commits, each verifiable on its own.

## `c0dd009` — the UTF-8 BOM

61 of the 213 `.cs` files carried a byte-order mark and the rest did not, depending on how each file happened to be created. `.editorconfig` already asked for `charset = utf-8`, which means *without* a BOM (the other value is `utf-8-bom`), so those files were already disagreeing with the setting the repo declares. Nothing else in the tree has one — TypeScript, CSS, JSON and XAML are clean throughout.

It compiles either way, so this is about the tools around the compiler: `dotnet format` wants to strip the mark, which would otherwise surface as 61 unexplained files in someone else's diff.

One line changed per file, always the first.

## `cd16a4a` — the conventions, written down

Each measured before being written, so the rules describe the code rather than asking it to change:

| Rule | Evidence |
|---|---|
| `csharp_style_namespace_declarations = file_scoped` | 205 of 253 declarations; the block ones are XAML code-behind |
| `dotnet_sort_system_directives_first = false` | 147 files sort as one alphabetical run, 16 hoisted System |
| `csharp_using_directive_placement = outside_namespace` | universal |
| `csharp_style_var_when_type_is_apparent = true` | 279 uses, no exceptions |

**One of these is a fix, not an addition.** `dotnet_style_require_accessibility_modifiers = always:error` was flagging **76 members** across `IClaudeClient`, `IPaneControl` and `IMcpTool` as errors for not writing a modifier the language already implies on interface members. `for_non_interface_members` is the value meant for exactly this — the code was right, the rule was wrong.

The 16 files that sorted `System` first are now sorted like the other 147. Usings only; nothing else moved.

## `6fc8475` — what the rules then found

Five `using` directives nothing referenced, the missing space in `GetUsage= "get_usage"`, and two WPF `Rectangle` initialisers that packed four properties onto one line while the rest of the same object listed one per line.

## Verification

- `build_solution` green — which is also what proves the five removed usings were genuinely dead
- `dotnet format style --verify-no-changes` passes clean, zero violations
- EOL normalised to LF after each tooling pass: `dotnet format` writes CRLF, and this repo is `eol=lf`, so without that step the diffs are unreadable

## A warning worth recording

**Do not run plain `dotnet format` on this repo.** It runs the analyzers, and on this codebase they wanted to:

- rename a public method (`IsFileVisible` → `IsFileVisibleAsync`) and rewrite its call sites
- insert ~50 `ThrowIfNotOnUIThread()` calls, **including one inside a `System.Threading.Timer` callback** — which runs on a pool thread, so that "formatting fix" would have thrown on every tick

`dotnet format style` and `dotnet format whitespace` skip the analyzers and are the safe ones.

## Left out deliberately

411 object initialisers sit on a single line, 84 of them over 120 characters and the worst at 183 — mostly WPF element construction in `CvDonut`, `CvHeatmap` and `IdeDebugService`. Breaking those is a real change to a lot of lines and belongs in its own pass, not in a commit about `.editorconfig`. No rule can do it either: C# has no line-width setting, so `.editorconfig` governs where things go once you break a line, never whether to break it.
