### PR TITLE
fix(chat): left-align the permission label that wraps

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-permission-banner.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-permission-banner.ts
@@ -198,6 +198,14 @@ export class CvPermissionBanner extends LitElement {
             }
             #permission-buttons fluent-button {
                 justify-content: flex-start;
+                /* The number sits on the first line of a label that wraps, not centred against
+                 * the whole block. */
+                align-items: baseline;
+                /* Fluent sizes the button for one line, so a wrapped label ended up touching the
+                 * border. height:auto is what gives the padding somewhere to go. */
+                height: auto;
+                padding-top: 6px;
+                padding-bottom: 6px;
             }
             /* Question Submit/Cancel: centred (no number badge like permission choices). */
             #permission-buttons.question-actions fluent-button {
@@ -244,9 +252,17 @@ export class CvPermissionBanner extends LitElement {
             }
             /* Wraps the suggestion label so "Yes, allow …", "for" and the clickable
              * scope flow as normal inline text (the fluent-button slot would otherwise
-             * flex-gap the spans and swallow the spaces between words). */
+             * flex-gap the spans and swallow the spaces between words).
+             *
+             * block + text-align:left because Fluent centres its content part, and a label
+             * long enough to wrap had its second line centred under the first — the tail of
+             * a sentence reading as an element of its own. The number stays OUTSIDE this
+             * span, as it is on the other two buttons, so the wrapped lines line up with the
+             * text rather than under the digit. */
             .label {
                 white-space: normal;
+                display: block;
+                text-align: left;
             }
             /* Clickable scope word inside "Yes, allow … for {scope}". Clicking it
              * cycles the scope (session/project/…) without confirming the choice. */
@@ -1020,8 +1036,8 @@ export class CvPermissionBanner extends LitElement {
                                   appearance=${this._scopeActive ? 'primary' : 'outline'}
                                   @click=${() => this._onAllowWith(suggestion)}
                               >
+                                  <span class="num">${n++}</span>
                                   <span class="label">
-                                      <span class="num">${n++}</span>
                                       ${this._suggestionLabel(suggestion)}${
                                           suggestion.type !== 'setMode'
                                               ? html` for


### PR DESCRIPTION
The permission suggestion button — `Yes, allow Bash(cd "K:/…") for this project (just you)` — wraps in a narrow pane, and its second line came out centred under the first. The tail of a sentence read as an element of its own, which is exactly what the clickable scope span is not.

Fluent centres its content part and the label inherited that. `Yes` and `No` never showed it because they never wrap.

## What changed

Three things, because the obvious one alone is not enough:

- **`text-align: left` on `.label`** — straightens the text.
- **`.num` moved out of `.label`**, to be a sibling as it already is on the other two buttons. Left inside, the wrapped lines started under the digit instead of under the first word.
- **`align-items: baseline`** on the button, so the number stays on the first line rather than centring against the whole block.

Plus a little vertical padding and `height: auto`: Fluent sizes these buttons for a single line, so a wrapped label sat against the border.

## Tried and rejected

Both checked in DevTools on the real button before touching the CSS:

- `display: flex` on the label — turns `for` and the scope span into flex items and scatters them across the width. The comment above the rule warns about precisely this.
- A hanging indent (`padding-left` + negative `text-indent`) — pushed the number outside the button's border, while the unwrapped buttons kept theirs inside.

The computed style confirmed the diagnosis: `text-align: center` both inherited on `.label` and on Fluent's own `content` part, but overridable from ordinary CSS — no `::part()` needed.

## Verification

Checked in the experimental instance with the pane narrow enough to wrap and wide enough not to, on all three buttons.
