### PR TITLE
feat(chat): show backgrounded sub-agents in the chip, on one clock

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents.Contracts/BridgeGenerationSpec.cs
+++ b/src/Corsinvest.VisualStudio.Agents.Contracts/BridgeGenerationSpec.cs
@@ -47,6 +47,11 @@ public class BridgeGenerationSpec : GenerationSpec
             .Member(x => nameof(x.Summary)).Null()
             .Member(x => nameof(x.ToolUseId)).Null();
         AddInterface<SubagentEndedNotification>();
+        // Both optional: a patch carries only the fields that changed.
+        AddInterface<SubagentUpdatedNotification>()
+            .Member(x => nameof(x.Status)).Null()
+            .Member(x => nameof(x.Description)).Null();
+        AddInterface<BackgroundTasksNotification>();
         AddInterface<CompactedNotification>();
         AddInterface<StatusNotification>();
         AddInterface<CliExitedNotification>();
@@ -188,6 +193,7 @@ public class BridgeGenerationSpec : GenerationSpec
         AddInterface<GetImageRequest>().Member(x => nameof(x.SessionId)).Optional();
         AddInterface<GetCompactSummaryRequest>().Member(x => nameof(x.SessionId)).Optional();
         AddInterface<SubagentCancelNotification>();
+        AddInterface<SubagentDetachNotification>();
         // getHistory always sends sessionId → keep it required-nullable.
         AddInterface<GetHistoryRequest>().Member(x => nameof(x.SessionId)).Null();
         AddInterface<GetUsageRequest>();

--- a/src/Corsinvest.VisualStudio.Agents.Contracts/FromWebViewDtos.cs
+++ b/src/Corsinvest.VisualStudio.Agents.Contracts/FromWebViewDtos.cs
@@ -102,6 +102,16 @@ public class SubagentCancelNotification
     public string TaskId { get; set; }
 }
 
+/// <summary>Detach one running sub-agent from the turn (chat_subagent_detach), so the turn stops
+/// waiting on it while it carries on.
+/// <para>Keyed by ToolUseId rather than TaskId, unlike cancel above: the CLI's request takes the
+/// originating tool_use block, not the task. A sub-agent whose launching row never arrived has
+/// none, and cannot be detached.</para></summary>
+public class SubagentDetachNotification
+{
+    public string ToolUseId { get; set; }
+}
+
 /// <summary>Load a page of transcript history (chat_get_history). beforeOffset = -1 for
 /// the initial page, else the byte offset to page older content above (default -1 so an
 /// absent value behaves like the initial page, matching the old data.Val default).</summary>

--- a/src/Corsinvest.VisualStudio.Agents.Contracts/ToWebViewDtos.cs
+++ b/src/Corsinvest.VisualStudio.Agents.Contracts/ToWebViewDtos.cs
@@ -152,6 +152,32 @@ public class SubagentEndedNotification
     public string Status { get; set; }
 }
 
+/// <summary>Which sub-agents are running in the background, as ids (background_tasks_changed).
+/// <para>Ids only, deliberately: the rows themselves — description, tools, tokens, duration —
+/// come from the task_started/task_progress pair and are already tracked. This says which of
+/// those to file under "background", nothing more.</para>
+/// <para>REPLACE semantics: the whole set every time, so the receiver swaps rather than merges.
+/// Empty means none. The CLI emits nothing at startup, so an empty set is also the right state
+/// after a restart.</para></summary>
+public class BackgroundTasksNotification
+{
+    public string[] TaskIds { get; set; } = [];
+}
+
+/// <summary>A change to a sub-agent already being tracked (task_updated): a new status, or a
+/// renamed description.
+/// <para>A patch on the task the started/progress pair already built, not a new one. Fields the
+/// CLI did not send stay null — the wire patch carries only what changed.</para>
+/// <para>The patch also carries is_backgrounded, which is NOT taken: it only ever describes a
+/// foreground task being pushed down, and the CLI's asynchronous agents are background from
+/// birth, so it never arrives for them. BackgroundTasksNotification is what says which are.</para></summary>
+public class SubagentUpdatedNotification
+{
+    public string TaskId { get; set; }
+    public string Status { get; set; }
+    public string Description { get; set; }
+}
+
 /// <summary>Context was compacted (chat_compacted): tokens before/after.</summary>
 public class CompactedNotification
 {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/BridgeMessages.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/BridgeMessages.cs
@@ -101,6 +101,9 @@ internal static class BridgeMessages
             public const string GetSubagent = "get_subagent";
             public const string SubagentCancel = "subagent_cancel";
             public const string SubagentCancelAll = "subagent_cancel_all";
+            /// <summary>Detach one sub-agent from the turn, so the turn stops waiting on it. Keyed
+            /// by toolUseId, which is what the CLI takes. One-way.</summary>
+            public const string SubagentDetach = "subagent_detach";
             public const string GetCompactSummary = "get_compact_summary";
         }
 
@@ -187,6 +190,12 @@ internal static class BridgeMessages
             public const string SubagentEnded = "subagent_ended";
             /// <summary>Turn ended — clear all active sub-agents (safety against a missed end).</summary>
             public const string SubagentClear = "subagent_clear";
+            /// <summary>A tracked sub-agent changed: a new status, or a new description. A patch
+            /// on an existing one, not a new task.</summary>
+            public const string SubagentUpdated = "subagent_updated";
+            /// <summary>The ids of the sub-agents currently running in the background. The whole
+            /// set every time — replace, do not merge.</summary>
+            public const string BackgroundTasks = "background_tasks";
             /// <summary>Response to get_compact_summary: a compaction's full summary text.</summary>
             public const string CompactSummaryResult = "compact_summary_result";
         }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Chat.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Chat.cs
@@ -199,6 +199,12 @@ internal sealed partial class WebViewMessageHandler
         }
     }
 
+    private void HandleSubagentDetach(JObject data, int? id)
+    {
+        var toolUseId = data.ToObject<Contracts.SubagentDetachNotification>().ToolUseId ?? "";
+        if (!string.IsNullOrEmpty(toolUseId)) { _ = client?.DetachTaskAsync(toolUseId); }
+    }
+
     private void HandleSubagentCancelAll(JObject data, int? id)
     {
         // The UI knows the active taskIds; it sends one cancel per id. As a fallback,

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.cs
@@ -111,6 +111,10 @@ internal sealed partial class WebViewMessageHandler(WebViewBridge bridge,
                 HandleSubagentCancelAll(data, id);
                 break;
 
+            case BridgeMessages.FromWebView.Chat.SubagentDetach:
+                HandleSubagentDetach(data, id);
+                break;
+
             case BridgeMessages.FromWebView.Chat.GetHistory:
                 HandleGetHistory(data, id);
                 break;

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.ClientEvents.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.ClientEvents.cs
@@ -556,6 +556,22 @@ public partial class ChatPaneControl
                     },
                 });
             }
+            else if (subtype == ClientMessages.SystemSubtype.TaskUpdated)
+            {
+                // A patch on a task the chip is already showing — backgrounding does not start a
+                // new one. Only what the chip renders is forwarded; the rest of the patch
+                // (end_time, total_paused_ms, error) has nowhere to go yet.
+                //
+                // Sent whether or not either is present: a patch about a task we never saw start
+                // is dropped on the other side, which is cheaper than reasoning about it here.
+                var patch = obj["patch"] as JObject;
+                _bridge.Send(BridgeMessages.ToWebView.Chat.SubagentUpdated, new Contracts.SubagentUpdatedNotification
+                {
+                    TaskId = obj.Val("task_id", ""),
+                    Status = patch?.Val("status", (string)null),
+                    Description = patch?.Val("description", (string)null),
+                });
+            }
             else if (subtype == ClientMessages.SystemSubtype.TaskNotification)
             {
                 _bridge.Send(BridgeMessages.ToWebView.Chat.SubagentEnded, new Contracts.SubagentEndedNotification
@@ -617,7 +633,20 @@ public partial class ChatPaneControl
                 // Authoritative active-agent list. Track whether any are running so a `result` that
                 // ends the MAIN turn (while async agents outlive it) doesn't fire a premature
                 // "finished" — we notify only when this is empty (updates on finish AND on cancel).
-                _hasBackgroundTasks = obj["tasks"] is JArray tasks && tasks.Count > 0;
+                var tasks = obj["tasks"] as JArray;
+                _hasBackgroundTasks = tasks != null && tasks.Count > 0;
+
+                // Forwarded as a set of ids, which is all it carries. task_updated's
+                // is_backgrounded covers only a foreground task being pushed down, and the agents
+                // the CLI launches asynchronously never make that transition — they are background
+                // from birth, so that flag never arrived and the chip filed them under the wrong
+                // heading. This list has them from the first moment.
+                _bridge.Send(BridgeMessages.ToWebView.Chat.BackgroundTasks, new Contracts.BackgroundTasksNotification
+                {
+                    TaskIds = tasks?.Select(t => t.Val("task_id", ""))
+                                    .Where(s => !string.IsNullOrEmpty(s))
+                                    .ToArray() ?? [],
+                });
             }
             else if (subtype == ClientMessages.SystemSubtype.Informational)
             {
@@ -783,6 +812,14 @@ public partial class ChatPaneControl
             // Workdir is fixed on the entry at creation; only the attached session changes here.
             // Track it so the History picker marks the live session with a ✓ (CLI sets it too).
             Entry.ActiveSessionId = e.SessionId;
+
+            // Background tasks belong to the process that was running them. The CLI emits nothing
+            // at startup — the level signal only speaks when membership CHANGES — so a set left
+            // over from the previous process would stand until the next task started.
+            _hasBackgroundTasks = false;
+            _bridge.Send(BridgeMessages.ToWebView.Chat.BackgroundTasks,
+                         new Contracts.BackgroundTasksNotification());
+
             // The banner only needs the "process is back up" signal to clear its error — it reads
             // no payload, so send a bare notification.
             _bridge.Send(BridgeMessages.ToWebView.Cli.Started, null);

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/bridge-messages.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/bridge-messages.ts
@@ -58,6 +58,7 @@ export const Msg = {
             getSubagent: 'get_subagent',
             subagentCancel: 'subagent_cancel',
             subagentCancelAll: 'subagent_cancel_all',
+            subagentDetach: 'subagent_detach',
             getCompactSummary: 'get_compact_summary',
         },
         ui: {
@@ -112,6 +113,8 @@ export const Msg = {
             subagentProgress: 'subagent_progress',
             subagentEnded: 'subagent_ended',
             subagentClear: 'subagent_clear',
+            subagentUpdated: 'subagent_updated',
+            backgroundTasks: 'background_tasks',
             compactSummaryResult: 'compact_summary_result',
         },
         ui: {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated/BackgroundTasksNotification.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated/BackgroundTasksNotification.ts
@@ -1,0 +1,8 @@
+/**
+ * This is a TypeGen auto-generated file.
+ * Any changes made to this file can be lost when this file is regenerated.
+ */
+
+export interface BackgroundTasksNotification {
+    taskIds: string[];
+}

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated/SubagentDetachNotification.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated/SubagentDetachNotification.ts
@@ -1,0 +1,8 @@
+/**
+ * This is a TypeGen auto-generated file.
+ * Any changes made to this file can be lost when this file is regenerated.
+ */
+
+export interface SubagentDetachNotification {
+    toolUseId: string;
+}

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated/SubagentUpdatedNotification.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated/SubagentUpdatedNotification.ts
@@ -1,0 +1,10 @@
+/**
+ * This is a TypeGen auto-generated file.
+ * Any changes made to this file can be lost when this file is regenerated.
+ */
+
+export interface SubagentUpdatedNotification {
+    taskId: string;
+    status: string | null;
+    description: string | null;
+}

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/tick.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/tick.ts
@@ -1,0 +1,85 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+/**
+ * One second-clock for the whole WebView, for the badges that count upwards.
+ *
+ * Every running sub-agent draws two of those — one in its transcript row, one in the chip — so a
+ * per-component timer means twice as many as there are agents, each started whenever its element
+ * happened to mount. That showed: the same task's two badges read 28s and 29s at the same moment,
+ * because their intervals had drifted apart. Sharing the tick makes them equal by construction.
+ *
+ * The subscription IS the reference count. There is no counter to keep in step with the
+ * subscribers, so a component that forgets nothing but its own unsubscribe cannot leave the timer
+ * running: when the last one goes, so does it.
+ *
+ * Not for one-shot delays (a "copied" label resetting, a notice dismissing itself): those want
+ * their own precise timeout, and rounding them to a second would only make them late.
+ */
+
+type Listener = () => void;
+
+/** What onTick hands back: call it to stop being ticked. Named so the field holding it reads as
+ *  something to call rather than as an anonymous `() => void`. */
+export type UnsubscribeTick = () => void;
+
+const listeners = new Set<Listener>();
+let timer = 0;
+
+function fire(): void {
+    // Copied first: a listener that unsubscribes while being notified would otherwise mutate the
+    // set under the iteration.
+    for (const fn of [...listeners]) {
+        fn();
+    }
+}
+
+function start(): void {
+    if (timer || listeners.size === 0 || document.hidden) {
+        return;
+    }
+    timer = window.setInterval(fire, 1000);
+}
+
+function stop(): void {
+    if (!timer) {
+        return;
+    }
+    clearInterval(timer);
+    timer = 0;
+}
+
+// A pane sitting behind another one for an hour has nothing to redraw, and its badges are read
+// again only when it comes back — so the clock stops with the pane and the first tick on return
+// catches everything up. Done here once rather than in every component, which is why none of them
+// did it.
+document.addEventListener('visibilitychange', () => {
+    if (document.hidden) {
+        stop();
+    } else {
+        fire();
+        start();
+    }
+});
+
+/**
+ * Call `fn` about once a second. Returns the unsubscribe — call it from `disconnectedCallback`,
+ * or whenever the badge stops needing a clock.
+ *
+ * The unsubscribe is returned rather than offered as an offTick(fn), because that one only works
+ * if the caller hands back the very same function object: an arrow written twice is two functions,
+ * and the delete would miss silently, leaving exactly the stuck timer this module exists to avoid.
+ * It is also the shape bridge.onNotification already uses throughout the WebView.
+ */
+export function onTick(fn: Listener): UnsubscribeTick {
+    listeners.add(fn);
+    start();
+    return () => {
+        listeners.delete(fn);
+        if (listeners.size === 0) {
+            stop();
+        }
+    };
+}

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/types.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/types.ts
@@ -75,6 +75,8 @@ export type { GetImageRequest } from './generated/GetImageRequest';
 export type { SubagentStartedNotification } from './generated/SubagentStartedNotification';
 export type { SubagentProgressNotification } from './generated/SubagentProgressNotification';
 export type { SubagentEndedNotification } from './generated/SubagentEndedNotification';
+export type { SubagentUpdatedNotification } from './generated/SubagentUpdatedNotification';
+export type { BackgroundTasksNotification } from './generated/BackgroundTasksNotification';
 export type { SubagentUsageDto } from './generated/SubagentUsageDto';
 
 /** Context compaction (`chat_compacted`, header-only: uuid/trigger/preTokens) and CLI process
@@ -193,6 +195,7 @@ export type { GetSuggestionsRequest } from './generated/GetSuggestionsRequest';
 export type { ToolOutputNotification } from './generated/ToolOutputNotification';
 export type { GetSubagentRequest } from './generated/GetSubagentRequest';
 export type { SubagentCancelNotification } from './generated/SubagentCancelNotification';
+export type { SubagentDetachNotification } from './generated/SubagentDetachNotification';
 export type { GetHistoryRequest } from './generated/GetHistoryRequest';
 export type { GetUsageRequest } from './generated/GetUsageRequest';
 export type { UsageDto } from './generated/UsageDto';
@@ -274,6 +277,14 @@ export interface SubagentTask {
     recentTools: string[]; // last 3 tool names — at(-1) is what it is doing now
     summary?: string;
     usage: SubagentUsageDto;
+    /** Running in the background, so it outlives the turn that launched it. Set from the
+     *  authoritative id list (background_tasks_changed), not from task_updated's is_backgrounded:
+     *  that flag only ever describes a foreground task being pushed down, and the agents the CLI
+     *  launches asynchronously are background from birth — measured, they never emit it. */
+    background?: boolean;
+    /** Last status the CLI reported for it — 'paused' and 'killed' have no other way in. Undefined
+     *  until a patch carries one. */
+    status?: string;
     /** The task that launched this one, undefined at top level. The wire carries no parent link,
      *  so it is derived from where the launching row sits in the entry tree; it settles once that
      *  row has arrived (the task can beat it by a few ms). */

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
@@ -48,6 +48,8 @@ import type {
     SubagentStartedNotification,
     SubagentProgressNotification,
     SubagentEndedNotification,
+    SubagentUpdatedNotification,
+    BackgroundTasksNotification,
     CompactedNotification,
     EvictMessagesNotification,
     StatusNotification,
@@ -99,6 +101,10 @@ export class CvApp extends LitElement {
     /** Groups for the current tree, keyed by the array they were built from. */
     private _groupCache: { src: readonly UiEntry[]; groups: UiEntry[][] } | null = null;
     @state() private _subagentTasks = new Map<string, SubagentTask>();
+
+    /** Ids the CLI last reported as running in the background. Not @state: it decides what a task
+     *  is created with, and the map above is what the view renders. */
+    private _backgroundTaskIds = new Set<string>();
     @state() private _isBusy = appState.isBusy;
     @state() private _status = appState.status;
     /** A permission/Ask prompt is awaiting the user → hide the "waiting" spinner
@@ -510,6 +516,12 @@ export class CvApp extends LitElement {
                 appState.hasMoreHistory = false;
                 appState.loadingOlder = false;
                 appState.contextUsage = null;
+                // The chip's tasks belonged to the session that just went. Left alone they would
+                // hang in the composer with no transcript under them, and their end notifications
+                // would land on a session that no longer exists.
+                this._subagentTasks = new Map();
+                this._backgroundTaskIds = new Set();
+                appState.subagentTasks = [];
                 // The CLI's advisories are about the session that just went away ("session model
                 // could not be restored"), so they'd read as stale against the new one. The dead-CLI
                 // row is about the process instead: it survives, and cli_started clears it.
@@ -712,6 +724,11 @@ export class CvApp extends LitElement {
                         recentTools: [],
                         usage: { totalTokens: 0, toolUses: 0, durationMs: 0 },
                         startedAt: Date.now(),
+                        // Asked here rather than waited for: the list naming this task arrives
+                        // BEFORE the task itself — measured 19ms earlier — so a row that only ever
+                        // got marked by a later list would sit under the wrong heading until one
+                        // happened to come, and for the last task launched, never.
+                        background: this._backgroundTaskIds.has(d.taskId),
                     });
                     this._subagentTasks = m;
                     this._publishSubagentTasks(m);
@@ -788,6 +805,56 @@ export class CvApp extends LitElement {
                     m.delete(d.taskId);
                     this._subagentTasks = m;
                     this._publishSubagentTasks(m);
+                },
+            ),
+        );
+        this._offs.push(
+            bridge.onNotification<SubagentUpdatedNotification>(
+                Msg.toWebView.chat.subagentUpdated,
+                (d) => {
+                    // A patch on a task already here. One we never saw start is not ours to invent:
+                    // the CLI backgrounds Bash commands too, and those have no sub-agent row.
+                    const prev = d?.taskId ? this._subagentTasks.get(d.taskId) : undefined;
+                    if (!prev) {
+                        return;
+                    }
+                    const m = new Map(this._subagentTasks);
+                    m.set(d.taskId, {
+                        ...prev,
+                        // Only what the patch carried: the wire sends the fields that changed, and
+                        // a missing one means unchanged, not absent.
+                        status: d.status ?? prev.status,
+                        description: d.description ?? prev.description,
+                    });
+                    this._subagentTasks = m;
+                    this._publishSubagentTasks(m);
+                },
+            ),
+        );
+        this._offs.push(
+            bridge.onNotification<BackgroundTasksNotification>(
+                Msg.toWebView.chat.backgroundTasks,
+                (d) => {
+                    // The authoritative set, so it is applied to every tracked task rather than
+                    // merged: one that drops off the list is no longer in the background, and one
+                    // never seen here never was. Ids only — the row's own figures stay untouched.
+                    const ids = new Set(d?.taskIds ?? []);
+                    // Kept for the tasks that have not arrived yet: this message beats
+                    // subagent_started to the WebView, so the set has to outlive the call.
+                    this._backgroundTaskIds = ids;
+                    let changed = false;
+                    const m = new Map(this._subagentTasks);
+                    for (const [id, t] of m) {
+                        const background = ids.has(id);
+                        if (background !== !!t.background) {
+                            m.set(id, { ...t, background });
+                            changed = true;
+                        }
+                    }
+                    if (changed) {
+                        this._subagentTasks = m;
+                        this._publishSubagentTasks(m);
+                    }
                 },
             ),
         );
@@ -1744,6 +1811,10 @@ export class CvApp extends LitElement {
                 }
                 ${this._exchanges.map((group) => this.renderExchange(group))}
                 ${
+                    // Only the main turn. Sub-agents outliving it are the chip's job — it sits in
+                    // the composer with a live count whether or not a turn is running, and it says
+                    // WHAT is working, which a spinner cannot. Lighting the spinner for them would
+                    // promise a reply that is not coming.
                     this._isBusy && !this._awaitingUser
                         ? html`<cv-spinner .status=${this._status}></cv-spinner>`
                         : nothing

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-elapsed.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-elapsed.ts
@@ -5,6 +5,7 @@
 import { LitElement, html, css } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { formatDuration } from '../helpers/format';
+import { onTick, type UnsubscribeTick } from '../../core/tick';
 
 /**
  * The running clock on an Agent row, advancing once a second while the sub-agent works.
@@ -46,7 +47,7 @@ export class CvElapsed extends LitElement {
     /** The clock the badge was last drawn against. Bumping it is what re-renders the text. */
     @state() private _now = Date.now();
 
-    private _timer = 0;
+    private _unsubscribeTick?: UnsubscribeTick;
 
     override connectedCallback() {
         super.connectedCallback();
@@ -59,24 +60,27 @@ export class CvElapsed extends LitElement {
     }
 
     override updated() {
-        // startedAt arrives (or is cleared) by property, so the timer follows it rather than the
-        // element's lifetime: a row can be built before its task is known.
+        // startedAt arrives (or is cleared) by property, so the subscription follows it rather than
+        // the element's lifetime: a row can be built before its task is known.
         this._sync();
     }
 
     private _sync(): void {
-        if (this.startedAt > 0 && !this._timer) {
-            this._timer = window.setInterval(() => {
+        if (this.startedAt > 0 && !this._unsubscribeTick) {
+            // The shared clock, not one of our own: a running sub-agent draws this badge twice —
+            // transcript row and chip — and two intervals started seconds apart showed the same
+            // task as 28s in one place and 29s in the other.
+            this._unsubscribeTick = onTick(() => {
                 this._now = Date.now();
-            }, 1000);
-        } else if (this.startedAt <= 0 && this._timer) {
+            });
+        } else if (this.startedAt <= 0 && this._unsubscribeTick) {
             this._stop();
         }
     }
 
     private _stop(): void {
-        clearInterval(this._timer);
-        this._timer = 0;
+        this._unsubscribeTick?.();
+        this._unsubscribeTick = undefined;
     }
 
     override render() {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-spinner.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-spinner.ts
@@ -6,6 +6,7 @@ import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import type { SpinnerVerbsConfigDto } from '../../core/types';
 import { formatDurationSec } from '../helpers/format';
+import { onTick, type UnsubscribeTick } from '../../core/tick';
 
 // Verbs the spinner cycles; replace/extend via setVerbsConfig at runtime.
 const DEFAULT_VERBS: readonly string[] = [
@@ -87,7 +88,6 @@ const FRAMES: readonly string[] = [...STAR_GROW, ...[...STAR_GROW].reverse()];
 const FRAME_INTERVAL_MS = 120;
 const VERB_MIN_MS = 2000;
 const VERB_MAX_MS = 5000;
-const ELAPSED_INTERVAL_MS = 1000;
 
 let _activeVerbs: readonly string[] = DEFAULT_VERBS;
 
@@ -166,31 +166,38 @@ export class CvSpinner extends LitElement {
 
     private _frameTimer = 0;
     private _verbTimer = 0;
-    private _elapsedTimer = 0;
+    private _unsubscribeTick?: UnsubscribeTick;
     private _startedAt = 0;
 
     override connectedCallback(): void {
         super.connectedCallback();
         let i = 0;
+        // The frames stay on their own timer: at 120ms they are an animation, and rounding them to
+        // the shared second would turn the spinner into a stutter.
         this._frameTimer = window.setInterval(() => {
             i = (i + 1) % FRAMES.length;
             this._frame = FRAMES[i];
         }, FRAME_INTERVAL_MS);
         this._scheduleNextVerb();
-        // performance.now(): monotonic, so a system-clock change mid-turn can't make the
-        // counter jump or go backwards. The element is created when the turn starts and
-        // destroyed when it ends, so mount time IS the turn start and needs no reset.
+        // performance.now(): monotonic, so a system-clock change mid-turn can't make the counter
+        // jump or go backwards. The element is created when the turn starts and destroyed when it
+        // ends, so mount time IS the turn start and needs no reset.
+        //
+        // The shared tick only says WHEN to recompute; the value still comes from performance.now(),
+        // so the monotonic guarantee survives while this second counts in step with the elapsed
+        // badges beside it instead of drifting against them.
         this._startedAt = performance.now();
-        this._elapsedTimer = window.setInterval(() => {
+        this._unsubscribeTick = onTick(() => {
             this._elapsedSec = Math.floor((performance.now() - this._startedAt) / 1000);
-        }, ELAPSED_INTERVAL_MS);
+        });
     }
 
     override disconnectedCallback(): void {
         super.disconnectedCallback();
         clearInterval(this._frameTimer);
         clearTimeout(this._verbTimer);
-        clearInterval(this._elapsedTimer);
+        this._unsubscribeTick?.();
+        this._unsubscribeTick = undefined;
     }
 
     private _scheduleNextVerb(): void {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-subagent-chip.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-subagent-chip.ts
@@ -8,6 +8,7 @@ import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import Bot16Regular from '@fluentui/svg-icons/icons/bot_16_regular.svg';
 import Stop16Filled from '@fluentui/svg-icons/icons/stop_16_filled.svg';
 import ArrowMinimize16Regular from '@fluentui/svg-icons/icons/arrow_minimize_16_regular.svg';
+import './cv-elapsed';
 import { formatTokens, formatDuration } from '../helpers/format';
 import { bridge } from '../../core/bridge';
 import { Msg } from '../../core/bridge-messages';
@@ -144,6 +145,14 @@ export class CvSubagentChip extends LitElement {
                 color: var(--colorNeutralForeground3);
                 font-variant-numeric: tabular-nums;
             }
+            /* cv-elapsed carries its own badge styling for the transcript row it was written for —
+               a left margin and a dimmer size. Here it is a column in a grid-like row, so those
+               are overridden rather than added to what .time already sets. */
+            cv-elapsed.time {
+                margin-left: 0;
+                font-size: 0.85em;
+                opacity: 1;
+            }
             /* Stop / Stop-all are <fluent-button> — keep them pure; only layout here. */
             .stopall,
             .stop {
@@ -265,7 +274,16 @@ export class CvSubagentChip extends LitElement {
                     <span class="v">${formatTokens(t.usage.totalTokens)}</span> tok
                 </div>
             </div>
-            <span class="time">${formatDuration(t.usage.durationMs)}</span>
+            <!-- A running clock, not the total the sub-agent reports: that one only moves when it
+                 reports a tool use, so between two tools the number sat still for as long as the
+                 call took. cv-elapsed derives it from startedAt and ticks on its own; a task with
+                 no startedAt (one that arrived before we tracked it) keeps the reported figure,
+                 which is at least honest about being a total. -->
+            ${
+                t.startedAt
+                    ? html`<cv-elapsed class="time" .startedAt=${t.startedAt}></cv-elapsed>`
+                    : html`<span class="time">${formatDuration(t.usage.durationMs)}</span>`
+            }
             <!-- Only on rows still attached to the turn. The CLI answers backgrounded:false when
                  there is nothing to detach, so offering it on one already down would be a button
                  that does nothing. -->

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-subagent-chip.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-subagent-chip.ts
@@ -7,11 +7,16 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import Bot16Regular from '@fluentui/svg-icons/icons/bot_16_regular.svg';
 import Stop16Filled from '@fluentui/svg-icons/icons/stop_16_filled.svg';
+import ArrowMinimize16Regular from '@fluentui/svg-icons/icons/arrow_minimize_16_regular.svg';
 import { formatTokens, formatDuration } from '../helpers/format';
 import { bridge } from '../../core/bridge';
 import { Msg } from '../../core/bridge-messages';
 import { iconStyles, statusDotStyles } from '../styles/shared';
-import type { SubagentTask, SubagentCancelNotification } from '../../core/types';
+import type {
+    SubagentTask,
+    SubagentCancelNotification,
+    SubagentDetachNotification,
+} from '../../core/types';
 
 /** A pulsing chip in the input row showing the count of active sub-agents.
  *  Hidden when none. Click opens a light-dismiss popover (like the permission
@@ -81,6 +86,18 @@ export class CvSubagentChip extends LitElement {
                 font-size: 1.1em;
                 font-weight: var(--fontWeightSemibold);
                 margin-bottom: 10px;
+            }
+            /* The second section's heading: quieter than the first, and spaced away from the rows
+             * above so the two groups read apart without a rule between them. */
+            .head.sub {
+                font-size: 1em;
+                margin-top: 12px;
+                color: var(--colorNeutralForeground3);
+            }
+            /* Nothing above it to be separated from — every task is in the background, which is
+               the common case once the CLI has launched them all asynchronously. */
+            .head.sub.first {
+                margin-top: 0;
             }
             .row {
                 display: flex;
@@ -216,9 +233,66 @@ export class CvSubagentChip extends LitElement {
         }
     }
 
+    /** Keyed by toolUseId, which is what the CLI's request takes — a task whose launching row
+     *  never arrived has none, and the button is not offered for it. */
+    private _detach(toolUseId: string) {
+        bridge.sendNotification<SubagentDetachNotification>(Msg.fromWebView.chat.subagentDetach, {
+            toolUseId,
+        });
+    }
+
     private _toggle = (): void => {
         this._open = !this._open;
     };
+
+    /** One task row. Identical for both sections — a backgrounded sub-agent is the same task with
+     *  the same figures, still running, which is the whole reason it is worth showing. */
+    private _row(t: SubagentTask, indents: Map<string, number>) {
+        const indent = indents.get(t.taskId);
+        const paused = t.status === 'paused';
+        // Read out once so the handler below can use it without an assertion.
+        const detachable = t.background ? undefined : t.toolUseId;
+        return html`<div class="row" style=${indent ? `padding-left:${indent}px` : ''}>
+            <!-- The blinking dot means "working"; a paused task keeps the neutral one, which is
+                 the same distinction the spinner makes. -->
+            <span class="cv-dot ${paused ? '' : 'active'}" title=${paused ? 'Paused' : ''}></span>
+            <div class="main">
+                <div class="desc" title=${this._desc(t)}>${this._desc(t)}</div>
+                <div class="meta">
+                    <span class="now">${t.recentTools[t.recentTools.length - 1] ?? '—'}</span>
+                    <span class="v">${t.usage.toolUses}</span>
+                    ${t.usage.toolUses === 1 ? 'tool' : 'tools'} ·
+                    <span class="v">${formatTokens(t.usage.totalTokens)}</span> tok
+                </div>
+            </div>
+            <span class="time">${formatDuration(t.usage.durationMs)}</span>
+            <!-- Only on rows still attached to the turn. The CLI answers backgrounded:false when
+                 there is nothing to detach, so offering it on one already down would be a button
+                 that does nothing. -->
+            ${
+                detachable
+                    ? html`<fluent-button
+                          class="stop"
+                          appearance="transparent"
+                          size="small"
+                          title="Run in the background — the turn stops waiting for it"
+                          aria-label="Run in the background"
+                          @click=${() => this._detach(detachable)}
+                          >${unsafeHTML(ArrowMinimize16Regular)}</fluent-button
+                      >`
+                    : nothing
+            }
+            <fluent-button
+                class="stop"
+                appearance="transparent"
+                size="small"
+                title="Stop"
+                aria-label="Stop"
+                @click=${() => this._stop(t.taskId)}
+                >${unsafeHTML(Stop16Filled)}</fluent-button
+            >
+        </div>`;
+    }
 
     override render() {
         const n = this.tasks.length;
@@ -226,6 +300,11 @@ export class CvSubagentChip extends LitElement {
             return nothing;
         }
         const indents = this._indents();
+        // Two sections rather than two tabs: the question the chip answers is "is anything still
+        // running", and a tab would hide half the answer behind a click. The background one only
+        // appears when there is something in it, so the usual case looks unchanged.
+        const foreground = this.tasks.filter((t) => !t.background);
+        const background = this.tasks.filter((t) => t.background);
         return html`<fluent-button
                 id="cv-subagent-chip-btn"
                 class="chip"
@@ -246,6 +325,9 @@ export class CvSubagentChip extends LitElement {
             </fluent-button>
             <div id="cv-subagents-popover" class="popover" ?hidden=${!this._open}>
                 <div class="head">
+                    <!-- The total, matching the badge — not the foreground count. Everything in
+                         here is a sub-agent; "Background" below is a subset of it, not a rival
+                         category, and Stop all acts on the lot. -->
                     <span>Sub-agents (${n})</span>
                     <fluent-button
                         class="stopall"
@@ -257,40 +339,15 @@ export class CvSubagentChip extends LitElement {
                         <span>Stop all</span>
                     </fluent-button>
                 </div>
-                ${this.tasks.map(
-                    (t) =>
-                        html`<div
-                            class="row"
-                            style=${
-                                indents.get(t.taskId)
-                                    ? `padding-left:${indents.get(t.taskId)}px`
-                                    : ''
-                            }
-                        >
-                            <span class="cv-dot active"></span>
-                            <div class="main">
-                                <div class="desc" title=${this._desc(t)}>${this._desc(t)}</div>
-                                <div class="meta">
-                                    <span class="now"
-                                        >${t.recentTools[t.recentTools.length - 1] ?? '—'}</span
-                                    >
-                                    <span class="v">${t.usage.toolUses}</span>
-                                    ${t.usage.toolUses === 1 ? 'tool' : 'tools'} ·
-                                    <span class="v">${formatTokens(t.usage.totalTokens)}</span> tok
-                                </div>
-                            </div>
-                            <span class="time">${formatDuration(t.usage.durationMs)}</span>
-                            <fluent-button
-                                class="stop"
-                                appearance="transparent"
-                                size="small"
-                                title="Stop"
-                                aria-label="Stop"
-                                @click=${() => this._stop(t.taskId)}
-                                >${unsafeHTML(Stop16Filled)}</fluent-button
-                            >
-                        </div>`,
-                )}
+                ${foreground.map((t) => this._row(t, indents))}
+                ${
+                    background.length > 0
+                        ? html`<div class="head sub ${foreground.length === 0 ? 'first' : ''}">
+                                  <span>Background (${background.length})</span>
+                              </div>
+                              ${background.map((t) => this._row(t, indents))}`
+                        : nothing
+                }
             </div>`;
     }
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-thinking.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-thinking.ts
@@ -6,6 +6,7 @@ import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { renderMarkdown } from '../../core/markdown';
+import { onTick, type UnsubscribeTick } from '../../core/tick';
 import { formatTokenCount, formatDuration } from '../helpers/format';
 import { statusDotStyles } from '../styles/shared';
 import ChevronDown16Regular from '@fluentui/svg-icons/icons/chevron_down_16_regular.svg';
@@ -33,22 +34,24 @@ export class CvThinking extends LitElement {
     /** Re-render tick while streaming. Only a clock: the elapsed value is derived from startedAt,
      *  so a missed tick shows the right number late, never a wrong one. */
     @state() private _now = 0;
-    private _timer = 0;
+    private _unsubscribeTick?: UnsubscribeTick;
 
     override disconnectedCallback(): void {
         super.disconnectedCallback();
-        clearInterval(this._timer);
+        this._unsubscribeTick?.();
+        this._unsubscribeTick = undefined;
     }
 
-    /** Runs the tick only while the block is open-ended: a finished thought has durationMs and
-     *  needs no clock, and the element outlives the streaming (it stays in the transcript). */
+    /** Subscribes only while the block is open-ended: a finished thought has durationMs and needs
+     *  no clock, and the element outlives the streaming (it stays in the transcript) — so this
+     *  follows `streaming`, not the element's lifetime. */
     override updated(): void {
         const wants = this.streaming && this.startedAt > 0;
-        if (wants && !this._timer) {
-            this._timer = window.setInterval(() => (this._now = Date.now()), 1000);
-        } else if (!wants && this._timer) {
-            clearInterval(this._timer);
-            this._timer = 0;
+        if (wants && !this._unsubscribeTick) {
+            this._unsubscribeTick = onTick(() => (this._now = Date.now()));
+        } else if (!wants && this._unsubscribeTick) {
+            this._unsubscribeTick();
+            this._unsubscribeTick = undefined;
         }
     }
 

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.cs
@@ -624,6 +624,15 @@ internal sealed partial class ClaudeClient : IClaudeClient
     public Task StopTaskAsync(string taskId)
         => SendControlRequestAsync(ClientMessages.ControlSubtype.StopTask, new { task_id = taskId });
 
+    /// <summary>Detach a running task from the turn: the blocking tool call returns at once and the
+    /// turn carries on, while the task keeps going and reports its end as usual.
+    /// <para>Keyed by tool_use_id, not task_id — that is what the CLI takes here. Omitting it
+    /// detaches every foreground task, which is what Ctrl+B does in the terminal.</para>
+    /// <para>One-way: there is no request that brings a task back into the turn.</para></summary>
+    public Task DetachTaskAsync(string toolUseId = null)
+        => SendControlRequestAsync(ClientMessages.ControlSubtype.DetachTask,
+                                   toolUseId == null ? null : new { tool_use_id = toolUseId });
+
     /// <summary>
     /// Asks the CLI to generate a short AI title for the current session, based on <paramref name="description"/>
     /// (typically the first user prompt). If <paramref name="persist"/> is true the CLI writes the title to the JSONL itself;

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClientMessages.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClientMessages.cs
@@ -42,6 +42,9 @@ internal static class ClientMessages
         public const string CommandsChanged = "commands_changed";
         public const string TaskStarted = "task_started";
         public const string TaskProgress = "task_progress";
+        // Patch on a running task: the subset of its state that changed (status, is_backgrounded…).
+        // A task always starts in the foreground, so being backgrounded arrives only here.
+        public const string TaskUpdated = "task_updated";
         public const string TaskNotification = "task_notification";
         // Authoritative list of the session's active background tasks (agents). Empty `tasks` = none
         // running — the reliable signal for "everything, main + agents, is finished".
@@ -84,6 +87,14 @@ internal static class ClientMessages
         public const string McpToggle = "mcp_toggle";
         public const string McpStatus = "mcp_status";
         public const string StopTask = "stop_task";
+        // Detach a running task from the turn: the blocking tool call returns at once and the turn
+        // carries on, while the task keeps going and reports its end as usual. With a tool_use_id,
+        // only that one; without, all of them — the CLI's own Ctrl+B.
+        //
+        // Named for what it does, because the wire value does not: "background_tasks" here is a
+        // VERB (detach these), one underscore away from the background_tasks_changed EVENT (here
+        // is the list), and the two mean opposite things. One-way — nothing brings a task back.
+        public const string DetachTask = "background_tasks";
         public const string ApplyFlagSettings = "apply_flag_settings";
         public const string GetSettings = "get_settings";
         public const string GenerateSessionTitle = "generate_session_title";

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/IClaudeClient.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/IClaudeClient.cs
@@ -75,6 +75,10 @@ public interface IClaudeClient : IDisposable
     Task RewindFilesAsync(string userMessageId);
     Task StopTaskAsync(string taskId);
 
+    /// <summary>Detach a running task from the turn — keyed by tool_use_id, unlike the stop above.
+    /// One-way: nothing brings it back.</summary>
+    Task DetachTaskAsync(string toolUseId = null);
+
     /// <summary>Generates a short AI title for the session via CLI (uses Haiku under the hood).</summary>
     Task<string> GenerateSessionTitleAsync(string description, bool persist = false);
 


### PR DESCRIPTION
Sub-agents that outlive the turn had nowhere to be seen: three of them still working while the chat looked finished. The chip is what answers "is anything running" — it sits in the composer with a live count whether or not a turn is in flight — but it could not say which of its rows were left running in the background, and the times on those rows had stopped moving.

## Which ones are in the background

From `background_tasks_changed`, the authoritative id list.

`task_updated` carries an `is_backgrounded` flag that looks like the obvious source and is not: it only ever describes a *foreground* task being pushed down, and the agents the CLI launches asynchronously — `run_in_background: true` on the Agent call — are background from birth. Measured over a full session: that flag never arrived once, while the list named every task from the moment it started.

The list also beats the task it names to the WebView, by about 19ms. Read only as a patch over what is already tracked, it therefore missed the row that had not been created yet — which is how a task ended up filed under the wrong heading, showing a detach button that answered `backgrounded: false`. One bug wearing three faces. The set is now kept and consulted when the row is built.

## The chip

Background renders as a section under the foreground rows rather than a second tab: a tab hides half the answer behind a click. Its heading counts the whole set, because that is what the badge says and what *Stop all* acts on — Background is a subset, not a rival category.

Also taken from `task_updated`: `status`, so a paused task keeps the neutral dot instead of blinking as if it were working, and `description`, which the chip renders and the patch can change.

Two resets, both missing before:

- `chat_cleared` empties the chip. Its tasks belonged to the session that just went, and their end notifications would land on one that no longer exists. This was already broken before this branch — the only reset was `subagent_clear`, a message with no emitters.
- The CLI restarting empties it too. The level signal says nothing at startup, so a set from the previous process would stand until the next task happened to start.

The spinner is deliberately left alone. It belongs to the main turn, and lighting it for work that outlives the turn would promise a reply that is not coming.

## One clock

The durations stood still while the agents worked: `formatDuration(usage.durationMs)` is the total the sub-agent *reports*, which only advances when it reports a tool use. Between two tools the number sat where it was — 28s and 53s, frozen, on screen.

`cv-elapsed` already solved this for the transcript's Agent row, so the chip now uses it too. But every running sub-agent then draws that badge twice, once in each place, and each kept its own interval started whenever its element happened to mount. The two drifted: the same task read 28s in one place and 29s in the other, side by side.

`core/tick.ts` is a single second-clock they subscribe to. The subscription *is* the reference count — there is no counter to keep in step, so a component that forgets nothing but its own unsubscribe cannot leave the timer running, and with no subscribers there is no timer at all. It also stops while the pane is hidden and catches up on return, which a WebView sitting behind other tabs all day wants and no per-component timer did.

Converted: `cv-elapsed`, `cv-thinking`, and the spinner's elapsed — that last one still reads `performance.now()` for the value, so its monotonic guarantee survives while the second falls in step with the badges beside it.

Left alone, deliberately: the spinner's 120ms frames and verb rotation (an animation and a random cadence, not a clock); `cv-time-ago`, hidden until hover and recomputed on `mouseenter` — subscribing it would recalculate dozens of invisible stamps every second; and the one-shot timeouts in `cv-copy-btn` and `cv-notice-stack`, which are deadlines, not clocks.

## Verified

In the experimental instance, with three sub-agents running: rows filed under Background from the first frame, times advancing, the same task showing the same number in the chip and in its transcript row, and the chip emptying on a new chat.
