### PR TITLE
fix(chat): the @ picker's ignore rules never matched what they were written to match

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/FileSuggestions.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/FileSuggestions.cs
@@ -37,13 +37,8 @@ internal static class FileSuggestions
             // The workspace rules are the bottom of the stack; EnumerateFiles pushes a nested
             // .gitignore onto it for the subtree that declares one.
             var ignores = new List<(string Root, GitIgnore Ignore)>();
-            using (OutputWindowLogger.Global.PerfSpan("[picker] gitignore load"))
-            {
-                var ignore = opts.UseGitIgnore ? GitIgnoreCache.Get(root) : null;
-                if (ignore != null) { ignores.Add((root, ignore)); }
-            }
-            GitIgnore.ResetStats();
-            if (ignores.Count > 0) { GitIgnore.CountFile(); }
+            var ignore = opts.UseGitIgnore ? GitIgnoreCache.Get(root) : null;
+            if (ignore != null) { ignores.Add((root, ignore)); }
 
             // Backslashes accepted as separators so a path pasted from Explorer still matches.
             var qLower = query.Replace('\\', '/').ToLowerInvariant();
@@ -119,20 +114,11 @@ internal static class FileSuggestions
 
             result.AddRange(hits.Values);
 
-            // rows/visited say how much of the tree the budget bought, and capped says whether the
-            // list is the whole tree or a prefix of the alphabet. regex/path is the multiplier the
-            // rules cost — it went from 201 to ~150 when the negations moved into their own list,
-            // and it is the number to watch if a big repository ever feels slow again.
-            // rules[] names the shape of what was parsed: neg>0 and files>1 only appear on a build
-            // that keeps negations and reads nested files, which is what tells a measurement of
-            // this code from one of a stale copy still installed alongside it.
-            var (ignoreCalls, ignoreRegex) = GitIgnore.Stats;
-            var last = result.Count > 0 ? result[result.Count - 1].Name : "-";
-            var shape = ignores.Count > 0 ? $"{ignores[0].Ignore.Shape},files={GitIgnore.FilesConsulted}" : "off";
+            // capped is the one worth reporting: it says the list is a prefix of the alphabet
+            // rather than the whole tree, which is how a folder late in the alphabet goes missing
+            // with nothing else to show for it.
             OutputWindowLogger.Global.Perf(() =>
-                $"[picker] rules[{shape}] rows={result.Count} visited={visited} capped={cappedBy ?? "no"} "
-                + $"ignore: calls={ignoreCalls} regex={ignoreRegex} "
-                + $"({(ignoreCalls > 0 ? (double)ignoreRegex / ignoreCalls : 0):0.0}/path) last={last}");
+                $"[picker] rows={result.Count} visited={visited} capped={cappedBy ?? "no"}");
         }
         catch (Exception ex) { OutputWindowLogger.Global.LogException("FileSuggestions.Get", ex); }
         return result;
@@ -185,7 +171,7 @@ internal static class FileSuggestions
             // A .gitignore here applies to this subtree only, so it is pushed for the descent and
             // popped after: the list is shared down the recursion rather than copied per level.
             var nested = GitIgnoreCache.GetNested(sub);
-            if (nested != null) { ignores.Add((sub, nested)); GitIgnore.CountFile(); }
+            if (nested != null) { ignores.Add((sub, nested)); }
             foreach (var file in EnumerateFiles(sub, root, configured, ignores))
             {
                 yield return file;
@@ -428,38 +414,6 @@ internal sealed class GitIgnore
         return false;
     }
 
-    // Counters for the picker's perf line: paths tested, and regex matches that cost. Plain
-    // statics because one Get() walks on one thread and reads them at the end; they are a
-    // diagnostic, so a lost increment would misreport nothing that matters.
-    private static int _calls;
-    private static int _regexRuns;
-
-    /// <summary>Nested .gitignore files pushed during the walk, plus the workspace one. Counted
-    /// where they are read rather than where they are used: one increment per directory entered
-    /// costs nothing, while marking each instance as it answers would put bookkeeping on the
-    /// per-path path.</summary>
-    private static int _filesConsulted;
-
-    internal static int FilesConsulted => _filesConsulted;
-
-    /// <summary>Record that a .gitignore joined the stack.</summary>
-    internal static void CountFile() => _filesConsulted++;
-
-    /// <summary>Zero the counters at the start of a walk.</summary>
-    internal static void ResetStats() { _calls = 0; _regexRuns = 0; _filesConsulted = 0; }
-
-    /// <summary>What this instance parsed, for the picker's perf line. A build that still drops
-    /// negations cannot report neg&gt;0, so the shape says which code is answering — a stale copy
-    /// of the extension otherwise reports numbers that look entirely plausible.</summary>
-    internal string Shape
-        => $"n={_excludes.Count + _negations.Count},neg={_negations.Count},"
-         + $"dir={_excludes.Count(p => p.DirOnly) + _negations.Count(p => p.DirOnly)}";
-
-    /// <summary>Paths tested, regex matches run, and milliseconds spent inside
-    /// <see cref="Matches"/> since <see cref="ResetStats"/>. Two counters rather than a timer:
-    /// the regex count is what the per-pattern work multiplies, and reading a clock twice per
-    /// path costs more than the thing it was measuring.</summary>
-    internal static (int Calls, int RegexRuns) Stats => (_calls, _regexRuns);
 
     public static GitIgnore Parse(string content)
     {
@@ -562,14 +516,12 @@ internal sealed class GitIgnore
         var rel = PathHelpers.Relative(root, fullPath);
         if (rel.Length == 0) { return false; }
 
-        _calls++;
         var name = NameOf(rel);
 
         var matched = false;
         foreach (var p in _excludes)
         {
             if (p.DirOnly && !isDirectory) { continue; }
-            _regexRuns++;
             if (p.Regex.IsMatch(p.NameOnly ? name : rel)) { matched = true; ignored = true; break; }
         }
         // Negations are only consulted for a path something excluded — except that a nested file's
@@ -577,7 +529,6 @@ internal sealed class GitIgnore
         foreach (var p in _negations)
         {
             if (p.DirOnly && !isDirectory) { continue; }
-            _regexRuns++;
             if (p.Regex.IsMatch(p.NameOnly ? name : rel)) { matched = true; ignored = false; break; }
         }
         return matched;

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/FileSuggestions.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/FileSuggestions.cs
@@ -24,14 +24,26 @@ internal static class FileSuggestions
 {
     public static List<FileSuggestionItem> Get(string root, string query)
     {
+        using var _ = OutputWindowLogger.Global.PerfSpan($"FileSuggestions.Get(q={query?.Length ?? 0} chars)");
         var result = new List<FileSuggestionItem>();
         try
         {
             if (!Directory.Exists(root)) { return result; }
 
             var opts = AgentsOptions.Chat;
-            var patterns = ParsePatterns(opts.IgnoredPatterns);
-            var ignore = opts.UseGitIgnore ? GitIgnoreCache.Get(root) : null;
+            // The picker's own rules, read from their file and parsed by the same .gitignore
+            // parser as the workspace's — one syntax, and the one already written in every repo.
+            var configured = GitIgnoreCache.GetConfigured();
+            // The workspace rules are the bottom of the stack; EnumerateFiles pushes a nested
+            // .gitignore onto it for the subtree that declares one.
+            var ignores = new List<(string Root, GitIgnore Ignore)>();
+            using (OutputWindowLogger.Global.PerfSpan("[picker] gitignore load"))
+            {
+                var ignore = opts.UseGitIgnore ? GitIgnoreCache.Get(root) : null;
+                if (ignore != null) { ignores.Add((root, ignore)); }
+            }
+            GitIgnore.ResetStats();
+            if (ignores.Count > 0) { GitIgnore.CountFile(); }
 
             // Backslashes accepted as separators so a path pasted from Explorer still matches.
             var qLower = query.Replace('\\', '/').ToLowerInvariant();
@@ -45,8 +57,11 @@ internal static class FileSuggestions
             // what the recursive walk now produces.
             var hits = new SortedList<string, FileSuggestionItem>(StringComparer.OrdinalIgnoreCase);
             var visited = 0;
+            // Which budget ended the walk, if either — the alphabetical cut it implies is why a
+            // folder late in the alphabet can be missing entirely.
+            string cappedBy = null;
 
-            foreach (var file in EnumerateFiles(root, root, patterns, ignore))
+            foreach (var file in EnumerateFiles(root, root, configured, ignores))
             {
                 // This runs on every keystroke, so the walk is bounded by how much of the tree it
                 // touches, not by how deep it goes: depth is what hides files, sheer volume is what
@@ -56,7 +71,11 @@ internal static class FileSuggestions
                 // tail of directories whose contents had all been dropped — `tools/cli-probe/` and
                 // nothing under it. Alphabetical order means the cut lands wherever it lands, which
                 // is the trade any capped file picker makes.
-                if (hits.Count >= MaxRows || ++visited > MaxVisited) { break; }
+                if (hits.Count >= MaxRows || ++visited > MaxVisited)
+                {
+                    cappedBy = hits.Count >= MaxRows ? nameof(MaxRows) : nameof(MaxVisited);
+                    break;
+                }
 
                 var rel = PathHelpers.Relative(root, file);
                 // Matched against the whole query, not just the part after the last slash: the
@@ -99,6 +118,21 @@ internal static class FileSuggestions
             }
 
             result.AddRange(hits.Values);
+
+            // rows/visited say how much of the tree the budget bought, and capped says whether the
+            // list is the whole tree or a prefix of the alphabet. regex/path is the multiplier the
+            // rules cost — it went from 201 to ~150 when the negations moved into their own list,
+            // and it is the number to watch if a big repository ever feels slow again.
+            // rules[] names the shape of what was parsed: neg>0 and files>1 only appear on a build
+            // that keeps negations and reads nested files, which is what tells a measurement of
+            // this code from one of a stale copy still installed alongside it.
+            var (ignoreCalls, ignoreRegex) = GitIgnore.Stats;
+            var last = result.Count > 0 ? result[result.Count - 1].Name : "-";
+            var shape = ignores.Count > 0 ? $"{ignores[0].Ignore.Shape},files={GitIgnore.FilesConsulted}" : "off";
+            OutputWindowLogger.Global.Perf(() =>
+                $"[picker] rules[{shape}] rows={result.Count} visited={visited} capped={cappedBy ?? "no"} "
+                + $"ignore: calls={ignoreCalls} regex={ignoreRegex} "
+                + $"({(ignoreCalls > 0 ? (double)ignoreRegex / ignoreCalls : 0):0.0}/path) last={last}");
         }
         catch (Exception ex) { OutputWindowLogger.Global.LogException("FileSuggestions.Get", ex); }
         return result;
@@ -106,123 +140,83 @@ internal static class FileSuggestions
 
     /// <summary>Rows shown, files and derived directories together. Deliberately generous: the walk
     /// is alphabetical, so a low cap does not sample the tree, it stops partway through and hides
-    /// everything from there to the end of the alphabet — `tools/` never showed up. Bounded all the
-    /// same: cv-popover-list renders every row it is given, with no virtualisation.</summary>
-    private const int MaxRows = 600;
+    /// everything from there to the end of the alphabet — at 600 this repository's own `tools/` was
+    /// cut, 31 rows short of the 631 it produces. Bounded all the same: cv-popover-list renders
+    /// every row it is given, with no virtualisation.
+    /// <para>Affordable at this size only because the ignore rules now prune what they always meant
+    /// to: the same walk was 1,165 files and ~1.4s of pattern matching before the character classes
+    /// were fixed, and is 563 files and ~190ms after.</para></summary>
+    private const int MaxRows = 2000;
 
     /// <summary>Files the walk will look at before giving up, ignored ones excluded. Guards the
     /// per-keystroke cost on a huge tree; it is not a depth limit.</summary>
     private const int MaxVisited = 20000;
 
     /// <summary>Files under <paramref name="dir"/>, at any depth, ignored ones left out.
-    /// Directories are pruned rather than filtered so their contents cost nothing.</summary>
-    private static IEnumerable<string> EnumerateFiles(string dir, string root, List<IgnorePattern> patterns, GitIgnore ignore)
+    /// Directories are pruned rather than filtered so their contents cost nothing.
+    /// <para><paramref name="ignores"/> holds the workspace rules plus one entry for every
+    /// <c>.gitignore</c> on the way down, each paired with the directory it was read from — its
+    /// patterns are relative to that directory, not to the workspace. The walk is already
+    /// recursive, so a nested file costs one lookup when its directory is entered rather than a
+    /// search per path. Without this, `WebViewSrc/.gitignore` went unread and its `dist/` — named
+    /// nowhere else — put 13 build artefacts in the menu.</para></summary>
+    private static IEnumerable<string> EnumerateFiles(
+        string dir, string root, GitIgnore configured, List<(string Root, GitIgnore Ignore)> ignores)
     {
         foreach (var file in Directory.GetFiles(dir).OrderBy(a => a, StringComparer.OrdinalIgnoreCase))
         {
-            if (IsIgnored(Path.GetFileName(file), file, root, isDir: false, patterns, ignore)) { continue; }
+            if (IsIgnored(file, root, isDir: false, configured, ignores)) { continue; }
             yield return file;
         }
 
         foreach (var sub in Directory.GetDirectories(dir).OrderBy(a => a, StringComparer.OrdinalIgnoreCase))
         {
-            if (IsIgnored(Path.GetFileName(sub), sub, root, isDir: true, patterns, ignore)) { continue; }
-            foreach (var file in EnumerateFiles(sub, root, patterns, ignore))
+            // An excluded directory is still walked when a `!` rule names something inside it:
+            // `.vscode/*` with `!.vscode/settings.json` means the directory goes, its settings
+            // file stays, and pruning here would take the file with it. The files inside are
+            // filtered individually, so only what the negations rescue comes back.
+            if (IsIgnored(sub, root, isDir: true, configured, ignores)
+                && !ignores.Any(x => x.Ignore.KeepsSubtree(sub, x.Root))
+                && configured?.KeepsSubtree(sub, root) != true)
+            {
+                continue;
+            }
+
+            // A .gitignore here applies to this subtree only, so it is pushed for the descent and
+            // popped after: the list is shared down the recursion rather than copied per level.
+            var nested = GitIgnoreCache.GetNested(sub);
+            if (nested != null) { ignores.Add((sub, nested)); GitIgnore.CountFile(); }
+            foreach (var file in EnumerateFiles(sub, root, configured, ignores))
             {
                 yield return file;
             }
+            if (nested != null) { ignores.RemoveAt(ignores.Count - 1); }
         }
     }
 
     /// <summary>
-    /// Tests <paramref name="name"/> against user patterns and the workspace `.gitignore`.
-    /// Patterns: glob (<c>*</c>/<c>?</c>), exact name (case-insensitive), or <c>.ext</c> shorthand.
+    /// Tests a path against the workspace's ignore rules, then against the configured patterns.
+    /// Both are read by the same parser, so there is one syntax here and it is git's.
     /// </summary>
-    private static bool IsIgnored(string name, string fullPath, string root, bool isDir, List<IgnorePattern> patterns, GitIgnore ignore)
+    private static bool IsIgnored(string fullPath, string root, bool isDir, GitIgnore configured, List<(string Root, GitIgnore Ignore)> ignores)
     {
-        foreach (var p in patterns)
+        // The workspace rules are asked FIRST, deepest file first: they are what this project says
+        // about itself, while the configured patterns are a default for a project that says
+        // nothing. Where the two disagree the specific answer is the right one — the defaults hide
+        // `.vscode/`, which this repository re-includes a settings.json from on purpose.
+        for (var i = ignores.Count - 1; i >= 0; i--)
         {
-            if (p.Regex != null)
-            {
-                if (p.Regex.IsMatch(name)) { return true; }
-                continue;
-            }
-            if (string.Equals(name, p.Text, StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-            if (!isDir && p.IsExtension && string.Equals(Path.GetExtension(name), p.Text, StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
+            if (ignores[i].Ignore.TryMatch(fullPath, ignores[i].Root, isDir, out var ignored)) { return ignored; }
         }
-        return ignore?.Matches(fullPath, root, isDir) == true;
-    }
 
-    /// <summary>
-    /// Compiles configured patterns into matchers: exact name, <c>.ext</c> shorthand, or glob regex.
-    /// </summary>
-    private static List<IgnorePattern> ParsePatterns(string[] entries)
-    {
-        var list = new List<IgnorePattern>();
-        if (entries == null) { return list; }
-        foreach (var raw in entries)
-        {
-            if (raw == null) { continue; }
-            var t = raw.Trim();
-            if (t.Length == 0) { continue; }
-
-            if (t.IndexOf('*') >= 0 || t.IndexOf('?') >= 0)
-            {
-                list.Add(new IgnorePattern { Regex = GlobToRegex(t) });
-                continue;
-            }
-
-            // ".ext" shorthand also matches as a name, so ".env" still matches the file `.env`.
-            var isExt = t.StartsWith(".") && t.IndexOf('.', 1) < 0
-                        && t.IndexOf('/') < 0 && t.IndexOf('\\') < 0;
-            list.Add(new IgnorePattern { Text = t, IsExtension = isExt });
-        }
-        return list;
-    }
-
-    private static Regex GlobToRegex(string glob)
-    {
-        var sb = new System.Text.StringBuilder("^");
-        foreach (var ch in glob)
-        {
-            switch (ch)
-            {
-                case '*': sb.Append("[^/\\\\]*"); break;
-                case '?': sb.Append("[^/\\\\]"); break;
-                case '.':
-                case '+':
-                case '(':
-                case ')':
-                case '|':
-                case '^':
-                case '$':
-                case '{':
-                case '}':
-                case '[':
-                case ']':
-                case '\\':
-                    sb.Append('\\').Append(ch); break;
-                default: sb.Append(ch); break;
-            }
-        }
-        sb.Append('$');
-        return new Regex(sb.ToString(), RegexOptions.IgnoreCase | RegexOptions.Compiled);
-    }
-
-    private sealed class IgnorePattern
-    {
-        /// <summary>Exact-match text (null when this is a glob pattern).</summary>
-        public string Text;
-        /// <summary>True when <see cref="Text"/> should also match as a file extension.</summary>
-        public bool IsExtension;
-        /// <summary>Compiled regex for glob patterns (null for plain names).</summary>
-        public Regex Regex;
+        // Nothing had an opinion, so the configured patterns decide. Skipping them inside a
+        // repository — on the argument that git's silence means "tracked" — was measured on a
+        // .gitignore with no node_modules rule: the walk listed 2,000 rows of dependencies and hit
+        // the cap, which is the alphabetical truncation this whole change set removed. They are
+        // the guard for exactly that, so they stay.
+        return configured != null
+            && configured.TryMatch(fullPath, root, isDir, out var byPattern)
+            && byPattern;
     }
 }
 
@@ -233,6 +227,10 @@ internal static class FileSuggestions
 internal static class GitIgnoreCache
 {
     private static readonly Dictionary<string, (DateTime Mtime, GitIgnore Ignore)> _cache
+        = new(StringComparer.OrdinalIgnoreCase);
+    // Keyed by the .gitignore's own path: a nested file is read once and reused across walks,
+    // which is what keeps the per-directory lookup from costing a parse each time.
+    private static readonly Dictionary<string, (DateTime Mtime, GitIgnore Ignore)> _nested
         = new(StringComparer.OrdinalIgnoreCase);
     private static readonly object _lock = new();
 
@@ -273,6 +271,64 @@ internal static class GitIgnoreCache
         }
     }
 
+    /// <summary>The picker's own rules (<see cref="IgnoreRulesStore"/>), parsed as a `.gitignore`.
+    /// Keyed on the file's mtime so editing it in VS takes effect on the next `@` without a
+    /// restart, while an unchanged file costs one stat per walk.</summary>
+    private static DateTime _configuredMtime = DateTime.MaxValue;
+    private static GitIgnore _configured;
+
+    public static GitIgnore GetConfigured()
+    {
+        var mtime = IgnoreRulesStore.LastWriteUtc;
+        lock (_lock)
+        {
+            if (_configuredMtime == mtime) { return _configured; }
+            try
+            {
+                var text = IgnoreRulesStore.Read();
+                _configured = string.IsNullOrWhiteSpace(text) ? null : GitIgnore.Parse(text);
+                _configuredMtime = mtime;
+                return _configured;
+            }
+            catch (Exception ex)
+            {
+                OutputWindowLogger.Global.LogException("GitIgnoreCache.GetConfigured", ex);
+                return null;
+            }
+        }
+    }
+
+    /// <summary>The `.gitignore` sitting in <paramref name="dir"/>, or null when there is none —
+    /// git's global excludes are NOT folded in here, unlike <see cref="Get"/>: those belong to the
+    /// workspace once, and re-applying them at every level would only repeat work. Called once per
+    /// directory the walk enters, so the absent case (the overwhelming majority) is one
+    /// File.Exists.</summary>
+    public static GitIgnore GetNested(string dir)
+    {
+        var path = Path.Combine(dir, ".gitignore");
+        if (!File.Exists(path)) { return null; }
+
+        var mtime = File.GetLastWriteTimeUtc(path);
+        lock (_lock)
+        {
+            if (_nested.TryGetValue(path, out var cached) && cached.Mtime == mtime)
+            {
+                return cached.Ignore;
+            }
+            try
+            {
+                var ignore = GitIgnore.Parse(File.ReadAllText(path));
+                _nested[path] = (mtime, ignore);
+                return ignore;
+            }
+            catch (Exception ex)
+            {
+                OutputWindowLogger.Global.LogException("GitIgnoreCache.GetNested", ex);
+                return null;
+            }
+        }
+    }
+
     /// <summary>Git's global excludes file. Resolved once: `core.excludesFile` can point anywhere,
     /// so it is asked of git rather than guessed, with git's own default as the fallback.</summary>
     private static readonly Lazy<string> GlobalExcludesFile = new(() =>
@@ -308,14 +364,102 @@ internal static class GitIgnoreCache
 
 /// <summary>
 /// Lightweight `.gitignore` matcher: plain names, anchored <c>/</c>, dir-only trailing <c>/</c>,
-/// basic <c>*</c>/<c>?</c> globs. Skips negations and brace expansions — rare enough that a full
-/// gitignore implementation would not pay for itself here.
+/// basic <c>*</c>/<c>?</c> globs, negations, and character classes. Skips brace expansions — rare
+/// enough that a full gitignore implementation would not pay for itself here.
 /// </summary>
 internal sealed class GitIgnore
 {
-    private readonly List<Pattern> _patterns;
+    // Split at construction rather than filtered per path: the exclusions answer almost every
+    // call on their own, and a path they don't match never touches the negation list at all.
+    private readonly List<Pattern> _excludes;
+    private readonly List<Pattern> _negations;
+    // Literal leading directories of the negations, e.g. `.vscode` for `!.vscode/settings.json`.
+    // Read by KeepsSubtree to tell a directory that must be descended into from one that can be
+    // pruned; empty for the overwhelming majority of files, where the test costs nothing.
+    private readonly List<string> _negatedPrefixes;
 
-    private GitIgnore(List<Pattern> patterns) => _patterns = patterns;
+    private GitIgnore(List<Pattern> patterns)
+    {
+        _excludes = patterns.Where(p => !p.Negate).ToList();
+        _negations = patterns.Where(p => p.Negate).ToList();
+        _negatedPrefixes = _negations
+            .Select(p => LiteralPrefix(p.Glob))
+            .Where(s => s.Length > 0)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    /// <summary>The part of a glob before its first wildcard, trimmed to whole path segments —
+    /// <c>src/Foo/Debug/**</c> gives <c>src/Foo/Debug</c>. Empty when the glob starts with a
+    /// wildcard, which is the "could be anywhere" case and prunes nothing.</summary>
+    private static string LiteralPrefix(string glob)
+    {
+        var wildcard = glob.IndexOfAny(['*', '?', '[']);
+        var head = wildcard < 0 ? glob : glob.Substring(0, wildcard);
+        var lastSlash = head.LastIndexOf('/');
+        return wildcard < 0 ? head : (lastSlash < 0 ? "" : head.Substring(0, lastSlash));
+    }
+
+    /// <summary>True when a negation could re-include something inside <paramref name="rel"/>, so
+    /// the directory must be walked even though a rule excludes it.
+    /// <para>git resolves `.vscode/*` plus `!.vscode/settings.json` by listing the directory and
+    /// filtering file by file; this walk prunes instead, and a pruned directory takes its
+    /// re-included files with it. Only directories that actually sit on a negation's path pay the
+    /// extra descent.</para></summary>
+    public bool KeepsSubtree(string fullPath, string root)
+    {
+        if (_negatedPrefixes.Count == 0) { return false; }
+        var rel = PathHelpers.Relative(root, fullPath);
+        foreach (var prefix in _negatedPrefixes)
+        {
+            // Either the directory contains the negation (`.vscode` for `.vscode/settings.json`)
+            // or it is inside one (`Mcp/Tools/Debug/Sub` for `Mcp/Tools/Debug/**`).
+            if (prefix.StartsWith(rel, StringComparison.OrdinalIgnoreCase)
+                && (prefix.Length == rel.Length || prefix[rel.Length] == '/'))
+            {
+                return true;
+            }
+            if (rel.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+                && (rel.Length == prefix.Length || rel[prefix.Length] == '/'))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // Counters for the picker's perf line: paths tested, and regex matches that cost. Plain
+    // statics because one Get() walks on one thread and reads them at the end; they are a
+    // diagnostic, so a lost increment would misreport nothing that matters.
+    private static int _calls;
+    private static int _regexRuns;
+
+    /// <summary>Nested .gitignore files pushed during the walk, plus the workspace one. Counted
+    /// where they are read rather than where they are used: one increment per directory entered
+    /// costs nothing, while marking each instance as it answers would put bookkeeping on the
+    /// per-path path.</summary>
+    private static int _filesConsulted;
+
+    internal static int FilesConsulted => _filesConsulted;
+
+    /// <summary>Record that a .gitignore joined the stack.</summary>
+    internal static void CountFile() => _filesConsulted++;
+
+    /// <summary>Zero the counters at the start of a walk.</summary>
+    internal static void ResetStats() { _calls = 0; _regexRuns = 0; _filesConsulted = 0; }
+
+    /// <summary>What this instance parsed, for the picker's perf line. A build that still drops
+    /// negations cannot report neg&gt;0, so the shape says which code is answering — a stale copy
+    /// of the extension otherwise reports numbers that look entirely plausible.</summary>
+    internal string Shape
+        => $"n={_excludes.Count + _negations.Count},neg={_negations.Count},"
+         + $"dir={_excludes.Count(p => p.DirOnly) + _negations.Count(p => p.DirOnly)}";
+
+    /// <summary>Paths tested, regex matches run, and milliseconds spent inside
+    /// <see cref="Matches"/> since <see cref="ResetStats"/>. Two counters rather than a timer:
+    /// the regex count is what the per-pattern work multiplies, and reading a clock twice per
+    /// path costs more than the thing it was measuring.</summary>
+    internal static (int Calls, int RegexRuns) Stats => (_calls, _regexRuns);
 
     public static GitIgnore Parse(string content)
     {
@@ -324,8 +468,21 @@ internal sealed class GitIgnore
         {
             var line = raw.Trim();
             if (line.Length == 0 || line[0] == '#') { continue; }
-            if (line[0] == '!') { continue; }                 // negations: skip
+            // A '!' re-includes what an earlier rule excluded. Kept rather than skipped because
+            // the two halves of this repository's own `[Dd]ebug/` + `!…/Mcp/Tools/Debug/**` pair
+            // only give the right answer together: honouring the first without the second hides
+            // 32 tracked source files.
+            var negate = line[0] == '!';
+            if (negate) { line = line.Substring(1); }
             if (line.IndexOfAny(['{', '}', ',']) >= 0) { continue; } // braces: skip
+
+            // `dir/*` and `dir/**` mean "everything inside dir", so the rule is really about dir:
+            // git never lists an ignored directory, while this walk asks about the directory
+            // itself to decide whether to descend. Left as written, `**/[Bb]in/*` matched neither
+            // the `bin` directory nor anything below its first level, and 450 build outputs of
+            // 1,165 listed files came from that one rule.
+            if (line.EndsWith("/**", StringComparison.Ordinal)) { line = line.Substring(0, line.Length - 3); }
+            else if (line.EndsWith("/*", StringComparison.Ordinal)) { line = line.Substring(0, line.Length - 2); }
 
             var dirOnly = false;
             if (line.EndsWith("/", StringComparison.Ordinal))
@@ -334,56 +491,103 @@ internal sealed class GitIgnore
                 line = line.Substring(0, line.Length - 1);
             }
 
-            var anchored = false;
-            if (line.StartsWith("/", StringComparison.Ordinal))
-            {
-                anchored = true;
-                line = line.Substring(1);
-            }
+            // A leading '/' anchors the pattern to the root. Stripping it is not enough: what
+            // decides is that the rule must then be matched against the PATH, never against a
+            // bare name — `/build/` compared by name would hide Mcp/Tools/Build/ exactly as the
+            // unanchored form does, which is the difference the anchor exists to express.
+            var anchored = line.StartsWith("/", StringComparison.Ordinal);
+            if (anchored) { line = line.Substring(1); }
 
             if (line.Length == 0) { continue; }
 
+            // A malformed character class would throw out of the Regex constructor and take the
+            // whole file with it; dropping the one rule leaves the rest working.
+            Regex regex;
+            try { regex = GlobToRegex(line); }
+            catch (ArgumentException ex)
+            {
+                OutputWindowLogger.Global.Warn($"[picker] skipped .gitignore pattern '{raw.Trim()}': {ex.Message}");
+                continue;
+            }
+
             patterns.Add(new Pattern
             {
-                Anchored = anchored,
                 DirOnly = dirOnly,
-                Regex = GlobToRegex(line),
+                Negate = negate,
+                // A pattern with no separator matches a NAME at any depth, one with a separator
+                // matches the path. git's own rule, and what decides which string to test below.
+                // An anchored rule is a path rule even when it has no separator left in it.
+                NameOnly = !anchored && line.IndexOf('/') < 0,
+                Glob = line,
+                Regex = regex,
             });
         }
         return new GitIgnore(patterns);
     }
 
     /// <summary>
-    /// True when <paramref name="fullPath"/> (an absolute path) matches
-    /// any non-negated pattern. Comparison is case-insensitive (Windows).
+    /// True when <paramref name="fullPath"/> (an absolute path) is ignored: the LAST rule that
+    /// matches decides, so a later <c>!</c> re-includes what an earlier rule excluded — git's own
+    /// precedence. Comparison is case-insensitive (Windows).
     /// </summary>
     public bool Matches(string fullPath, string root, bool isDirectory)
     {
         var rel = PathHelpers.Relative(root, fullPath);
         if (rel.Length == 0) { return false; }
 
-        // Each path segment is also a candidate for unanchored patterns
-        // (so `node_modules` matches `src/foo/node_modules`).
-        var segments = rel.Split('/');
+        // One test per rule, against the string that rule is about: the name for a
+        // separator-less pattern, the relative path otherwise.
+        //
+        // A name pattern used to be tried against every path segment as well, so that
+        // `node_modules` would match `src/foo/node_modules`. That was reachable only for a path
+        // whose ANCESTOR matched, and the walk prunes an ignored directory before descending into
+        // it (FileSuggestions.EnumerateFiles) — so those segments had already been ruled out by the
+        // time this saw them.
+        //
+        // The exclusions are walked first and stop at the first match, which is the common case:
+        // a path nothing excludes is the one that ends up in the list, and it costs one pass.
+        // Only a path that IS excluded pays for the negations — 11 rules of 273 here — and only
+        // the LAST rule that matches decides, so those are walked in full.
+        return TryMatch(fullPath, root, isDirectory, out var ignored) && ignored;
+    }
 
-        foreach (var p in _patterns)
+    /// <summary>The verdict of THIS file's rules, and whether it has one at all. False when no rule
+    /// here mentions the path, which is what lets a stack of nested files be consulted deepest
+    /// first: a file that says nothing hands the question to the one above it, while a `!` here
+    /// answers "not ignored" and stops the search rather than falling through to a parent that
+    /// would exclude it.</summary>
+    public bool TryMatch(string fullPath, string root, bool isDirectory, out bool ignored)
+    {
+        ignored = false;
+        var rel = PathHelpers.Relative(root, fullPath);
+        if (rel.Length == 0) { return false; }
+
+        _calls++;
+        var name = NameOf(rel);
+
+        var matched = false;
+        foreach (var p in _excludes)
         {
             if (p.DirOnly && !isDirectory) { continue; }
-
-            if (p.Anchored)
-            {
-                if (p.Regex.IsMatch(rel)) { return true; }
-            }
-            else
-            {
-                if (p.Regex.IsMatch(rel)) { return true; }
-                foreach (var seg in segments)
-                {
-                    if (p.Regex.IsMatch(seg)) { return true; }
-                }
-            }
+            _regexRuns++;
+            if (p.Regex.IsMatch(p.NameOnly ? name : rel)) { matched = true; ignored = true; break; }
         }
-        return false;
+        // Negations are only consulted for a path something excluded — except that a nested file's
+        // `!` also has to answer for a path excluded further up, so they are checked either way.
+        foreach (var p in _negations)
+        {
+            if (p.DirOnly && !isDirectory) { continue; }
+            _regexRuns++;
+            if (p.Regex.IsMatch(p.NameOnly ? name : rel)) { matched = true; ignored = false; break; }
+        }
+        return matched;
+    }
+
+    /// <summary>The last segment of a forward-slashed relative path.</summary>
+    private static string NameOf(string rel)
+    {
+        var slash = rel.LastIndexOf('/');
+        return slash < 0 ? rel : rel.Substring(slash + 1);
     }
 
     private static Regex GlobToRegex(string glob)
@@ -403,6 +607,25 @@ internal sealed class GitIgnore
                 sb.Append("(?:.*/)?");
                 continue;
             }
+            // `[Dd]ebug` is a character class in a glob exactly as it is in a regex, so it goes
+            // through rather than being escaped. Escaping it was why every bracketed rule in the
+            // stock VisualStudio .gitignore — [Dd]ebug/, [Rr]elease/, [Bb]in, [Oo]bj — was inert:
+            // they compiled to the literal text "[Oo]bj", which names no directory, so 615 build
+            // artefacts of 1,165 listed files were offered by the picker.
+            if (ch == '[')
+            {
+                var close = IndexOfClassEnd(glob, i);
+                // Unterminated: git treats the bracket as an ordinary character, so escape it.
+                if (close < 0) { sb.Append("\\["); continue; }
+                var body = glob.Substring(i + 1, close - i - 1);
+                // git negates a class with '!', .NET with '^'.
+                if (body.Length > 0 && body[0] == '!') { body = "^" + body.Substring(1); }
+                // A class must not match a separator: a path is compared whole, and `[Bb]in` has
+                // no business matching the '/' that ends a directory name.
+                sb.Append("(?!/)[").Append(body).Append(']');
+                i = close;
+                continue;
+            }
             switch (ch)
             {
                 case '*': sb.Append("[^/]*"); break;
@@ -416,7 +639,6 @@ internal sealed class GitIgnore
                 case '$':
                 case '{':
                 case '}':
-                case '[':
                 case ']':
                 case '\\':
                     sb.Append('\\').Append(ch); break;
@@ -424,13 +646,33 @@ internal sealed class GitIgnore
             }
         }
         sb.Append('$');
-        return new Regex(sb.ToString(), RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        // Interpreted, not Compiled: these are ~270 DIFFERENT patterns, each run a few hundred
+        // times per walk, so the IL each Compiled regex emits on first use is never amortised —
+        // it is paid once per pattern and thrown away with the cache.
+        return new Regex(sb.ToString(), RegexOptions.IgnoreCase);
+    }
+
+    /// <summary>Index of the <c>]</c> closing the class opened at <paramref name="open"/>, or -1
+    /// when there is none. A <c>]</c> in first position (after an optional negator) is a literal
+    /// member of the class, not its end — <c>[]]</c> matches a bracket.</summary>
+    private static int IndexOfClassEnd(string glob, int open)
+    {
+        var i = open + 1;
+        if (i < glob.Length && (glob[i] == '!' || glob[i] == '^')) { i++; }
+        if (i < glob.Length && glob[i] == ']') { i++; }
+        return glob.IndexOf(']', i);
     }
 
     private sealed class Pattern
     {
-        public bool Anchored;
         public bool DirOnly;
+        /// <summary>The glob carries no separator, so it matches a bare name at any depth.</summary>
+        public bool NameOnly;
+        /// <summary>A <c>!</c> rule: matching re-includes the path instead of ignoring it.</summary>
+        public bool Negate;
+        /// <summary>The glob as parsed, prefixes stripped. Kept for the negations, whose literal
+        /// head decides which directories cannot be pruned.</summary>
+        public string Glob;
         public Regex Regex;
     }
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/IgnoreRulesStore.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/IgnoreRulesStore.cs
@@ -1,0 +1,136 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using Corsinvest.VisualStudio.Agents.Helpers;
+using System;
+using System.IO;
+
+namespace Corsinvest.VisualStudio.Agents.Chat.Host;
+
+/// <summary>
+/// The `@` picker's own ignore rules, kept as a `.gitignore` file in the app data folder
+/// (<see cref="AppPaths.IgnoreRulesFile"/>) rather than in the VS settings store: the content is
+/// a rule list with comments and sections, which is a thing to edit in a real editor and copy
+/// between machines, not a preference to toggle.
+/// <para>These apply only where the workspace's own ignore rules say nothing —
+/// <c>FileSuggestions.IsIgnored</c> asks the .gitignore stack first. They exist for the project
+/// that ships no rules at all: without them a repository with an unignored node_modules fills the
+/// menu with 2,000 rows of dependencies.</para>
+/// </summary>
+internal static class IgnoreRulesStore
+{
+    /// <summary>The rules as written on disk, or <see cref="Defaults"/> when there is no file yet.
+    /// Never throws: an unreadable file falls back to the defaults, because a picker that lists
+    /// everything is worse than one using rules the user did not choose.</summary>
+    public static string Read()
+    {
+        try
+        {
+            return File.Exists(AppPaths.IgnoreRulesFile)
+                ? File.ReadAllText(AppPaths.IgnoreRulesFile)
+                : Defaults;
+        }
+        catch (Exception ex)
+        {
+            OutputWindowLogger.Global.LogException("IgnoreRulesStore.Read", ex);
+            return Defaults;
+        }
+    }
+
+    /// <summary>Write the defaults out if the file does not exist yet, and return its path. Called
+    /// before opening the file for editing, so the user always lands on a commented starting point
+    /// rather than an empty buffer. Returns null when the file cannot be created.</summary>
+    public static string EnsureFile()
+    {
+        try
+        {
+            if (!File.Exists(AppPaths.IgnoreRulesFile))
+            {
+                Directory.CreateDirectory(AppPaths.DataFolder);
+                File.WriteAllText(AppPaths.IgnoreRulesFile, Defaults);
+            }
+            return AppPaths.IgnoreRulesFile;
+        }
+        catch (Exception ex)
+        {
+            OutputWindowLogger.Global.LogException("IgnoreRulesStore.EnsureFile", ex);
+            return null;
+        }
+    }
+
+    /// <summary>Timestamp used to tell a re-read from a cache hit. <see cref="DateTime.MinValue"/>
+    /// when there is no file, which is a stable key for "the defaults".</summary>
+    public static DateTime LastWriteUtc
+    {
+        get
+        {
+            try
+            {
+                return File.Exists(AppPaths.IgnoreRulesFile)
+                    ? File.GetLastWriteTimeUtc(AppPaths.IgnoreRulesFile)
+                    : DateTime.MinValue;
+            }
+            catch { return DateTime.MinValue; }
+        }
+    }
+
+    /// <summary>Shipped starting point, also the fallback when the file is missing or unreadable.
+    /// Read by the .gitignore parser, so these ARE gitignore rules: a trailing `/` marks a
+    /// directory, a leading `/` anchors to the workspace root, and `*.ext` is a glob rather than
+    /// the bare extension an earlier shorthand accepted.</summary>
+    public const string Defaults = """
+        # Hidden from the @ file picker, on top of the workspace's own .gitignore.
+        # Same syntax as a .gitignore: one rule per line, # for a comment, a trailing /
+        # for a directory, a leading / to anchor at the workspace root, and * ? [Dd] !
+        # as git defines them.
+        #
+        # These only apply where the workspace's rules say nothing, so a project that
+        # ignores its own build output is already covered without touching this file.
+
+        # Version control and IDE state
+        .git/
+        .vs/
+        .vscode/
+        .idea/
+        .hg/
+        .svn/
+
+        # Dependencies and build output. Directory-only, so a source file named bin.cs stays.
+        node_modules/
+        bin/
+        obj/
+        dist/
+        .next/
+        .nuxt/
+        .svelte-kit/
+        __pycache__/
+        .venv/
+        venv/
+        .pytest_cache/
+        .gradle/
+        .terraform/
+        .cache/
+
+        # Anchored to the workspace root: these are output there, but ordinary source folder
+        # names deeper in a tree — this extension's own Mcp/Tools/Build/ holds four of them.
+        /build/
+        /out/
+        /target/
+
+        # Noise and binaries
+        .DS_Store
+        Thumbs.db
+        .env
+        *.exe
+        *.dll
+        *.pdb
+        *.ilk
+        *.suo
+        *.user
+        *.log
+        *.tmp
+        *.bak
+        """;
+}

--- a/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.cs
@@ -144,12 +144,16 @@ internal sealed partial class SessionManager
             var line = lines[i];
             if (line.Length == 0) { continue; }
 
-            info.CustomTitle ??= MatchField(line, "custom-title", "customTitle");
-            info.AiTitle ??= MatchField(line, "ai-title", "aiTitle");
-            info.LastPrompt ??= MatchField(line, "last-prompt", "lastPrompt")
+            // Read the line's type ONCE: every test below used to re-scan the whole line for it,
+            // and a tool_result line runs to tens of KB.
+            var lineType = FindJsonStringValue(line, "type");
+
+            info.CustomTitle ??= MatchField(lineType, line, "custom-title", "customTitle");
+            info.AiTitle ??= MatchField(lineType, line, "ai-title", "aiTitle");
+            info.LastPrompt ??= MatchField(lineType, line, "last-prompt", "lastPrompt")
                                ?? ExtractUserText(line);
-            bool isUser = IsType(line, "user");
-            bool isAssistant = IsType(line, "assistant");
+            bool isUser = lineType == "user";
+            bool isAssistant = lineType == "assistant";
             bool isTurnLine = isUser || isAssistant;
             if (isTurnLine)
             {
@@ -178,8 +182,10 @@ internal sealed partial class SessionManager
     private static bool IsType(string line, string type)
         => string.Equals(FindJsonStringValue(line, "type"), type, StringComparison.Ordinal);
 
-    private static string MatchField(string line, string type, string field)
-        => IsType(line, type) ? FindJsonStringValue(line, field) : null;
+    /// <summary>The field, when the line is of the wanted type. Takes the type the caller already
+    /// resolved: ScanLines reads it once per line rather than re-scanning for it per field.</summary>
+    private static string MatchField(string lineType, string line, string type, string field)
+        => string.Equals(lineType, type, StringComparison.Ordinal) ? FindJsonStringValue(line, field) : null;
 
     /// <summary>True when the line carries <c>"key": true</c>. Tolerates the space after the colon
     /// for the same reason as <see cref="IsType"/>.</summary>

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsService.cs
@@ -955,8 +955,11 @@ internal static class StatsService
         return rel.Replace('\\', '/');
     }
 
+    // Both separators tested in place: the Replace this used to do copied the whole path, once per
+    // file, inside the indexing Parallel.ForEach.
     private static bool IsSubagentPath(string fullPath) =>
-        fullPath.Replace('\\', '/').Contains("/subagents/");
+        fullPath.IndexOf(@"\subagents\", StringComparison.OrdinalIgnoreCase) >= 0
+        || fullPath.IndexOf("/subagents/", StringComparison.OrdinalIgnoreCase) >= 0;
 
     /// <summary>Re-aggregate a file only if changed: same mtime → reuse; grown (append) → delta
     /// from the cached size; shrunk/rewritten → recompute; new → full. Returns the fresh entry and

--- a/src/Corsinvest.VisualStudio.Agents/Corsinvest.VisualStudio.Agents.csproj
+++ b/src/Corsinvest.VisualStudio.Agents/Corsinvest.VisualStudio.Agents.csproj
@@ -305,6 +305,7 @@
     <Compile Include="Core\Plugins\PluginService.cs" />
     <Compile Include="Chat\Host\BridgeMessages.cs" />
     <Compile Include="Chat\Host\FileSuggestions.cs" />
+    <Compile Include="Chat\Host\IgnoreRulesStore.cs" />
     <Compile Include="Chat\Host\WebViewBridge.cs" />
     <Compile Include="Chat\Host\WebViewBridge.Payloads.cs" />
     <Compile Include="Chat\Host\WebViewMessageHandler.cs" />
@@ -319,6 +320,7 @@
       <SubType>Component</SubType>
     </Compile>
     <Compile Include="Options\AgentsGeneralPage.cs" />
+    <Compile Include="Options\IgnoreRulesFileEditor.cs" />
     <Compile Include="Options\AgentsChatPage.cs">
       <SubType>Component</SubType>
     </Compile>

--- a/src/Corsinvest.VisualStudio.Agents/Options/AgentsChatPage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Options/AgentsChatPage.cs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
+using System;
 using System.ComponentModel;
 using System.Drawing.Design;
 using System.Runtime.InteropServices;
@@ -148,17 +149,15 @@ public class AgentsChatPage : AgentsOptionsPage
 
     [Category("Ignore")]
     [DisplayName("Ignored patterns")]
-    [Description("Patterns hidden from the `@` file picker. Each entry can be: an exact folder/file name (e.g. `node_modules`, `.DS_Store`), an extension prefixed with `.` (e.g. `.exe` matches `*.exe`), or a glob with `*`/`?` (e.g. `*.bak`). Click `…` to edit one entry per line.")]
-    [Editor("System.Windows.Forms.Design.StringArrayEditor, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", typeof(UITypeEditor))]
-    public string[] IgnoredPatterns { get; set; } =
-    [
-        ".git", ".vs", ".vscode", ".idea", ".hg", ".svn",
-        "node_modules", "bin", "obj", "dist", "build", "out", "target",
-        ".next", ".nuxt", ".svelte-kit",
-        "__pycache__", ".venv", "venv", ".pytest_cache",
-        ".gradle", ".terraform", ".cache",
-        ".DS_Store", "Thumbs.db", ".env",
-        ".exe", ".dll", ".pdb", ".ilk", ".suo", ".user",
-        ".log", ".tmp", ".bak",
-    ];
+    [Description("Extra rules hiding files from the `@` file picker, on top of the workspace's own. Written as a `.gitignore` and kept as one — click `…` to open the file in the editor. Applied only where the workspace's rules say nothing.")]
+    [Editor(typeof(IgnoreRulesFileEditor), typeof(UITypeEditor))]
+    // Not the rules themselves: those live in a file (Chat/Host/IgnoreRulesStore.cs), because a
+    // commented rule list is something to edit in a real editor and copy between machines, not a
+    // settings-store value. This property exists to give the Options page a row to put the button
+    // on, and reports where the file is.
+    public string IgnoredPatterns
+    {
+        get => AppPaths.IgnoreRulesFile;
+        set { /* read-only: the editor opens the file, it never writes a value back */ }
+    }
 }

--- a/src/Corsinvest.VisualStudio.Agents/Options/IgnoreRulesFileEditor.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Options/IgnoreRulesFileEditor.cs
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using Corsinvest.VisualStudio.Agents.Chat.Host;
+using Microsoft.VisualStudio.Shell;
+using System;
+using System.ComponentModel;
+using System.Drawing.Design;
+
+namespace Corsinvest.VisualStudio.Agents.Options;
+
+/// <summary>
+/// The `…` button next to the picker's ignore rules: opens the rules FILE in the IDE rather than
+/// showing a dialog. The content is a `.gitignore`, so the editor that already colours that format
+/// and offers find/undo beats a modal text box — and the file is the storage, so there is no value
+/// to hand back.
+/// <para>The file is created from the shipped defaults on first open, so the user lands on a
+/// commented starting point instead of an empty buffer.</para>
+/// </summary>
+internal sealed class IgnoreRulesFileEditor : UITypeEditor
+{
+    // Modal: the button opens a document and returns immediately, but the grid still needs to be
+    // told this is a "click to act" cell rather than a drop-down.
+    public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext context)
+        => UITypeEditorEditStyle.Modal;
+
+    public override object EditValue(ITypeDescriptorContext context, IServiceProvider provider, object value)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        try
+        {
+            var path = IgnoreRulesStore.EnsureFile();
+            if (path != null)
+            {
+                VsShellUtilities.OpenDocument(ServiceProvider.GlobalProvider, path);
+            }
+        }
+        catch (Exception ex)
+        {
+            OutputWindowLogger.Global.LogException("IgnoreRulesFileEditor.EditValue", ex);
+        }
+
+        // The value is unchanged by design — the file is what holds the rules. Returning the
+        // incoming value leaves the grid's cell (the file path) exactly as it was.
+        return value;
+    }
+}

--- a/src/Corsinvest.VisualStudio.Agents/Utils/AppPaths.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Utils/AppPaths.cs
@@ -25,6 +25,13 @@ internal static class AppPaths
     /// the menu is queried constantly by VS, long before any Options page exists.</summary>
     public static readonly string EditorPromptsFile = Path.Combine(DataFolder, "editor-prompts.json");
 
+    /// <summary>What the `@` file picker hides on top of the workspace's own rules. A file rather
+    /// than a settings-store value because the content IS a .gitignore — comments, sections, one
+    /// rule per line — which is a thing to read and copy between machines, not a preference.
+    /// <para>Named `.gitignore` rather than `.json` so VS opens it with the editor that already
+    /// colours the format, and so nothing has to be escaped into a JSON string.</para></summary>
+    public static readonly string IgnoreRulesFile = Path.Combine(DataFolder, "picker-ignore.gitignore");
+
     /// <summary>
     /// Cache folder for file-type icons rasterised from VS KnownMonikers. The
     /// WebView serves these via the `cv4vs-icons.local` virtual host, generated

--- a/src/Corsinvest.VisualStudio.Agents/Utils/ClaudePaths.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Utils/ClaudePaths.cs
@@ -43,7 +43,12 @@ public sealed class ClaudePaths
     // Not replicated (rare on Windows): the CLI also realpath's the cwd (symlink/junction
     // canonicalization). The >200-char case IS handled, by SessionFolder rather than here.
     public static string ProjectFolderName(string workingDirectory)
-        => Regex.Replace(Path.GetFullPath(workingDirectory), "[^a-zA-Z0-9]", "-");
+        => NonAlphanumeric.Replace(Path.GetFullPath(workingDirectory), "-");
+
+    /// <summary>The CLI's character class verbatim: it is the contract, so it stays legible as the
+    /// rule it mirrors rather than becoming a hand-written char walk. Static because ConfigId is a
+    /// property and re-ran the shared-cache lookup on every read.</summary>
+    private static readonly Regex NonAlphanumeric = new("[^a-zA-Z0-9]", RegexOptions.Compiled);
 
     /// <summary>Longest folder name the CLI writes before it truncates — filesystems cap a single
     /// path component at 255 bytes, and it leaves room for the suffix it adds.</summary>
@@ -81,7 +86,7 @@ public sealed class ClaudePaths
     /// <summary>Stable filesystem-safe id for this config-dir, used to namespace our own per-config-dir
     /// data (e.g. stats). Derived from the resolved config-dir path with the same folder-name rule, so it
     /// stays stable across profile renames and two profiles on the SAME config-dir share the same id.</summary>
-    public string ConfigId => Regex.Replace(ClaudeFolder, "[^a-zA-Z0-9]", "-");
+    public string ConfigId => NonAlphanumeric.Replace(ClaudeFolder, "-");
 
     /// <summary>Paths for a profile's config-dir. A profile always exists (native "Claude" included),
     /// so there is no null case — the config-dir comes from <see cref="GetConfigDir"/>.</summary>


### PR DESCRIPTION
Opening the `@` file picker on this repository took **1495 ms** and offered **1,165 files, 615 of which git hides** — `bin/`, `obj/` and their build output. The cap meant to bound a huge tree was being spent on artefacts, so it fired at 538 files and cut the list mid-alphabet: `tools/` was never reachable, exactly as the comment above `MaxRows` predicted it would not be.

The picker now lists **the same files VS Code's does — 553 of 553** — in about 200 ms.

| | before | after |
| --- | --- | --- |
| `FileSuggestions.Get` | 1495 ms | ~200 ms |
| time inside the matcher | 1384 ms | ~130 ms |
| files listed | 1165 | 553 |
| listed but hidden by `git check-ignore` | 615 (53%) | **0** |
| list vs `git ls-files` | 4+ differences | identical |
| capped | `MaxRows` (538 files) | no |

## What was wrong

Four defects in how a `.gitignore` pattern was compiled or applied. They had to be fixed together — the third only becomes visible once the first works.

**Character classes were escaped.** `GlobToRegex` escaped `[` and `]`, so `[Oo]bj` compiled to the literal text `[Oo]bj`, naming a directory that does not exist. Every bracketed rule in the stock VisualStudio `.gitignore` — `[Dd]ebug/`, `[Rr]elease/`, `[Bb]in`, `[Oo]bj`, `[Ww][Ii][Nn]32/` — matched nothing at all.

**`dir/*` did not prune `dir`.** git never lists an ignored directory; this walk asks about the directory itself to decide whether to descend, and `**/[Bb]in/*` describes neither `bin` nor anything below its first level. That one rule accounted for 450 of the 615.

**Negations were dropped at parse.** Not separable from the first: the moment `[Dd]ebug/` started working, the 32 tracked sources under `Mcp/Tools/Debug/` would have vanished, because the `!` that rescues them was skipped too. Two bugs had been cancelling out. Matching now follows git's rule — last match wins — with exclusions and negations in separate lists so the common path still stops at the first match.

**`RegexOptions.Compiled` on ~270 distinct patterns**, each run a few hundred times per walk. The IL emitted on first use is never amortised at that ratio.

Plus: nested `.gitignore` files are read (the walk is already recursive, so each is pushed for its subtree and popped after); a leading `/` now actually anchors, which it did not — the slash was stripped and the rule matched by name, so `/build/` hid `Mcp/Tools/Build/` exactly as the unanchored form did; and a directory an exclusion covers is still descended into when a negation names something inside it, since git resolves `.vscode/*` + `!.vscode/settings.json` by filtering file by file where this walk pruned the file away with its directory.

`MaxRows` goes 600 → 2000. The tree produces 631 rows, so 600 cut `tools/` by 31 — affordable only now that the rules prune what they always meant to.

## The picker's own ignore list moves to a file

It was a `string[]` of bare names in the settings store, matched by a **second** glob implementation that knew nothing of paths, anchors or negations — which is how `build` came to hide four tracked sources under `Mcp/Tools/Build/`.

It is now a `.gitignore` file in the app data folder, read by the same parser as the workspace's: one syntax, and the one already written in every repository. The file is what a rule list wants to be — comments, sections, something to open in an editor that colours it and to copy between machines. The Options row keeps its `…` button; it opens the file instead of a text box.

The workspace's own rules are consulted **first**, and these apply only where those say nothing. They are not redundant: on a `.gitignore` with no `node_modules` rule, the walk was measured listing 2,000 rows of dependencies and hitting the cap — the truncation this whole change removes.

## Also here: three allocation fixes (07703d8)

Separate commit, unrelated to the picker. `ScanLines` pulled the line's `type` out four times per line, each a fresh scan of a line that runs to tens of KB on a `tool_result`; `IsSubagentPath` copied the whole path just to search it, once per file inside the indexing `Parallel.ForEach`; `ClaudePaths` ran a static `Regex.Replace` through the shared cache on every read of a property.

`FindJsonStringValue` and `IsFlagTrue` are deliberately untouched — rewriting them to avoid two short pattern allocations cost 65 lines and introduced two off-by-ones, which is a bad trade against gen0.

## Verification

No test project, so both commits were checked by running the real code against an oracle rather than by inspection:

- **the allocation commit**: old and new readers ported to JS and run over **283,528 real `.jsonl` lines** from `~/.claude/projects` across 14 keys — no disagreement.
- **the picker**: the compiled `GitIgnore` driven by reflection over the real tree, scored against `git check-ignore` and `git ls-files` — 0 divergences, `Mcp/Tools/Debug/` still 32 files, `tools/` present, `.vscode/settings.json` present.
- **the worst case**: a `.gitignore` stripped of its `node_modules` rule, against the 29,749 files actually on disk — 0 rows listed, cap not reached.

Then in the experimental instance: `@` with no filter, reading the `PERF` line for `capped=no` and the rule shape.

## Not done, deliberately

A cache of the walk was designed (`docs/internal/specs/todo/2026-08-15-file-picker-cache-design.md`) when the picker cost 1495 ms per keystroke. At ~200 ms it buys an invisible improvement in exchange for a staleness window and an invalidation rule to get right, so it was not built. The design is kept with the measurements and the condition for reopening it — the `PERF` line already reports what would trigger that.

## Risk

`IgnoredPatterns` changes type (`string[]` → a file). A user who customised the list falls back to the shipped defaults; there is no failed conversion, the property is now a path. Worth a changelog line.

`MaxRows` at 2000 with no virtualisation in `cv-popover-list` — 631 rows render fine here, but a far larger tree will render more rows than before. `MaxVisited` still bounds the walk.
