### PR TITLE
fix(chat): don't pin a queued message as if the turn had started

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/chat.css
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/chat.css
@@ -109,10 +109,13 @@ cv-message[queued] {
 cv-message {
     transition: opacity 0.15s ease-in;
 }
-/* Pin only when the exchange's first message is a REAL user bubble. A history page can
- * start on a synthetic role:user line (tool_result / meta-injection) that renders as a
- * tool/other; the [role="user"] guard keeps that leading group from pinning wrongly. */
-body.sticky-user .cv-exchange > cv-message[role="user"]:first-child {
+/* Pin only when the exchange's first message is a REAL user bubble, and one the CLI has
+ * actually been given. A history page can start on a synthetic role:user line (tool_result /
+ * meta-injection) that renders as a tool/other; the [role="user"] guard keeps that leading
+ * group from pinning wrongly. A queued message is a user bubble in every other respect, so
+ * :not([queued]) is what keeps it out: pinning it would head a turn that has not begun. It
+ * scrolls with the rest until it is sent, then loses the attribute and pins like any other. */
+body.sticky-user .cv-exchange > cv-message[role="user"]:not([queued]):first-child {
     position: sticky;
     top: -12px;
     padding-top: 12px;
@@ -120,7 +123,7 @@ body.sticky-user .cv-exchange > cv-message[role="user"]:first-child {
     z-index: 2;
     background: var(--colorNeutralBackground1);
 }
-body.sticky-user .cv-exchange > cv-message[role="user"]:first-child .cv-message.user {
+body.sticky-user .cv-exchange > cv-message[role="user"]:not([queued]):first-child .cv-message.user {
     background: var(--colorNeutralBackground3);
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
 }


### PR DESCRIPTION
Write a second prompt while a turn is running and it waits in the queue — faded, not yet handed to the CLI. Scroll, and it pinned itself to the top like any other exchange header, announcing *"this is the turn you are reading"* for a turn that had never begun. Needs Options → Chat → sticky user messages.

## Why

The rule only looked at position and role:

```css
body.sticky-user .cv-exchange > cv-message[role="user"]:first-child
```

A queued message is a `cv-message[role="user"]` like every other one. What sets it apart is the `queued` attribute (`cv-app.ts`, from `appState.queuedUuids`), which the selector did not read.

## Fix

`:not([queued])` on both `sticky-user` rules. The bubble stays visible and faded but scrolls with the rest until it is actually sent; at that point it loses the attribute and becomes pinnable like any other.

The attribute is reflected — `@property({ type: Boolean, reflect: true }) queued` in `cv-message.ts` — so the selector matches. No JS change.

The comment above the rule already documented one exclusion: the synthetic `role:user` line a history page can lead with (a `tool_result` / meta-injection that renders as a tool). The selector was written knowing it had to tell real user bubbles apart — this is the second case, and the comment now carries both.

## Test

Options → Chat → sticky user messages on. Send a prompt, and while it runs type a second one. Scroll up: the faded bubble scrolls away with the transcript instead of sticking to the top. When the queue flushes it fills in and pins normally.
