### PR TITLE
fix(chat): don't let a queued message end the running turn's exchange

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/exchanges.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/exchanges.ts
@@ -7,14 +7,26 @@ import type { UiEntry } from './types';
  * Group a transcript into exchanges: each user message opens one, and whatever precedes the first
  * user message (a history page boundary) gets its own leading group.
  *
+ * A message still in the queue is the exception — it heads no turn, since the CLI has not been
+ * given it. Opening an exchange for it would end the running turn's <section> early, and the
+ * sticky user bubble pins only within its own section (.cv-exchange in chat.css): that turn's
+ * header would come unstuck while its reply is still arriving. It opens its own group once sent.
+ *
  * Pure and derived — cv-app calls this from a memoised getter instead of holding the groups as
  * state, so the groups can never drift from the entries they are built from.
  */
-export function buildGroups(entries: readonly UiEntry[]): UiEntry[][] {
+export function buildGroups(
+    entries: readonly UiEntry[],
+    queued?: ReadonlySet<string>,
+): UiEntry[][] {
+    const isQueued = (uuid?: string): boolean => !!uuid && !!queued?.has(uuid);
+    const opensExchange = (e: UiEntry): boolean =>
+        e.kind === 'text' && e.role === 'user' && !isQueued(e.uuid);
+
     const groups: UiEntry[][] = [];
     let current: UiEntry[] = [];
     for (const e of entries) {
-        if (e.kind === 'text' && e.role === 'user') {
+        if (opensExchange(e)) {
             if (current.length) {
                 groups.push(current);
             }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/exchanges.test.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/exchanges.test.ts
@@ -6,7 +6,13 @@ import assert from 'node:assert/strict';
 import { buildGroups } from '../core/exchanges.ts';
 import type { UiAssistantEntry, UiUserEntry } from '../core/types';
 
-const user = (id: number): UiUserEntry => ({ kind: 'text', id, role: 'user', text: `u${id}` });
+const user = (id: number, uuid?: string): UiUserEntry => ({
+    kind: 'text',
+    id,
+    role: 'user',
+    text: `u${id}`,
+    uuid,
+});
 const bot = (id: number): UiAssistantEntry => ({
     kind: 'text',
     id,
@@ -44,4 +50,39 @@ test('le entry prima del primo utente vanno in un gruppo di testa', () => {
 
 test('lista vuota produce zero gruppi', () => {
     assert.deepEqual(buildGroups([]), []);
+});
+
+test('un messaggio ancora in coda non apre uno scambio', () => {
+    // Il turno 1 sta ancora rispondendo (bot(4) arriva dopo) quando l utente scrive il secondo
+    // prompt: finche resta in coda deve stare nel gruppo del turno che gira, o la sua <section>
+    // finirebbe li e l intestazione del turno in corso si sbloccherebbe a meta risposta.
+    const groups = buildGroups([user(1), bot(2), user(3, 'q'), bot(4)], new Set(['q']));
+
+    assert.equal(groups.length, 1);
+    assert.deepEqual(
+        groups[0].map((e) => e.id),
+        [1, 2, 3, 4],
+    );
+});
+
+test('lo stesso messaggio apre lo scambio appena esce dalla coda', () => {
+    const entries = [user(1), bot(2), user(3, 'q')];
+
+    assert.equal(buildGroups(entries, new Set(['q'])).length, 1);
+    assert.equal(buildGroups(entries, new Set()).length, 2);
+});
+
+test('la coda trattiene solo il suo uuid, non ogni utente', () => {
+    // 'b' e in coda, 'a' no: 'a' apre il suo scambio, 'b' resta nel gruppo che trova.
+    const groups = buildGroups([user(1, 'z'), user(2, 'b'), user(3, 'a')], new Set(['b']));
+
+    assert.equal(groups.length, 2);
+    assert.deepEqual(
+        groups[0].map((e) => e.id),
+        [1, 2],
+    );
+    assert.deepEqual(
+        groups[1].map((e) => e.id),
+        [3],
+    );
 });

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
@@ -98,8 +98,13 @@ export class CvApp extends LitElement {
      *  before the batch with the one after, so two invalidations in the same microtask would
      *  toggle a boolean back to where it started and the render would be skipped. */
     @state() private _rev = 0;
-    /** Groups for the current tree, keyed by the array they were built from. */
-    private _groupCache: { src: readonly UiEntry[]; groups: UiEntry[][] } | null = null;
+    /** Groups for the current tree, keyed by the array they were built from and the queued set
+     *  that decided which user messages were allowed to open an exchange. */
+    private _groupCache: {
+        src: readonly UiEntry[];
+        queued: ReadonlySet<string>;
+        groups: UiEntry[][];
+    } | null = null;
     @state() private _subagentTasks = new Map<string, SubagentTask>();
 
     /** Ids the CLI last reported as running in the background. Not @state: it decides what a task
@@ -138,11 +143,14 @@ export class CvApp extends LitElement {
     @state() private _queuedUuids = new Set(appState.queuedUuids);
 
     /** Derived, never stored: recomputed only when the tree changes identity. Holding the groups
-     *  as state gave them two writers, and that is how they and the entries drifted apart. */
+     *  as state gave them two writers, and that is how they and the entries drifted apart.
+     *  Keyed on the queued set too: a message leaving the queue opens the exchange it was held
+     *  out of, and the entries array does not change identity when that happens. */
     private get _exchanges(): UiEntry[][] {
         const src = this._transcript.entries;
-        if (this._groupCache?.src !== src) {
-            this._groupCache = { src, groups: buildGroups(src) };
+        const queued = this._queuedUuids;
+        if (this._groupCache?.src !== src || this._groupCache.queued !== queued) {
+            this._groupCache = { src, queued, groups: buildGroups(src, queued) };
         }
         return this._groupCache.groups;
     }


### PR DESCRIPTION
Write a second prompt while a turn is running, and the header of the turn **actually in flight** came unstuck halfway through its own reply — scrolling away while the answer was still arriving. Needs Options → Chat → sticky user messages.

## Why

`buildGroups` opened an exchange on every `role: 'user'` entry, queued ones included:

```ts
if (e.kind === 'text' && e.role === 'user') { /* start a new group */ }
```

A message waiting in the queue heads no turn — the CLI has not been given it — but it closed the running turn's `<section class="cv-exchange">` the moment it was echoed into the transcript.

That matters because the sticky user bubble pins only **within its own section**. `.cv-exchange` sets `position: relative` for exactly that reason, and says so:

```css
/* position:relative limits the sticky scope so each user bubble pins only
 * to the top of its own exchange, not the whole scroll area. */
```

So ending the section early unpinned the header of a turn that had not finished.

## Fix

`buildGroups` now takes the queued uuids and keeps those messages in the group they land in. They open their own exchange once actually sent — where `moveToEnd` has already put them at the end.

The set comes from `_queuedUuids`, the mirror `cv-app` already keeps to fade the bubble, so there is no new state — the data reached the render but not the grouping. The group cache is keyed on it as well: a message leaving the queue changes the grouping without changing the entries array, and a cache keyed only on the array would have kept serving the old groups.

**No CSS change.** The sticky rule was right; it was being handed a section that ended too soon.

## Tests

Three added to `tests/exchanges.test.ts` (6 pass): a queued message does not open an exchange, the same message opens one as soon as it leaves the queue, and the queue holds back only its own uuid rather than every user entry.

## Test by hand

Options → Chat → sticky user messages on. Send a prompt with a long answer; while it streams, type a second one. Scroll up: the header of the running turn stays pinned until its reply has scrolled past, instead of letting go as soon as the grey bubble appears.
