### PR TITLE
fix(chat): follow a queued message to the bottom when you were already there

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
@@ -1286,13 +1286,22 @@ export class CvApp extends LitElement {
      * so that reply keeps the question which actually prompted it. The fading is already handled —
      * the uuid left `appState.queuedUuids` — so only the position is left.
      *
-     * No scroll: the user may well be reading further up, often the very reason they queued
-     * something, and the jump button already covers going back down.
+     * Follows only if the view was already at the bottom, like every other path that changes the
+     * transcript. Someone reading further up — often the very reason they queued something — is
+     * left where they are, with the jump button to come back; someone at the bottom would otherwise
+     * watch the bubble slide out of view and be left staring at the gap it came from.
+     *
+     * Read before the mutation: moving the bubble is what changes the height, so asking afterwards
+     * measures the layout the answer is supposed to decide about.
      */
     private _onQueuedSent = (e: CustomEvent<{ uuid: string }>): void => {
         const uuid = e.detail?.uuid;
         if (uuid) {
+            const atBottom = this._isNearBottom();
             this._mutate(() => this._transcript.moveToEnd(uuid));
+            if (atBottom) {
+                queueMicrotask(() => this._scrollToBottom());
+            }
         }
     };
 


### PR DESCRIPTION
Sending a queued message moves its bubble below the reply it had been sitting above. `_onQueuedSent` stopped at the move, and the comment called that deliberate:

> *No scroll: the user may well be reading further up, often the very reason they queued something*

Right for that reader, silent about the other one. **If you were at the bottom, the bubble slides out of view and leaves you staring at the gap it came from.**

## The fix

Three lines — the same shape as every other path that changes the transcript:

```ts
const atBottom = this._isNearBottom();
this._mutate(() => this._transcript.moveToEnd(uuid));
if (atBottom) { queueMicrotask(() => this._scrollToBottom()); }
```

The check reads **before** the mutation, as it does at the other six call sites (`:331`, `:362`, `:545`, `:625`, `:643`, `:1114`): moving the bubble is what changes the height, so asking afterwards measures the layout the answer is meant to decide about.

## Why it was missed

Neither PR that met here was wrong:

- **#139** put the near-bottom rule on every **arrival** of content — assistant text, tool rows, thinking, errors
- **#143** later added a **move**, which is a case that rule had never seen

It is the gap between the two, not a regression in either.

## Deliberately not touched

A message you send yourself still scrolls **unconditionally** (`chat.userText`, `:297`). That is the same rule seen from the other side, and it is worth stating because it looks like an inconsistency:

| origin | behaviour |
| --- | --- |
| you did it (send, history page) | always scroll |
| it arrived (streaming, tools, thinking) | only if already at the bottom |

The gate protects reading from content you did not ask for. Pressing Enter is not content arriving — it is the thing you were doing. A queued message sits on the other side of that line: it leaves minutes later, when the CLI frees up, at which point you are a reader again, not a sender.

## Verification

`npm run typecheck` clean, `npm run lint` 0 errors, `npm run format` no changes. Behaviour confirmed in the experimental instance: queue a message while at the bottom, it now follows; queue one while scrolled up, the view stays put and the jump button appears.
