### PR TITLE
fix(chat): the queue row, in the two things it is for

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-queue-row.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-queue-row.ts
@@ -7,12 +7,20 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import Delete16Regular from '@fluentui/svg-icons/icons/delete_16_regular.svg';
 import TextBulletList16Regular from '@fluentui/svg-icons/icons/text_bullet_list_16_regular.svg';
+import Attach16Regular from '@fluentui/svg-icons/icons/attach_16_regular.svg';
 import { parseIdeContextTags } from '../../core/ide';
 import { iconStyles } from '../styles/shared';
+import { iconUrl } from '../../core/icon-url';
+import type { Attachment } from '../../core/types';
+import './cv-attach-chip';
 
 export interface QueuedMessage {
     text: string;
     uuid: string;
+    /** What the message carries. cv-prompt's queue entries have always held these; the type
+     *  simply did not say so, and the list could not tell a prompt with a screenshot from one
+     *  without. */
+    attachments?: Attachment[];
 }
 
 /** The row above the composer while messages are waiting to be sent. Stop drops the whole queue
@@ -61,6 +69,20 @@ export class CvQueueRow extends LitElement {
             }
             .spacer {
                 flex: 1;
+            }
+            /* Sits between the text and the buttons, so it must not be what gives way when the
+               text is long — the text has the ellipsis for that. */
+            .file-count {
+                display: inline-flex;
+                align-items: center;
+                gap: 2px;
+                flex-shrink: 0;
+                font-size: 0.85em;
+                color: var(--colorNeutralForeground3);
+            }
+            .file-count svg {
+                width: 14px;
+                height: 14px;
             }
             /* Triggers are <fluent-button> — keep them pure (layout only). */
             .count-btn,
@@ -151,19 +173,34 @@ export class CvQueueRow extends LitElement {
                 color: var(--colorNeutralForeground3);
                 font-variant-numeric: tabular-nums;
             }
-            /* The whole message, not a label: by the time a turn has been running the echoed
-               bubble has scrolled out of the viewport, so this is the only place left to read
-               what is about to be sent. Clamped so one long message cannot push the others out
-               of reach; the title attribute still carries the rest. */
+            /* Enough of the message to tell it from the others, not the message itself: by the
+               time a turn has been running the echoed bubble has scrolled out of the viewport, so
+               this is the only place left to check what is about to be sent — but three lines of
+               a pasted function already say which one it is, and six let one entry crowd out the
+               rest. The title attribute carries the whole text.
+               Plain text, never rendered markdown: this is for recognising a message, and a code
+               block with its own background and padding would add height exactly where there is
+               none to spare. */
             .item-text {
-                flex: 1;
-                min-width: 0;
                 white-space: pre-wrap;
                 overflow-wrap: anywhere;
                 overflow: hidden;
                 display: -webkit-box;
                 -webkit-box-orient: vertical;
-                -webkit-line-clamp: 6;
+                -webkit-line-clamp: 3;
+            }
+            /* The same chip the composer and the sent bubble use, so an attachment looks the same
+               at all three points of one message's life. Wraps under the text rather than beside
+               it: the row is already tight between the ordinal and the bin. */
+            .item-files {
+                display: flex;
+                flex-wrap: wrap;
+                gap: 4px;
+                margin-top: 4px;
+            }
+            .item-body {
+                flex: 1;
+                min-width: 0;
             }
         `,
     ];
@@ -208,6 +245,47 @@ export class CvQueueRow extends LitElement {
         return parseIdeContextTags(text).text;
     }
 
+    /** Built here rather than inline in the list: `.item-text` is `white-space: pre-wrap`, so the
+     *  indentation the template would put around the interpolation becomes leading whitespace on
+     *  screen — which is what pushed every entry away from its ordinal. */
+    private static _renderItemText(text: string) {
+        const shown = CvQueueRow._shown(text);
+        return html`<div class="item-text" title=${shown}>${shown}</div>`;
+    }
+
+    /** The single-message row has only the width left over by the label and the two buttons, so
+     *  what fits there is a paperclip and a number — enough to say the message is not text alone.
+     *  The names are in the title, and in the chips once there is a list to hold them. */
+    private static _renderFileCount(files?: Attachment[]) {
+        if (!files?.length) {
+            return nothing;
+        }
+        const names = files.map((f) => f.name).join('\n');
+        return html`<span class="file-count" title=${names}>
+            ${unsafeHTML(Attach16Regular)}${files.length > 1 ? files.length : nothing}
+        </span>`;
+    }
+
+    /** What the message carries, as the chips the composer and the sent bubble already use.
+     *  Not removable and not clickable: taking one attachment out of a queued message is not a
+     *  thing the queue can do — the bin drops the message whole — and opening it would put a
+     *  lightbox over the list you are reading. */
+    private static _renderFiles(files?: Attachment[]) {
+        if (!files?.length) {
+            return nothing;
+        }
+        return html`<div class="item-files">
+            ${files.map(
+                (a) =>
+                    html`<cv-attach-chip
+                        .src=${a.isImage ? (a.preview ?? a.dataUrl) : iconUrl(a.name)}
+                        .label=${a.name}
+                        title=${a.name}
+                    ></cv-attach-chip>`,
+            )}
+        </div>`;
+    }
+
     private _drop(uuid: string): void {
         this.dispatchEvent(
             new CustomEvent('drop-queued', { detail: { uuid }, bubbles: true, composed: true }),
@@ -242,8 +320,9 @@ export class CvQueueRow extends LitElement {
                 ${
                     n === 1
                         ? html`<span class="text" title=${CvQueueRow._shown(this.messages[0].text)}
-                              >${CvQueueRow._shown(this.messages[0].text)}</span
-                          >`
+                                  >${CvQueueRow._shown(this.messages[0].text)}</span
+                              >
+                              ${CvQueueRow._renderFileCount(this.messages[0].attachments)}`
                         : html`<span class="spacer"></span>
                               <fluent-button
                                   class="count-btn"
@@ -272,9 +351,10 @@ export class CvQueueRow extends LitElement {
                     (m, i) =>
                         html`<div class="item">
                             <span class="ord">${i + 1}</span>
-                            <span class="item-text" title=${CvQueueRow._shown(m.text)}
-                                >${CvQueueRow._shown(m.text)}</span
-                            >
+                            <div class="item-body">
+                                ${CvQueueRow._renderItemText(m.text)}
+                                ${CvQueueRow._renderFiles(m.attachments)}
+                            </div>
                             <fluent-button
                                 class="drop-btn"
                                 appearance="subtle"

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-queue-row.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-queue-row.ts
@@ -68,6 +68,19 @@ export class CvQueueRow extends LitElement {
             .drop-btn {
                 flex-shrink: 0;
             }
+            /* Cut to icon width, like every other icon trigger in the composer: at Fluent's width
+               for a labelled button the bin never reached the edge the send button below it sits
+               on, however much padding the row was given. */
+            .count-btn,
+            .clear-btn {
+                padding: 3px;
+                min-width: 0;
+            }
+            /* The row's 4px gap was set when these were wide enough to space themselves; at icon
+               width it leaves the bin looking like part of the count control. */
+            .count-btn {
+                margin-right: 4px;
+            }
             .count-btn svg,
             .clear-btn svg,
             .drop-btn svg {
@@ -208,8 +221,9 @@ export class CvQueueRow extends LitElement {
     private _renderClear(count: number) {
         return html`<fluent-button
             class="clear-btn"
-            appearance="transparent"
+            appearance="subtle"
             size="small"
+            icon-only
             title=${count === 1 ? 'Remove from queue' : 'Clear queue'}
             aria-label=${count === 1 ? 'Remove from queue' : 'Clear queue'}
             @click=${this._clear}
@@ -263,8 +277,9 @@ export class CvQueueRow extends LitElement {
                             >
                             <fluent-button
                                 class="drop-btn"
-                                appearance="transparent"
+                                appearance="subtle"
                                 size="small"
+                                icon-only
                                 title="Remove from queue"
                                 aria-label="Remove from queue"
                                 @click=${() => this._drop(m.uuid)}


### PR DESCRIPTION
The row above the composer, in the two things it is for: hitting the bin without looking, and checking what is about to be sent.

## The buttons never matched the composer below them

**The bin never reached the edge the send button sits on.** Not the row's padding — that already matched `#toolbar`'s 4px. It was the button: without `icon-only` and `min-width: 0`, Fluent gives a `fluent-button` the minimum width of a button **with a label**, and that spare width is what held the bin clear of the edge. No amount of padding on the row could have fixed it.

Cut to icon width with the same metrics `#send` uses, the two stacked rows now end on the same line. The row's `gap: 4px` was sized for buttons wide enough to space themselves, so the count carries an explicit margin now that they are not.

**Neither bin lit up on hover.** `appearance="transparent"` has no hover state in Fluent, while the count beside it is `"subtle"` and does — one reacted to the pointer and the one immediately next to it did not. Both bins move to `"subtle"`, matching the composer's other icon triggers (attach, gauge, copy, mic); the one in the list also gains the `icon-only` it was missing.

## The list did not say enough about the messages it holds

**A pasted function filled it.** Text clamped at six lines, so one entry pushed the ones after it out of reach. Three lines already say which message it is, and the `title` still carries the whole thing.

Not one line: with a turn running the echoed bubble has scrolled out of the viewport, so this list is the only place left to read what is queued — which is what the comment at `:141-144` was already saying.

Still plain text, never rendered markdown. The markdown in a bubble is there because you are *reading* it; here you are recognising which message it is, and a code block with its own background and padding would add height exactly where there is none to spare.

**A message with a screenshot looked like one without.** Attachments now render as `cv-attach-chip` — the same chip the composer (`cv-prompt.ts:1507`) and the sent bubble (`cv-message.ts:319/333/378`) use, so one attachment looks the same at all three points of a message's life, and it carries the file *name*, which is what tells you whether you queued the right screenshot.

Neither removable nor clickable: the queue drops messages whole, and a lightbox would land on top of the list being read. The single-message row has only the width the label and buttons leave, so it gets a paperclip and a count instead, with the names in the title.

`QueuedMessage` grows an `attachments` field — `cv-prompt`'s queue entries have always carried it (`_queue`, `:291`), the type simply never said so.

## Scope

One component. No behaviour change: the queue, its events and the popover are untouched — `cv-prompt` still owns the state and this only renders it.

One implementation note worth knowing before reformatting: the list text is built in a helper rather than inline, because `.item-text` is `white-space: pre-wrap` and the indentation around an interpolation becomes real leading whitespace on screen.

`npm run typecheck` clean, `npm run lint` 0 errors, `npm run format` no changes. Checked in the experimental instance: the bin lines up with send, all three bins respond to hover, long messages clamp, and a queued screenshot shows its chip.
