### PR TITLE
fix(chat): the chevron on Ask and Update Todos toggled nothing

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/base.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/base.ts
@@ -136,18 +136,6 @@ export abstract class ToolRenderer {
         });
     }
 
-    /** Header + a custom body the tool builds (todos, questions). */
-    protected rowCustom(body: TemplateResult, autoOpen = true): TemplateResult {
-        const show = this.host.status !== 'pending';
-        return this.chrome({
-            body: show ? body : null,
-            open: show && (autoOpen || this.host.expanded),
-            // No explicit onClick: chrome's rowClick falls back to toggleExpanded via the chevron.
-            onClick: null,
-            chevron: show,
-        });
-    }
-
     /** Whether the row has something to expand into (drives the chevron + row toggle). Default: a
      *  non-empty body. Agent widens this to include its live sub-agent children, so the chevron
      *  shows while the sub-agent runs, not only once it finishes. */
@@ -169,7 +157,10 @@ export abstract class ToolRenderer {
         return false;
     }
 
-    private chrome(opts: {
+    /** The row itself. The rowX helpers above are the shared shapes; a tool whose body is its
+     *  own (Ask, TodoWrite) calls this directly rather than through a shape that, not knowing
+     *  what the body holds, can't tell whether there is anything to expand into. */
+    protected chrome(opts: {
         body: TemplateResult | null;
         open: boolean;
         onClick: (() => void) | null;

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/renderers.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/renderers.ts
@@ -365,8 +365,15 @@ export class ReadMcpResourceRenderer extends HeaderOnlyRenderer {
 
 export class TodoWriteRenderer extends ToolRenderer {
     readonly name = 'TodoWrite';
+    /** The list is the whole content — no chevron, there is no second view to expand into. */
     override row(): TemplateResult {
-        return this.rowCustom(this.todoBody());
+        const done = this.host.status !== 'pending';
+        return this.chrome({
+            body: done ? this.todoBody() : null,
+            open: done,
+            onClick: null,
+            chevron: false,
+        });
     }
     override header(): TemplateResult {
         return html`${this.nameSpan('Update Todos')}`;
@@ -401,8 +408,15 @@ export class TodoWriteRenderer extends ToolRenderer {
 
 export class AskUserQuestionRenderer extends ToolRenderer {
     readonly name = 'AskUserQuestion';
+    /** Same shape as TodoWrite: the questions body is what there is, so no chevron. */
     override row(): TemplateResult {
-        return this.rowCustom(this.questionsBody());
+        const done = this.host.status !== 'pending';
+        return this.chrome({
+            body: done ? this.questionsBody() : null,
+            open: done,
+            onClick: null,
+            chevron: false,
+        });
     }
     override header(): TemplateResult {
         const qs = (this.host.input.questions ?? []) as AskQuestion[];


### PR DESCRIPTION
The chevron on an **Ask** or **Update Todos** row was visible at rest, already
rotated as if open, and did nothing when clicked.

## Why

Both rows went through `rowCustom`, which lit the chevron on `status !== 'pending'`
and computed:

```ts
open: show && (autoOpen || this.host.expanded)
```

Both callers take the default `autoOpen = true`, so the `||` short-circuits and
`expanded` never reaches `open`. Clicking flipped a flag nobody read. And with
`open` permanently true the chevron kept the `.expanded` class, which pins it
visible and rotated (`chat.css:371-373`) — so it read as an active control at rest
while being inert.

`rowCustom` had no way to decide otherwise. The other shapes name a body they know
— no body (`rowHeaderOnly`), a count line (`rowCount`), a diff (`rowDiff`) — and
hardcode `chevron: false` from that knowledge; `rowStandard` asks
`hasExpandableContent()`. `rowCustom` only knows "the caller brings its own body",
so it guessed.

## What changed

- `rowCustom` removed, its two callers build their row from `chrome()` directly,
  as the other shapes do, each passing `chevron: false`.
- `chrome()` `private` → `protected` to allow that. Its body is unchanged.

The todo list and the questions body are the whole content — there is no second
view to expand into, so no chevron.

## Scope

The four shapes are untouched, and Agent keeps the one chevron that works (starts
collapsed, click opens). `rowCustom` had exactly two callers, both here, so nothing
else is affected — the typecheck would have caught a third.

## Not in scope

With the compact answered view on (`compactOutputAskAnswers`, the default), an Ask
row shows only the chosen option and the alternatives stay unreachable. Offering
them back is a feature, not this fix — the chevron never delivered it, since
`questionsBody` picks compact/full from the setting alone and never looked at
`expanded`.

## Verification

`npm run typecheck` and `npm run lint` clean (the 7 `no-explicit-any` warnings are
pre-existing, in files not touched here), Prettier reports both files unchanged.
Built and checked in the Exp instance.
