### PR TITLE
perf(chat): stop re-rendering and re-measuring the whole transcript on every token

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/dialog-host.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/dialog-host.ts
@@ -13,9 +13,14 @@ import type { LightboxRequest, DiffDialogNotification } from './types';
 // The dialog custom elements are registered by the UI layer (cv-app imports them),
 // not here — core/ must not import ui/. mount() only creates the already-defined tag.
 
+// Close of the instance currently up for a tag, so a reopen tears the old one down the same way
+// its own `close` event would.
+const mounted = new Map<string, (keepFocus?: boolean) => void>();
+
 function mount(tag: string, props?: Record<string, unknown>): void {
-    // Replace any already-open dialog of the same tag (reopen = fresh data, last wins).
-    document.querySelector(tag)?.remove();
+    // Replace any already-open dialog of the same tag (reopen = fresh data, last wins). Keep the
+    // focus: the outgoing restore is delayed, so it would land after this one is up and steal it.
+    mounted.get(tag)?.(true);
 
     const el = document.createElement(tag);
     if (props) {
@@ -27,20 +32,27 @@ function mount(tag: string, props?: Record<string, unknown>): void {
     // Esc → ui_escape → closeTopDialog → close()). Removing the element without popping leaves a
     // phantom entry that swallows the next Esc before it reaches the composer menus.
     let closed = false;
-    const close = (): void => {
+    // Arg is ours, not the listener's: `close` is also an event handler, so guard on `true`.
+    const close = (keepFocus?: unknown): void => {
         if (closed) {
             return;
         }
         closed = true;
         popDialog(close);
+        if (mounted.get(tag) === close) {
+            mounted.delete(tag);
+        }
         el.remove();
-        restoreFocus(returnFocus);
+        if (keepFocus !== true) {
+            restoreFocus(returnFocus);
+        }
     };
 
     // The component emits `close` on toggle-closed (Esc/backdrop) or its ✕.
     el.addEventListener('close', close, { once: true });
 
     pushDialog(close);
+    mounted.set(tag, close);
     document.body.appendChild(el);
     (el as { open?: boolean }).open = true;
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/lang.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/lang.ts
@@ -110,19 +110,46 @@ export function resolveLang(label: string | undefined | null): string {
     return ALIASES[lc] || lc;
 }
 
+// Bounded like the markdown one, and for the same reason: the callers are Lit render() bodies, so
+// a tool row re-highlights its whole body whenever anything about the row changes. Only settled
+// text benefits — a growing code fence is a new key on every pass, so the streaming path (which
+// goes through renderMarkdown's own cache) neither hits this nor thrashes it.
+const HL_CACHE_MAX = 100;
+const _hlCache = new Map<string, string | null>();
+
+/** Drop the memoized highlights. Paired with clearMarkdownCache() — same lifetime, same reason. */
+export function clearHighlightCache(): void {
+    _hlCache.clear();
+}
+
 /**
  * Highlight `code` as `label` (a fence label or a file extension), returning HTML.
  * Null when the language is unknown or hljs throws — the caller then renders the text
  * plain, which is what an unhighlighted file should look like anyway.
+ * Memoized by code+language — see HL_CACHE_MAX.
  */
 export function highlightCode(code: string, label: string | undefined | null): string | null {
     const language = resolveLang(label);
     if (!language || !hljs.getLanguage(language)) {
         return null;
     }
-    try {
-        return hljs.highlight(code, { language, ignoreIllegals: true }).value;
-    } catch {
-        return null;
+    const key = `${language} ${code}`;
+    const cached = _hlCache.get(key);
+    // has() and not a null check: null is a real result (hljs threw) and worth keeping.
+    if (cached !== undefined || _hlCache.has(key)) {
+        _hlCache.delete(key);
+        _hlCache.set(key, cached ?? null);
+        return cached ?? null;
     }
+    let out: string | null;
+    try {
+        out = hljs.highlight(code, { language, ignoreIllegals: true }).value;
+    } catch {
+        out = null;
+    }
+    _hlCache.set(key, out);
+    if (_hlCache.size > HL_CACHE_MAX) {
+        _hlCache.delete(_hlCache.keys().next().value as string);
+    }
+    return out;
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/markdown-split.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/markdown-split.ts
@@ -7,8 +7,8 @@
 
 /**
  * Offset of the last point in `text` that later text cannot change the meaning of — a blank line
- * outside a fenced block. Markdown separates blocks there, so everything before it is settled and
- * can be rendered once instead of on every delta.
+ * outside a fenced block, or the line that closes one. Markdown separates blocks there, so
+ * everything before it is settled and can be rendered once instead of on every delta.
  *
  * Returns 0 when there is no such point (a single growing paragraph, or nothing but a settled
  * prefix), which tells the caller to render the whole thing. Deliberately conservative: cutting
@@ -26,6 +26,12 @@ export function stableMarkdownSplit(text: string): number {
         const line = lines[i];
         if (/^\s*```/.test(line)) {
             inFence = !inFence;
+            // The line that CLOSES a fence settles the whole block: nothing later can reopen it.
+            // Without this the open fence stays in the tail and every pass re-highlights all of
+            // it — the cost that grows with the block, on the content most likely to be long.
+            if (!inFence) {
+                cut = pos + line.length + 1;
+            }
         } else if (!inFence && i > 0 && line.trim() === '') {
             // Everything up to and including this blank line is final.
             cut = pos + line.length + 1;

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/markdown.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/markdown.ts
@@ -7,7 +7,7 @@
 
 import { marked, type Renderer, type Tokens } from 'marked';
 import DOMPurify from 'dompurify';
-import { resolveLang, highlightCode } from './lang';
+import { resolveLang, highlightCode, clearHighlightCache } from './lang';
 import { escapeHtml } from './html';
 import { findFileRefs, firstRefHint, parseFileRef } from './file-links';
 
@@ -139,6 +139,8 @@ const _mdCache = new Map<string, string>();
  *  messages compete with a dead one's for the same 200 slots. */
 export function clearMarkdownCache(): void {
     _mdCache.clear();
+    // The highlight memo holds fragments of the same messages, so it goes with them.
+    clearHighlightCache();
 }
 
 /**

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/types.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/types.ts
@@ -8,6 +8,14 @@
 import type { SubagentUsageDto } from './generated/SubagentUsageDto';
 import type { ToolResultExtrasDto } from './generated/ToolResultExtrasDto';
 
+/**
+ * The one empty array the render passes hand out, because a fresh `[]` is a new identity and Lit
+ * compares properties by identity: a literal in a template marks its element dirty on EVERY pass,
+ * so a single streaming delta re-rendered every message and every tool row in the transcript.
+ * Frozen so a consumer that mutates its own prop can't reach the others through it.
+ */
+export const EMPTY: readonly never[] = Object.freeze([]);
+
 export type Theme = 'dark' | 'light';
 
 /** Reasoning effort level union ('low'|'medium'|'high'|'xhigh'), generated from C#. */

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/markdown-split.test.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/markdown-split.test.ts
@@ -25,6 +25,20 @@ test('split: riprende dopo una fence chiusa', () => {
     assert.equal(t.slice(0, cut), 'testo\n\n```ts\nconst a = 1;\n```\n\n');
 });
 
+test('split: la riga che chiude una fence e gia un punto di taglio', () => {
+    // Senza riga vuota dopo la fence: il blocco e' comunque finito, e lasciarlo nella coda
+    // significa ri-evidenziarlo per intero a ogni passata.
+    const t = 'testo\n\n```ts\nconst a = 1;\n```\ncoda in corso';
+    const cut = stableMarkdownSplit(t);
+    assert.equal(t.slice(0, cut), 'testo\n\n```ts\nconst a = 1;\n```\n');
+});
+
+test('split: una fence ancora aperta non e un punto di taglio', () => {
+    const t = 'testo\n\n```ts\nconst a = 1;';
+    const cut = stableMarkdownSplit(t);
+    assert.equal(t.slice(0, cut), 'testo\n\n');
+});
+
 test('split: senza righe vuote non taglia', () => {
     assert.equal(stableMarkdownSplit('un solo paragrafo che cresce'), 0);
 });

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
@@ -70,6 +70,7 @@ import type {
     CliExitedNotification,
     RemoteControlNotification,
 } from '../../core/types';
+import { EMPTY } from '../../core/types';
 import { GetHistoryReq } from '../../core/request-types';
 import { modelLabel } from '../../core/ai-models';
 import { turnErrorLabel, turnErrorDetail, isUserAbort } from '../../core/turn-errors';
@@ -80,14 +81,6 @@ let _entryIdSeq = 0;
 /** Notice key for the "CLI process exited" row, so a restart clears exactly that one. */
 const CLI_EXITED_KEY = 'cli-exited';
 const REMOTE_CONTROL_ERROR_KEY = 'remote-control-error';
-
-/**
- * The one empty array the render passes hand out, because a fresh `[]` is a new identity and Lit
- * compares properties by identity: a literal in a template marks its element dirty on EVERY pass,
- * so a single streaming delta re-rendered every message and every tool row in the transcript.
- * Frozen so a consumer that mutates its own prop can't reach the others through it.
- */
-const EMPTY: readonly never[] = Object.freeze([]);
 
 /**
  * Root component. Owns the chat entry list and wires the bridge messages

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
@@ -904,6 +904,7 @@ export class CvApp extends LitElement {
         this.removeEventListener('model-switched', this._onModelSwitched as EventListener);
         this.removeEventListener('queued-sent', this._onQueuedSent as EventListener);
         this.removeEventListener('queued-dropped', this._onQueuedDropped as EventListener);
+        this.removeEventListener('show-remote-link', this._onShowRemoteLink);
         for (const off of this._offs) {
             off();
         }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
@@ -82,6 +82,14 @@ const CLI_EXITED_KEY = 'cli-exited';
 const REMOTE_CONTROL_ERROR_KEY = 'remote-control-error';
 
 /**
+ * The one empty array the render passes hand out, because a fresh `[]` is a new identity and Lit
+ * compares properties by identity: a literal in a template marks its element dirty on EVERY pass,
+ * so a single streaming delta re-rendered every message and every tool row in the transcript.
+ * Frozen so a consumer that mutates its own prop can't reach the others through it.
+ */
+const EMPTY: readonly never[] = Object.freeze([]);
+
+/**
  * Root component. Owns the chat entry list and wires the bridge messages
  * that produce or update entries (`user_text`, `text`, `text_delta`,
  * `tool_use`, `tool_result`, `tool_progress`, `result`, `error`,
@@ -105,6 +113,9 @@ export class CvApp extends LitElement {
         queued: ReadonlySet<string>;
         groups: UiEntry[][];
     } | null = null;
+    /** Copy text of an exchange's actions row, keyed on the group buildGroups produced it from.
+     *  Weak so a group the next rebuild drops takes its entry with it. */
+    private _joinCache = new WeakMap<UiEntry[], string>();
     @state() private _subagentTasks = new Map<string, SubagentTask>();
 
     /** Ids the CLI last reported as running in the background. Not @state: it decides what a task
@@ -1728,7 +1739,14 @@ export class CvApp extends LitElement {
         if (last.role === 'assistant' && last.streaming) {
             return nothing;
         }
-        const text = blocks.map((b) => b.text).join('\n\n');
+        // Joining every block of every exchange on each pass is the kind of work that only shows up
+        // once a chat is long. Keyed on the group array, which buildGroups rebuilds whenever the
+        // transcript changes and keeps otherwise — so any edit to any block gives a new key.
+        let text = this._joinCache.get(group);
+        if (text === undefined) {
+            text = blocks.map((b) => b.text).join('\n\n');
+            this._joinCache.set(group, text);
+        }
         const ts = last.timestamp ?? 0;
         // Keyed on the last text block — the one entry both writers can name: `assistantText` has
         // only the message it just closed, and `exchangeEnded` looks the same one up. Keying on the
@@ -1798,8 +1816,8 @@ export class CvApp extends LitElement {
             ?loaded=${e.role === 'compact' ? !!e.loaded : false}
             .uuid=${e.role === 'compact' || e.role === 'user' ? (e.uuid ?? '') : ''}
             ?queued=${e.role === 'user' && !!e.uuid && this._queuedUuids.has(e.uuid)}
-            .images=${e.role === 'user' ? (e.images ?? []) : []}
-            .files=${e.role === 'user' ? (e.files ?? []) : []}
+            .images=${e.role === 'user' ? (e.images ?? EMPTY) : EMPTY}
+            .files=${e.role === 'user' ? (e.files ?? EMPTY) : EMPTY}
             ?streaming=${e.role === 'assistant' ? !!e.streaming : false}
             ?isError=${e.role === 'slash-result' ? e.isError : e.role === 'assistant' && !!e.error}
             .timestamp=${
@@ -1816,7 +1834,7 @@ export class CvApp extends LitElement {
             .status=${e.status}
             .result=${e.result}
             .elapsedSec=${e.elapsedSec}
-            .childItems=${e.children?.items ?? []}
+            .childItems=${e.children?.items ?? EMPTY}
             .fullLineCount=${e.fullLineCount}
             .extras=${e.extras ?? null}
             .agentId=${e.agentId ?? ''}

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-message.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-message.ts
@@ -22,6 +22,7 @@ import { displayPathUi } from '../paths';
 import { parseIdeContextTags } from '../../core/ide';
 import { renderSlashCommand } from '../../core/slash-commands';
 import { openLightbox } from '../../core/dialog-host';
+import { observeSize } from '../resize';
 import type {
     IdeContextRef,
     ForkNotification,
@@ -65,7 +66,7 @@ export class CvMessage extends LitElement {
     @state() private _isOverflowing = false;
     // Re-measure the truncation on width changes: text re-wraps, so the px cap and the "Show more"
     // decision must be recomputed. updated() alone fires on property change, not on resize.
-    private _resizeObs?: ResizeObserver;
+    private _unobserve?: () => void;
     // Last observed width — the observer fires on our own max-height writes too, so re-measure only
     // when the WIDTH actually changed (that's what re-wraps the text). Avoids a feedback loop.
     private _lastWidth = 0;
@@ -152,26 +153,25 @@ export class CvMessage extends LitElement {
             clearTimeout(this._streamTimer);
             this._streamTimer = undefined;
         }
-        this._resizeObs?.disconnect();
-        this._resizeObs = undefined;
+        this._unobserve?.();
+        this._unobserve = undefined;
     }
 
     override updated(): void {
         this._measure();
         // Observe width once the row exists: re-wrapping on resize changes the truncation.
-        if (this.role === 'user' && !this._resizeObs) {
+        if (this.role === 'user' && !this._unobserve) {
             const el = this.querySelector('.cv-message.user') as HTMLElement | null;
             if (el) {
                 this._lastWidth = el.clientWidth;
-                this._resizeObs = new ResizeObserver((entries) => {
-                    const w = entries[0]?.contentRect.width ?? 0;
+                this._unobserve = observeSize(el, (entry) => {
+                    const w = entry.contentRect.width;
                     if (Math.abs(w - this._lastWidth) < 1) {
                         return; // height-only change (our own max-height write) — skip
                     }
                     this._lastWidth = w;
                     this._measure();
                 });
-                this._resizeObs.observe(el);
             }
         }
     }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-message.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-message.ts
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
-import { LitElement, html, nothing } from 'lit';
+import { LitElement, html, nothing, type PropertyValues } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import BranchFork16Regular from '@fluentui/svg-icons/icons/branch_fork_16_regular.svg';
@@ -67,6 +67,7 @@ export class CvMessage extends LitElement {
     // Re-measure the truncation on width changes: text re-wraps, so the px cap and the "Show more"
     // decision must be recomputed. updated() alone fires on property change, not on resize.
     private _unobserve?: () => void;
+    private _offUi?: () => void;
     // Last observed width — the observer fires on our own max-height writes too, so re-measure only
     // when the WIDTH actually changed (that's what re-wraps the text). Avoids a feedback loop.
     private _lastWidth = 0;
@@ -147,8 +148,16 @@ export class CvMessage extends LitElement {
         return this;
     }
 
+    override connectedCallback(): void {
+        super.connectedCallback();
+        // previewLines IS the cap, so a change to it changes the truncation of every bubble.
+        this._offUi = appState.on('ui', () => this._measure());
+    }
+
     override disconnectedCallback(): void {
         super.disconnectedCallback();
+        this._offUi?.();
+        this._offUi = undefined;
         if (this._streamTimer) {
             clearTimeout(this._streamTimer);
             this._streamTimer = undefined;
@@ -157,8 +166,15 @@ export class CvMessage extends LitElement {
         this._unobserve = undefined;
     }
 
-    override updated(): void {
-        this._measure();
+    override updated(changed: PropertyValues): void {
+        // Only what can change the measured height. _measure() writes maxHeight and then reads
+        // scrollHeight, which is a synchronous layout: doing it on every update meant one forced
+        // reflow per user bubble per pass. Width changes come from the ResizeObserver below, and
+        // previewLines — the cap itself, which lives in the options and not in a property — from
+        // the state subscription in connectedCallback.
+        if (changed.has('text') || changed.has('expanded') || changed.has('role')) {
+            this._measure();
+        }
         // Observe width once the row exists: re-wrapping on resize changes the truncation.
         if (this.role === 'user' && !this._unobserve) {
             const el = this.querySelector('.cv-message.user') as HTMLElement | null;

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-mic-button.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-mic-button.ts
@@ -55,6 +55,29 @@ export class CvMicButton extends LitElement {
     // Text accumulated from final results in this recording session.
     private _finalText = '';
 
+    /**
+     * Stop the recognition session when the button goes away (pane closed mid-dictation): the
+     * engine holds the microphone until someone says otherwise, and nothing else would.
+     *
+     * `abort()` and not `stop()`: stop() finalises the pending utterance and fires one last
+     * `onresult`, which would dispatch `transcript` at a detached listener. The handlers are
+     * cleared first because abort() still fires `onend`, and that branch dispatches
+     * `recording-end` — cv-prompt's handler reads its textarea, which is gone by then.
+     */
+    override disconnectedCallback(): void {
+        super.disconnectedCallback();
+        const sr = this._speech;
+        if (!sr) {
+            return;
+        }
+        this._speech = null;
+        this._recording = false;
+        sr.onresult = null;
+        sr.onend = null;
+        sr.onerror = null;
+        sr.abort();
+    }
+
     private _onClick = (): void => {
         if (this._recording) {
             this._speech?.stop();

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-segmented-slider.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-segmented-slider.ts
@@ -165,14 +165,21 @@ export class CvSegmentedSlider<V = unknown> extends LitElement {
         const track = e.currentTarget as HTMLElement;
         track.setPointerCapture(e.pointerId);
         this._commit(this._indexFromPointer(e.clientX, track));
-        const move = (ev: PointerEvent) => this._commit(this._indexFromPointer(ev.clientX, track));
-        const up = (ev: PointerEvent) => {
+        // pointercancel too, not just pointerup: a gesture the browser takes over (touch scroll,
+        // capture lost) ends without one, and every such drag would leave its pair behind.
+        const drag = new AbortController();
+        const { signal } = drag;
+        const end = (ev: PointerEvent) => {
             track.releasePointerCapture(ev.pointerId);
-            track.removeEventListener('pointermove', move);
-            track.removeEventListener('pointerup', up);
+            drag.abort();
         };
-        track.addEventListener('pointermove', move);
-        track.addEventListener('pointerup', up);
+        track.addEventListener(
+            'pointermove',
+            (ev: PointerEvent) => this._commit(this._indexFromPointer(ev.clientX, track)),
+            { signal },
+        );
+        track.addEventListener('pointerup', end, { signal });
+        track.addEventListener('pointercancel', end, { signal });
     };
 
     private _onKeyDown = (e: KeyboardEvent): void => {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-speak-btn.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-speak-btn.ts
@@ -72,6 +72,12 @@ export class CvSpeakBtn extends LitElement {
     override disconnectedCallback(): void {
         super.disconnectedCallback();
         this._stopSpeaking();
+    }
+
+    /** Back to idle, and out of `active` — which is what it means to no longer be reading. Leaving
+     *  a finished button in the set is what made it hold every button that had ever spoken. */
+    private _toIdle(): void {
+        this._state = 'idle';
         active.delete(this);
     }
 
@@ -79,9 +85,10 @@ export class CvSpeakBtn extends LitElement {
      *  unmount. (cancel() clears the queue — only one utterance is ever queued.) */
     _stopSpeaking(): void {
         if (this._state !== 'idle') {
-            this._state = 'idle';
+            this._toIdle();
             window.speechSynthesis.cancel();
         }
+        active.delete(this);
     }
 
     private _onClick = (e: Event): void => {
@@ -105,12 +112,8 @@ export class CvSpeakBtn extends LitElement {
         window.speechSynthesis.cancel();
         const u = new SpeechSynthesisUtterance(text);
         // Reset to idle when the engine finishes or errors so the icon never stays stuck on "pause".
-        u.onend = () => {
-            this._state = 'idle';
-        };
-        u.onerror = () => {
-            this._state = 'idle';
-        };
+        u.onend = () => this._toIdle();
+        u.onerror = () => this._toIdle();
         this._state = 'speaking';
         active.add(this);
         window.speechSynthesis.speak(u);

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-tool-row.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-tool-row.ts
@@ -13,6 +13,7 @@ import './cv-copy-btn';
 // The Agent row's running clock, rendered by AgentRenderer.header() into this row's light DOM.
 import './cv-elapsed';
 import type { ToolStatus, ToolUseData, UiEntry, ToolResultExtrasDto } from '../../core/types';
+import { EMPTY } from '../../core/types';
 import { makeRenderer } from '../tool-renderers';
 import { BridgeToolHost, cleanResult } from '../tool-renderers/tool-host';
 import type { ToolRowState } from '../tool-renderers/types';
@@ -217,7 +218,7 @@ export class CvToolRow extends LitElement implements ToolRowState {
                                     .status=${c.status}
                                     .result=${c.result}
                                     .elapsedSec=${c.elapsedSec}
-                                    .childItems=${c.children?.items ?? []}
+                                    .childItems=${c.children?.items ?? EMPTY}
                                     .fullLineCount=${c.fullLineCount}
                                     .extras=${c.extras ?? null}
                                     .agentId=${c.agentId ?? ''}

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/chat.css
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/chat.css
@@ -98,6 +98,23 @@
     margin-bottom: 10px;
     position: relative;
 }
+/* Skip the layout of answers that are off screen. A long chat is thousands of nodes the browser
+ * re-measures on every reflow, and almost none of them are in view: measured on a 24.5k-node
+ * transcript the median full layout went from 45.3ms to 9.7ms, i.e. from three dropped frames to
+ * inside the budget.
+ *
+ * On .cv-response and NOT on .cv-exchange: the leading user bubbles are position:sticky and live
+ * in the exchange, and the containment content-visibility applies would pin them to their own box.
+ *
+ * The size is the median of a real transcript (p25 650, median 1121, p75 1552 px). It only ever
+ * applies to a block that has never been laid out — `auto` means the real height is remembered
+ * from the first render on, viewport or not — so it matters for the first pass through a chat and
+ * for scrollHeight, which _prependWithAnchor anchors history loading on. Measured: 400/800/1550px
+ * are indistinguishable once the chat has been scrolled through, which is what that `auto` says. */
+.cv-exchange > .cv-response {
+    content-visibility: auto;
+    contain-intrinsic-size: auto 1100px;
+}
 /* A message typed while a turn was running: the bubble is there because the user wrote it, but
  * the CLI has not been given it yet. Faded rather than badged — in a column of full-strength
  * bubbles a pale one reads at a glance, and the bubble already carries copy/fork actions on hover

--- a/src/Corsinvest.VisualStudio.Agents/Options/AgentsChatPage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Options/AgentsChatPage.cs
@@ -53,7 +53,7 @@ public class AgentsChatPage : AgentsOptionsPage
 
     [Category("Display")]
     [DisplayName("Preview lines")]
-    [Description("Number of lines shown in preview areas (tool output and user messages). 0 = no preview.")]
+    [Description("Number of lines shown in preview areas (tool output and user messages). 0 turns previews off: tool rows start collapsed (the chevron opens them in full) and user bubbles keep a short 3-line preview.")]
     public int PreviewLines { get; set; } = 3;
 
     [Category("File links")]


### PR DESCRIPTION
Audit of the chat pane for memory and rendering cost, then the fixes it turned up. Read-only analysis first, one commit per finding, each verified in the Exp instance before the next.

## What was actually wrong

**The render loop, which is what everything else was hiding.** `renderMessage` handed every `cv-message` a fresh `[]` for `images`/`files`, and `renderToolRow` one for `childItems`. Lit compares properties by identity and lit-html commits non-primitives without comparing, so a new array marked its element dirty on every pass: **one streaming delta re-rendered every message and every tool row in the transcript**. `cv-tool-row` did the same thing for nested sub-agent rows, where it compounds with the depth of the tree.

`Transcript` already goes to some length to preserve the identity of branches that did not change so Lit can skip them — the array literals threw that away before it reached the children.

Two consequences fixed with it: `cv-message.updated()` called `_measure()` unconditionally, and for `role="user"` that writes `maxHeight` then reads `scrollHeight` — a forced synchronous layout, once per user bubble per token. And `renderResponseActions` joined the text of every block of every exchange on each pass.

**Off-screen layout.** A long chat is thousands of nodes the browser re-measures on every reflow, almost none of them in view. `content-visibility: auto` on `.cv-response` — measured on a 24.5k-node transcript, median full layout **46.4ms → 8.8ms** (81%), two independent runs agreeing. It grows with the transcript, so it was worst exactly in the long sessions where it is felt.

**Re-highlighting settled code.** A closed fence is now a cut point for the stable prefix, not just a blank line: a code block used to sit in the growing tail until a blank line happened to follow it, and every 75ms pass re-ran hljs over all of it. Plus a bounded memo on `highlightCode`, whose callers are Lit `render()` bodies.

**One real resource leak.** `cv-mic-button` had no `disconnectedCallback`, so closing the pane mid-dictation **left the microphone on**, with `sr.onresult` still dispatching from a detached node.

**A phantom entry on the Esc stack.** Reopening a dialog replaced the previous instance with `.remove()`, so its `close` closure never ran and `popDialog` never fired — the entry stayed for the rest of the session, swallowing the next Esc. This is the third path the comment above `close` describes, and the only one that was not covered.

Plus four small lifecycle asymmetries (a drag that never handled `pointercancel`, a module-level `Set` that only shed entries on unmount, one custom-event listener out of six left attached, a per-bubble `ResizeObserver` where a shared helper exists).

## What was deliberately not done

**highlight.js stays whole.** The full bundle is ~190 languages, and switching to `lib/core` would trade a bundle that is not on the critical path (the startup investigation already found 1.8mb and 3.3mb give the same open time, the ~2s stall being inside WebView2) for a frozen language list. `resolveLang` is `ALIASES[lc] || lc`, so the tables list only the exceptions — the set actually used is whatever the model writes after the backticks. Shiki was evaluated and rejected on the same grounds, plus its WASM engine cannot be instantiated from the `file://` origin the pane runs on.

**`Preview lines = 0` keeps both its behaviours**, only the description was wrong. Tool rows start collapsed (`autoOpen()` is `previewLines > 0`) but open in full on the chevron; user bubbles fall back to a 3-line preview. Enforcing a minimum of 3 would make `previewLines > 0` always true and tool rows would never start collapsed, losing the compact chat that 0 exists for.

## Numbers

Measured on a real 24.5k-node transcript (318 tool rows, 402 messages, 40MB heap against a 4192MB limit — the DOM was never the problem, the number of times it was touched was):

| | before | after |
|---|---|---|
| median full layout | 46.4ms | 8.8ms |
| messages updated per streaming token | all of them | the one that changed |
| forced reflows per token | one per user bubble | none |

## Verification

`npm run check` (typecheck, lint, prettier, 68 tests) green; `build_solution` green on `Debug|Any CPU`. Manually exercised in the Exp instance across the whole series — mic in the tray after closing a pane mid-dictation, double Esc after reopening a dialog, a long C# block that stops recolouring once its fence closes, and a 24.5k-node chat scrolled end to end.

Two tests worth repeating on a session that still has history to load: the sticky user bubble, and the scroll anchor in `_prependWithAnchor`, which reads `scrollHeight` — now an estimate for blocks never laid out. `contain-intrinsic-size` is the measured median; `auto` means it only applies before a block's first render, which is why 400/800/1550px are indistinguishable once a chat has been scrolled through.

One trade-off, stated: the layout cost moves rather than disappearing. Dragging the scrollbar fast now paints blocks as they arrive instead of having done it all up front — a rare gesture against a cost that was paid on every reflow.
