### PR TITLE
perf(sessions): the picker froze Visual Studio while it read the folder

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.cs
@@ -29,8 +29,9 @@ internal sealed partial class WebViewMessageHandler(WebViewBridge bridge,
     private ClaudePaths PaneClaudePaths => entry.ClaudePaths;
 
     /// <summary>Build a SessionManager keyed on this session's config-dir and working directory.
-    /// New instance per call — SessionManager is stateless besides the readonly fields.</summary>
-    private SessionManager Sessions => new(PaneClaudePaths, client.WorkingDirectory);
+    /// New instance per call: these are single-session reads, so the scan cache a long-lived
+    /// instance would keep is of no use to them.</summary>
+    private SessionManager Sessions => new(PaneClaudePaths, client.WorkingDirectory, log);
 
     // id is the request/response correlation id (null for notifications). The 5 request cases
     // (get_image/get_history/get_subagent/get_usage/file_get_suggestions) echo it back via

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
@@ -24,9 +24,10 @@ public partial class ChatPaneControl : PaneControlBase
 {
     public override bool SupportsTitleEditing => true;
 
-    /// <summary>New instance per call, keyed on the pane's current working directory
-    /// (constant for the pane's lifetime). Cheap enough that a shared field would add nothing.</summary>
-    private SessionManager Sessions => new(PaneClaudePaths, Entry.WorkingDirectory);
+    /// <summary>New instance per call, keyed on the pane's current working directory (constant for
+    /// the pane's lifetime). These callers read one session at a time, so the scan cache a
+    /// long-lived instance would keep buys them nothing.</summary>
+    private SessionManager Sessions => new(PaneClaudePaths, Entry.WorkingDirectory, _log);
 
     /// <summary>Re-read the freshest title (custom/ai/last-prompt) for the current
     /// session from its JSONL. Called on load/fork and at turn end so a generated

--- a/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.History.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.History.cs
@@ -26,7 +26,7 @@ internal sealed partial class SessionManager
 
     public HistoryPage ReadHistoryRaw(string sessionId, int batchSize, long beforeOffset, out SessionInfo info)
     {
-        using var _ = OutputWindowLogger.Global.PerfSpan($"ReadHistoryRaw({sessionId}, batch={batchSize}, before={beforeOffset})");
+        using var _ = log.PerfSpan($"ReadHistoryRaw({sessionId}, batch={batchSize}, before={beforeOffset})");
         var page = new HistoryPage { Messages = [] };
         var folder = FolderFor();
         var path = FileFor(sessionId);
@@ -35,7 +35,7 @@ internal sealed partial class SessionManager
         if (!File.Exists(path)) { return page; }
 
         var fileSize = new FileInfo(path).Length;
-        OutputWindowLogger.Global.Perf(() => $"history file: {fileSize / 1024} KB");
+        log.Perf(() => $"history file: {fileSize / 1024} KB");
 
         // `info` is built only on the initial load (beforeOffset == -1); lazy pages skip it.
         var isInitialLoad = beforeOffset < 0;
@@ -44,7 +44,7 @@ internal sealed partial class SessionManager
             info = new SessionInfo
             {
                 Id = sessionId,
-                WorkingDirectory = _workingDirectory,
+                WorkingDirectory = workingDirectory,
                 LastUsedAt = File.GetLastWriteTime(path),
             };
         }
@@ -186,7 +186,7 @@ internal sealed partial class SessionManager
                 page.HasMore = pos > 0;
             }
         }
-        catch (Exception ex) { _log.LogException("SessionManager.ReadHistoryRaw", ex); }
+        catch (Exception ex) { log.LogException("SessionManager.ReadHistoryRaw", ex); }
 
         if (info != null)
         {
@@ -202,7 +202,7 @@ internal sealed partial class SessionManager
         // oldestIsPrompt tells whether the page ends on a real user prompt (good) or was cut by
         // reaching the file start / a metadata-only tail.
         var oldestIsPrompt = messagesNewestFirst.Count > 0 && IsRealUserPrompt(messagesNewestFirst[0]);
-        OutputWindowLogger.Global.Perf(() => $"history: scanned {totalLinesScanned} lines ({skippedLines} skipped, {parsedLines} parsed), kept {messagesNewestFirst.Count} (batch={batchSize}) " +
+        log.Perf(() => $"history: scanned {totalLinesScanned} lines ({skippedLines} skipped, {parsedLines} parsed), kept {messagesNewestFirst.Count} (batch={batchSize}) " +
             $"bytes[{page.OldestOffset}..{(isInitialLoad ? "END" : beforeOffset.ToString())}] hasMore={page.HasMore} oldestIsPrompt={oldestIsPrompt}");
         page.Messages = new JArray(messagesNewestFirst);
         return page;
@@ -217,7 +217,7 @@ internal sealed partial class SessionManager
     /// meant to run off the UI thread after the initial render.</summary>
     public List<string> ReadUserPrompts(string sessionId)
     {
-        using var _ = OutputWindowLogger.Global.PerfSpan($"ReadUserPrompts({sessionId})");
+        using var _ = log.PerfSpan($"ReadUserPrompts({sessionId})");
         var promptsNewestFirst = new List<string>();
         var folder = FolderFor();
         var path = FileFor(sessionId);
@@ -273,7 +273,7 @@ internal sealed partial class SessionManager
                 }
             }
         }
-        catch (Exception ex) { _log.LogException("SessionManager.ReadUserPrompts", ex); }
+        catch (Exception ex) { log.LogException("SessionManager.ReadUserPrompts", ex); }
 
         promptsNewestFirst.Reverse(); // chronological (oldest first) for the WebView
         return promptsNewestFirst;
@@ -473,7 +473,7 @@ internal sealed partial class SessionManager
                     : content[blockIdx] as JObject;
             }
         }
-        catch (Exception ex) { _log.LogException("SessionManager.ReadMessageBlock", ex); }
+        catch (Exception ex) { log.LogException("SessionManager.ReadMessageBlock", ex); }
         return null;
     }
 
@@ -506,7 +506,7 @@ internal sealed partial class SessionManager
                 return ""; // next line wasn't the summary
             }
         }
-        catch (Exception ex) { _log.LogException("SessionManager.ReadCompactSummary", ex); }
+        catch (Exception ex) { log.LogException("SessionManager.ReadCompactSummary", ex); }
         return "";
     }
 
@@ -537,7 +537,7 @@ internal sealed partial class SessionManager
 
         /// <summary>A session with no sidecars yields an empty map, which leaves every row exactly
         /// as it was before this existed.</summary>
-        public static SubagentContext Read(string dir)
+        public static SubagentContext Read(string dir, OutputWindowLogger log)
         {
             var ctx = new SubagentContext();
             if (!Directory.Exists(dir)) { return ctx; }
@@ -558,8 +558,7 @@ internal sealed partial class SessionManager
                     catch { /* a malformed sidecar only costs that one link */ }
                 }
             }
-            // Static nested helper: no SessionManager instance, so no pane tag here.
-            catch (Exception ex) { OutputWindowLogger.Global.LogException("SessionManager.SubagentContext.Read", ex); }
+            catch (Exception ex) { log.LogException("SessionManager.SubagentContext.Read", ex); }
             return ctx;
         }
 
@@ -582,7 +581,7 @@ internal sealed partial class SessionManager
     /// tools); true reads the whole file. Missing file or empty agentId → empty page (no throw).</summary>
     public HistoryPage ReadSubagentHistory(string sessionId, string agentId, bool fullFile)
     {
-        using var _ = OutputWindowLogger.Global.PerfSpan($"ReadSubagentHistory({agentId}, full={fullFile})");
+        using var _ = log.PerfSpan($"ReadSubagentHistory({agentId}, full={fullFile})");
         // agentId/sessionId reach here from the WebView; reject anything that isn't a
         // plain id token so they can't traverse out of the session dir into the path.
         if (!IsSafePathToken(sessionId) || !IsSafePathToken(agentId)) { return new HistoryPage { Messages = [] }; }
@@ -606,8 +605,8 @@ internal sealed partial class SessionManager
                 var size = fs.Length;
                 lines = ReadWindow(fs, Math.Max(0, size - LiteReadWindowBytes), dropPartialFirstLine: size > LiteReadWindowBytes);
             }
-            return BuildHistoryPageFromLines(lines, SubagentContext.Read(dir));
+            return BuildHistoryPageFromLines(lines, SubagentContext.Read(dir, log));
         }
-        catch (Exception ex) { _log.LogException("SessionManager.ReadSubagentHistory", ex); return new HistoryPage { Messages = [] }; }
+        catch (Exception ex) { log.LogException("SessionManager.ReadSubagentHistory", ex); return new HistoryPage { Messages = [] }; }
     }
 }

--- a/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.cs
@@ -8,6 +8,7 @@ using Corsinvest.VisualStudio.Agents.Helpers;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -18,7 +19,7 @@ namespace Corsinvest.VisualStudio.Agents.Core.Sessions;
 /// <summary>Reads/writes CLI session JSONL files for one config-dir. The config-dir is
 /// constant for a pane's lifetime, so it's injected once via the constructor rather than
 /// threaded through every call — a config-dir can never be silently forgotten.</summary>
-internal sealed partial class SessionManager
+internal sealed partial class SessionManager(ClaudePaths paths, string workingDirectory, OutputWindowLogger log)
 {
     // Metadata scan: read a fixed 64 KB window from the start and from the end
     // of the JSONL in one read each, decode once, scan the lines.
@@ -28,21 +29,9 @@ internal sealed partial class SessionManager
     // scan hit at chunk boundaries (garbled accented chars in titles).
     private const int LiteReadWindowBytes = 64 * 1024;
 
-    private readonly ClaudePaths _paths;
-    private readonly string _workingDirectory;
-    private readonly OutputWindowLogger _log;
-
-    // Optional: the session dialog builds one with no pane behind it (→ Global, unprefixed).
-    public SessionManager(ClaudePaths paths, string workingDirectory, OutputWindowLogger log = null)
-    {
-        _paths = paths ?? throw new ArgumentNullException(nameof(paths));
-        _workingDirectory = workingDirectory ?? throw new ArgumentNullException(nameof(workingDirectory));
-        _log = log ?? OutputWindowLogger.Global;
-    }
-
     // The session folder / a session .jsonl path for this instance's workdir, honouring
     // this instance's config-dir. One place each so the path construction lives in a single spot.
-    private string FolderFor() => LongPath(_paths.SessionFolder(_workingDirectory));
+    private string FolderFor() => LongPath(paths.SessionFolder(workingDirectory));
 
     /// <summary>Null for an id that isn't a plain token, so a traversal never reaches Path.Combine.
     /// <para>The id can come straight off a WebView DTO (<c>p.SessionId ?? client.SessionId</c> in
@@ -54,7 +43,7 @@ internal sealed partial class SessionManager
     /// and File.Exists(null) is false — a rejected id degrades to "no such session".</para></summary>
     private string FileFor(string sessionId)
         => IsSafePathToken(sessionId)
-            ? LongPath(Path.Combine(_paths.SessionFolder(_workingDirectory), sessionId + ".jsonl"))
+            ? LongPath(Path.Combine(paths.SessionFolder(workingDirectory), sessionId + ".jsonl"))
             : null;
 
     /// <summary>Past 260 characters .NET Framework refuses the path outright — DirectoryNotFoundException
@@ -67,9 +56,31 @@ internal sealed partial class SessionManager
     private static string LongPath(string path)
         => path.Length < 260 || path.StartsWith(@"\\", StringComparison.Ordinal) ? path : @"\\?\" + path;
 
+    /// <summary>One scanned .jsonl. A session file only ever grows — even Rename appends — so a
+    /// file whose write stamp hasn't moved cannot have new metadata, and the scan can be skipped.
+    /// <para><see cref="Title"/> null = scanned and not listable (a sub-agent sidechain, or a
+    /// session no prompt was ever sent in). Cached all the same, so those aren't re-read either.</para></summary>
+    private sealed class CacheEntry
+    {
+        public DateTime LastWriteUtc;
+        public string Title;
+    }
+
+    /// <summary>Scans kept between calls to <see cref="Load"/>, so a caller that lists the same
+    /// folder repeatedly — the session picker reopening — only re-reads what changed.
+    /// <para>Per instance, not static: an instance is one working directory, which is both why the
+    /// bare session id works as a key and why the memory can't pile up. A caller that Loads once
+    /// and drops the manager (the Statistics tree does, for every project on the machine) takes
+    /// the cache down with it.</para></summary>
+    private readonly ConcurrentDictionary<string, CacheEntry> _scanCacheById = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>The sessions for this workdir, newest first, as list rows — Id, Title, LastUsedAt
+    /// and WorkingDirectory, which is all any caller has ever read. Sessions with no title of any
+    /// kind and sub-agent sidechains are left out; neither is something a user picks.
+    /// <para>For the full metadata of one session use <see cref="ScanTitle"/> or ScanMetadata.</para></summary>
     public List<SessionInfo> Load()
     {
-        using var _ = OutputWindowLogger.Global.PerfSpan("SessionManager.Load");
+        using var _ = log.PerfSpan("SessionManager.Load");
         var folder = FolderFor();
         if (!Directory.Exists(folder)) { return []; }
 
@@ -77,22 +88,48 @@ internal sealed partial class SessionManager
             .OrderByDescending(f => f.LastWriteTime)
             .ToArray();
 
-        OutputWindowLogger.Global.Perf(() => $"sessions: loading {files.Length} files");
-
-        return files
+        var scanned = 0;
+        var result = files
             // FullName, not FolderFor's own prefixing: a folder can sit under the limit while the
             // file inside it goes over — the CLI's folder name is nearly the whole workdir, and a
             // GUID plus ".jsonl" is another 41 characters on top.
             .AsParallel()
-            .Select(f => ReadSessionFile(LongPath(f.FullName)))
-            .Where(x => x != null)
-            .OrderByDescending(x => x.LastUsedAt)
+            .Select(f =>
+            {
+                // The id IS the file name, so it doubles as the cache key.
+                var id = Path.GetFileNameWithoutExtension(f.Name);
+                var stamp = f.LastWriteTimeUtc;
+                if (!_scanCacheById.TryGetValue(id, out var entry) || entry.LastWriteUtc != stamp)
+                {
+                    System.Threading.Interlocked.Increment(ref scanned);
+                    var scan = ReadSessionFile(LongPath(f.FullName));
+                    entry = new CacheEntry { LastWriteUtc = stamp, Title = scan?.Title };
+                    _scanCacheById[id] = entry;
+                }
+                return (id, entry);
+            })
+            // No title: a sub-agent sidechain, or a session no prompt was ever sent in.
+            .Where(x => x.entry.Title != null)
+            .OrderByDescending(x => x.entry.LastWriteUtc)
+            // The entry keeps UTC so comparing stamps can't be tripped by a DST change between
+            // two Loads; SessionInfo wants local.
+            .Select(x => new SessionInfo
+            {
+                Id = x.id,
+                Title = x.entry.Title,
+                LastUsedAt = x.entry.LastWriteUtc.ToLocalTime(),
+                WorkingDirectory = workingDirectory,
+            })
             .ToList();
+
+        log.Perf(() => $"sessions: {files.Length} files, {scanned} scanned, {files.Length - scanned} from cache");
+        return result;
     }
 
-    // Instance method (not static): needs _workingDirectory to stamp SessionInfo.WorkingDirectory.
-    // Called only from Load(), including from its .AsParallel() — reading a readonly field
-    // concurrently is safe, so this doesn't need to stay static.
+    /// <summary>The scan of one session file, or null when it holds no listable session — a
+    /// sub-agent sidechain, or one no prompt was ever sent in. Only Title is filled beyond what
+    /// ScanMetadata returns: Load() has the id, the workdir and the write time already, and asking
+    /// the filesystem for the date here would cost a syscall per session.</summary>
     private SessionInfo ReadSessionFile(string path)
     {
         try
@@ -100,16 +137,14 @@ internal sealed partial class SessionManager
             var info = ScanMetadata(path);
             if (info == null) { return null; }
 
-            info.Id = Path.GetFileNameWithoutExtension(path);
-            info.WorkingDirectory = _workingDirectory;
-            info.LastUsedAt = File.GetLastWriteTime(path);
-
+            // IsNullOrWhiteSpace, not != null: a prompt of nothing but blank lines survives
+            // ToSingleLine as blanks, and listing it gives a row with no text on it.
             var rawTitle = info.CustomTitle ?? info.AiTitle ?? info.LastPrompt;
-            if (rawTitle == null) { return null; }
+            if (string.IsNullOrWhiteSpace(rawTitle)) { return null; }
             info.Title = StringHelpers.ToSingleLine(rawTitle, MaxTitleLength);
             return info;
         }
-        catch (Exception ex) { _log.Warn($"[sessions] skipped {Path.GetFileName(path)}: {ex.GetType().Name}: {ex.Message}"); return null; }
+        catch (Exception ex) { log.Warn($"[sessions] skipped {Path.GetFileName(path)}: {ex.GetType().Name}: {ex.Message}"); return null; }
     }
 
     private static SessionInfo ScanMetadata(string path)
@@ -402,7 +437,7 @@ internal sealed partial class SessionManager
                 if (!string.IsNullOrEmpty(uuid)) { uuidMap[uuid] = Guid.NewGuid().ToString(); }
                 kept.Add(obj);
             }
-            if (!foundCut) { _log.Debug(() => "[sessions] fork-at uuid not found in source session → fork aborted"); return null; }
+            if (!foundCut) { log.Debug(() => "[sessions] fork-at uuid not found in source session → fork aborted"); return null; }
 
             // Remap every id that references a message — leaving one pointing at an
             // old uuid would dangle, since those ids are all regenerated above.
@@ -418,7 +453,7 @@ internal sealed partial class SessionManager
                 writer.WriteLine(obj.ToString(Formatting.None));
             }
         }
-        catch (Exception ex) { _log.LogException("SessionManager.fork", ex); return null; }
+        catch (Exception ex) { log.LogException("SessionManager.fork", ex); return null; }
 
         return new ForkResult { NewSessionId = newSessionId, ExcludedPrompt = excludedPrompt };
     }

--- a/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManagerControl.xaml
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManagerControl.xaml
@@ -224,7 +224,8 @@
       </ListBox.ItemTemplate>
     </ListBox>
 
-    <!-- Empty state hint -->
+    <!-- Empty state hint, and the loading message too: the scan is off the UI thread, so the list
+         is briefly empty on open. Text is set in ApplyFilter. -->
     <TextBlock Grid.Row="2" x:Name="EmptyHint"
                Text="No sessions found." Margin="12,8"
                Foreground="{DynamicResource {x:Static vsui:EnvironmentColors.SystemGrayTextBrushKey}}"

--- a/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManagerControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManagerControl.xaml.cs
@@ -3,12 +3,14 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
+using Microsoft.VisualStudio.Shell;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -49,8 +51,14 @@ public partial class SessionManagerControl : UserControl
         _paths = paths;
         _workingDirectory = workingDirectory;
         _activeSessionId = activeSessionId;
+        _sessions = new SessionManager(paths, workingDirectory, OutputWindowLogger.Global);
         Loaded += (_, _) => Refresh();
     }
+
+    /// <summary>One for the control's lifetime so its scan cache survives between opens: the
+    /// picker lists the same folder every time, so every Refresh after the first is a directory
+    /// listing and nothing more.</summary>
+    private readonly SessionManager _sessions;
 
     private void ApplyActiveFlag()
     {
@@ -61,8 +69,11 @@ public partial class SessionManagerControl : UserControl
         }
     }
 
-    /// <summary>Reload the session list from disk. Cheap (~50 ms), safe to
-    /// call on popup open or after a rename/delete.</summary>
+    /// <summary>Reload the session list from disk, off the UI thread — a workdir worked on daily
+    /// runs to a couple of thousand sessions, one file opened each, and doing that synchronously
+    /// froze Visual Studio for as long as it took.
+    /// <para>Safe to call on popup open or after a rename/delete: late results are dropped
+    /// (see <see cref="_loadGeneration"/>), so overlapping calls can't interleave rows.</para></summary>
     public void Refresh()
     {
         _allSessions.Clear();
@@ -71,22 +82,57 @@ public partial class SessionManagerControl : UserControl
             ApplyFilter();
             return;
         }
-        try
+
+        // Or the empty-state hint announces "No sessions found." while they are still being read.
+        _loading = true;
+        ApplyFilter();
+
+        var generation = ++_loadGeneration;
+        var sessionManager = _sessions;
+        _ = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
         {
-            foreach (var s in new SessionManager(_paths, _workingDirectory).Load())
+            List<SessionInfo> sessions;
+            try
+            {
+                sessions = await Task.Run(sessionManager.Load);
+            }
+            catch (Exception ex)
+            {
+                // Swallowed: an unreadable folder shouldn't crash the picker. Still has to clear
+                // the loading state, or the hint sits on "Loading sessions…" for good.
+                OutputWindowLogger.Global.LogException("SessionManagerControl.Refresh", ex);
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                if (generation == _loadGeneration)
+                {
+                    _loading = false;
+                    ApplyFilter();
+                }
+                return;
+            }
+
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            // A newer Refresh started while this one was reading: its rows are the ones that
+            // belong on screen, and it has already cleared the list.
+            if (generation != _loadGeneration) { return; }
+
+            foreach (var s in sessions)
             {
                 _allSessions.Add(SessionRow.From(s));
             }
-        }
-        catch
-        {
-            // Swallowed: an unreadable folder shouldn't crash the picker.
-            OutputWindowLogger.Global.Warn("[sessions] failed to load the session list — picker may be empty");
-        }
-        ApplyActiveFlag();
-        ApplyFilter();
+            _loading = false;
+            ApplyActiveFlag();
+            ApplyFilter();
+        });
         // Focus is the host's job: FocusSearch must run after the popup is up.
     }
+
+    /// <summary>Bumped by every <see cref="Refresh"/>; a scan whose generation is stale by the
+    /// time it finishes throws its rows away rather than appending them to a newer list.</summary>
+    private int _loadGeneration;
+
+    /// <summary>True while a scan is in flight, so the empty list reads as "reading" rather
+    /// than "there are none".</summary>
+    private bool _loading;
 
     private void ApplyFilter()
     {
@@ -102,6 +148,7 @@ public partial class SessionManagerControl : UserControl
         {
             _filtered.Add(r);
         }
+        EmptyHint.Text = _loading ? "Loading sessions…" : "No sessions found.";
         EmptyHint.Visibility = _filtered.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
     }
 
@@ -265,7 +312,7 @@ public partial class SessionManagerControl : UserControl
         }
         try
         {
-            new SessionManager(_paths, _workingDirectory).Rename(row.Id, trimmed);
+            _sessions.Rename(row.Id, trimmed);
             row.DisplayTitle = trimmed;
             row.CancelEdit();
         }
@@ -342,7 +389,7 @@ public partial class SessionManagerControl : UserControl
     {
         try
         {
-            new SessionManager(_paths, _workingDirectory).Delete(row.Id);
+            _sessions.Delete(row.Id);
             _allSessions.Remove(_allSessions.FirstOrDefault(r => r.Id == row.Id));
             ApplyFilter();
         }

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsService.cs
@@ -413,7 +413,7 @@ internal static class StatsService
         }
         try
         {
-            return [.. new Sessions.SessionManager(paths, cwd).Load().Where(s => s.Id != null)];
+            return [.. new Sessions.SessionManager(paths, cwd, OutputWindowLogger.Global).Load().Where(s => s.Id != null)];
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
Opening the session list called `Load()` synchronously on the UI thread, on the strength of a comment that said *"Cheap (~50 ms), safe to call on popup open"*. That holds for a handful of sessions. This repo's own working directory has **2031 of them — 520 MB** — and each one is a file opened for a head+tail scan, so the whole IDE stopped for as long as it took.

### Off the UI thread

The scan now runs on a background thread and the rows land when it returns. A generation counter drops results from a `Refresh` that has been superseded, so opening the picker twice in quick succession can't interleave two lists.

### Scans kept between calls

Keyed on each file's write stamp: a session file only ever grows — even `Rename` appends — so a stamp that hasn't moved means the metadata can't have changed.

```
sessions: 2031 files, 2031 scanned,    0 from cache    508ms
sessions: 2031 files,    0 scanned, 2031 from cache     40ms
```

What remains is the directory listing rather than any reading.

The cache is a **field, not a static**. An instance is one working directory, which is why the bare session id works as a key and why nothing piles up: the callers that read a single session build one and drop it, and the Statistics tree — which walks every project on the machine — takes its cache down with it.

`Load()` now returns the four fields its callers have always read (`Id`, `Title`, `LastUsedAt`, `WorkingDirectory`). It was handing back whole `SessionInfo`s, and caching those meant holding the raw title sources — one of them a full prompt — plus the branch, the CLI version and the model, per session, for nothing.

### Found along the way

- The empty list said **"No sessions found."** while the scan was still running. It now says what it is doing.
- A session whose only prompt is blank lines survived the title check as whitespace and listed as a row with no text on it.
- `ReadSessionFile` asked the filesystem for a write time `Load()` already had, once per session.
- `SessionManager` took its logger as an optional argument and then logged half its lines through `Global` anyway, so session reads were untagged no matter which pane asked. It is a required constructor parameter now, and every partial uses it.

---

MSBuild green. Verified in the Exp instance: the popup opens immediately and fills in, the second open is instant, and the log reports the counts above.
