### PR TITLE
fix(ui): the confirmation dialogs were drawn by Windows, not by Visual Studio

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManagerControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManagerControl.xaml.cs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
+using Corsinvest.VisualStudio.Agents.Helpers;
 using Microsoft.VisualStudio.Shell;
 using System;
 using System.Collections.Generic;
@@ -319,11 +320,7 @@ public partial class SessionManagerControl : UserControl
         catch (Exception ex)
         {
             row.CancelEdit();
-            MessageBox.Show(
-                $"Failed to rename session:\n{ex.Message}",
-                "Rename failed",
-                MessageBoxButton.OK,
-                MessageBoxImage.Warning);
+            ShellHelpers.ShowMessage($"Failed to rename session:\n{ex.Message}", "Rename failed", warning: true);
         }
     }
 
@@ -356,13 +353,7 @@ public partial class SessionManagerControl : UserControl
         {
             // Always confirm: delete unlinks the JSONL from disk, no undo.
             var preview = string.IsNullOrEmpty(row.DisplayTitle) ? row.Id : row.DisplayTitle;
-            var ok = MessageBox.Show(
-                $"Delete session \"{preview}\"?\nThis cannot be undone.",
-                "Delete session",
-                MessageBoxButton.YesNo,
-                MessageBoxImage.Warning,
-                MessageBoxResult.No);
-            if (ok != MessageBoxResult.Yes) { return; }
+            if (!ShellHelpers.Confirm($"Delete session \"{preview}\"?\nThis cannot be undone.", "Delete session")) { return; }
 
             DeleteRow(row);
         }
@@ -395,11 +386,7 @@ public partial class SessionManagerControl : UserControl
         }
         catch (Exception ex)
         {
-            MessageBox.Show(
-                $"Failed to delete session:\n{ex.Message}",
-                "Delete failed",
-                MessageBoxButton.OK,
-                MessageBoxImage.Warning);
+            ShellHelpers.ShowMessage($"Failed to delete session:\n{ex.Message}", "Delete failed", warning: true);
         }
     }
 }

--- a/src/Corsinvest.VisualStudio.Agents/Helpers/ShellHelpers.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Helpers/ShellHelpers.cs
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 using System;
 using System.Diagnostics;
 
@@ -25,5 +28,53 @@ internal static class ShellHelpers
         {
             OutputWindowLogger.Global.LogException("ShellHelpers.OpenExternal", ex);
         }
+    }
+
+    /// <summary>A themed message box, in place of System.Windows.MessageBox — WPF's own dialog is
+    /// drawn by Windows and knows nothing about the IDE, so on a dark theme it opens white.
+    /// <para>Not Community.VisualStudio.Toolkit's VS.MessageBox: it makes the same
+    /// VsShellUtilities call underneath, but its ShowWarning shows OK/Cancel rather than OK, and
+    /// its ShowConfirm hardcodes Yes as the default button (see <see cref="Confirm"/>).</para>
+    /// <para>UI thread only — the shell cannot raise a dialog from anywhere else.</para></summary>
+    public static void ShowMessage(string text, string title, bool warning = false)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        VsShellUtilities.ShowMessageBox(
+            ServiceProvider.GlobalProvider,
+            text,
+            title,
+            warning ? OLEMSGICON.OLEMSGICON_WARNING : OLEMSGICON.OLEMSGICON_INFO,
+            OLEMSGBUTTON.OLEMSGBUTTON_OK,
+            OLEMSGDEFBUTTON.OLEMSGDEFBUTTON_FIRST);
+    }
+
+    /// <summary>A themed Yes/No prompt; true when the user picked Yes.
+    /// <para>Defaults to No, so a stray Enter or Esc cancels rather than confirms — every caller
+    /// guards something irreversible. This is the one reason not to use the toolkit's
+    /// ShowConfirm, which defaults to Yes and offers no way to change it.</para></summary>
+    public static bool Confirm(string text, string title)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        return VsShellUtilities.ShowMessageBox(
+            ServiceProvider.GlobalProvider,
+            text,
+            title,
+            OLEMSGICON.OLEMSGICON_WARNING,
+            OLEMSGBUTTON.OLEMSGBUTTON_YESNO,
+            OLEMSGDEFBUTTON.OLEMSGDEFBUTTON_SECOND) == (int)VSConstants.MessageBoxResult.IDYES;
+    }
+
+    /// <summary>A themed OK/Cancel prompt; true when the user picked OK. Same default-to-cancel
+    /// reasoning as <see cref="Confirm"/>.</summary>
+    public static bool ConfirmOkCancel(string text, string title)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        return VsShellUtilities.ShowMessageBox(
+            ServiceProvider.GlobalProvider,
+            text,
+            title,
+            OLEMSGICON.OLEMSGICON_WARNING,
+            OLEMSGBUTTON.OLEMSGBUTTON_OKCANCEL,
+            OLEMSGDEFBUTTON.OLEMSGDEFBUTTON_SECOND) == (int)VSConstants.MessageBoxResult.IDOK;
     }
 }

--- a/src/Corsinvest.VisualStudio.Agents/Options/AgentsEditorPromptsPage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Options/AgentsEditorPromptsPage.cs
@@ -4,6 +4,7 @@
  */
 
 using Corsinvest.VisualStudio.Agents.Editor;
+using Corsinvest.VisualStudio.Agents.Helpers;
 using Microsoft.VisualStudio.Shell;
 using System.Collections.Generic;
 using System.Linq;
@@ -49,7 +50,7 @@ public class AgentsEditorPromptsPage : UIElementDialogPage
             }
             else
             {
-                MessageBox.Show(error, "Editor prompts", MessageBoxButton.OK, MessageBoxImage.Warning);
+                ShellHelpers.ShowMessage(error, "Editor prompts", warning: true);
                 e.ApplyBehavior = ApplyKind.Cancel;
                 return;
             }

--- a/src/Corsinvest.VisualStudio.Agents/Options/AgentsProfilesPage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Options/AgentsProfilesPage.cs
@@ -4,6 +4,7 @@
  */
 
 using Corsinvest.VisualStudio.Agents.Core.Profiles;
+using Corsinvest.VisualStudio.Agents.Helpers;
 using Microsoft.VisualStudio.Shell;
 using System.Collections.Generic;
 using System.Linq;
@@ -55,8 +56,7 @@ public class AgentsProfilesPage : UIElementDialogPage
             }
             else
             {
-                MessageBox.Show(error, "Profiles",
-                    MessageBoxButton.OK, MessageBoxImage.Warning);
+                ShellHelpers.ShowMessage(error, "Profiles", warning: true);
                 e.ApplyBehavior = ApplyKind.Cancel; // keep the Options dialog open, don't save
                 return;
             }

--- a/src/Corsinvest.VisualStudio.Agents/Options/EditorPromptsControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Options/EditorPromptsControl.xaml.cs
@@ -4,6 +4,7 @@
  */
 
 using Corsinvest.VisualStudio.Agents.Editor;
+using Corsinvest.VisualStudio.Agents.Helpers;
 using System.Collections.ObjectModel;
 using System.Windows;
 using System.Windows.Controls;
@@ -46,11 +47,9 @@ public partial class EditorPromptsControl : UserControl
 
     private void OnRestoreDefaultsClick(object sender, RoutedEventArgs e)
     {
-        if (MessageBox.Show(
+        if (!ShellHelpers.ConfirmOkCancel(
                 "Replace the list with the prompts the extension ships with? Your own are lost.",
-                "Editor prompts",
-                MessageBoxButton.OKCancel,
-                MessageBoxImage.Warning) != MessageBoxResult.OK)
+                "Editor prompts"))
         {
             return;
         }

--- a/src/Corsinvest.VisualStudio.Agents/Options/ProfilesControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Options/ProfilesControl.xaml.cs
@@ -4,6 +4,7 @@
  */
 
 using Corsinvest.VisualStudio.Agents.Core.Profiles;
+using Corsinvest.VisualStudio.Agents.Helpers;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
@@ -241,8 +242,7 @@ public partial class ProfilesControl : UserControl
         }
         catch (Exception)
         {
-            MessageBox.Show("Cannot read the clipboard.", "Paste from JSON",
-                MessageBoxButton.OK, MessageBoxImage.Warning);
+            ShellHelpers.ShowMessage("Cannot read the clipboard.", "Paste from JSON", warning: true);
             return;
         }
 
@@ -254,20 +254,17 @@ public partial class ProfilesControl : UserControl
         }
         catch (Exception)
         {
-            MessageBox.Show("Invalid JSON", "Paste from JSON",
-                MessageBoxButton.OK, MessageBoxImage.Warning);
+            ShellHelpers.ShowMessage("Invalid JSON", "Paste from JSON", warning: true);
             return;
         }
 
         if (_envRows.Count > 0)
         {
-            var ok = MessageBox.Show(
-                "Replace the current environment variables with the pasted ones?",
-                "Paste from JSON",
-                MessageBoxButton.YesNo,
-                MessageBoxImage.Question,
-                MessageBoxResult.No);
-            if (ok != MessageBoxResult.Yes) { return; }
+            if (!ShellHelpers.Confirm("Replace the current environment variables with the pasted ones?",
+                                     "Paste from JSON"))
+            {
+                return;
+            }
         }
 
         _envRows.Clear();


### PR DESCRIPTION
`System.Windows.MessageBox` knows nothing about the IDE, so every prompt the extension raised — deleting a session, restoring the default editor prompts, pasting a bad profile — opened as a white box in the middle of a dark theme.

All nine call sites now go through `VsShellUtilities.ShowMessageBox`, wrapped in three helpers that say what they are for:

```csharp
ShellHelpers.ShowMessage(text, title, warning: true)
ShellHelpers.Confirm(text, title)          // Yes/No, defaults to No
ShellHelpers.ConfirmOkCancel(text, title)  // OK/Cancel, defaults to Cancel
```

### Why not the Community Toolkit

`Community.VisualStudio.Toolkit` is already referenced and ships `VS.MessageBox`, which looks like the obvious choice. Decompiling the pinned **17.0.551** says otherwise — its `Show()` body is, in full:

```
ThreadHelper.ThrowIfNotOnUIThread("Show");
VsShellUtilities.ShowMessageBox(ServiceProvider.GlobalProvider, line2, line1, icon, buttons, defaultButton);
```

The same call we now make, so there is nothing to gain on theming. And `ShowConfirm` hardcodes `OLEMSGDEFBUTTON_FIRST` — Yes — with no overload to change it.

Both Yes/No prompts here already passed `MessageBoxResult.No`, and they guard a delete and a wholesale replace. A stray Enter must not confirm either, so the default matters more than the convenience. (`ShowWarning` also shows OK/**Cancel** rather than OK, a second silent difference.)

### No async variants

All nine call sites are click handlers or `OnApply`, already on the UI thread — the only async code in the picker is the session scan, which shows no dialog. Adding `ConfirmAsync` is four lines the day something needs to prompt from a background thread; until then it would be a method with no callers.

---

MSBuild green. Verified in the Exp instance: the delete confirmation is themed, and Enter without choosing does **not** delete.
