### PR TITLE
chore: parameter defaults no call site relies on

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/ContentBlockTranslator.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/ContentBlockTranslator.cs
@@ -278,7 +278,7 @@ internal static class ContentBlockTranslator
         }
     }
 
-    private static Contracts.ToolPermissionNotification BuildToolPermission(JToken item, string parentToolUseId, bool needsPermission = false, JArray permissionSuggestions = null)
+    private static Contracts.ToolPermissionNotification BuildToolPermission(JToken item, string parentToolUseId, bool needsPermission, JArray permissionSuggestions)
     {
         var name = item.Val("name", "");
         var id = item.Val("id", "");

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/IgnoreRulesStore.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/IgnoreRulesStore.cs
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
-using Corsinvest.VisualStudio.Agents.Helpers;
 using System;
 using System.IO;
 

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Helpers.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Helpers.cs
@@ -68,8 +68,8 @@ internal sealed partial class WebViewMessageHandler
                                                                    string sessionId,
                                                                    string toolUseId,
                                                                    ClaudePaths paths,
-                                                                   string toolName = "",
-                                                                   string agentId = null)
+                                                                   string toolName,
+                                                                   string agentId)
     {
         var path = TranscriptPathFor(workingDirectory, sessionId, toolUseId, paths, agentId);
         if (path == null) { return default; }
@@ -102,7 +102,7 @@ internal sealed partial class WebViewMessageHandler
     /// <summary>What the tool answered. Unlike the IN side this is always text meant for the model,
     /// never a file: a Write reports "File created successfully at: …", a Read returns the content
     /// with line numbers prefixed. That is why the temp it opens into stays .txt.</summary>
-    private static string FindToolResult(string workingDirectory, string sessionId, string toolUseId, ClaudePaths paths, string agentId = null)
+    private static string FindToolResult(string workingDirectory, string sessionId, string toolUseId, ClaudePaths paths, string agentId)
     {
         var path = TranscriptPathFor(workingDirectory, sessionId, toolUseId, paths, agentId);
         if (path == null) { return null; }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
@@ -306,7 +306,7 @@ public partial class ChatPaneControl : PaneControlBase
     /// than fresh, pre-filling the composer with <paramref name="initialPrompt"/>.
     /// Must be called before the pane's Loaded fires (PaneLauncher does this right
     /// after creating the window, like AssignPaneId).</summary>
-    internal void SetStartupSession(string sessionId, string initialPrompt = null)
+    internal void SetStartupSession(string sessionId, string initialPrompt)
     {
         _startupSessionId = sessionId;
         _startupPrompt = initialPrompt;

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
@@ -567,7 +567,7 @@ public partial class ChatPaneControl : PaneControlBase
     /// <summary>Writes text into the composer. <paramref name="withIdeContext"/> also re-opens the
     /// IDE-context eye: a prompt picked from the editor context menu is about the file it came
     /// from, and with the eye shut the CLI is never told which file that is.</summary>
-    private void SetComposerText(string text, bool withIdeContext = false)
+    private void SetComposerText(string text, bool withIdeContext)
         => Dispatcher.Invoke(() =>
         {
             if (withIdeContext && Entry != null && !Entry.Options.SendSelection)

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneWindow.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneWindow.cs
@@ -55,7 +55,7 @@ public sealed class ChatPaneWindow : PaneWindowBase, IOleCommandTarget
 
     /// <summary>Forward to the hosted control so the launcher can seed a forked
     /// session before the pane loads (Content is a DockPanel, not the control).</summary>
-    internal void SetStartupSession(string sessionId, string initialPrompt = null)
+    internal void SetStartupSession(string sessionId, string initialPrompt)
     {
         if (PaneControl is ChatPaneControl ctl) { ctl.SetStartupSession(sessionId, initialPrompt); }
     }

--- a/src/Corsinvest.VisualStudio.Agents/Cli/ClaudeCliLauncher.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Cli/ClaudeCliLauncher.cs
@@ -21,7 +21,7 @@ public static class ClaudeCliLauncher
     /// filtered by the CLI to just executeCode/getDiagnostics — and pre-approves them with
     /// --allowedTools (every MCP tool otherwise prompts on each call). Returns <c>null</c>
     /// if the binary is missing.</summary>
-    public static string BuildConPtyCommandLine(bool ide = true, int mcpPort = 0, string mcpAuthToken = null)
+    public static string BuildConPtyCommandLine(bool ide, int mcpPort, string mcpAuthToken)
     {
         var exe = ClaudeInstall.ResolveExecutable();
         if (exe == null) { return null; }

--- a/src/Corsinvest.VisualStudio.Agents/Cli/ConPty.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Cli/ConPty.cs
@@ -76,7 +76,7 @@ internal static class ConPty
     /// CLI/z.ai) coexist without a shared-env race. The returned session owns all handles.
     /// </summary>
     public static Session Create(string command, string workingDirectory, short cols, short rows,
-        IReadOnlyDictionary<string, string> env = null)
+        IReadOnlyDictionary<string, string> env)
     {
         var (inRead, inWrite, outRead, outWrite) = CreatePipes();
 

--- a/src/Corsinvest.VisualStudio.Agents/Cli/TerminalProcess.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Cli/TerminalProcess.cs
@@ -51,8 +51,8 @@ internal sealed class TerminalProcess : IDisposable
     /// A non-empty <paramref name="env"/> gives the child a per-process environment (see
     /// <see cref="ConPty.Create"/>). Throws if already started or disposed.
     /// </summary>
-    public void Start(string command, string workingDirectory, short cols = 120, short rows = 40,
-        IReadOnlyDictionary<string, string> env = null)
+    public void Start(string command, string workingDirectory, short cols, short rows,
+        IReadOnlyDictionary<string, string> env)
     {
         lock (_gate)
         {

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/NdjsonTransport.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/NdjsonTransport.cs
@@ -60,7 +60,7 @@ internal sealed class NdjsonTransport : IDisposable
     }
 
     public void Start(string exePath, string arguments, string workingDirectory,
-        System.Collections.Generic.IReadOnlyDictionary<string, string> extraEnv = null)
+        System.Collections.Generic.IReadOnlyDictionary<string, string> extraEnv)
     {
         if (_disposed) { return; }
 

--- a/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.History.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.History.cs
@@ -513,7 +513,7 @@ internal sealed partial class SessionManager
     /// <summary>Build a HistoryPage from a flat array of JSONL lines (chronological order).
     /// Used by ReadSubagentHistory (forward pass). ReadHistoryRaw keeps its own reverse-scan
     /// paginated reader — its algorithm can't share this simple forward builder.</summary>
-    private static HistoryPage BuildHistoryPageFromLines(string[] lines, SubagentContext subagent = null)
+    private static HistoryPage BuildHistoryPageFromLines(string[] lines, SubagentContext subagent)
     {
         var messages = new List<JToken>();
         string lastUserText = null;

--- a/src/Corsinvest.VisualStudio.Agents/Helpers/ShellHelpers.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Helpers/ShellHelpers.cs
@@ -36,7 +36,7 @@ internal static class ShellHelpers
     /// VsShellUtilities call underneath, but its ShowWarning shows OK/Cancel rather than OK, and
     /// its ShowConfirm hardcodes Yes as the default button (see <see cref="Confirm"/>).</para>
     /// <para>UI thread only — the shell cannot raise a dialog from anywhere else.</para></summary>
-    public static void ShowMessage(string text, string title, bool warning = false)
+    public static void ShowMessage(string text, string title, bool warning)
     {
         ThreadHelper.ThrowIfNotOnUIThread();
         VsShellUtilities.ShowMessageBox(

--- a/src/Corsinvest.VisualStudio.Agents/Helpers/Win32Focus.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Helpers/Win32Focus.cs
@@ -54,8 +54,7 @@ internal static class Win32Focus
     /// expired), or null when the toast could not be shown. Disposing it twice is harmless.
     /// <paramref name="onClosed"/> runs when the balloon goes away on its own, so the caller can
     /// drop the handle it is holding.</summary>
-    public static IDisposable ShowToast(string title, string message, Action onClick = null,
-                                        Action onClosed = null)
+    public static IDisposable ShowToast(string title, string message, Action onClick, Action onClosed)
     {
         ThreadHelper.ThrowIfNotOnUIThread();
         try

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.Operations.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.Operations.cs
@@ -114,7 +114,7 @@ internal sealed partial class IdeContextService
     /// plus the Error List down to <paramref name="severity"/>. Kicks the build without waiting and
     /// polls SolutionBuild.BuildState, so the IDE stays live while it runs — see
     /// <see cref="WaitForBuildAsync"/>.</summary>
-    public async Task<BuildResult> BuildAsync(string projectName, string severity = "error")
+    public async Task<BuildResult> BuildAsync(string projectName, string severity)
     {
         await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
         var dte = Package.GetGlobalService(typeof(DTE)) as DTE;

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.cs
@@ -74,18 +74,17 @@ internal sealed partial class IdeContextService : IDisposable
     public event Action<EditorContext> ContextChanged;
 
     /// <summary>Start tracking the active editor's selection. Idempotent.
-    /// Must be called on the UI thread. The package passes in the MEF
-    /// <see cref="IVsEditorAdaptersFactoryService"/> (resolved via
-    /// IComponentModel) so we can map IVsTextView → IWpfTextView.</summary>
-    public void SubscribeToEditorEvents(IVsEditorAdaptersFactoryService editorAdapters = null)
+    /// Must be called on the UI thread. The MEF
+    /// <see cref="IVsEditorAdaptersFactoryService"/> is resolved via
+    /// IComponentModel so we can map IVsTextView → IWpfTextView.</summary>
+    public void SubscribeToEditorEvents()
     {
         ThreadHelper.ThrowIfNotOnUIThread();
         if (_subscribed) { return; }
         try
         {
-            _editorAdapters = editorAdapters
-                ?? (Package.GetGlobalService(typeof(SComponentModel)) as IComponentModel)
-                    ?.GetService<IVsEditorAdaptersFactoryService>();
+            _editorAdapters = (Package.GetGlobalService(typeof(SComponentModel)) as IComponentModel)
+                ?.GetService<IVsEditorAdaptersFactoryService>();
             if (_editorAdapters == null)
             {
                 OutputWindowLogger.Global.Warn("[ide-context] editor adapters unavailable — selection tracking will not fire");

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.cs
@@ -316,7 +316,7 @@ internal sealed partial class IdeDebugService
     /// if VS can't bind it yet (it binds when the code loads), as long as the request was
     /// accepted.</summary>
     public async Task<DebugResult> SetBreakpointAsync(string filePath, int line, string condition,
-                                                      int hitCount = 0, string hitCountType = null)
+                                                      int hitCount, string hitCountType)
     {
         await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
         try
@@ -363,7 +363,7 @@ internal sealed partial class IdeDebugService
     /// "MyNamespace.MyClass.Calculate"), instead of a file/line — handy when you know the method
     /// but not the line. Optional condition. Works in any mode.</summary>
     public async Task<DebugResult> SetFunctionBreakpointAsync(string functionName, string condition,
-                                                              int hitCount = 0, string hitCountType = null)
+                                                              int hitCount, string hitCountType)
     {
         await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
         try

--- a/src/Corsinvest.VisualStudio.Agents/Options/AgentsChatPage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Options/AgentsChatPage.cs
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
-using System;
 using System.ComponentModel;
 using System.Drawing.Design;
 using System.Runtime.InteropServices;


### PR DESCRIPTION
An optional parameter says something to whoever reads the signature: *someone calls this without that argument*. Across the C# side, twenty of them were saying it untruthfully — every call site passed the value. This makes the signatures agree with the calls again.

Nothing changes at runtime. No call site was edited; the arguments were already there.

## What went

| Signature | Was |
|---|---|
| `ClaudeCliLauncher.BuildConPtyCommandLine` | `ide = true, mcpPort = 0, mcpAuthToken = null` |
| `ContentBlockTranslator.BuildToolPermission` | `needsPermission = false, permissionSuggestions = null` |
| `Win32Focus.ShowToast` | `onClick = null, onClosed = null` |
| `TerminalProcess.Start` | `cols = 120, rows = 40, env = null` |
| `ConPty.Create` | `env = null` |
| `NdjsonTransport.Start` | `extraEnv = null` |
| `SessionManager.BuildHistoryPageFromLines` | `subagent = null` |
| `WebViewMessageHandler.FindToolInput` / `FindToolResult` | `toolName = "", agentId = null` |
| `ChatPaneWindow` / `ChatPaneControl.SetStartupSession` | `initialPrompt = null` |
| `IdeContextService.BuildAsync` | `severity = "error"` |
| `IdeDebugService.SetBreakpointAsync` / `SetFunctionBreakpointAsync` | `hitCount = 0, hitCountType = null` |
| `ChatPaneControl.SetComposerText` | `withIdeContext = false` |
| `ShellHelpers.ShowMessage` | `warning = false` |

`BuildAsync` was the worst of them: both MCP tools already spell the same
fallback themselves (`args.Severity ?? "error"`), so one decision was written
out three times.

`ShowMessage` keeps its `warning` parameter and its info branch — only the
default is gone.

`IdeContextService.SubscribeToEditorEvents` lost the whole parameter, not just
its default: the one caller never passed it, so the `??` fell through to the
`SComponentModel` lookup every time. That lookup is now the plain path it
always was.

Two unused `using` directives went with them (`IgnoreRulesStore`,
`AgentsChatPage`).

## What deliberately stayed

Each of these was checked and kept for a reason:

- **`VsReflection.CreateInstance(Type t, bool nonPublic = false)`** — the
  default is load-bearing. Two callers write `CreateInstance(t)`, which the
  compiler resolves to this overload rather than the `params object[]` one.
  Removing the default would silently re-resolve them onto `params`, changing
  what `Activator` does at runtime, in the Roslyn reflection paths, with no
  compile error to warn anyone.
- **`IClaudeClient`'s `ResumeSessionAsync` / `DetachTaskAsync` /
  `GenerateSessionTitleAsync`** — the defaults belong to the interface.
- **`OnPropertyChanged`** — `CallerMemberName` requires one.
- **`ButtonAction.iconId`** — a genuinely optional field on a model type.
- Everything with a caller that really does omit the argument:
  `EmitAssistant`/`EmitUser`, `TrackActiveView`, `OpenNew`,
  `SendRemoteControl`, `SendDirect`, `SendControlRequest`/`Response`,
  `TryProcessHistoryLine`, `Truncate(max = 500)`,
  `StartOrRestartAsync(120, 40)`, `Val<T>`, `GetField`, `FindProjectItem`,
  `Separator`, the `StatsService` pass flags, and the logger constructors.

## Checks

Build green — `Debug|Any CPU`, 0 errors, 0 warnings. No test project exists
(the repo's gate is a green MSBuild); every changed signature is
`private`/`internal`/`static` with callers that already passed the argument,
so there is no runtime surface to exercise beyond compilation.

One thing worth a second pair of eyes: the `CreateInstance` reasoning above is
the only place where keeping a default is a correctness matter rather than a
style one.
