### PR TITLE
fix(chat): the vanishing context chip, and the code it never carried

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,8 +370,15 @@ telemetry. See [Context, usage & statistics](docs/chat/context-and-usage.md).
 
 ## IDE integration
 
-- **IDE context badge** — a chip above the composer showing the active file; click opens it at the
-  selection. An eye icon toggles whether the file/selection is shared with the session.
+- **IDE context badge** — a chip above the composer showing the active file and, when you have
+  selected code, its line range. Clicking it toggles whether that context is shared with the
+  session; while it is off the chip dims and shows a struck-through eye.
+  - A trailing icon says **what** is going out: 🔖 the position alone (file and lines), 🧾 the
+    position **plus the selected code**. The second appears only with *Options → Chat → Send the
+    selected text* on **and** a live selection — an open file with no selection has no code to
+    attach, so it stays a bookmark. Sending the code is what makes an **unsaved** buffer readable,
+    since otherwise Claude opens the file and sees the saved version; it also costs those tokens on
+    every message. See [Spending less context](#spending-less-context).
 - **Post-edit diagnostics** *(experimental, off by default)* — after Claude edits a file, feed back the
   **new** errors/warnings that edit introduced (diffed against the Error List before the edit). The idea
   is to close the edit → error → fix loop without a manual build, as the VS Code extension does. **It is
@@ -410,6 +417,31 @@ you can answer immediately. It clears when you answer, click into the pane, or u
 
 - **CLI banner** — a bar shown if the CLI process exits unexpectedly.
 - **Open Claude in Terminal** — launch an interactive CLI session.
+
+---
+
+## Spending less context
+
+Tokens are a budget, and the chat's context window is the part of it you can watch filling up — the
+gauge in the composer shows how much room is left before the CLI compacts the conversation.
+
+Most of what looks like a saving isn't. **A setting that changes what the chat draws changes nothing
+about what was sent**: by the time a tool result is on screen it has already been through the model.
+Preview lines, Compact Ask answers, Show tool errors inline, the diff options — all rendering. These
+four are the ones that reach the wire:
+
+| | Where | Default | What it does |
+|---|---|---|---|
+| **The eye** on the file chip | composer, **per pane** | open | Shuts off the file/lines block on every message. The biggest single knob — reach for it when the conversation has nothing to do with what is on screen. |
+| **Send the selected text with the message** | Options → Chat | **off** | On, your selected code rides along with *every* message while that selection stands (the chip's icon turns from 🔖 to 🧾). Off, Claude opens the file when it needs it. Turn it on for unsaved buffers, where the copy on disk is the stale one. |
+| **Extended thinking / effort** | model menu, **per session** | thinking off | Buys the model room to reason before answering — worth it on a hard bug, wasted on a rename. |
+| **Send post-edit diagnostics** | Options → Chat | **off** | Feeds the errors an edit introduced back into the context after every edit. |
+
+Three of the four already default to the cheap setting, so the one to know about is the eye — it is
+per-pane and per-session, made to be flicked rather than configured.
+
+Full detail, including what specifically does *not* help:
+[Spending less context](docs/chat/context-and-usage.md#spending-less-context).
 
 ---
 

--- a/docs/chat/context-and-usage.md
+++ b/docs/chat/context-and-usage.md
@@ -85,3 +85,95 @@ moved. The first run indexes everything and shows progress, later runs are near-
 
 Because the source is the shared session store, statistics cover conversations started **anywhere**
 — this extension, the VS Code extension, or the terminal.
+
+---
+
+## Spending less context
+
+The gauge tells you the window is filling; this is what you can actually do about it.
+
+Worth saying first, because most of the Chat options page looks like it belongs here and does not:
+**a setting that changes what the chat draws changes nothing about what was sent.** By the time the
+tool result is on screen, it has already been through the model. Preview lines, Compact Ask answers,
+Show tool errors inline, the diff options — every one of those is a rendering choice. The knobs
+below are the ones that reach the wire.
+
+### What travels with every message
+
+Each message carries a short block naming the file you have open and, if you have selected code,
+which lines — so Claude knows what "this method" means without you pasting it.
+
+That block is a couple of dozen tokens, and *Options → Chat → Send the selected text with the
+message* decides whether the code goes with it:
+
+| | What the block says | Cost |
+|---|---|---|
+| **Off** *(default)* | `lines 40 to 78 from Foo.cs` | ~30 tokens, every message |
+| **On** | the same, plus the selected code | ~30 tokens **plus the selection**, every message |
+
+Off, Claude opens the file when it needs the code — once, on its own initiative, and free to read
+around the selection. On, the code is there immediately but goes out again with **every** message
+sent while that selection stands, including "yes", "go on" and "no, the other one".
+
+Turn it on when you routinely ask about code you have not saved: on disk the file is stale, and
+Claude reading it would see the wrong thing. Otherwise leave it off.
+
+#### The chip tells you which one is going out
+
+A setting in a dialog you opened once is easy to forget, so the context chip carries the answer. The
+icon at its right end names the shape of the block:
+
+| Icon | Going out | When |
+|---|---|---|
+| 🔖 bookmark | the position — file and line numbers | the setting is off, **or** there is no selection |
+| 🧾 code block | the position **and** the selected code | the setting is on **and** you have a selection |
+
+The second row needs both conditions: an open file with nothing selected has no code to attach, so
+it stays a bookmark whatever the setting says. The icon follows what actually goes out, not how the
+option is configured — and it disappears entirely when the eye is shut, since then nothing does.
+
+The tooltip spells the same thing out in words, so the icon never has to be guessed at.
+
+> **This does not stop the CLI from seeing your selection.** Visual Studio also pushes editor
+> selections — the code included — over the IDE integration channel, the same way the VS Code
+> extension does, and that path does not consult this setting. What the setting controls is the
+> block prepended to *your message*, which is what accumulates in the conversation turn after turn.
+> That accumulation is the cost worth managing; the live selection is re-sent, not stacked.
+
+### The eye: sending nothing at all
+
+Clicking the chip stops the block entirely — no file, no lines — for **that pane only**, until you
+click it again. It then dims and picks up a struck-through eye; sharing is the ordinary state, so
+only the exception is marked.
+
+Worth doing when the conversation has nothing to do with what is on screen: a design discussion, a
+question about another repo, a long back-and-forth about something abstract. This is the bigger of
+the two knobs — the setting above changes what the block *contains*, the eye decides whether there
+is one at all.
+
+Picking an [editor prompt](../options.md#editor-prompts) re-opens it: a question about "this code"
+with nothing saying which code would reach the CLI as a question about nothing.
+
+### Thinking and effort
+
+The model menu in the composer toolbar carries the extended-thinking toggle and the effort level.
+Thinking buys the model room to reason before answering — real output tokens, on every turn it uses
+them. It earns its cost on a hard debugging session and wastes it on "rename this variable".
+
+These are per-session and live in the toolbar, not in Options, because they are the ones worth
+changing *during* a conversation rather than once and for all.
+
+### Post-edit diagnostics
+
+*Options → Chat → Send post-edit diagnostics* (off by default) feeds the new errors an edit
+introduced back to Claude after every edit. That is extra content into the context on each one.
+It is [experimental and unreliable in Visual Studio](../../README.md#ide-integration) for reasons
+that have nothing to do with tokens — but if you did turn it on, this is part of what it costs.
+
+### What does not help
+
+- **Autosave before Claude reads/writes** — turning it *off* costs more, not less: Claude reads the
+  stale file, then has to ask for the editor buffer separately.
+- **Respect `.gitignore` / Ignored patterns** — they filter the `@` picker's list. They make it
+  harder to attach a huge generated file by accident, which is a guard-rail, not a dial.
+- **Keep file checkpoints (Rewind)** — copies files to disk. Costs disk space, never context.

--- a/docs/options.md
+++ b/docs/options.md
@@ -25,6 +25,7 @@ go to `%LOCALAPPDATA%` — see [Settings and data](settings-and-data.md).
 | Chat font size | int (px) | `13` | Font size of the chat message text. |
 | Show WebView developer entries | bool | `false` | Add "WebView DevTools" and "WebView task manager" to the chat toolbar's "More" (…) menu — the browser console/DOM/network on the chat itself, and the browser's processes with their memory and CPU. Pre-release builds always offer both. |
 | Autosave before Claude reads/writes | bool | `true` | Save a dirty file before Claude reads/writes it, so it sees your in-editor edits, not the stale on-disk version. |
+| Send the selected text with the message | bool | `false` | Attach the selected code itself, not just its file and line numbers. Off, the message names the lines and Claude opens the file to read them — the same content, but only if it needs it, and only once. On, the code travels with **every** message sent with a selection. The composer's context chip shows which of the two is going out (🔖 position / 🧾 position + code). See [Spending less context](chat/context-and-usage.md#spending-less-context). |
 | Keep file checkpoints (Rewind) | bool | `true` | Let Claude copy a file before editing it, so [`/rewind`](chat/rewind.md) can restore it. Copies live under `~/.claude/file-history` and are never cleaned up — the reason to turn this off if you do not use Rewind. Read when a chat starts, so it applies to the next one you open. |
 | Send post-edit diagnostics to Claude (experimental) | bool | `false` | Feed back the new errors/warnings an edit introduced. Experimental — unreliable because VS only analyses files open in an editor (see IDE integration). |
 | Allowed upload file extensions | string[] | 93 defaults | Extensions accepted on upload/drop. Images → images, `.pdf` → document, rest → text; anything else rejected. Editable list. |
@@ -101,7 +102,7 @@ add the half line that matters before it goes.
 | Column | Meaning |
 |---|---|
 | Title | What the menu item reads. |
-| Prompt | What reaches the composer. The instruction alone: the file and selection travel with it through the IDE context, and Claude reads the symbol itself with the `nav_*` tools, so pasting code in here only duplicates what the pane already sends. |
+| Prompt | What reaches the composer. The instruction alone: which file and which lines travel with it through the IDE context, and Claude reads the symbol itself with the `nav_*` tools, so pasting code in here only duplicates what the pane already points at. |
 | Needs selection | Greys the entry out when nothing is selected, the way Copilot greys "Optimize selection". Leave it off for prompts that read fine against the whole file. |
 
 Rows appear in the menu in the order listed, so the one you reach for most belongs at the top;

--- a/src/Corsinvest.VisualStudio.Agents.Contracts/ToWebViewDtos.cs
+++ b/src/Corsinvest.VisualStudio.Agents.Contracts/ToWebViewDtos.cs
@@ -615,6 +615,11 @@ public class VsOptionsDto
     /// command when it is not: a command that can only answer "nothing to restore" is worse than
     /// one that is not offered.</summary>
     public bool FileCheckpoints { get; set; }
+
+    /// <summary>Whether the selected code itself rides along with the prompt, or only its file and
+    /// line numbers. The host composes the tag either way — the WebView is told so the context chip
+    /// can show WHICH of the two is going out.</summary>
+    public bool SendSelectionText { get; set; }
     public bool DiffIgnoreWhitespace { get; set; }
     public bool ShowOpenDiffInVsButton { get; set; }
     public string[] AllowedUploadExtensions { get; set; }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/ContentBlockTranslator.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/ContentBlockTranslator.cs
@@ -229,7 +229,11 @@ internal static class ContentBlockTranslator
                 }
                 else if (type == "text")
                 {
-                    userText = item.Val("text", "");
+                    // Join, don't overwrite: one submitted string can arrive as several text
+                    // blocks — the IDE-context tag gets one of its own. The newline is the one
+                    // the split consumed.
+                    var blockText = item.Val("text", "");
+                    userText = userText == null ? blockText : userText + "\n" + blockText;
                 }
                 else if (type == "image")
                 {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.Payloads.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.Payloads.cs
@@ -38,6 +38,7 @@ internal sealed partial class WebViewBridge
             CompactOutputAskAnswers = chat.CompactOutputAskAnswers,
             AllowDangerouslySkipPermissions = chat.AllowDangerouslySkipPermissions,
             FileCheckpoints = chat.FileCheckpoints,
+            SendSelectionText = chat.SendSelectionText,
             DiffIgnoreWhitespace = chat.DiffIgnoreWhitespace,
             ShowOpenDiffInVsButton = chat.ShowOpenDiffInVsButton,
             AllowedUploadExtensions = NormalizeExtensions(chat.AllowedUploadFileExtensions),

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Cli.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Cli.cs
@@ -21,8 +21,32 @@ internal sealed partial class WebViewMessageHandler
         var p = data.ToObject<Contracts.SendPromptNotification>();
         log.Debug(() => $"[{BridgeMessages.FromWebView.Cli.SendPrompt}] text len={(p.Text ?? "").Length} sessionId={client.SessionId ?? "(none)"} running={client.IsRunning}");
         // attachments stays a raw JArray: BuildContentBlocks turns it into CLI blocks.
-        var blocks = WebViewBridge.BuildContentBlocks(p.Text ?? "", data["attachments"] as JArray);
+        var blocks = WebViewBridge.BuildContentBlocks(BuildIdeContextBlock() + (p.Text ?? ""),
+                                                     data["attachments"] as JArray);
         client.SendPrompt(blocks, p.Uuid ?? "");
+    }
+
+    /// <summary>The `&lt;ide_*&gt;` block that goes in front of the prompt, or "" when there is no
+    /// editor context to report. Composed here rather than in the composer so the selected code
+    /// never crosses the bridge — the WebView only needs the file and the lines for its chip.</summary>
+    private string BuildIdeContextBlock()
+    {
+        if (entry?.Options.SendSelection == false) { return ""; }
+        var ctx = Ide.IdeContextService.Instance.GetCurrentContext();
+        if (string.IsNullOrEmpty(ctx?.FilePath)) { return ""; }
+        if (!ctx.HasSelection)
+        {
+            return $"<ide_opened_file>The user opened the file {ctx.FilePath} in the IDE. " +
+                   "This may or may not be related to the current task.</ide_opened_file>\n";
+        }
+        var head = $"<ide_selection>The user selected the lines {ctx.StartLine} to {ctx.EndLine} " +
+                   $"from {ctx.FilePath}";
+        const string tail = "This may or may not be related to the current task.</ide_selection>\n";
+        // With the text, the shape is the VS Code webview's — what the CLI's readers expect.
+        // Without, the tag ends on the path rather than trailing a colon over nothing.
+        return Options.AgentsOptions.Chat.SendSelectionText
+            ? $"{head}:\n{ctx.SelectedText ?? ""}\n\n{tail}"
+            : $"{head}. {tail}";
     }
 
     private void HandleRespondPermission(JObject data, int? id)
@@ -46,9 +70,8 @@ internal sealed partial class WebViewMessageHandler
 
     private void HandleSetSendSelection(JObject data, int? id)
     {
-        // Eye toggle: flip this session's SendSelection. OnEditorContextChangedForChat
-        // reads it and sends an empty selection while off. Re-emit the current context on
-        // re-enable so the chat regains the selection without waiting for the next change.
+        // Re-emit after the flip so re-opening the eye recovers the current selection instead of
+        // waiting for the next editor change.
         entry.Options.SendSelection = data.ToObject<Contracts.SetSendSelectionNotification>().Enabled;
         Ide.IdeContextService.Instance.ForceEmitCurrentContext();
     }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
@@ -426,10 +426,6 @@ public partial class ChatPaneControl : PaneControlBase
         WebView.HostFilesDropped -= OnHostFilesDropped;
         WebView.PreviewMouseDown -= OnWebViewClicked;
         IdeContextService.Instance.ContextChanged -= OnEditorContextChanged;
-        // EnsureClient hooked this on the IdeContextService singleton; without the unhook the
-        // closed pane leaks (singleton keeps it alive) and its dead _client keeps logging
-        // "transport not running" on every selection change. -= is safe even if never hooked.
-        IdeContextService.Instance.ContextChanged -= OnEditorContextChangedForChat;
         _handler?.Dispose();
         // Detach the client events before disposing: an event still in flight (a final
         // stdout line as the process closes) would otherwise reach this disposed control.
@@ -627,11 +623,6 @@ public partial class ChatPaneControl : PaneControlBase
             McpMessageHandler = json => Mcp.McpServerHost.Instance.ServeMcpMessageAsync(json)
         };
         AttachClientEvents(_client);
-        // Unhook first, like MessageReceived below: the subscription lives on a singleton that
-        // outlives the client, so a second pass here would send every selection change twice.
-        IdeContextService.Instance.ContextChanged -= OnEditorContextChangedForChat;
-        IdeContextService.Instance.ContextChanged += OnEditorContextChangedForChat;
-
         _handler = new WebViewMessageHandler(_bridge, _client, Entry, _log);
         _bridge.MessageReceived -= OnBridgeMessage;
         _bridge.MessageReceived += OnBridgeMessage;
@@ -671,31 +662,4 @@ public partial class ChatPaneControl : PaneControlBase
         }
     }
 
-    private void OnEditorContextChangedForChat(EditorContext ctx)
-    {
-        if (_client == null)
-        {
-            _log.Trace(() => "[ChatSelection] skip: _client null");
-            return;
-        }
-        // Eye closed for this session (the composer's IDE-context badge): don't leak the editor
-        // selection into the chat. Send an empty selection so the CLI drops any cached one.
-        if (ctx == null || Entry?.Options.SendSelection == false)
-        {
-            _log.Trace(() => "[ChatSelection] no context / eye off → empty selection");
-            _client.SendSelectionChanged(string.Empty, null, null, 0, 0, 0, 0, isEmpty: true);
-        }
-        else
-        {
-            _log.Trace(() => $"[ChatSelection] file={ctx.FilePath} sel={ctx.HasSelection} lines={ctx.StartLine}-{ctx.EndLine} running={_client.IsRunning}");
-            _client.SendSelectionChanged(ctx.SelectedText ?? string.Empty,
-                                         ctx.FilePath,
-                                         PathHelpers.ToFileUri(ctx.FilePath),
-                                         Math.Max(0, ctx.StartLine - 1),
-                                         Math.Max(0, ctx.StartColumn),
-                                         Math.Max(0, ctx.EndLine - 1),
-                                         Math.Max(0, ctx.EndColumn),
-                                         !ctx.HasSelection);
-        }
-    }
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated/VsOptionsDto.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated/VsOptionsDto.ts
@@ -14,6 +14,7 @@ export interface VsOptionsDto {
     compactOutputAskAnswers: boolean;
     allowDangerouslySkipPermissions: boolean;
     fileCheckpoints: boolean;
+    sendSelectionText: boolean;
     diffIgnoreWhitespace: boolean;
     showOpenDiffInVsButton: boolean;
     allowedUploadExtensions: string[];

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/ide.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/ide.ts
@@ -33,7 +33,11 @@ export function parseIdeContextTags(text: string | undefined | null): {
             }
             const selection = match.match(/<ide_selection>([\s\S]*?)<\/ide_selection>/);
             if (selection) {
-                const selMatch = selection[1].match(/lines (\d+) to (\d+) from (.+):\s*\n/);
+                // Either shape: `from PATH:` then the code, or `from PATH.` when only the lines
+                // were sent. The path is lazy so it stops at whichever terminator comes first.
+                const selMatch = selection[1].match(
+                    /lines (\d+) to (\d+) from (.+?)(?::\s*\n|\.\s)/,
+                );
                 if (selMatch) {
                     refs.push({
                         filePath: selMatch[3].trim(),

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/state.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/state.ts
@@ -206,6 +206,7 @@ const _impl = new StoreImpl<AppState>({
         compactOutputAskAnswers: true,
         allowDangerouslySkipPermissions: false,
         fileCheckpoints: false,
+        sendSelectionText: false,
         diffIgnoreWhitespace: false,
         showOpenDiffInVsButton: true,
         allowedUploadExtensions: [],

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/types.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/types.ts
@@ -7,6 +7,8 @@
 
 import type { SubagentUsageDto } from './generated/SubagentUsageDto';
 import type { ToolResultExtrasDto } from './generated/ToolResultExtrasDto';
+// Imported, not just re-exported below: UserTextEcho extends it, and a re-export is not in scope.
+import type { UserTextNotification } from './generated/UserTextNotification';
 
 /**
  * The one empty array the render passes hand out, because a fresh `[]` is a new identity and Lit
@@ -129,7 +131,7 @@ export type { CliErrorNotification } from './generated/CliErrorNotification';
 
 /** A user message echo (`chat_user_text`) + its stripped image/document placeholders.
  *  Generated from C# by TypeGen — re-exported here. */
-export type { UserTextNotification } from './generated/UserTextNotification';
+export type { UserTextNotification };
 export type { UserImageDto } from './generated/UserImageDto';
 export type { UserFileDto } from './generated/UserFileDto';
 
@@ -257,12 +259,19 @@ export interface PendingPermission {
  *  IDE-context badge. Generated from C# by TypeGen — re-exported here. */
 export type { IdeContextNotification } from './generated/IdeContextNotification';
 
-// Bare reference to a file open/selected in the IDE.
-// Returned by parseIdeContextTags; the UI layer turns each ref into a chip.
+// Bare reference to a file open/selected in the IDE; the UI layer turns each one into a chip.
+// Two sources: the composer on submit, and parseIdeContextTags on a replayed message.
 export interface IdeContextRef {
     filePath: string;
     startLine?: number;
     endLine?: number;
+}
+
+/** The host's notification plus the editor refs the composer holds itself. A field rather than an
+ *  `<ide_*>` tag on the text: the tag the model reads is composed host-side, and one glued on here
+ *  would only be parsed back apart by this same WebView. */
+export interface UserTextEcho extends UserTextNotification {
+    ideRefs?: IdeContextRef[];
 }
 
 /** Token usage of a single assistant turn — generated from C# (Contracts.ContextUsageDto)
@@ -364,6 +373,9 @@ export interface UiUserEntry extends UiEntryBase {
     uuid?: string;
     images?: UiImage[];
     files?: UiFile[];
+    /** What the editor was showing when this turn was sent. Taken out of `text` at build time,
+     *  so a long selection doesn't sit in the transcript for the whole session. */
+    ideRefs?: IdeContextRef[];
 }
 
 /** An assistant turn; `streaming` is UI-only (true while the delta text is still growing). */

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
@@ -14,7 +14,7 @@ import { Transcript } from '../../core/transcript';
 import { clearMarkdownCache } from '../../core/markdown';
 import { buildGroups } from '../../core/exchanges';
 import { openRewindDialog } from '../../core/dialog-host';
-import { cleanMessageOnlyText } from '../../core/ide';
+import { cleanMessageOnlyText, parseIdeContextTags } from '../../core/ide';
 import './cv-notice-stack';
 import type { CvNoticeStack } from './cv-notice-stack';
 import './cv-welcome';
@@ -66,7 +66,7 @@ import type {
     AssistantTextNotification,
     ExchangeEndedNotification,
     CliErrorNotification,
-    UserTextNotification,
+    UserTextEcho,
     ToolPermissionNotification,
     HistoryEventDto,
     HistoryLoadedNotification,
@@ -294,7 +294,7 @@ export class CvApp extends LitElement {
         );
 
         this._offs.push(
-            bridge.onNotification<UserTextNotification>(Msg.toWebView.chat.userText, (data) => {
+            bridge.onNotification<UserTextEcho>(Msg.toWebView.chat.userText, (data) => {
                 const entry = CvApp.buildUserEntry(data);
                 if (!entry) {
                     return;
@@ -974,7 +974,7 @@ export class CvApp extends LitElement {
         for (const ev of events ?? []) {
             switch (ev.type) {
                 case Msg.toWebView.chat.userText: {
-                    const d = ev.data as UserTextNotification;
+                    const d = ev.data as UserTextEcho;
                     const e = CvApp.buildUserEntry(d);
                     if (e) {
                         place(e, d.parentToolUseId);
@@ -1337,11 +1337,9 @@ export class CvApp extends LitElement {
     // and the history replay (then batch/prepend). Zero side effects: no _entries,
     // no _appendEntry, no scroll, no gauge. The one construction path for both.
 
-    /** UserTextNotification → a user or slash-result entry (with lazy image/file chips), or null when
+    /** A user message → a user or slash-result entry (with lazy image/file chips), or null when
      *  it's a sub-agent tool-result echo / meta-injection / empty envelope that shouldn't render. */
-    private static buildUserEntry(
-        d: UserTextNotification,
-    ): UiUserEntry | UiSlashResultEntry | null {
+    private static buildUserEntry(d: UserTextEcho): UiUserEntry | UiSlashResultEntry | null {
         if (d.parentToolUseId && !d.text?.startsWith('[Request interrupted')) {
             return null;
         }
@@ -1361,6 +1359,11 @@ export class CvApp extends LitElement {
                   }
                 : null;
         }
+        // Once, here — not at render time. Live the composer hands the refs over structured;
+        // replayed they are still a tag inside the text, as in any session the terminal or VS
+        // Code wrote.
+        const { text: ownText, refs: parsedRefs } = parseIdeContextTags(text);
+        const ideRefs = d.ideRefs ?? parsedRefs;
         const images: UiImage[] = (d.images ?? []).map((img) => ({
             name: 'image',
             lazy: img.uuid ? { uuid: img.uuid, blockIdx: img.blockIdx } : undefined,
@@ -1372,17 +1375,18 @@ export class CvApp extends LitElement {
         }));
         // CLI meta-injections are filtered host-side (ContentBlockTranslator via MetaInjection),
         // so anything that reaches here is a real user turn.
-        if (!text && images.length === 0 && files.length === 0) {
+        if (!ownText && images.length === 0 && files.length === 0 && ideRefs.length === 0) {
             return null;
         }
         return {
             kind: 'text',
             id: ++_entryIdSeq,
             role: 'user',
-            text,
+            text: ownText,
             uuid: d.uuid ?? undefined,
             images: images.length > 0 ? images : undefined,
             files: files.length > 0 ? files : undefined,
+            ideRefs: ideRefs.length > 0 ? ideRefs : undefined,
             timestamp: d.timestamp ?? undefined,
         };
     }
@@ -1839,6 +1843,7 @@ export class CvApp extends LitElement {
             ?queued=${e.role === 'user' && !!e.uuid && this._queuedUuids.has(e.uuid)}
             .images=${e.role === 'user' ? (e.images ?? EMPTY) : EMPTY}
             .files=${e.role === 'user' ? (e.files ?? EMPTY) : EMPTY}
+            .ideRefs=${e.role === 'user' ? (e.ideRefs ?? EMPTY) : EMPTY}
             ?streaming=${e.role === 'assistant' ? !!e.streaming : false}
             ?isError=${e.role === 'slash-result' ? e.isError : e.role === 'assistant' && !!e.error}
             .timestamp=${

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-ide-context-badge.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-ide-context-badge.ts
@@ -6,6 +6,8 @@ import { LitElement, html, css, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import EyeOff16Regular from '@fluentui/svg-icons/icons/eye_off_16_regular.svg';
+import Bookmark16Regular from '@fluentui/svg-icons/icons/bookmark_16_regular.svg';
+import CodeBlock16Regular from '@fluentui/svg-icons/icons/code_block_16_regular.svg';
 import { state as appState } from '../../core/state';
 import type { IdeContextNotification, SetSendSelectionNotification } from '../../core/types';
 import { bridge } from '../../core/bridge';
@@ -69,6 +71,20 @@ export class CvIdeContextBadge extends LitElement {
                 height: 14px;
                 display: block;
             }
+            /* Trailing "what goes out" glyph. Dimmer than the name it follows: it qualifies the
+               chip, it is not the point of it. */
+            .what {
+                flex-shrink: 0;
+                display: inline-flex;
+                align-items: center;
+                color: var(--colorNeutralForeground3);
+                opacity: 0.8;
+            }
+            .what svg {
+                width: 13px;
+                height: 13px;
+                display: block;
+            }
             /* A ceiling, not a width: a short name takes the room it needs and a long one stops
                here. The ellipsis goes at the START — a truncated name keeps its extension and last
                words, which is what tells one file from another, while the head is usually a shared
@@ -100,9 +116,13 @@ export class CvIdeContextBadge extends LitElement {
 
     @state() private _ctx: IdeContextNotification | null = appState.ideContext;
     @state() private _enabled = appState.ideContextEnabled;
+    /** Mirrored rather than read at render time because Options → Apply replaces the whole `ui`
+     *  block while the chat is open, and the chip has to follow it. */
+    @state() private _withText = appState.ui.sendSelectionText;
 
     private _offCtx?: () => void;
     private _offEnabled?: () => void;
+    private _offUi?: () => void;
 
     override connectedCallback(): void {
         super.connectedCallback();
@@ -112,12 +132,16 @@ export class CvIdeContextBadge extends LitElement {
         this._offEnabled = appState.on('ideContextEnabled', (v) => {
             this._enabled = v;
         });
+        this._offUi = appState.on('ui', (v) => {
+            this._withText = v.sendSelectionText;
+        });
     }
 
     override disconnectedCallback(): void {
         super.disconnectedCallback();
         this._offCtx?.();
         this._offEnabled?.();
+        this._offUi?.();
     }
 
     private _onToggleEye = (e: Event): void => {
@@ -146,6 +170,9 @@ export class CvIdeContextBadge extends LitElement {
         // Editor-style `:start-end` range, shown only for a real selection
         // (a bare open file carries no lines). Matches the in-bubble chip.
         const lineInfo = ctx.hasSelection ? `:${ctx.startLine}-${ctx.endLine}` : '';
+        // The option alone doesn't decide it: with no selection there is no code to attach, so an
+        // open file stays a bookmark whatever the setting says.
+        const withCode = this._withText && ctx.hasSelection;
 
         return html`
             <fluent-button
@@ -167,16 +194,31 @@ export class CvIdeContextBadge extends LitElement {
                 <img class="file-icon" src=${iconUrl(ctx.fileName)} width="16" height="16" alt="" />
                 <span class="name"><bdi>${ctx.fileName}</bdi></span>
                 ${lineInfo ? html`<span class="info">${lineInfo}</span>` : nothing}
+                <!-- An indicator, not a second button: the chip has one action and it is the eye.
+                     Dropped while paused — nothing is going out to describe. -->
+                ${
+                    this._enabled
+                        ? html`<span class="what"
+                              >${unsafeHTML(withCode ? CodeBlock16Regular : Bookmark16Regular)}</span
+                          >`
+                        : nothing
+                }
             </fluent-button>
             <!-- The path, not the bare name the chip already shows: it says WHICH file, through
                  displayPathUi so it follows "Show relative paths" like the tool rows and falls back
                  to the full path outside the workdir. That line is the data, so it keeps tip-name;
-                 the second says which of the two states the toggle is in, which the eye alone does
-                 not. Not "click to stop" — clicking a toggle is what a toggle is for. -->
+                 the second is where the trailing glyph gets its words — an icon on its own is a
+                 riddle. Not "click to stop": clicking a toggle is what a toggle is for. -->
             <fluent-tooltip anchor="ide-badge" positioning="after">
                 <span class="tip-name">${displayPathUi(ctx.filePath)}${lineInfo}</span>
                 <span class="tip-desc"
-                    >${this._enabled ? 'Sent with every message' : 'Not sent'}</span
+                    >${
+                        !this._enabled
+                            ? 'Not sent'
+                            : withCode
+                              ? 'Sent with every message, selected code included'
+                              : 'Sent with every message — the position, not the code'
+                    }</span
                 >
             </fluent-tooltip>
         `;

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-message.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-message.ts
@@ -19,10 +19,11 @@ import { iconUrl } from '../../core/icon-url';
 import { fileName } from '../../core/path';
 import { formatTokenCount } from '../helpers/format';
 import { displayPathUi } from '../paths';
-import { parseIdeContextTags, cleanMessageOnlyText } from '../../core/ide';
+import { cleanMessageOnlyText } from '../../core/ide';
 import { renderSlashCommand } from '../../core/slash-commands';
 import { openLightbox } from '../../core/dialog-host';
 import { observeSize } from '../resize';
+import { EMPTY } from '../../core/types';
 import type {
     IdeContextRef,
     ForkNotification,
@@ -63,6 +64,9 @@ export class CvMessage extends LitElement {
     @property({ type: Boolean }) isError = false;
     @property({ attribute: false }) images: UiImage[] = [];
     @property({ attribute: false }) files: UiFile[] = [];
+    /** Editor context for this turn, extracted by buildUserEntry — `text` never carries the
+     *  `<ide_*>` block any more. */
+    @property({ attribute: false }) ideRefs: IdeContextRef[] = [];
 
     @property({ type: Boolean, reflect: true }) expanded = false;
     @state() private _isOverflowing = false;
@@ -386,7 +390,7 @@ export class CvMessage extends LitElement {
     }
 
     /** Render one chip per IDE context ref attached to a user message. */
-    private _renderIdeChips(refs: IdeContextRef[]) {
+    private _renderIdeChips(refs: readonly IdeContextRef[]) {
         return refs.map((r) => {
             // Chip shows `name:start-end` (editor style, range only for a real
             // selection); tooltip carries the full relative path.
@@ -423,13 +427,11 @@ export class CvMessage extends LitElement {
             case 'user': {
                 // A slash-command envelope renders as the raw "/name args" in a normal user
                 // bubble (blue band), same as a typed message. A bare "/compact" has no envelope
-                // and flows through parseIdeContextTags unchanged.
+                // and reaches here as plain text.
                 const slashText = renderSlashCommand(this.text);
-                // Strip CLI-injected <ide_*> tags and render them as chips
-                // above the bubble instead of showing them verbatim.
-                const { text, refs } = slashText
-                    ? { text: slashText, refs: [] as IdeContextRef[] }
-                    : parseIdeContextTags(this.text);
+                const text = slashText || this.text;
+                // The chips come from the entry, built once when the message arrived.
+                const refs = slashText ? (EMPTY as readonly IdeContextRef[]) : this.ideRefs;
                 // Skip empty user envelopes (e.g. tool_result-only messages,
                 // consumed by the host for the tool row's OUT cell).
                 if (

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-prompt.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-prompt.ts
@@ -20,7 +20,8 @@ import type {
     NoticeNotification,
     NoticeDismissedDetail,
     PromptHistoryNotification,
-    UserTextNotification,
+    UserTextEcho,
+    IdeContextRef,
     UserImageDto,
     UserFileDto,
     SendPromptNotification,
@@ -959,24 +960,24 @@ export class CvPrompt extends LitElement implements CommandHost {
         // Client-minted uuid: the CLI reuses it for the JSONL entry, so
         // fork_session works on live messages too (not just replayed ones).
         const uuid = crypto.randomUUID();
-        // Build the final prompt once: prepend the active editor's <ide_*> tag
-        // when the IDE-context toggle is on. Doing it here (not in _dispatch)
-        // means the echoed bubble and the CLI get the identical text — and
-        // cv-message parses the tag back into a file/selection chip.
+        // For the bubble's chip only — the tag the model reads is composed host-side, where the
+        // selected code is, so nothing here has to match its wording.
         // A slash command never carries IDE context (matches the VS Code webview:
         // ct = enabled && !startsWith('/')) — the file/selection chip would be noise on /model etc.
         const ctx =
             appState.ideContextEnabled && !text.startsWith('/') ? appState.ideContext : null;
-        const ideBlock = !ctx?.filePath
-            ? ''
-            : ctx.hasSelection
-              ? `<ide_selection>The user selected the lines ${ctx.startLine} to ${ctx.endLine} from ${ctx.filePath}:\n\nThis may or may not be related to the current task.</ide_selection>\n`
-              : `<ide_opened_file>The user opened the file ${ctx.filePath} in the IDE. This may or may not be related to the current task.</ide_opened_file>\n`;
-        const payload = { text: ideBlock + text, attachments: this._attachments, uuid };
+        const ideRefs: IdeContextRef[] = !ctx?.filePath
+            ? []
+            : [
+                  ctx.hasSelection
+                      ? { filePath: ctx.filePath, startLine: ctx.startLine, endLine: ctx.endLine }
+                      : { filePath: ctx.filePath },
+              ];
+        const payload = { text, attachments: this._attachments, uuid };
         // Echo the user bubble locally now (stream-json doesn't reflect the
         // submitted message back). Same path for live and queued messages, so
         // a queued one shows up immediately instead of waiting for the flush.
-        this._echoUserMessage(payload);
+        this._echoUserMessage(payload, ideRefs);
         if (this._isBusy) {
             // Already running → enqueue. Drained when isBusy flips to false.
             this._setQueue([...this._queue, payload]);
@@ -1087,11 +1088,14 @@ export class CvPrompt extends LitElement implements CommandHost {
      *  they resolve from the JSONL on click, matching the history-replay format so
      *  there's a single rendering path. blockIdx is the send-order index, matching
      *  the content[] block the host writes. */
-    private _echoUserMessage(payload: {
-        text: string;
-        attachments: Attachment[];
-        uuid: string;
-    }): void {
+    private _echoUserMessage(
+        payload: {
+            text: string;
+            attachments: Attachment[];
+            uuid: string;
+        },
+        ideRefs: IdeContextRef[] = [],
+    ): void {
         if (!payload.text && payload.attachments.length === 0) {
             return;
         }
@@ -1109,12 +1113,13 @@ export class CvPrompt extends LitElement implements CommandHost {
                 files.push({ name: att.name, uuid: payload.uuid, blockIdx: i });
             }
         });
-        const msg: UserTextNotification = {
+        const msg: UserTextEcho = {
             text: payload.text,
             uuid: payload.uuid,
             images: images.length > 0 ? images : null,
             files: files.length > 0 ? files : null,
             parentToolUseId: null,
+            ideRefs: ideRefs.length > 0 ? ideRefs : undefined,
         };
         bridge.emit(Msg.toWebView.chat.userText, msg);
     }

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.cs
@@ -835,41 +835,6 @@ internal sealed partial class ClaudeClient : IClaudeClient
     public Task McpToggleAsync(string serverName, bool enabled)
         => SendControlRequestAsync(ClientMessages.ControlSubtype.McpToggle, new { serverName, enabled });
 
-    public void SendSelectionChanged(string text, string filePath, string fileUrl,
-                                      int startLine, int startChar, int endLine, int endChar,
-                                      bool isEmpty)
-    {
-        var transport = _transport;
-        if (!transport.IsRunning)
-        {
-            _log.Trace(() => "[ChatSelection] SendSelectionChanged skip: transport not running");
-            return;
-        }
-        _log.Trace(() => $"[ChatSelection] SendSelectionChanged → filePath={filePath} isEmpty={isEmpty} line={startLine}-{endLine}");
-        transport.Write(new
-        {
-            type = "request",
-            channelId = "",
-            requestId = "",
-            request = new
-            {
-                type = "selection_changed",
-                selection = new
-                {
-                    text = text ?? string.Empty,
-                    filePath,
-                    fileUrl,
-                    selection = new
-                    {
-                        start = new { line = startLine, character = startChar },
-                        end = new { line = endLine, character = endChar },
-                        isEmpty,
-                    },
-                },
-            },
-        });
-    }
-
     public void SendPrompt(JArray contentBlocks, string uuid)
     {
         EnsureRunning();

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/IClaudeClient.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/IClaudeClient.cs
@@ -96,9 +96,6 @@ public interface IClaudeClient : IDisposable
     Task McpReconnectAsync(string serverName);
     Task McpToggleAsync(string serverName, bool enabled);
 
-    void SendSelectionChanged(string text, string filePath, string fileUrl,
-                              int startLine, int startChar, int endLine, int endChar,
-                              bool isEmpty);
     void SendPrompt(JArray contentBlocks, string uuid);
 
     /// <summary>Responds to a ToolPermissionRequested event, correlating by the

--- a/src/Corsinvest.VisualStudio.Agents/Options/AgentsChatPage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Options/AgentsChatPage.cs
@@ -127,6 +127,11 @@ public class AgentsChatPage : AgentsOptionsPage
     public bool UseCtrlEnterToSend { get; set; } = false;
 
     [Category("Input")]
+    [DisplayName("Send the selected text with the message")]
+    [Description("Attach the selected code to the message, not just its file and line numbers. Costs tokens on every message sent with a selection, so it is off by default — but it is what makes an unsaved buffer readable, since otherwise the model opens the file from disk and sees the saved version. The composer's file badge shows which of the two is going out.")]
+    public bool SendSelectionText { get; set; } = false;
+
+    [Category("Input")]
     [DisplayName("Initial permission mode")]
     [Description("Permission mode every new chat session starts in. You can still change it per-session from the toolbar. \"Manual\" (Default) is the most cautious. \"BypassPermissions\" also requires \"Allow dangerously skip permissions\" below — without it, sessions start in Manual.")]
     public InitialPermissionMode InitialPermissionMode { get; set; } = InitialPermissionMode.Default;


### PR DESCRIPTION
The chip above the composer kept disappearing when a session was reopened. Chasing
that turned up the reason, and then the larger thing behind it: the tag it is built
from named the lines of your selection but never carried the code, so on an unsaved
buffer the model opened the file and read the stale version on disk.

## The bug

A submitted message can reach the CLI as several `text` blocks — the IDE-context tag
gets one of its own — and `EmitUser` assigned each one to `userText` instead of
accumulating. Only the last survived. Live the chip was fine; on replay the tag was
the block that got overwritten.

Verified against a real session that happens to contain both shapes: one message
split into `[tag][text]`, another arriving whole.

## The selected code

`<ide_selection>` said *lines 40 to 78 from Foo.cs* and stopped there. The VS Code
webview puts `${selectedText}` inside the same tag; we did not — so for an unsaved
buffer the model had nowhere to read the real content.

New **Chat → Send the selected text with the message**, off by default: the code
goes out again with *every* message while that selection stands, including "yes"
and "go on". Off, the model opens the file when it needs it — once, and free to read
around the selection.

The tag is now composed host-side. The selected text is already there, so it never
crosses the bridge, and the composer stops having to write a tag whose wording has
to match the one the model reads.

## The chip

An option in a dialog you opened once is easy to forget, so the chip carries the
answer: a bookmark for the position alone, a code block when the text rides along.
Both conditions, not just the setting — an open file with nothing selected has no
code to attach, so it stays a bookmark however the option is set. Gone entirely
while the eye is shut.

## Along the way

- `SendSelectionChanged` wrote `selection_changed` to the CLI's stdin, which is the
  VS Code extension's *own* extension-to-webview channel — nothing on the CLI side
  reads it there. A probe confirms it: turn completes, no attachment. Removed.
- The echo built an `<ide_*>` tag that `cv-app` pulled apart again with a regex two
  steps later, on data the WebView already had. It also meant the tag was written in
  two places that had to agree, which is exactly the failure this branch opened with.
  It now passes the refs. The parser stays — replayed sessions really do carry the
  tag inside the text.
- Docs: which settings actually save context and which only look like they do (most
  of the Chat page is rendering), and a README claim that the context badge opens
  the file on click. It toggles sharing; there is no open action.

## Verification

Build green, typecheck and prettier clean. The three tag shapes — pre-option, option
off, option on — were exercised live and all three parse, path separators and dotted
filenames included.

Left for a follow-up, in TODO: temp files from the diff viewer (`claude-diff-*`)
become IDE context and leave a chip pointing at something that no longer exists.

Worth knowing: this option governs the block prepended to *your message*, which is
what accumulates turn after turn. Visual Studio also pushes editor selections over
the IDE integration channel, as VS Code does, and that path does not consult it.
