### PR TITLE
perf(chat): two seconds of every chat open were a DNS timeout

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.cs
@@ -80,8 +80,10 @@ internal sealed partial class WebViewBridge(Microsoft.Web.WebView2.Wpf.WebView2C
             // Inject boot-time theme script BEFORE navigation to avoid FOUC (refreshed via InjectTheme).
             if (_pendingTheme.HasValue) { await RegisterBootThemeScriptAsync(_pendingTheme.Value); }
 
-            // Virtual https host instead of file:// — file:// makes every resource cross-origin
-            // (browser warnings, hljs CSS silently ignored). Virtual host gives same-origin + correct MIME.
+            // Virtual https host instead of file:// — Chromium gives every file: document an origin
+            // unique to its own path, so the page cannot even reach itself ("Unsafe attempt to load
+            // URL … from frame with URL …", the same URL on both sides). The virtual host gives one
+            // real origin, correct MIME types, and a secure context.
             var indexPath = AppPaths.WebViewHtml();
             var folder = Path.GetDirectoryName(indexPath);
             if (!File.Exists(indexPath))
@@ -90,15 +92,17 @@ internal sealed partial class WebViewBridge(Microsoft.Web.WebView2.Wpf.WebView2C
                 // nothing — say which path we resolved before it does.
                 log.Warn($"[webview] index.html not found at '{indexPath}' — the chat can't load");
             }
-            webView.CoreWebView2.SetVirtualHostNameToFolderMapping("cv4vs.local", folder, CoreWebView2HostResourceAccessKind.Allow);
+            webView.CoreWebView2.SetVirtualHostNameToFolderMapping(AppPaths.WebViewHost, folder, CoreWebView2HostResourceAccessKind.Allow);
 
             // Lazy-served icons: virtual-host would serve from disk and 404 on not-yet-generated PNGs,
             // so intercept the request instead and generate on demand from KnownMonikers on the UI thread.
             Directory.CreateDirectory(AppPaths.IconCacheFolder);
-            webView.CoreWebView2.AddWebResourceRequestedFilter("https://cv4vs-icons.local/*", CoreWebView2WebResourceContext.Image);
+            webView.CoreWebView2.AddWebResourceRequestedFilter($"https://{AppPaths.IconHost}/*", CoreWebView2WebResourceContext.Image);
             webView.CoreWebView2.WebResourceRequested += OnIconRequested;
 
-            webView.Source = new Uri("https://cv4vs.local/" + Path.GetFileName(indexPath));
+            // https, not http: the scheme costs nothing either way (nothing ever connects — the
+            // host is served from disk), and https is what gives the page a secure context.
+            webView.Source = new Uri($"https://{AppPaths.WebViewHost}/" + Path.GetFileName(indexPath));
         }
         catch (Exception ex)
         {
@@ -469,7 +473,7 @@ internal sealed partial class WebViewBridge(Microsoft.Web.WebView2.Wpf.WebView2C
         || type == BridgeMessages.ToWebView.Chat.ToolProgress;
 
     /// <summary>
-    /// Intercepts every `https://cv4vs-icons.local/<key>.png` fetch from
+    /// Intercepts every `<see cref="AppPaths.IconHost"/>/<key>.png` fetch from
     /// the WebView. Ensures the PNG exists on disk (generating it from
     /// the matching VS KnownMoniker on first hit), then serves the bytes
     /// back as the HTTP response.

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/icon-url.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/icon-url.ts
@@ -3,10 +3,14 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 // File-type icon URL helper.
-// Icons live on the `cv4vs-icons.local` virtual host; the C# side generates
-// PNGs lazily from VS KnownMonikers and caches them on disk.
+// Icons live on a virtual host; the C# side generates PNGs lazily from VS KnownMonikers and
+// caches them on disk.
+//
+// Must match AppPaths.IconHost, which is where the suffix is explained — a copy rather than a
+// value we are told, because URLs are built on the first render, before any message from the
+// host could have arrived. Drift shows up as icons missing on the next run.
 
-const ICON_HOST = 'https://cv4vs-icons.local';
+const ICON_HOST = 'https://cv4vs-icons.invalid';
 
 /**
  * URL of the icon that best represents the given path.

--- a/src/Corsinvest.VisualStudio.Agents/Utils/AppPaths.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Utils/AppPaths.cs
@@ -32,10 +32,25 @@ internal static class AppPaths
     /// colours the format, and so nothing has to be escaped into a JSON string.</para></summary>
     public static readonly string IgnoreRulesFile = Path.Combine(DataFolder, "picker-ignore.gitignore");
 
+    /// <summary>The virtual hosts the WebView is served from: one for the bundle, one for the
+    /// lazily-rasterised file icons.
+    /// <para>The `.invalid` suffix is the load-bearing part. `.local` belongs to mDNS, so Windows
+    /// answers a name under it with a multicast query and waits ~2s for a reply that never comes —
+    /// before WebView2 serves the file from disk anyway. Measured here: 2551ms from responseEnd to
+    /// domInteractive under `.local`, 397ms under `.invalid`, on an otherwise identical load. The
+    /// WebView2 docs say the same ("using .local … can cause a delay during navigations. You should
+    /// avoid using .local if you can") and point at RFC 6761's reserved names, of which this is
+    /// one.</para>
+    /// <para>The WebView has its own copy of the icon host in `core/icon-url.ts` — it builds URLs
+    /// on the first render, before any message from us could have arrived. If the two ever drift
+    /// apart the icons vanish on the next run, which is a loud enough failure.</para></summary>
+    public const string WebViewHost = "cv4vs.invalid";
+    public const string IconHost = "cv4vs-icons.invalid";
+
     /// <summary>
-    /// Cache folder for file-type icons rasterised from VS KnownMonikers. The
-    /// WebView serves these via the `cv4vs-icons.local` virtual host, generated
-    /// lazily the first time an extension is requested.
+    /// Cache folder for file-type icons rasterised from VS KnownMonikers, served
+    /// over <see cref="IconHost"/> and generated lazily the first time an
+    /// extension is requested.
     /// </summary>
     public static readonly string IconCacheFolder = Path.Combine(DataFolder, "icons");
 


### PR DESCRIPTION
Opening a chat took about four and a half seconds, and roughly two of them
were Windows waiting out a DNS timeout on a hostname that never needed
resolving.

## What the page was doing

```
fetchStart      1.4ms
responseEnd     4.5ms     ← 2246 bytes of HTML, delivered
domInteractive  2551ms    ← parsing starts two and a half seconds later
```

The gap held to ±3ms across runs made under very different load. A constant
that rigid is a fixed wait, not work.

## The hostname

`.local` belongs to mDNS. Windows answers a name under it with a multicast
query and waits for a reply that never comes — and only then does WebView2
serve the file from disk, as it was always going to.

The WebView2 docs say it outright: *"using `.local` as the top-level domain
name will work but can cause a delay during navigations. You should avoid
using `.local` if you can"*, and point at RFC 6761's reserved names.
[WebView2Feedback#2381](https://github.com/MicrosoftEdge/WebView2Feedback/issues/2381)
is the same two seconds, open since 2022.

Both virtual hosts move to `.invalid`, and both now live in `AppPaths` so
the reason is written down once instead of three times.

## Measured

Three consecutive warm panes, after:

| | before | after |
|---|---|---|
| page stall | 2551ms | **397ms** |
| `WebView.Init` | ~3.5s | **~1.2s** |
| `OnLoaded` → `webview_ready` | ~4.5s | **~1.5s** |

The spread closes too: 1215/1255/1334ms, against 2.1–4.3s before.

## Ruled out

Each by measuring, not by reasoning about it:

- **the CLI spawn** — the stall is unchanged when it is skipped entirely
- **TLS** — `http` matches `https` to the millisecond, and
  `secureConnectionStart` is 0: nothing ever connects
- **the mapping call** — 1ms
- **`file:///`** — 443ms, but every file gets its own opaque origin and the
  page cannot even reach itself (*"Unsafe attempt to load URL … from frame
  with URL …"*, the same URL on both sides)
- **the bundle** — CSS and JS load in 55-95ms

## What is left

~900ms of `EnsureCoreWebView2Async`, which is WebView2 building its browser
processes. It does not shrink; it can only be moved out of the open by
keeping a control warm ahead of time, which costs a live renderer and a
lifecycle to manage. Noted in TODO with the numbers, not done here — the
jump people will feel has already happened.
