### PR TITLE
fix(chat): a file reference in backticks is where the model puts most of them

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Helpers.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Helpers.cs
@@ -318,12 +318,15 @@ internal sealed partial class WebViewMessageHandler
         {
             if (AgentsOptions.Chat.SelectLinesOnOpen && endLine >= startLine && endLine > 0)
             {
-                sel.GotoLine(startLine, true);
-                if (endLine > startLine)
-                {
-                    sel.LineDown(true, endLine - startLine);
-                }
-                sel.EndOfLine(true);
+                // Anchored at the END and extended upwards, so the caret — and with it the view —
+                // lands on the first line. A range names a block by where it begins: selecting
+                // downwards leaves the caret at the bottom, and an 80-line range then scrolls its
+                // own first line off the top of the screen, which is the one the model meant.
+                // MoveToLineAndOffset rather than GotoLine, as everywhere else here: it says which
+                // column it wants instead of inheriting wherever the caret happened to be.
+                sel.MoveToLineAndOffset(endLine, 1, false);
+                sel.EndOfLine(false);
+                sel.MoveToLineAndOffset(startLine, 1, true);
             }
             else
             {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/codespan-link.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/codespan-link.ts
@@ -1,0 +1,81 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+// Inline `code` that is a file reference and nothing else — `ClientEvents.cs:208` — rendered as a
+// link inside the code span.
+//
+// Why this exists: marked tokenizes inline code before any extension runs, so the file-link
+// tokenizer in markdown.ts never sees what is inside backticks. That would be the right rule for a
+// fence, and it is kept there; for an inline span it loses almost everything. Counted over 25 real
+// sessions in this repo: 33 references written inside backticks against 2 written bare — the model
+// backticks a filename because it IS a filename, and treating that as untouchable code inverts the
+// intent.
+//
+// Its own module rather than a branch in markdown.ts so the rule can be tested: markdown.ts pulls
+// in marked, DOMPurify and highlight.js, and node --test cannot resolve extensionless value imports
+// anyway. What it needs from elsewhere is passed in — same shape as formatTimeAgo taking its clock —
+// which keeps this file import-free and therefore loadable by the test runner as it stands.
+
+import type { FileRef } from './file-links';
+
+/** What this needs from the rest of the app: the parser, and the escaper. */
+export interface CodespanDeps {
+    /** file-links.parseFileRef — a ref only when it is the WHOLE token. */
+    parseFileRef: (token: string, strictness: 'known-ext') => FileRef | null;
+    escapeHtml: (s: unknown) => string;
+}
+
+/** The link markup for one reference, in the shape cv-message's click handler expects. */
+function anchor(
+    esc: CodespanDeps['escapeHtml'],
+    path: string,
+    label: string,
+    line: number,
+    end: number,
+): string {
+    return (
+        `<a class="cv-file-link" data-file="${esc(path)}" data-line="${line}" ` +
+        `data-line-end="${end}" title="Open in editor">${esc(label)}</a>`
+    );
+}
+
+/**
+ * The inner HTML of an inline code span: a link when the whole span is a file reference, the
+ * escaped text otherwise.
+ *
+ * Whole span or nothing. `Foo.cs:12` is the model naming a location; `cat Foo.cs:12` is a command
+ * that happens to contain one, and linking part of a command would be wrong twice over — it claims
+ * the command is a file, and it splits a thing meant to be copied whole. parseFileRef already
+ * enforces exactly this (`start === 0 && match === token`), so the rule is one call, not a second
+ * parser that could drift from the first.
+ *
+ * A comma list keeps the shape prose gets: the first link carries `name:line`, the rest carry the
+ * bare line numbers, so `Foo.cs:12,40` reads as one file at two places rather than as two files.
+ */
+export function renderCodespanInner(text: string, deps: CodespanDeps): string {
+    const { parseFileRef, escapeHtml } = deps;
+    const ref = parseFileRef(text, 'known-ext');
+    if (!ref) {
+        return escapeHtml(text);
+    }
+    const link = (label: string, line: number, end: number) =>
+        anchor(escapeHtml, ref.path, label, line, end);
+    // No line: the whole path is the link, opened at the top.
+    if (ref.lines.length === 0) {
+        return link(ref.path, 0, 0);
+    }
+    // The label is what was written, so a range stays readable as "35-48" and "#L128" keeps its
+    // GitHub shape instead of being normalised to its first line.
+    const written = ref.match.slice(ref.path.length);
+    if (ref.lines.length === 1) {
+        return link(ref.path + written, ref.lines[0], ref.ends[0]);
+    }
+    const parts = written.replace(/^:/, '').split(',');
+    const [first, ...rest] = ref.lines;
+    let html = link(`${ref.path}:${parts[0] ?? first}`, first, ref.ends[0]);
+    rest.forEach((ln, i) => {
+        html += ',' + link(parts[i + 1] ?? String(ln), ln, ref.ends[i + 1]);
+    });
+    return html;
+}

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/markdown.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/markdown.ts
@@ -197,7 +197,7 @@ export function renderMarkdown(text: string | undefined | null): string {
  * on the real (still-growing) text, and the final render uses `renderMarkdown`
  * on the complete text. Same sanitized pipeline → same safety.
  */
-function closeOpenMarkdown(text: string): string {
+export function closeOpenMarkdown(text: string): string {
     // Walk lines tracking whether we're inside a fenced code block. A line that
     // *starts* with ``` flips the state — so ``` that appear as content (not at
     // line start, or while already inside a block) don't throw off the count.

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/markdown.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/markdown.ts
@@ -10,6 +10,7 @@ import DOMPurify from 'dompurify';
 import { resolveLang, highlightCode, clearHighlightCache } from './lang';
 import { escapeHtml } from './html';
 import { findFileRefs, firstRefHint, parseFileRef } from './file-links';
+import { renderCodespanInner } from './codespan-link';
 
 // CLI-internal tags that look like HTML but are content; DOMPurify would
 // drop them silently, so escape up-front to render as literal text.
@@ -20,6 +21,15 @@ const _LITERAL_TAG_RE =
 const renderer = new marked.Renderer() as Renderer & {
     code: (token: Tokens.Code) => string;
     link: (token: Tokens.Link) => string;
+    codespan: (token: Tokens.Codespan) => string;
+};
+
+// Inline `code` that is a file reference and nothing else becomes a link inside the span. marked
+// tokenizes code spans before any extension runs, so the fileLink tokenizer below never sees them —
+// which is the right rule for a fence and the wrong one here, since the model backticks a filename
+// precisely because it is one. The decision lives in codespan-link.ts so it can be tested.
+renderer.codespan = function (token: Tokens.Codespan): string {
+    return `<code>${renderCodespanInner(token.text ?? '', { parseFileRef, escapeHtml })}</code>`;
 };
 
 renderer.code = function (token: Tokens.Code): string {
@@ -162,7 +172,9 @@ export function renderMarkdown(text: string | undefined | null): string {
     try {
         const html = marked.parse(normalized, { async: false }) as string;
         out = DOMPurify.sanitize(html, {
-            ADD_ATTR: ['target', 'frompre', 'data-file', 'data-line'],
+            // data-line-end is what makes a range select rather than just scroll. It was missing
+            // here while the renderer emitted it, so "x.cs:35-48" opened at 35 and selected nothing.
+            ADD_ATTR: ['target', 'frompre', 'data-file', 'data-line', 'data-line-end'],
             ADD_TAGS: ['cv-copy-btn'],
         });
     } catch (err) {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/package.json
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/package.json
@@ -10,7 +10,7 @@
         "build:dev": "node tools/gen-bridge.mjs && node esbuild.config.mjs --dev",
         "dev": "node tools/gen-bridge.mjs && node esbuild.config.mjs --watch",
         "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
-        "test": "node --test \"tests/**/*.test.ts\"",
+        "test": "node --import ./tests/_helpers/register.mjs --test \"tests/**/*.test.ts\"",
         "lint": "eslint \"{core,ui,tests}/**/*.ts\"",
         "lint:fix": "eslint --fix \"{core,ui,tests}/**/*.ts\"",
         "format": "prettier --write \"{core,ui,tests}/**/*.ts\" \"*.ts\"",

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/_helpers/register.mjs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/_helpers/register.mjs
@@ -1,0 +1,2 @@
+import { register } from 'node:module';
+register('./ts-resolve.mjs', import.meta.url);

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/_helpers/ts-resolve.mjs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/_helpers/ts-resolve.mjs
@@ -1,0 +1,15 @@
+// Node requires an extension on a relative ESM import; the WebView's own modules omit it, because
+// esbuild and tsc's "Bundler" resolution both accept that. Append it when the bare specifier does
+// not resolve, so `node --test` can load them as they are written.
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+export function resolve(specifier, context, next) {
+    if (specifier.startsWith('.') && !/\.[a-z]+$/i.test(specifier)) {
+        const guess = new URL(specifier + '.ts', context.parentURL);
+        if (existsSync(fileURLToPath(guess))) {
+            return next(specifier + '.ts', context);
+        }
+    }
+    return next(specifier, context);
+}

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/codespan-link.test.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/codespan-link.test.ts
@@ -1,0 +1,128 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+// Cosa fa un `code span` inline: linka quando il contenuto E' un riferimento, resta testo quando
+// contiene anche altro. La regola vale o non vale sul contenuto intero — non ci sono link parziali.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { renderCodespanInner as render } from '../core/codespan-link.ts';
+import { parseFileRef } from '../core/file-links.ts';
+import { escapeHtml } from '../core/html.ts';
+
+// Le dipendenze vere, non finte: la regola vale solo se combacia con il parser che gira davvero.
+const renderCodespanInner = (text: string) => render(text, { parseFileRef, escapeHtml });
+
+/** Quanti link a file nel frammento reso. */
+function links(html: string): number {
+    return (html.match(/class="cv-file-link"/g) ?? []).length;
+}
+
+function fileOf(html: string): string | null {
+    return html.match(/data-file="([^"]*)"/)?.[1] ?? null;
+}
+
+// Linka: il contenuto e' il riferimento e nient'altro.
+
+test('un riferimento con riga diventa link', () => {
+    const html = renderCodespanInner('ClientEvents.cs:208');
+    assert.equal(links(html), 1);
+    assert.equal(fileOf(html), 'ClientEvents.cs');
+    assert.match(html, /data-line="208"/);
+});
+
+test('la label tiene quello che era scritto', () => {
+    assert.match(renderCodespanInner('ClientEvents.cs:208'), />ClientEvents\.cs:208</);
+});
+
+test('un percorso relativo linka', () => {
+    const html = renderCodespanInner('Core/Stats/StatsService.cs:45');
+    assert.equal(fileOf(html), 'Core/Stats/StatsService.cs');
+});
+
+test('un intervallo porta la riga finale nel data-line-end', () => {
+    const html = renderCodespanInner('StatsService.cs:35-48');
+    assert.match(html, /data-line="35" data-line-end="48"/);
+    assert.match(html, />StatsService\.cs:35-48</, 'la label non va normalizzata alla prima riga');
+});
+
+test('una lista di righe da un link per riga, il primo col nome del file', () => {
+    const html = renderCodespanInner('AgentsPackage.cs:124,185,202');
+    assert.equal(links(html), 3);
+    assert.match(html, />AgentsPackage\.cs:124</);
+    assert.match(html, />185</);
+    assert.match(html, />202</);
+});
+
+test('la forma GitHub linka e tiene la sua scrittura', () => {
+    const html = renderCodespanInner('ClaudeInstall.cs#L103');
+    assert.equal(links(html), 1);
+    assert.match(html, /data-line="103"/);
+    assert.match(html, />ClaudeInstall\.cs#L103</);
+});
+
+test('le parentesi tonde linkano', () => {
+    const html = renderCodespanInner('foo.cs(339)');
+    assert.equal(links(html), 1);
+    assert.match(html, /data-line="339"/);
+});
+
+test('un percorso con cartella linka anche senza riga, aperto in cima', () => {
+    const html = renderCodespanInner('docs/file-links.md');
+    assert.equal(links(html), 1);
+    assert.match(html, /data-line="0"/);
+});
+
+// Non linka: c'e' dell'altro oltre al riferimento, o non e' un riferimento.
+
+test('un comando che contiene un riferimento resta testo', () => {
+    assert.equal(links(renderCodespanInner('cat Foo.cs:12')), 0);
+});
+
+test('un riferimento seguito da altro resta testo', () => {
+    assert.equal(links(renderCodespanInner('Foo.cs:12 e poi')), 0);
+});
+
+test('due riferimenti in uno span restano testo', () => {
+    // Ambiguo: lo span e' una citazione doppia o un frammento? Non si indovina.
+    assert.equal(links(renderCodespanInner('a.cs:1 b.ts:2')), 0);
+});
+
+test('una versione non e un file', () => {
+    assert.equal(links(renderCodespanInner('1.5.0')), 0);
+    assert.equal(links(renderCodespanInner('v2.1.237')), 0);
+});
+
+test('un orario, un host e un prezzo non sono file', () => {
+    assert.equal(links(renderCodespanInner('10:30')), 0);
+    assert.equal(links(renderCodespanInner('localhost.net:4040')), 0);
+    assert.equal(links(renderCodespanInner('19.99:2')), 0);
+});
+
+test('un identificatore di codice qualunque resta testo', () => {
+    assert.equal(links(renderCodespanInner('appState.ideContext')), 0);
+    assert.equal(links(renderCodespanInner('const x = 1')), 0);
+});
+
+test('un nome nudo senza riga ne cartella resta testo', () => {
+    // Stessa soglia della prosa: "README.md" da solo e' troppo rumoroso per linkare.
+    assert.equal(links(renderCodespanInner('README.md')), 0);
+});
+
+test('testo vuoto non lancia', () => {
+    assert.equal(renderCodespanInner(''), '');
+});
+
+// L'HTML prodotto deve restare sicuro: il contenuto viene dal modello.
+
+test('il testo non linkato e escapato', () => {
+    const html = renderCodespanInner('<script>alert(1)</script>');
+    assert.doesNotMatch(html, /<script/);
+    assert.match(html, /&lt;script&gt;/);
+});
+
+test('il percorso finisce escapato dentro lattributo', () => {
+    // Un nome con virgolette romperebbe data-file="..." se non fosse escapato.
+    const html = renderCodespanInner('a"b.cs:1');
+    assert.doesNotMatch(html, /data-file="a"b/);
+});

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/file-links.test.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/file-links.test.ts
@@ -1,0 +1,235 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+// Il parser dei riferimenti a file: ogni forma che docs/file-links.md promette, e i non-casi che
+// la allow-list esiste per bloccare. Scritti contro il comportamento ATTUALE — un test che fallisce
+// qui e' o un bug o una promessa della doc che il codice non mantiene, e le due vanno distinte.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { findFileRefs, parseFileRef, firstRefHint } from '../core/file-links.ts';
+
+/** Il primo ref di un testo, o null. Le asserzioni sotto guardano quasi sempre solo quello. */
+function first(text: string) {
+    return findFileRefs(text)[0] ?? null;
+}
+
+// Le sette forme della tabella in docs/file-links.md.
+
+test('forma: nome.ext:riga', () => {
+    const r = first('vedi ClientEvents.cs:208 per il resto');
+    assert.equal(r?.path, 'ClientEvents.cs');
+    assert.deepEqual(r?.lines, [208]);
+    assert.equal(r?.match, 'ClientEvents.cs:208');
+});
+
+test('forma: percorso relativo', () => {
+    const r = first('in Core/Stats/StatsService.cs:45 succede');
+    assert.equal(r?.path, 'Core/Stats/StatsService.cs');
+    assert.deepEqual(r?.lines, [45]);
+});
+
+test('forma: intervallo, ends porta la riga finale', () => {
+    const r = first('StatsService.cs:35-48 e il blocco');
+    assert.deepEqual(r?.lines, [35]);
+    assert.deepEqual(r?.ends, [48]);
+});
+
+test('forma: intervallo con en-dash', () => {
+    const r = first('StatsService.cs:35–48');
+    assert.deepEqual(r?.lines, [35]);
+    assert.deepEqual(r?.ends, [48]);
+});
+
+test('forma: lista di righe, una per link', () => {
+    const r = first('AgentsPackage.cs:124,185,202 tre punti');
+    assert.deepEqual(r?.lines, [124, 185, 202]);
+    assert.deepEqual(r?.ends, [124, 185, 202]);
+});
+
+test('forma: lista i cui elementi sono intervalli', () => {
+    const r = first('StatsService.cs:100-120,130');
+    assert.deepEqual(r?.lines, [100, 130]);
+    assert.deepEqual(r?.ends, [120, 130]);
+});
+
+test('forma: parentesi tonde', () => {
+    const r = first('in foo.cs(339) qui');
+    assert.equal(r?.path, 'foo.cs');
+    assert.deepEqual(r?.lines, [339]);
+});
+
+test('forma: parentesi quadre con colonna', () => {
+    const r = first('bar.ts[45:12] la');
+    assert.equal(r?.path, 'bar.ts');
+    assert.deepEqual(r?.lines, [45]);
+});
+
+test('forma: GitHub #L', () => {
+    const r = first('ClaudeInstall.cs#L103 e li');
+    assert.deepEqual(r?.lines, [103]);
+});
+
+test('forma: GitHub #L con intervallo', () => {
+    const r = first('x.ts#L35-L48');
+    assert.deepEqual(r?.lines, [35]);
+    assert.deepEqual(r?.ends, [48]);
+});
+
+test('forma: GitHub # senza L', () => {
+    const r = first('bar.ts#45');
+    assert.deepEqual(r?.lines, [45]);
+});
+
+test('la colonna e parsata e scartata, non diventa la fine di una selezione', () => {
+    const r = first('x.ts:47:12 qui');
+    assert.deepEqual(r?.lines, [47]);
+    assert.deepEqual(r?.ends, [47]);
+});
+
+// Piu' riferimenti nello stesso testo.
+
+test('due file in una riga danno due ref distinti', () => {
+    const refs = findFileRefs('markdown.ts:57,file-links.ts:130');
+    assert.equal(refs.length, 2);
+    assert.equal(refs[0].path, 'markdown.ts');
+    assert.equal(refs[1].path, 'file-links.ts');
+});
+
+test('i ref tornano in ordine e non si sovrappongono', () => {
+    const refs = findFileRefs('prima a.cs:1 poi b.ts:2 infine c.py:3');
+    assert.deepEqual(
+        refs.map((r) => r.path),
+        ['a.cs', 'b.ts', 'c.py'],
+    );
+    for (let i = 1; i < refs.length; i++) {
+        assert.ok(refs[i].start >= refs[i - 1].end, 'ref sovrapposti');
+    }
+});
+
+// I non-casi: cio' che la allow-list delle estensioni esiste per NON linkare.
+
+test('un orario non e un file', () => {
+    assert.equal(first('alle 10:30 di sera'), null);
+});
+
+test('un host:porta non e un file', () => {
+    assert.equal(first('su localhost.net:4040 gira'), null);
+});
+
+test('una versione non e un file', () => {
+    assert.equal(first('la 2.1.220:5 di ieri'), null);
+});
+
+test('un prezzo non e un file', () => {
+    assert.equal(first('costa 19.99:2 euro'), null);
+});
+
+test('una estensione sconosciuta in prosa resta testo', () => {
+    assert.equal(first('apri report.xyzzy:12'), null);
+});
+
+test('un nome senza riga ne cartella e troppo rumoroso per linkare', () => {
+    // "vedi il README.md" a meta' frase: nessuna struttura, nessun link.
+    assert.equal(first('vedi il README.md e basta'), null);
+});
+
+test('un nome con cartella linka anche senza riga', () => {
+    const r = first('sta in docs/file-links.md quindi');
+    assert.equal(r?.path, 'docs/file-links.md');
+    assert.deepEqual(r?.lines, []);
+});
+
+// Casi limite del percorso.
+
+test('una cartella con il punto nel nome non ruba lancora', () => {
+    // "Corsinvest.VisualStudio.Agents" e' una cartella: il ref vero e' l'ultimo segmento.
+    const r = first('src/Corsinvest.VisualStudio.Agents/Chat/x.ts:5');
+    assert.equal(r?.path, 'src/Corsinvest.VisualStudio.Agents/Chat/x.ts');
+    assert.deepEqual(r?.lines, [5]);
+});
+
+test('un percorso windows assoluto tiene la lettera di unita', () => {
+    const r = first('apri C:\\src\\repo\\Foo.cs:12 adesso');
+    assert.equal(r?.path, 'C:\\src\\repo\\Foo.cs');
+    assert.deepEqual(r?.lines, [12]);
+});
+
+test('una estensione sola senza nome non e un ref', () => {
+    assert.equal(first('un file .ts qualunque'), null);
+});
+
+test('le parentesi attorno al ref non ci finiscono dentro', () => {
+    const r = first('(NdjsonTransport.cs:91)');
+    assert.equal(r?.path, 'NdjsonTransport.cs');
+    assert.equal(r?.match, 'NdjsonTransport.cs:91');
+});
+
+test('righe duplicate nella lista sono scartate, la prima vince', () => {
+    const r = first('x.cs:10,10,20');
+    assert.deepEqual(r?.lines, [10, 20]);
+});
+
+test('testo vuoto non produce ref', () => {
+    assert.deepEqual(findFileRefs(''), []);
+});
+
+// parseFileRef: il token deve essere il ref e NIENTE altro. E' il test che serve anche
+// all'inline code, dove il contenuto del backtick e' o un riferimento o un frammento di codice.
+
+test('parseFileRef accetta un token che e interamente un ref', () => {
+    const r = parseFileRef('Foo.cs:12', 'known-ext');
+    assert.equal(r?.path, 'Foo.cs');
+    assert.deepEqual(r?.lines, [12]);
+});
+
+test('parseFileRef rifiuta un token che contiene altro', () => {
+    assert.equal(parseFileRef('cat Foo.cs:12', 'known-ext'), null);
+    assert.equal(parseFileRef('Foo.cs:12 e poi', 'known-ext'), null);
+});
+
+test('parseFileRef rifiuta una versione', () => {
+    assert.equal(parseFileRef('1.5.0', 'known-ext'), null);
+    assert.equal(parseFileRef('v2.1.237', 'known-ext'), null);
+});
+
+// plausible-path: la strictness degli href markdown, dove il modello ha gia' dichiarato "e' un link".
+
+test('plausible-path accetta una estensione fuori allow-list', () => {
+    const r = parseFileRef('src/utils/helper.rb#L12', 'plausible-path');
+    assert.equal(r?.path, 'src/utils/helper.rb');
+    assert.deepEqual(r?.lines, [12]);
+});
+
+test('plausible-path rifiuta comunque cio che non ha forma di file', () => {
+    // Una "estensione" tutta cifre e' un prezzo o una versione, mai un file.
+    assert.equal(parseFileRef('19.99#L2', 'plausible-path'), null);
+});
+
+test('plausible-path accetta un percorso senza riga', () => {
+    const r = parseFileRef('notes.md', 'plausible-path');
+    assert.equal(r?.path, 'notes.md');
+    assert.deepEqual(r?.lines, []);
+});
+
+// firstRefHint: il contratto con marked. Deve essere un limite INFERIORE — mai oltre l'inizio vero,
+// o il tokenizer non viene mai offerto quella posizione e il ref sparisce in silenzio.
+
+test('il suggerimento non supera mai linizio reale del ref', () => {
+    for (const t of [
+        'vedi ClientEvents.cs:208 qui',
+        'apri C:\\src\\Foo.cs:12 adesso',
+        'in Core/Stats/StatsService.cs:45',
+        '(NdjsonTransport.cs:91)',
+    ]) {
+        const hint = firstRefHint(t);
+        const ref = first(t);
+        assert.ok(ref, `nessun ref in "${t}"`);
+        assert.ok(hint !== undefined, `nessun hint per "${t}"`);
+        assert.ok(hint <= ref.start, `hint ${hint} oltre lo start ${ref.start} in "${t}"`);
+    }
+});
+
+test('nessun suggerimento quando non ci sono estensioni', () => {
+    assert.equal(firstRefHint('nessun file qui dentro'), undefined);
+});

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/markdown.test.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/markdown.test.ts
@@ -1,0 +1,179 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+// Che marked chiami i renderer giusti: la meta' che i test su funzioni pure non possono vedere.
+// I casi limite di COSA sia un riferimento stanno in codespan-link.test.ts e file-links.test.ts.
+//
+// LIMITE, da sapere prima di aggiungere test qui: renderMarkdown chiude con DOMPurify, che ha
+// bisogno di un `window` e sotto node --test non ce l'ha — `sanitize is not a function`, e la
+// funzione degrada al suo ramo di errore. Quindi qui si testa il TOKENIZER, cioe' quali token
+// marked produce e con quale renderer, non l'HTML finale. Per quello servirebbe jsdom (~10MB di
+// devDependency) per verificare una sanificazione che e' di DOMPurify, non nostra.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { marked } from 'marked';
+import { closeOpenMarkdown } from '../core/markdown.ts'; // importa anche renderer ed estensione
+
+/** L'HTML di marked, prima di DOMPurify. */
+function md(text: string): string {
+    return marked.parse(text, { async: false }) as string;
+}
+
+function links(html: string): number {
+    return (html.match(/class="cv-file-link"/g) ?? []).length;
+}
+
+// I tre percorsi che producono un link, uno per renderer.
+
+test('prosa: lestensione fileLink intercetta un riferimento nudo', () => {
+    const html = md('vedi ClientEvents.cs:208 per il resto');
+    assert.equal(links(html), 1);
+    assert.match(html, /data-file="ClientEvents\.cs"/);
+});
+
+test('inline code: il renderer codespan intercetta un riferimento in backtick', () => {
+    // La forma che il modello usa quasi sempre: 33 volte contro 2 su 25 sessioni reali.
+    const html = md('vedi `ClientEvents.cs:208` per il resto');
+    assert.equal(links(html), 1);
+    assert.match(html, /<code>/, 'il link vive DENTRO il code span, non al suo posto');
+});
+
+test('link markdown: il renderer link usa lhref e tiene la label', () => {
+    const html = md('[McpServerHost.cs:192](src/Mcp/McpServerHost.cs:192)');
+    assert.equal(links(html), 1);
+    assert.match(html, /data-file="src\/Mcp\/McpServerHost\.cs"/);
+    assert.match(html, />McpServerHost\.cs:192</);
+});
+
+// Il fence: la regola che NON deve cadere insieme a quella del code span.
+
+test('fence: un riferimento in un blocco di codice resta testo', () => {
+    assert.equal(links(md('```\ncat ClientEvents.cs:208\n```')), 0);
+});
+
+test('fence: nemmeno con un linguaggio dichiarato', () => {
+    assert.equal(links(md('```bash\nvim Foo.cs:12\n```')), 0);
+});
+
+test('fence: il pulsante Copia resta, e legge dal pre', () => {
+    // Un link dentro il blocco romperebbe la copia: cv-copy-btn prende il testo dal <pre> fratello.
+    const html = md('```\nFoo.cs:12\n```');
+    assert.match(html, /<cv-copy-btn[^>]*frompre="1"/);
+});
+
+// Gli attributi che il host legge al click. Non passano da DOMPurify qui, ma la ADD_ATTR di
+// markdown.ts deve elencarli tutti: data-line-end mancava mentre il renderer lo emetteva da sempre,
+// e l'intervallo apriva senza selezionare.
+
+test('un intervallo emette data-line-end, in prosa e in backtick', () => {
+    for (const src of ['guarda StatsService.cs:35-48', 'guarda `StatsService.cs:35-48`']) {
+        const html = md(src);
+        assert.match(html, /data-line="35"/, src);
+        assert.match(html, /data-line-end="48"/, src);
+    }
+});
+
+test('una lista di righe diventa un link per riga, in entrambe le forme', () => {
+    assert.equal(links(md('AgentsPackage.cs:124,185,202 tre punti')), 3);
+    assert.equal(links(md('`AgentsPackage.cs:124,185,202`')), 3);
+});
+
+test('un href http resta un link esterno, non un file', () => {
+    const html = md('[doc](https://example.com/a.cs:12)');
+    assert.equal(links(html), 0);
+    assert.match(html, /href="https:\/\/example\.com/);
+});
+
+test('un code span che non e un riferimento resta un code span', () => {
+    const html = md('esegui `npm run build` adesso');
+    assert.equal(links(html), 0);
+    assert.match(html, /<code>npm run build<\/code>/);
+});
+
+// La ADD_ATTR di DOMPurify. Non possiamo eseguire sanitize qui (serve un window), ma il modo in cui
+// quel bug si manifesta e' un attributo emesso dai renderer e non elencato nella allow-list: il
+// confronto fra i due insiemi lo prende senza bisogno di un DOM.
+
+test('ogni attributo emesso dai renderer e nella ADD_ATTR di DOMPurify', () => {
+    const src = new URL('../core/markdown.ts', import.meta.url);
+    const allowed = new Set(
+        (readFileSync(src, 'utf8').match(/ADD_ATTR:\s*\[([^\]]*)\]/)?.[1] ?? '')
+            .split(',')
+            .map((s) => s.trim().replace(/^['"]|['"]$/g, ''))
+            .filter(Boolean),
+    );
+    // Sempre permessi da DOMPurify, non serve dichiararli.
+    const builtin = new Set(['class', 'href', 'title', 'rel', 'src', 'alt', 'id', 'style']);
+
+    // Un markdown che passa da TUTTI i renderer che emettono attributi nostri.
+    const html = md(
+        'prosa Foo.cs:12-20 e `Bar.ts:34` e [x](src/Baz.cs:5)\n\n```ts\nconst a = 1;\n```',
+    );
+    const emitted = new Set([...html.matchAll(/\s([a-z-]+)="/g)].map((m) => m[1]));
+    const missing = [...emitted].filter((a) => !allowed.has(a) && !builtin.has(a));
+    assert.deepEqual(missing, [], `attributi che DOMPurify butterebbe via: ${missing.join(', ')}`);
+});
+
+// closeOpenMarkdown: il percorso dello streaming, che gira a OGNI token. Chiude i costrutti aperti
+// perche' un chunk parziale renda in modo stabile invece di ribaltare il layout a meta' risposta.
+
+test('streaming: una fence aperta viene chiusa', () => {
+    assert.equal(
+        closeOpenMarkdown('testo\n```ts\nconst a = 1;'),
+        'testo\n```ts\nconst a = 1;\n```',
+    );
+});
+
+test('streaming: una fence gia chiusa non viene toccata', () => {
+    const t = 'testo\n```ts\nconst a = 1;\n```\ncoda';
+    assert.equal(closeOpenMarkdown(t), t);
+});
+
+test('streaming: un backtick spaiato sullultima riga viene chiuso', () => {
+    assert.equal(closeOpenMarkdown('vedi `Foo.cs:12'), 'vedi `Foo.cs:12`');
+});
+
+test('streaming: un backtick pari resta com e', () => {
+    const t = 'vedi `Foo.cs:12` qui';
+    assert.equal(closeOpenMarkdown(t), t);
+});
+
+test('streaming: i backtick dentro una fence aperta sono letterali', () => {
+    // Dentro un blocco i backtick non sono inline code: chiudere la fence basta, aggiungere anche
+    // un backtick spaiato romperebbe il blocco.
+    assert.equal(closeOpenMarkdown('```\nusa `x`'), '```\nusa `x`\n```');
+});
+
+test('streaming: un backtick spaiato su una riga PRECEDENTE non viene toccato', () => {
+    // Solo l'ultima riga e' in costruzione; una precedente e' gia' come il modello l'ha scritta.
+    const t = 'riga con ` spaiato\nriga finita';
+    assert.equal(closeOpenMarkdown(t), t);
+});
+
+test('streaming: testo vuoto resta vuoto', () => {
+    assert.equal(closeOpenMarkdown(''), '');
+});
+
+test('streaming: un riferimento a meta non linka, completo si', () => {
+    // Il caso che conta a ogni token: il testo cresce sotto il render. Il nome senza riga non
+    // qualifica (troppo rumoroso), quindi il link compare quando il ref e' davvero finito — e non
+    // lampeggia mentre i numeri arrivano una cifra per volta.
+    assert.equal(links(md(closeOpenMarkdown('vedi `Foo.cs'))), 0, 'senza riga: nessun link');
+    assert.equal(links(md(closeOpenMarkdown('vedi `Foo.cs:12`'))), 1, 'completo: link');
+});
+
+test('streaming: le cifre che arrivano una per volta spostano solo la riga, non il link', () => {
+    // "Foo.cs:1" e' gia' un riferimento valido (riga 1), quindi il link c'e' da subito e la riga si
+    // aggiorna man mano. Meglio cosi' che un link che appare e sparisce: la bolla non si muove.
+    for (const [src, line] of [
+        ['vedi `Foo.cs:1`', '1'],
+        ['vedi `Foo.cs:12`', '12'],
+        ['vedi `Foo.cs:123`', '123'],
+    ] as const) {
+        const html = md(closeOpenMarkdown(src));
+        assert.equal(links(html), 1, src);
+        assert.match(html, new RegExp(`data-line="${line}"`), src);
+    }
+});

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/chat.css
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/chat.css
@@ -363,7 +363,9 @@ body.sticky-user .cv-exchange > cv-message[msg-role="user"]:first-child .cv-mess
     text-decoration: underline;
     color: inherit;
 }
-/* "path:line" file link inside rendered markdown (fileLink marked extension) — opens in VS on click. */
+/* "path:line" file link inside rendered markdown — opens in VS on click. Appears both in prose
+ * (the fileLink marked extension) and inside an inline code span whose whole content is a
+ * reference, where it keeps the span's monospace and only takes the link colour. */
 .cv-file-link {
     color: var(--colorBrandForegroundLink);
     text-decoration: none;


### PR DESCRIPTION
The model writes a file reference inside backticks — `ClientEvents.cs:208` —
because it is a filename, and that is exactly where the link stopped
working. Counted over 25 real sessions in this repo: **33 references in
inline code against 2 written bare**. The feature worked on one case in
seventeen.

## Why it was that way

marked tokenizes code spans before any extension runs, so the file-link
parser never saw inside them. That is the right rule for a fence — a path in
an example command must stay literal, and the copy button must copy text
rather than markup — but for an inline span it inverts the intent.

A code span is now linked **only when its whole content is a reference**.
`Foo.cs:12` qualifies; `cat Foo.cs:12` does not. `parseFileRef` already
enforced precisely that for markdown hrefs, so the rule is one call, not a
second parser that could drift from the first. On the sample: 33 links, 0
false positives.

## Two things found while writing the tests

**`data-line-end` was never in DOMPurify's `ADD_ATTR`.** The renderer had
been emitting it all along and the sanitizer dropped it, which means the
range selection documented in `docs/file-links.md` has never worked —
`x.cs:35-48` opened at line 35 and selected nothing.

**A range selected downwards leaves the caret on the last line**, and Visual
Studio scrolls to the caret. `file-links.ts:23-307` opened showing line 307,
with the block's own beginning off the top of the screen. It now anchors at
the end and extends upwards: same selection, the view lands where the range
starts.

## Tests: 103 → 141

`file-links.ts` had none — 461 lines, seven syntactic shapes, ~270
extensions, and no coverage. It has 30 now: every shape
`docs/file-links.md` promises, and the non-cases the allow-list exists to
reject (a clock, a host:port, a version, a price).

The other 18 cover the code-span rule itself, and 10 cover the wiring.

That last group needed an unblock. `node --test` cannot resolve `./lang`
without an extension, and `allowImportingTsExtensions` lives only in
`tsconfig.test.json`, so `core/` cannot write it — which looked like a wall
and was a fifteen-line resolve hook. It matters because the untestable half
is the half that broke: `renderCodespanInner` emitted `data-line-end`
correctly, and no test on a pure function could have seen DOMPurify throw it
away.

`markdown.test.ts` stops one step short of the sanitized HTML — DOMPurify
wants a `window` and answers `sanitize is not a function` without one, and
jsdom is ~10MB to verify a sanitizer that is not ours. The part that IS ours
— that `ADD_ATTR` lists every attribute the renderers emit — is checked by
reading the allow-list from source and diffing it against the output.
Removing `data-line-end` makes that test fail; putting it back makes it
pass.

`closeOpenMarkdown` also gets 8 tests. It runs on every streamed token and
had none.

Suite: 141 tests, 1.3s.
