### PR TITLE
fix(chat): the composer toolbar had tooltips but no names

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-attach-menu.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-attach-menu.ts
@@ -92,6 +92,7 @@ export class CvAttachMenu extends LitElement {
                     id="menu-trigger"
                     slot="trigger"
                     class="trigger"
+                    aria-label="Add"
                     appearance="subtle"
                     shape="rounded"
                     size="small"

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-effort-selector.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-effort-selector.ts
@@ -82,6 +82,7 @@ export class CvEffortSelector extends LitElement {
             <fluent-button
                 id="effort-trigger"
                 class="trigger"
+                aria-label="Effort"
                 appearance="subtle"
                 size="small"
                 @click=${this._onClick}

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-mic-button.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-mic-button.ts
@@ -133,6 +133,7 @@ export class CvMicButton extends LitElement {
         return html`<fluent-button
                 id="btn-mic"
                 class=${`trigger${this._recording ? ' is-recording' : ''}`}
+                aria-label=${this._recording ? 'Stop recording' : 'Voice recording'}
                 appearance="subtle"
                 shape="rounded"
                 size="small"

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-model-selector.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-model-selector.ts
@@ -87,6 +87,7 @@ export class CvModelSelector extends LitElement {
             <fluent-button
                 id="model-trigger"
                 class="trigger"
+                aria-label="Model"
                 appearance="subtle"
                 size="small"
                 @click=${this._onClick}

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-permission-selector.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-permission-selector.ts
@@ -71,6 +71,7 @@ export class CvPermissionSelector extends LitElement {
             <fluent-button
                 id="perm-trigger"
                 class="trigger"
+                aria-label="Permission mode"
                 appearance="subtle"
                 size="small"
                 @click=${this._onClick}

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-prompt.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-prompt.ts
@@ -1613,6 +1613,7 @@ export class CvPrompt extends LitElement implements CommandHost {
                         <fluent-button
                             id="send"
                             class=${this._isBusy ? 'is-busy' : ''}
+                            aria-label=${this._isBusy ? 'Stop' : 'Send'}
                             appearance="primary"
                             shape="rounded"
                             size="small"

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-remote-chip.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-remote-chip.ts
@@ -97,6 +97,7 @@ export class CvRemoteChip extends LitElement {
                     id="menu-trigger"
                     slot="trigger"
                     class="trigger"
+                    aria-label="Remote control"
                     appearance="subtle"
                     shape="rounded"
                     size="small"

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-thinking-toggle.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-thinking-toggle.ts
@@ -94,6 +94,7 @@ export class CvThinkingToggle extends LitElement {
             <fluent-button
                 id="thinking-trigger"
                 class="trigger"
+                aria-label="Thinking"
                 appearance="subtle"
                 shape="rounded"
                 size="small"

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/shared.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/shared.ts
@@ -59,6 +59,9 @@ export const tooltipStyles = css`
         padding: 6px 8px;
         max-width: 320px;
         box-sizing: border-box;
+        /* A tooltip is chrome, not content: it gets read, not copied. Without this it inherits the
+           document default and clicking an open one highlights its text in blue. */
+        user-select: none;
         /* Lets a plain string with newlines break where it says to, so a tooltip with two or three
            lines doesn't need an element per line. */
         white-space: pre-line;


### PR DESCRIPTION
A tooltip is drawn next to a control, not attached to it: `fluent-tooltip` anchors by `anchor=` and never writes `aria-describedby` on its trigger — that attribute has **zero occurrences** anywhere in `ui/`. Every icon-only button in the composer was therefore drawn with a label a screen reader could not reach.

## The census

The note in TODO listed six components. Counting every `fluent-button` with no visible text and no `aria-label` found **eleven**, in two groups.

**Fixed here — no name by any route (8):**

| Component | Label |
|---|---|
| `cv-attach-menu` | `Add` |
| `cv-effort-selector` | `Effort` |
| `cv-mic-button` | `Stop recording` / `Voice recording` |
| `cv-model-selector` | `Model` |
| `cv-permission-selector` | `Permission mode` |
| `cv-thinking-toggle` | `Thinking` |
| **`cv-prompt`** (Send) | `Stop` / `Send` |
| **`cv-remote-chip`** | `Remote control` |

**Left alone — they carry a `title` (3):** `cv-message` (Fork), `cv-speak-btn`, `cv-tool-row`. A screen reader reads `title` as a fallback, so these are degraded rather than mute. Swapping it for `aria-label` would trade one name for another and lose the native tooltip; giving them both is a different change.

## Two things the note did not have

**The Send button.** Not in the old list, and it has neither `aria-label` nor `title` — the most important control on the page, completely unnamed.

**Two labels have to move.** Send becomes Stop while a turn runs; the mic becomes Stop recording. Both are bound to the same condition as their icon, because a fixed string would be wrong half the time.

`cv-remote-chip` does not copy its tooltip: that one says *"Driven from claude.ai/code"*, which describes a state, while the button opens a menu.

## Also: tooltip text was selectable

Nothing in the WebView sets `user-select`, so tooltips inherited the document default and clicking an open one highlighted it in blue. A tooltip is chrome — it gets read, not copied. One line in `tooltipStyles`, which every component with a tooltip already imports.

## Verification

`npm run build`, `typecheck`, `lint` green; 141 tests pass. Re-running the census after the change reports **0 mute buttons**.
