### PR TITLE
chore: two comments that said more than they meant to

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/file-links.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/file-links.ts
@@ -362,8 +362,7 @@ const DRIVE = /[A-Za-z]:$/;
 
 /** How strict the path check is. Prose is scanned blind, so it needs the extension allow-list to keep
  *  "localhost.net:4040" / "19.99:2" from rendering as dead links; a markdown href was written as a link
- *  by the model on purpose, so any plausible path shape is enough. See the file-link entry in
- *  docs/internal/TODO.md for the measurements. */
+ *  by the model on purpose, so any plausible path shape is enough. */
 export type RefStrictness = 'known-ext' | 'plausible-path';
 
 /** Scan `text` for file references, growing outwards from each ".ext" anchor. Returns them in order,

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsService.cs
@@ -180,7 +180,7 @@ internal static class StatsService
         foreach (var p in projects)
         {
             // Walked to the folder the project IS, not to the one above it. A project whose cwd also
-            // has projects beneath it — C:\Users\daniele.corsini, with AppData and source under it —
+            // has projects beneath it — a user profile folder, with AppData and source under it —
             // would otherwise be filed one level up while its own name branched separately, showing
             // the same folder twice. Filed here, it meets that branch and ToFolderNode folds the two
             // into the single node a folder with nothing under it already produces.


### PR DESCRIPTION
A sweep for references to things outside this repository turned up two comments that should not ship as they are.

**`Core/Stats/StatsService.cs:183`** named a real user profile path to illustrate "a folder that has projects under it":

```diff
- // has projects beneath it — C:\Users\daniele.corsini, with AppData and source under it —
+ // has projects beneath it — a user profile folder, with AppData and source under it —
```

The example works the same without the name, and this is a public repository.

**`core/file-links.ts:366`** pointed at `docs/internal/TODO.md` for the measurements behind the strictness rule. That directory is gitignored, so anyone reading the source is sent to a file they do not have — and the comment already explains the reason on its own. It was also the last `TODO` marker left anywhere in `src/`.

## The rest of the sweep came back clean

- **VS Code** (12 references) — the protocol reference the CLAUDE.md points to, not leftovers
- **Copilot** (2) — comparative, in `CHANGELOG.md` and `docs/options.md`
- **SPDX headers** — present on every `.cs`
- **Local paths** — only in `.claude/settings.local.json`, confirmed gitignored via `git check-ignore`
- No trace of the predecessor repository in any published file

## Verification

`typecheck` clean, prettier reports no reformat, 141 tests pass. Comments only — no behaviour touched.
