### PR TITLE
fix(mcp): the debugger answered with the editor's caret, not its own position

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.Common.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.Common.cs
@@ -19,15 +19,29 @@ internal sealed partial class IdeDebugService
     private static DTE GetDte() => Package.GetGlobalService(typeof(DTE)) as DTE;
 
     /// <summary>The debugger, noting on the way which thread a break landed on. Every entry point
-    /// goes through here, which is the only reason that note can be trusted: it is taken before any
-    /// of them acts, so it predates the debug_select_thread that would otherwise overwrite the
-    /// answer. See <see cref="TrackStoppedThread"/>.</summary>
+    /// goes through here, which is the only reason the note can be trusted: it is taken before any
+    /// of them acts, so it predates the debug_select_thread that would otherwise overwrite it.</summary>
     private static Debugger GetDebugger()
     {
         var dbg = GetDte()?.Debugger;
-        if (dbg != null) { TrackStoppedThread(dbg); }
+        if (dbg == null) { return null; }
+        try
+        {
+            if (dbg.CurrentMode != dbgDebugMode.dbgBreakMode) { _stoppedThreadId = 0; }
+            // Only the first read while stopped counts: after that CurrentThread is whatever the
+            // caller selected, and taking it again would record the choice instead of the break.
+            else if (_stoppedThreadId == 0) { _stoppedThreadId = SafeThreadId(dbg.CurrentThread); }
+        }
+        catch (Exception) { /* mode unreadable mid-transition: leave the note as it was */ }
         return dbg;
     }
+
+    private static int _stoppedThreadId;
+
+    /// <summary>Forget which thread the break landed on, before resuming. Called by whatever lets
+    /// the program run — the next break may be on another thread and can get there before anything
+    /// reads the debugger again, which would leave the note naming the thread we left.</summary>
+    private static void LeavingBreak() => _stoppedThreadId = 0;
 
     /// <summary>Reported instead of a real mode by the transitions that do not block — start, stop
     /// and detach all return before VS has moved. A null mode there reads as "something went
@@ -42,21 +56,18 @@ internal sealed partial class IdeDebugService
         _ => "unknown",
     };
 
-    /// <summary>Where execution is paused: file + 1-based line.
-    /// <para>When a breakpoint is what stopped us, it knows its own File/FileLine and that is the
-    /// answer — the editor's caret is not. It reads as the same place most of the time, but
-    /// run_to_line and set_next_statement move the caret themselves (the VS commands work off the
-    /// selection), so after either of those the "position" was the one we had just put there.
-    /// Measured: a break on line 19 reported as line 17, a comment.</para>
-    /// <para>Everything else — a step, a thrown exception, Break All — has no such record, and
-    /// falls back to the active document. That is fine, and measured: VS brings the caret to the
-    /// suspension point itself, so a Break All with the editor left on another file at line 60 still
-    /// reported the executing file's line. EnvDTE has nothing better to offer anyway — no
-    /// StackFrame2, and Debugger3 adds no file/line.</para></summary>
+    /// <summary>Where execution is paused: file + 1-based line, from the TOP frame of the stopped
+    /// thread — not the selected one, which debug_select_frame moves to inspect a caller. Those are
+    /// two different questions: this one is where the program stopped, and it does not change
+    /// because someone is reading a caller's locals.
+    /// <para>The caret is the fallback, for frames that carry no position of their own. It is not
+    /// the first choice because run_to_line and set_next_statement move it themselves (the VS
+    /// commands work off the selection), so after either of those it named the line we had just put
+    /// there — measured: a break on line 19 reported as line 17, a comment.</para></summary>
     private static (string file, int line) CurrentLocation()
     {
-        var fromBreakpoint = BreakpointLocation();
-        if (fromBreakpoint.line > 0) { return fromBreakpoint; }
+        var fromFrame = FrameLocation(TopFrame());
+        if (fromFrame.line > 0) { return fromFrame; }
 
         try
         {
@@ -76,25 +87,57 @@ internal sealed partial class IdeDebugService
         }
     }
 
-    /// <summary>The breakpoint we are stopped on, as file + line, or (null, 0) for a break that did
-    /// not come from one. Gated on LastBreakReason: BreakpointLastHit keeps naming the last one hit
-    /// after the program has moved on, so without the check a later step would report the line of a
-    /// breakpoint it left behind.</summary>
-    private static (string file, int line) BreakpointLocation()
+    /// <summary>Frame 0 of the thread the break landed on: where execution actually is.
+    /// <para>Neither selection can be trusted for this. Debugger.CurrentStackFrame follows
+    /// debug_select_frame, and Debugger.CurrentThread follows debug_select_thread — both move while
+    /// the caller reads a caller's locals or another thread's stack, and neither should change the
+    /// answer to "where did the program stop". VS exposes no "thread that broke", so the id is
+    /// recorded on the way in; see <see cref="StoppedThread"/>. StackFrames is 1-based.</para></summary>
+    private static StackFrame TopFrame()
     {
         try
         {
-            var dbg = GetDebugger();
-            if (dbg == null || dbg.CurrentMode != dbgDebugMode.dbgBreakMode) { return (null, 0); }
-            if (dbg.LastBreakReason != dbgEventReason.dbgEventReasonBreakpoint) { return (null, 0); }
-
-            var bp = dbg.BreakpointLastHit;
-            return bp == null || bp.FileLine < 1 ? (null, 0) : (bp.File, bp.FileLine);
+            var frames = StoppedThread()?.StackFrames;
+            return frames == null || frames.Count < 1 ? null : frames.Item(1);
         }
         catch (Exception)
         {
-            // A conditional or function breakpoint can refuse to answer for a file it never bound
-            // to. The caller falls back to the document, which is where this started.
+            return null;
+        }
+    }
+
+    /// <summary>The thread the break landed on, found by the id noted when the break arrived.
+    /// Falls back to the current thread when the note is missing or the thread is gone.</summary>
+    private static EnvDTE.Thread StoppedThread()
+    {
+        var dbg = GetDebugger();
+        if (dbg == null) { return null; }
+        if (_stoppedThreadId == 0) { return dbg.CurrentThread; }
+        try
+        {
+            foreach (EnvDTE.Thread t in dbg.CurrentProgram?.Threads ?? (Threads)null)
+            {
+                if (t.ID == _stoppedThreadId) { return t; }
+            }
+        }
+        catch (Exception) { /* the program went away mid-read */ }
+        return dbg.CurrentThread;
+    }
+
+    /// <summary>File + 1-based line of one stack frame, or (null, 0) when the frame cannot say.
+    /// EnvDTE's own StackFrame carries neither; EnvDTE90a.StackFrame2 adds them. Matched with `is`
+    /// rather than cast: a frame with no source (native, mixed-mode) does not implement it, and that
+    /// is a fallback case, not an error.</summary>
+    private static (string file, int line) FrameLocation(StackFrame frame)
+    {
+        try
+        {
+            if (frame is not EnvDTE90a.StackFrame2 sf2) { return (null, 0); }
+            var line = (int)sf2.LineNumber;
+            return line < 1 ? (null, 0) : (sf2.FileName, line);
+        }
+        catch (Exception)
+        {
             return (null, 0);
         }
     }

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.Inspection.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.Inspection.cs
@@ -41,9 +41,7 @@ internal sealed partial class IdeDebugService
                 return new DebugResult { Ok = false, Mode = ModeToString(dbg.CurrentMode), Reason = NotInBreak };
             }
             dbg.Go(false);
-            // This break is over: the next one may land on another thread, and nothing guarantees a
-            // read in between to notice the program ran.
-            _stoppedThreadId = 0;
+            LeavingBreak();
             // No Mode: Go() returns before the transition, so this reads the state being left. It
             // happened to be right — "run" either way — which is why it outlived the same fix on
             // start/stop/restart/break.
@@ -96,9 +94,7 @@ internal sealed partial class IdeDebugService
                     };
             }
 
-            // The step leaves this break: whatever it lands on is a new one, on a thread this has no
-            // say over. Cleared so the wait below records the landing rather than keeping the old id.
-            _stoppedThreadId = 0;
+            LeavingBreak();
 
             var landed = await WaitForBreakAsync(StepSettleTimeout);
             if (!landed)
@@ -122,27 +118,6 @@ internal sealed partial class IdeDebugService
         }
     }
 
-    /// <summary>The thread the debugger stopped on, or 0 when not stopped. CurrentLocation() answers
-    /// for that one thread — the breakpoint that was hit, or the caret VS brought to the suspension
-    /// point — so only its frames may carry a file and line.
-    ///
-    /// Recorded rather than derived because debug_select_thread moves Debugger.CurrentThread and
-    /// nothing remembers where the break landed. Tracking the thread the CALLER selected instead was
-    /// wrong in the symmetric case: selecting the stopping thread explicitly made it match too, and
-    /// the position was withheld from the one thread entitled to it.</summary>
-    private static int _stoppedThreadId;
-
-    /// <summary>Note which thread a break landed on, and forget it once the program runs again.
-    /// Called from GetDebugger(), so it runs before whatever the entry point came to do — including
-    /// the debug_select_thread that moves CurrentThread away from the answer.
-    /// <para>Only the first read while stopped counts: after that CurrentThread is whatever the
-    /// caller selected, and taking it again would record the choice instead of the break.</para></summary>
-    private static void TrackStoppedThread(Debugger dbg)
-    {
-        if (dbg.CurrentMode != dbgDebugMode.dbgBreakMode) { _stoppedThreadId = 0; return; }
-        if (_stoppedThreadId == 0) { _stoppedThreadId = SafeThreadId(dbg.CurrentThread); }
-    }
-
     /// <summary>Wait for the debugger to be back in break, or give up. Yields the UI thread between
     /// looks — the transition is processed there, so holding it would stop the very thing being
     /// waited for. Returns false on timeout.</summary>
@@ -162,13 +137,9 @@ internal sealed partial class IdeDebugService
         return false;
     }
 
-    /// <summary>Call stack of the current thread (only while paused).</summary>
     /// <summary>The call stack of one thread by id, WITHOUT selecting it. Reading another thread's
     /// stack otherwise means debug_select_thread first, which moves the debugger's current thread —
-    /// the user's Call Stack and Locals windows follow it, and nothing puts them back.
-    ///
-    /// No frame carries file/line here: EnvDTE reads those from the active document, which follows
-    /// the SELECTED frame, so they would describe the wrong thread entirely.</summary>
+    /// the user's Call Stack and Locals windows follow it, and nothing puts them back.</summary>
     public async Task<CallStackResult> GetThreadCallStackAsync(int threadId)
     {
         await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
@@ -203,11 +174,14 @@ internal sealed partial class IdeDebugService
             var i = 0;
             foreach (StackFrame sf in match.StackFrames)
             {
+                var (file, line) = FrameLocation(sf);
                 frames.Add(new StackFrameInfo
                 {
                     Index = i++,
                     Function = sf.FunctionName,
                     Module = SafeModule(sf),
+                    File = file,
+                    Line = line,
                 });
             }
             return new CallStackResult { Ok = true, InBreak = true, Frames = [.. frames] };
@@ -244,35 +218,21 @@ internal sealed partial class IdeDebugService
                 foreach (StackFrame sf in thread.StackFrames)
                 {
                     if (currentIndex < 0 && current != null && SameFrame(sf, current)) { currentIndex = i; }
+                    var (file, line) = FrameLocation(sf);
                     frames.Add(new StackFrameInfo
                     {
                         Index = i++,
                         Function = sf.FunctionName,
                         Module = SafeModule(sf),
-                        // EnvDTE StackFrame has no file/line; those come from the active doc, which
-                        // follows the SELECTED frame — so they go on that one, below.
+                        File = file,
+                        Line = line,
                     });
                 }
             }
             // No match means the selected frame belongs to a DIFFERENT thread than the one whose
-            // stack this is. Falling back to frame 0 used to hang the editor's position on it —
-            // a worker blocked in WaitOne came back reading Program.cs:27, which is where the main
-            // thread was paused. Better to mark no frame current than to name the wrong file.
-            if (currentIndex >= 0)
-            {
-                frames[currentIndex].IsCurrent = true;
-                // Only for the thread the debugger stopped on. CurrentLocation answers with the
-                // breakpoint that was hit or the editor's caret, and both belong to that one
-                // thread: asked after a debug_select_thread onto a worker, it named the main
-                // thread's line as if it were the worker's. Other threads get no position —
-                // EnvDTE's StackFrame carries none of its own, and none beats someone else's.
-                if (thread.ID == _stoppedThreadId)
-                {
-                    var (file, line) = CurrentLocation();
-                    frames[currentIndex].File = file;
-                    frames[currentIndex].Line = line;
-                }
-            }
+            // stack this is. Marking none current is better than pointing at frame 0 of the wrong
+            // thread.
+            if (currentIndex >= 0) { frames[currentIndex].IsCurrent = true; }
             return new CallStackResult { Ok = true, InBreak = true, Frames = [.. frames] };
         }
         catch (Exception ex)

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.cs
@@ -43,16 +43,9 @@ internal sealed partial class IdeDebugService
             var state = new DebugState { Mode = ModeToString(dbg.CurrentMode) };
             if (dbg.CurrentMode == dbgDebugMode.dbgBreakMode)
             {
-                // In break mode VS moves the caret to the current statement; the active
-                // document's selection gives us file + line of where execution is paused.
-                // (EnvDTE's StackFrame exposes only FunctionName, not a source location.)
-                try
-                {
-                    var doc = GetDte()?.ActiveDocument;
-                    state.CurrentFile = doc?.FullName;
-                    if (doc?.Selection is TextSelection sel) { state.CurrentLine = sel.ActivePoint.Line; }
-                }
-                catch { /* location not available — leave file/line unset */ }
+                var (file, line) = CurrentLocation();
+                state.CurrentFile = file;
+                state.CurrentLine = line;
 
                 // If we're paused on an exception, $exception holds it (debugger pseudo-variable).
                 // Absent/invalid when the break is a plain breakpoint — leave the fields null.
@@ -192,9 +185,8 @@ internal sealed partial class IdeDebugService
             try { dte.ExecuteCommand("Debug.SetNextStatement", ""); }
             catch (Exception ex) { return new DebugResult { Ok = false, Reason = $"Visual Studio refused the jump: {ex.Message.Trim()}" }; }
 
-            // The line asked for, not CurrentLocation(): we are still stopped on whatever breakpoint
-            // got us here, so that would report where the jump came FROM. It is also the one place
-            // that already knows the answer — the jump either landed on the requested line or threw.
+            // The line asked for: the jump either landed there or threw, so this is already the
+            // answer and re-reading the frame would only risk disagreeing with it.
             return new DebugResult
             {
                 Ok = true,
@@ -244,6 +236,8 @@ internal sealed partial class IdeDebugService
 
             try { dte.ExecuteCommand("Debug.RunToCursor", ""); }
             catch (Exception ex) { return new DebugResult { Ok = false, Reason = $"Visual Studio refused it: {ex.Message.Trim()}" }; }
+
+            LeavingBreak();
 
             return new DebugResult { Ok = true, Reason = $"Running to {System.IO.Path.GetFileName(filePath)}:{line} — poll debug_get_state; it may stop earlier." };
         }

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/GetDebugCallStackTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/GetDebugCallStackTool.cs
@@ -15,10 +15,10 @@ internal sealed class GetDebugCallStackTool : McpTool<NoArgs>
     public override string Name => "debug_get_callstack";
     public override string Description =>
         "Get the call stack of the selected thread while paused (break mode): each frame's index, " +
-        "function and module. Index 0 is where execution is paused; isCurrent marks the frame the " +
-        "inspection tools are reading, which debug_select_frame moves — and file/line come with " +
-        "that one, since the editor follows the selection rather than the top of the stack. This " +
-        "is one thread's stack: debug_list_threads shows the others, debug_select_thread switches. " +
+        "function, module, and its own file/line where the frame has source. Index 0 is where " +
+        "execution is paused; isCurrent marks the frame debug_get_locals and debug_evaluate read, " +
+        "which debug_select_frame moves. This is one thread's stack: debug_list_threads shows the " +
+        "others, debug_select_thread switches. " +
         "Only valid in break mode — if the program is still running, poll debug_get_state until " +
         "mode='break'.";
 

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/GetDebugStateTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/GetDebugStateTool.cs
@@ -17,8 +17,9 @@ internal sealed class GetDebugStateTool : McpTool<NoArgs>
         "Get the current debug state: mode is 'design' (not debugging), 'run' (running), or " +
         "'break' (paused on a breakpoint/exception). In 'break' mode also returns the current " +
         "file and 1-based line where execution is paused, and — if paused ON AN EXCEPTION — its " +
-        "type and message. Poll this after debug_start to know when the program has hit a " +
-        "breakpoint or thrown.";
+        "type and message. That position is where the program stopped and stays put while you " +
+        "look around: debug_select_frame changes which frame the inspection tools read, not this. " +
+        "Poll this after debug_start to know when the program has hit a breakpoint or thrown.";
 
     public override bool ReadOnly => true;
     public override bool Idempotent => true;

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/GetThreadCallStackTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/GetThreadCallStackTool.cs
@@ -26,8 +26,8 @@ internal sealed class GetThreadCallStackTool : McpTool<GetThreadCallStackArgs>
         "several threads — chasing a deadlock, seeing what a worker is blocked on — where " +
         "debug_select_thread + debug_get_callstack would move the debugger's current thread each " +
         "time, taking the user's Call Stack and Locals windows with it and never putting them " +
-        "back. Frames carry no file or line here: the IDE reads those from the selected frame, so " +
-        "they would describe a different thread. Needs break mode; debug_list_threads has the ids.";
+        "back. Each frame carries its own file and line where it has source. Needs break mode; " +
+        "debug_list_threads has the ids.";
 
     public override bool ReadOnly => true;
     public override bool Idempotent => true;
@@ -40,7 +40,14 @@ internal sealed class GetThreadCallStackTool : McpTool<GetThreadCallStackArgs>
         {
             ok = true,
             threadId = args.ThreadId,
-            frames = r.Frames.Select(f => new { index = f.Index, function = f.Function, module = f.Module }).ToArray(),
+            frames = r.Frames.Select(f => new
+            {
+                index = f.Index,
+                function = f.Function,
+                module = f.Module,
+                file = f.File,
+                line = f.Line,
+            }).ToArray(),
         };
     }
 }


### PR DESCRIPTION
## The bug

Where execution is paused was read from the active document's caret. That is the editor's idea of the position, not the debugger's. The two agree most of the time, which is why it survived — they part company exactly when a tool moves the caret itself.

`run_to_line` and `set_next_statement` both do (the VS commands work off the selection), so after either of them `debug_get_state` reported the line we had just planted. Opening any file in the editor while paused was enough to make it point somewhere else entirely.

A comment in the code asserted this was unavoidable — *"EnvDTE has nothing better to offer anyway — no StackFrame2"*. That was wrong: `EnvDTE90a.StackFrame2` carries `FileName` and `LineNumber` on the frame, and the VS SDK metapackage already brings it in, the same route as the `EnvDTE90.Debugger3` we already use. No new dependency.

## Which frame

The part worth getting right. `Debugger.CurrentStackFrame` follows `debug_select_frame` and `CurrentThread` follows `debug_select_thread` — both move while the caller inspects a caller's locals or another thread's stack, and neither should change where the *program* stopped.

Those are two different questions:

- `debug_get_state` — where execution is paused. Frame 0 of the thread the break landed on.
- `debug_get_locals` / `debug_get_callstack` — what you are currently looking at. Follows the selection, as it should.

Since VS exposes no "thread that broke", that id keeps being noted on the way in.

## Consequences

- **Every frame of a call stack now carries its own file and line**, not just the selected one. `debug_get_thread_callstack` used to return function names alone, which made the deadlock case it exists for unreadable.
- **`BreakpointLocation()` is gone.** Preferring the breakpoint's own line was a way around the caret being wrong after `run_to_line`; a frame that knows its own position needs no such preference.

Frames without source — native, mixed-mode — still fall back to the caret, which is a decent answer for them: VS brings it to the suspension point itself.

## Verification

Manual, in the experimental instance, stopped inside a called method three frames deep (`ClienteRepository.Aggiungi` ← `Seed.Popola` ← `Program.<Main>$`):

| Check | Result |
|---|---|
| Breakpoint position | `ClienteRepository.cs:8`, matches |
| Call stack | 3 frames, all with file/line |
| `select_frame(1)` then `get_state` | still `ClienteRepository.cs:8` |
| ...and `get_locals` | moved to `Seed.Popola` (`repo`, `i` vs `cliente`, `this`) |
| `select_thread(worker)` then `get_state` | still `ClienteRepository.cs:8` |
| ...and `get_callstack` | shows the worker at `Seed.cs:53` |
| Opening another file while paused | position unchanged |
| `step` then `get_state` | agree on `ClienteRepository.cs:9` |
| Worker thread stack | `Seed.cs:53` on its user-code frame; framework frames null |

Build green. No WARN/ERROR in the output pane across the run.
