### PR TITLE
fix(mcp): three debug-tool gaps — evaluate timeout, breakpoint binding, break while paused

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.Dtos.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.Dtos.cs
@@ -30,6 +30,11 @@ internal sealed partial class IdeDebugService
         public bool Ok { get; set; }
         public string Mode { get; set; }
         public string Reason { get; set; }
+
+        /// <summary>How many code locations a breakpoint resolved to, or null outside a debug
+        /// session, where nothing has bound yet and 0 would read as a failure. 0 during a session
+        /// means the breakpoint will not stop anything. Only set by the breakpoint tools.</summary>
+        public int? Bound { get; set; }
     }
 
     /// <summary>One breakpoint in the solution (file/line OR function, plus condition/enabled).</summary>
@@ -50,6 +55,12 @@ internal sealed partial class IdeDebugService
         /// <summary>Times it has been hit in this session — the difference between "never reached"
         /// and "reached, and the condition said no".</summary>
         public int CurrentHits { get; set; }
+
+        /// <summary>Code locations this breakpoint resolved to, or null outside a session where
+        /// nothing has bound yet. The third answer to "why did it not break", after the hit count:
+        /// 0 means it never will, because the line holds no code or the module's symbols are not
+        /// loaded — as opposed to bound and simply not reached.</summary>
+        public int? Bound { get; set; }
     }
 
     public sealed class BreakpointsResult

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.Inspection.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.Inspection.cs
@@ -529,7 +529,7 @@ internal sealed partial class IdeDebugService
                 return new EvalResult { Ok = false, InBreak = false, Reason = NotInBreak };
             }
 
-            var ex = dbg.GetExpression(expression, true, -1);
+            var ex = dbg.GetExpression(expression, true, EvalTimeoutMs);
             return new EvalResult
             {
                 Ok = true,
@@ -567,7 +567,7 @@ internal sealed partial class IdeDebugService
                 return new ExpandResult { Ok = false, InBreak = false, Reason = NotInBreak };
             }
 
-            var root = dbg.GetExpression(expression, true, -1);
+            var root = dbg.GetExpression(expression, true, EvalTimeoutMs);
             if (!root.IsValidValue)
             {
                 return new ExpandResult
@@ -650,6 +650,12 @@ internal sealed partial class IdeDebugService
     /// remote call — and a walk well within its node limits still hangs the IDE. This is the ceiling
     /// that counts what the nodes cost rather than how many were asked for.</para></summary>
     private static readonly TimeSpan WalkDeadline = TimeSpan.FromMilliseconds(2000);
+
+    /// <summary>How long GetExpression may take on the expression itself, in milliseconds. The same
+    /// hazard as <see cref="WalkDeadline"/> one level up: evaluating the root runs a getter too, and
+    /// -1 — the value this used to pass — means "no limit", so one that blocks parks the UI thread
+    /// with nothing to end the wait.</summary>
+    private const int EvalTimeoutMs = 2000;
 
     /// <summary>One level of members, recursing while <paramref name="depth"/> is left. Sorted by
     /// name like the locals list, so two reads of the same object line up.

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.cs
@@ -255,6 +255,29 @@ internal sealed partial class IdeDebugService
     /// location resolved to. Reading the parent's own CurrentHits therefore answers 0 for a
     /// breakpoint that has been hit five hundred times, which is worse than not reporting it at
     /// all. Must be called on the UI thread.</summary>
+    /// <summary>How many code locations a breakpoint resolved to, or null outside a session.
+    /// <para>Children is the binding: one child per address the debugger resolved. Read here rather
+    /// than after Breakpoints.Add because binding is asynchronous — measured, every breakpoint reads
+    /// as 0 in the instant after it is created, whether or not it goes on to bind, so the answer is
+    /// only worth anything once some time has passed.</para></summary>
+    private static int? BoundCount(Breakpoint bp, Debugger dbg)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        try
+        {
+            // Nothing binds in design mode, and 0 there would read as "broken" for every breakpoint
+            // set before the session starts — which is the normal way to set one.
+            if (dbg == null || dbg.CurrentMode == dbgDebugMode.dbgDesignMode) { return null; }
+            if (bp is not EnvDTE80.Breakpoint2 bp2) { return null; }
+            return bp2.Children?.Count ?? 0;
+        }
+        catch (Exception ex)
+        {
+            OutputWindowLogger.Global.Warn($"[debug] could not read a breakpoint's bound locations: {ex.Message}");
+            return null;
+        }
+    }
+
     private static int CountHits(Breakpoint bp)
     {
         ThreadHelper.ThrowIfNotOnUIThread();
@@ -481,6 +504,7 @@ internal sealed partial class IdeDebugService
                     HitCount = bp.HitCountType == dbgHitCountType.dbgHitCountTypeNone ? 0 : bp.HitCountTarget,
                     HitCountType = HitCountTypeToString(bp.HitCountType),
                     CurrentHits = CountHits(bp),
+                    Bound = BoundCount(bp, dbg),
                 });
             }
             // Stable order so the model can compare across calls (file bps by file/line,

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.cs
@@ -532,9 +532,15 @@ internal sealed partial class IdeDebugService
         {
             var dbg = GetDebugger();
             if (dbg == null) { return new DebugResult { Ok = false, Reason = "Debugger not available." }; }
+            // Already paused is what the caller asked for, not a failure: refusing it made a model
+            // that had lost track of the mode retry or give up, when the answer was "you are there".
+            if (dbg.CurrentMode == dbgDebugMode.dbgBreakMode)
+            {
+                return new DebugResult { Ok = true, Mode = "break", Reason = "Already paused — debug_get_state has the position." };
+            }
             if (dbg.CurrentMode != dbgDebugMode.dbgRunMode)
             {
-                return new DebugResult { Ok = false, Mode = ModeToString(dbg.CurrentMode), Reason = "Can only break while running." };
+                return new DebugResult { Ok = false, Mode = ModeToString(dbg.CurrentMode), Reason = "Not debugging — debug_start first." };
             }
             dbg.Break(false); // false = don't block until the break completes
             // No Mode, same as start/stop/restart: the call returns before the transition, so

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/BreakDebugTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/BreakDebugTool.cs
@@ -17,7 +17,8 @@ internal sealed class BreakDebugTool : McpTool<NoArgs>
         "Pause the running program immediately (Debug > Break All), without waiting for a " +
         "breakpoint, so the call stack and variables can be inspected. Non-blocking, so mode comes " +
         "back null rather than a guess: poll debug_get_state to see it reach 'break' and learn " +
-        "where it stopped. Only valid while running.";
+        "where it stopped. Calling it on an already-paused program succeeds and says so, rather " +
+        "than failing — there is nothing to do. Needs a session: debug_start first.";
 
     public override bool Idempotent => true;
 

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/ListBreakpointsTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/ListBreakpointsTool.cs
@@ -16,8 +16,11 @@ internal sealed class ListBreakpointsTool : McpTool<NoArgs>
     public override string Description =>
         "List all breakpoints in the solution: each with its file+line (or function name), " +
         "condition and hit-count rule (if any), how many times it has been hit this session, and " +
-        "whether it's enabled. currentHits separates 'never reached' from 'reached, and the " +
-        "condition said no'. Set them with debug_set_breakpoint or " +
+        "whether it's enabled. Two fields answer \"why did it not break\": currentHits separates " +
+        "'never reached' from 'reached, and the condition said no', and bound — how many code " +
+        "locations it resolved to, during a session — catches the case before both, a " +
+        "breakpoint that will never stop anything because the line holds no code or its " +
+        "symbols are not loaded. Set them with debug_set_breakpoint or " +
         "debug_set_function_breakpoint, remove one with debug_remove_breakpoint or all with " +
         "debug_clear_breakpoints. Worth a look when a run stops somewhere unexpected — a " +
         "breakpoint left from earlier is the usual reason.";
@@ -42,6 +45,7 @@ internal sealed class ListBreakpointsTool : McpTool<NoArgs>
                 hitCount = b.HitCount,
                 hitCountType = b.HitCountType,
                 currentHits = b.CurrentHits,
+                bound = b.Bound,
             }).ToArray(),
         };
     }

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/SetBreakpointTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/SetBreakpointTool.cs
@@ -41,7 +41,10 @@ internal sealed class SetBreakpointTool : McpTool<SetBreakpointArgs>
         "that must be true for the breakpoint to trigger), or a hitCount to skip the first passes " +
         "— the way to stop on the 500th iteration of a loop without a counter variable to test. " +
         "Works whether or not a debug session is running. Combine with debug_start + " +
-        "debug_get_state to pause execution at this point.";
+        "debug_get_state to pause execution at this point. " +
+        "Accepting the line does not mean the debugger can stop on it: binding happens later, and a " +
+        "line with no executable code binds to nothing. debug_list_breakpoints reports bound once " +
+        "the session is running, which is where \"why did it never stop\" gets answered.";
 
     public override bool Idempotent => true;
 

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/SetFunctionBreakpointTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/SetFunctionBreakpointTool.cs
@@ -40,7 +40,10 @@ internal sealed class SetFunctionBreakpointTool : McpTool<SetFunctionBreakpointA
         "to test. Works whether or not a debug session is running. Use when you know the method but not " +
         "the exact line, or to avoid opening the file. debug_set_breakpoint takes a file and " +
         "line instead, debug_list_breakpoints shows what is set, and debug_start begins the " +
-        "session that will hit it.";
+        "session that will hit it. " +
+        "A name that matches nothing is accepted just the same — it stays unresolved instead of " +
+        "failing. debug_list_breakpoints reports bound once the session is running: 0 there means " +
+        "the name never matched, so check the spelling or how the type is qualified.";
 
     public override bool Idempotent => true;
 


### PR DESCRIPTION
Three independent gaps in the debug tools, one commit each.

## 1. Evaluating an expression had no time limit

`GetExpression` was passed `-1` — "wait as long as it takes". Reading a value runs a getter inside the debuggee, so one that blocks parked the UI thread with nothing to end the wait.

The member walk already had a ceiling for exactly this reason; the root evaluation it starts from did not.

## 2. A breakpoint that could never stop anything looked like any other

`debug_set_breakpoint` answered `ok=true` whether the line held executable code or not, and `debug_set_function_breakpoint` did the same for a method name matching nothing in the solution. The model had no way to tell a breakpoint that will fire from one that never can — half of "why did it not break".

Binding is what separates them, and `Breakpoint2.Children` is one child per resolved location. That count now rides along in **`debug_list_breakpoints`** as `bound`.

**It belongs there rather than on the set tools**, and this took two tries to get right:

- `Breakpoints.Add` returns what it *created*, not what bound — a function breakpoint on a type that does not exist still comes back as one entry.
- Reading `Children` straight after `Add` returns 0 for everything, because **binding is asynchronous**. Waiting for it would mean blocking the UI thread on the debugger, which is worse than the question is worth.

By the time anyone lists the breakpoints, the answer is there. `null` outside a session, where nothing has bound yet and `0` would read as broken for every breakpoint set before `debug_start` — the normal way to set one.

The result is three distinct answers to "why did it not break", where there were two:

| | meaning |
|---|---|
| `bound = 0` | never will — no code on that line, or symbols not loaded |
| `bound ≥ 1`, `currentHits = 0` | bound, not reached |
| `currentHits > 0` | reached; a condition said no |

## 3. Asking to pause an already-paused program was an error

`debug_break` refused anything not running, so calling it while already in break came back `ok=false` — the state the caller was asking for. A model that had lost track of the mode read the refusal as a failure and retried or gave up. It now succeeds and says so; the genuinely wrong case (no session) keeps its own message.

## Verification

Manual, in the experimental instance. The one that matters is a paused session with four breakpoints set:

| breakpoint | bound | currentHits |
|---|---|---|
| real code line | 1 | 0 |
| brace-only line (method epilogue) | 1 | 0 |
| `Seed.Popola` — real method | 1 | 1 |
| `ClasseInesistente.MetodoFinto` | **0** | 0 |

The last two had been indistinguishable. Before the session all four report `null`.

Also checked: `debug_break` while paused returns `ok=true, "Already paused"`, and while running returns the poll message; evaluate stays fast on both valid and invalid expressions; a breakpoint on a nonexistent file is still rejected with `ok=false` and logs one handled COMException.

Build green, no WARN/ERROR in the output pane across the runs.
