### PR TITLE
feat(mcp): four tool gaps — buffer reads, output filtering, startup project, breakpoint enable

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Corsinvest.VisualStudio.Agents.csproj
+++ b/src/Corsinvest.VisualStudio.Agents/Corsinvest.VisualStudio.Agents.csproj
@@ -195,6 +195,7 @@
     <Compile Include="Mcp\Tools\Debug\SetBreakpointTool.cs" />
     <Compile Include="Mcp\Tools\Debug\SetFunctionBreakpointTool.cs" />
     <Compile Include="Mcp\Tools\Debug\RemoveBreakpointTool.cs" />
+    <Compile Include="Mcp\Tools\Debug\EnableBreakpointTool.cs" />
     <Compile Include="Mcp\Tools\Debug\ClearBreakpointsTool.cs" />
     <Compile Include="Mcp\Tools\Debug\ListBreakpointsTool.cs" />
     <Compile Include="Mcp\Tools\Debug\BreakDebugTool.cs" />

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.Common.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.Common.cs
@@ -56,6 +56,24 @@ internal sealed partial class IdeContextService
             && d != 0;
     }
 
+    /// <summary>The path of an open document, matched the way the shell sees it. Returns the
+    /// moniker rather than a bool so the caller can then look the document up by a path DTE agrees
+    /// with, whatever casing or separator style it came in as.
+    /// <para>Goes through the frames for the reason the enumeration exists: DTE.Documents misses
+    /// tabs whose buffer is not materialised yet. A preview tab reported "not open" from there while
+    /// checkDocumentDirty, which does use the frames, said it was open AND dirty — for exactly the
+    /// file whose buffer differs from disk, which is the one case worth asking about.</para></summary>
+    private static string OpenDocumentMoniker(string path)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        foreach (var frame in DocumentFrames())
+        {
+            var moniker = FrameMoniker(frame);
+            if (PathEquals(moniker, path)) { return moniker; }
+        }
+        return null;
+    }
+
     private static bool PathEquals(string a, string b)
         => !string.IsNullOrEmpty(a) && !string.IsNullOrEmpty(b)
            && string.Equals(a.Replace('/', '\\').TrimEnd('\\'),

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.Operations.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.Operations.cs
@@ -425,23 +425,68 @@ internal sealed partial class IdeContextService
     /// <summary>Report the active solution configuration and the ones that can be asked for.
     /// Reading this through a build would mean compiling the solution to learn a setting, and
     /// finding out what exists at all would mean sending a wrong name and reading the error.</summary>
-    public async Task<(bool Ok, string Configuration, string[] Available, string Reason)> GetConfigurationAsync()
+    public async Task<(bool Ok, string Configuration, string[] Available, string StartupProject, string Reason)> GetConfigurationAsync()
     {
         await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
         var dte = Package.GetGlobalService(typeof(DTE)) as DTE;
         var sb = dte?.Solution?.SolutionBuild;
-        if (sb == null) { return (false, null, [], "No solution open."); }
+        if (sb == null) { return (false, null, [], null, "No solution open."); }
 
         try
         {
             var names = CollectConfigurations(sb, null, out _);
-            return (true, ActiveConfigurationName(sb), [.. names], null);
+            return (true, ActiveConfigurationName(sb), [.. names], StartupProjectName(dte, sb), null);
         }
         catch (Exception ex)
         {
             OutputWindowLogger.Global.LogException("Ide.GetConfigurationAsync", ex);
-            return (false, null, [], $"Could not read the configuration: {ex.Message}");
+            return (false, null, [], null, $"Could not read the configuration: {ex.Message}");
         }
+    }
+
+    /// <summary>The startup project's display name, or null when none is set — or when more than
+    /// one is, which is a multi-startup solution this cannot describe in one name.
+    /// <para>StartupProjects holds UNIQUE names ("src\App\App.csproj"), while the name every
+    /// other tool takes and reports is the display one ("App"). Translating here keeps the pair
+    /// symmetric: what this returns is what solution_set_startup_project accepts.</para></summary>
+    private static string StartupProjectName(DTE dte, SolutionBuild sb)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        try
+        {
+            if (sb.StartupProjects is not Array arr || arr.Length != 1) { return null; }
+            var unique = arr.GetValue(0) as string;
+            if (string.IsNullOrEmpty(unique)) { return null; }
+
+            foreach (Project p in dte.Solution.Projects)
+            {
+                var found = FindByUniqueName(p, unique);
+                if (found != null) { return found.Name; }
+            }
+            // Known by the build but not found in the tree: better the unique name than nothing.
+            return unique;
+        }
+        catch (Exception ex)
+        {
+            OutputWindowLogger.Global.Warn($"[ide] could not read the startup project: {ex.Message}");
+            return null;
+        }
+    }
+
+    /// <summary>Depth-first match on UniqueName, descending solution folders — a project nested in
+    /// one is not in Solution.Projects at the top level.</summary>
+    private static Project FindByUniqueName(Project project, string unique)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        if (string.Equals(project.UniqueName, unique, StringComparison.OrdinalIgnoreCase)) { return project; }
+        if (project.ProjectItems == null) { return null; }
+        foreach (ProjectItem item in project.ProjectItems)
+        {
+            if (item.SubProject == null) { continue; }
+            var found = FindByUniqueName(item.SubProject, unique);
+            if (found != null) { return found; }
+        }
+        return null;
     }
 
     /// <summary>The solution's configurations as sorted "name|platform" strings, and — when

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.cs
@@ -458,6 +458,10 @@ internal sealed partial class IdeContextService : IDisposable
         public string Content { get; set; }
         public int TotalLines { get; set; }
         public bool Truncated { get; set; }
+
+        /// <summary>1-based line the content starts at, so a range read can be placed back in the
+        /// file without counting from the top.</summary>
+        public int StartLine { get; set; }
         public string Reason { get; set; }
     }
 
@@ -465,7 +469,7 @@ internal sealed partial class IdeContextService : IDisposable
     /// changes included. With no path, reads the active document: "what I'm looking at" is the
     /// gesture this exists for, and it's the user who picks it, not the model. The on-disk
     /// version is the Read tool's job; this one is for what hasn't been written yet.</summary>
-    public async Task<BufferReadResult> ReadDocumentBufferAsync(string filePath, int maxLines)
+    public async Task<BufferReadResult> ReadDocumentBufferAsync(string filePath, int maxLines, int startLine, int endLine)
     {
         await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
         try
@@ -483,9 +487,16 @@ internal sealed partial class IdeContextService : IDisposable
             {
                 doc = null;
                 var target = PathHelpers.FromFileUri(filePath);
-                foreach (Document d in dte.Documents)
+                // Ask the shell whether it is open, then DTE for the buffer: the frames see preview
+                // tabs that DTE.Documents does not, and the moniker they answer with is a path DTE
+                // will match on.
+                var moniker = OpenDocumentMoniker(target);
+                if (moniker != null)
                 {
-                    if (string.Equals(d.FullName, target, StringComparison.OrdinalIgnoreCase)) { doc = d; break; }
+                    foreach (Document d in dte.Documents)
+                    {
+                        if (PathEquals(d.FullName, moniker)) { doc = d; break; }
+                    }
                 }
                 if (doc == null)
                 {
@@ -501,19 +512,38 @@ internal sealed partial class IdeContextService : IDisposable
             }
 
             var totalLines = td.EndPoint.Line;
-            var truncated = maxLines > 0 && totalLines > maxLines;
+
+            // A range wins over maxLines: asked for lines 400-450, taking 450 from the top and
+            // throwing away 400 is the whole file's worth of tokens for fifty lines of answer.
+            var from = startLine > 0 ? Math.Min(startLine, totalLines) : 1;
+            var to = endLine > 0 ? Math.Min(Math.Max(endLine, from), totalLines) : 0;
+
             var start = td.StartPoint.CreateEditPoint();
+            if (from > 1) { start.MoveToLineAndOffset(from, 1); }
+
+            bool truncated;
             string text;
-            if (truncated)
+            if (to > 0)
+            {
+                var stop = td.StartPoint.CreateEditPoint();
+                // Start of the line after the last one wanted, so the range is inclusive.
+                if (to < totalLines) { stop.MoveToLineAndOffset(to + 1, 1); }
+                else { stop.MoveToPoint(td.EndPoint); }
+                text = start.GetText(stop) ?? string.Empty;
+                truncated = to < totalLines;
+            }
+            else if (maxLines > 0 && totalLines - from + 1 > maxLines)
             {
                 // Keep the head: unlike an output pane, a file is read top-down.
                 var stop = td.StartPoint.CreateEditPoint();
-                stop.MoveToLineAndOffset(maxLines + 1, 1);
+                stop.MoveToLineAndOffset(from + maxLines, 1);
                 text = start.GetText(stop) ?? string.Empty;
+                truncated = true;
             }
             else
             {
                 text = start.GetText(td.EndPoint) ?? string.Empty;
+                truncated = false;
             }
 
             return new BufferReadResult
@@ -524,6 +554,7 @@ internal sealed partial class IdeContextService : IDisposable
                 Content = text,
                 TotalLines = totalLines,
                 Truncated = truncated,
+                StartLine = from,
             };
         }
         catch (Exception ex)

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.cs
@@ -530,7 +530,11 @@ internal sealed partial class IdeContextService : IDisposable
                 if (to < totalLines) { stop.MoveToLineAndOffset(to + 1, 1); }
                 else { stop.MoveToPoint(td.EndPoint); }
                 text = start.GetText(stop) ?? string.Empty;
-                truncated = to < totalLines;
+                // Not "there is more file after this": the caller asked for a range and got all of
+                // it, so nothing was cut. Saying otherwise made truncated useless for deciding
+                // whether to ask again — which is the only thing it is for. It only turns true when
+                // the range itself was clipped, i.e. endLine ran past the end of the file.
+                truncated = endLine > totalLines;
             }
             else if (maxLines > 0 && totalLines - from + 1 > maxLines)
             {

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.cs
@@ -440,6 +440,7 @@ internal sealed partial class IdeDebugService
             }
 
             var changed = 0;
+            var matched = 0;
             foreach (Breakpoint bp in dbg.Breakpoints)
             {
                 var isFile = bp.LocationType == dbgBreakpointLocationType.dbgBreakpointLocationTypeFile;
@@ -448,14 +449,29 @@ internal sealed partial class IdeDebugService
                     : isFile && bp.FileLine == line && string.Equals(bp.File, filePath, StringComparison.OrdinalIgnoreCase);
                 if (!match) { continue; }
 
+                matched++;
                 // Setting Enabled to what it already is is not an error, but counting it would
                 // report work that did not happen.
                 if (bp.Enabled != enabled) { bp.Enabled = enabled; changed++; }
             }
 
             var what = byFunction ? functionName : $"{System.IO.Path.GetFileName(filePath)}:{line}";
+            var state = enabled ? "enabled" : "disabled";
+            // "Found nothing" and "found it, already that way" read the same when they share a
+            // message, and the first one is a mistake the caller has to fix — most often a line
+            // number VS moved: a breakpoint asked for on a blank line binds to the next statement,
+            // and that new line is the one this matches on. debug_list_breakpoints has the real one.
+            if (matched == 0)
+            {
+                return new DebugResult
+                {
+                    Ok = true,
+                    Mode = ModeToString(dbg.CurrentMode),
+                    Reason = $"No breakpoint at {what} — debug_list_breakpoints has the ones that exist; VS may have moved it to the nearest line with code.",
+                };
+            }
             return changed == 0
-                ? new DebugResult { Ok = true, Mode = ModeToString(dbg.CurrentMode), Reason = $"Nothing changed for {what} — no breakpoint there, or it was already {(enabled ? "enabled" : "disabled")}." }
+                ? new DebugResult { Ok = true, Mode = ModeToString(dbg.CurrentMode), Reason = $"Already {state}: {matched} at {what}." }
                 : new DebugResult { Ok = true, Mode = ModeToString(dbg.CurrentMode), Reason = $"{(enabled ? "Enabled" : "Disabled")} {changed} at {what}." };
         }
         catch (Exception ex)

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.cs
@@ -420,6 +420,51 @@ internal sealed partial class IdeDebugService
 
     /// <summary>Remove the breakpoint(s) at <paramref name="filePath"/>:<paramref name="line"/>.
     /// Returns the number removed in Reason (0 if none matched).</summary>
+    /// <summary>Enable or disable the breakpoints at a file+line, or the ones on a function name.
+    /// <para>The non-destructive half of debug_remove_breakpoint: disabling keeps the condition and
+    /// hit-count rule, which removing throws away with no way to put them back. The case is a
+    /// breakpoint in hot code that keeps stopping the session while the caller is trying to reach a
+    /// different one.</para></summary>
+    public async Task<DebugResult> EnableBreakpointAsync(string filePath, int line, string functionName, bool enabled)
+    {
+        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+        try
+        {
+            var dbg = GetDebugger();
+            if (dbg == null) { return new DebugResult { Ok = false, Reason = "Debugger not available." }; }
+
+            var byFunction = !string.IsNullOrWhiteSpace(functionName);
+            if (!byFunction && (string.IsNullOrEmpty(filePath) || line < 1))
+            {
+                return new DebugResult { Ok = false, Reason = "Either functionName, or filePath and a 1-based line, are required." };
+            }
+
+            var changed = 0;
+            foreach (Breakpoint bp in dbg.Breakpoints)
+            {
+                var isFile = bp.LocationType == dbgBreakpointLocationType.dbgBreakpointLocationTypeFile;
+                var match = byFunction
+                    ? !isFile && string.Equals(bp.FunctionName, functionName, StringComparison.OrdinalIgnoreCase)
+                    : isFile && bp.FileLine == line && string.Equals(bp.File, filePath, StringComparison.OrdinalIgnoreCase);
+                if (!match) { continue; }
+
+                // Setting Enabled to what it already is is not an error, but counting it would
+                // report work that did not happen.
+                if (bp.Enabled != enabled) { bp.Enabled = enabled; changed++; }
+            }
+
+            var what = byFunction ? functionName : $"{System.IO.Path.GetFileName(filePath)}:{line}";
+            return changed == 0
+                ? new DebugResult { Ok = true, Mode = ModeToString(dbg.CurrentMode), Reason = $"Nothing changed for {what} — no breakpoint there, or it was already {(enabled ? "enabled" : "disabled")}." }
+                : new DebugResult { Ok = true, Mode = ModeToString(dbg.CurrentMode), Reason = $"{(enabled ? "Enabled" : "Disabled")} {changed} at {what}." };
+        }
+        catch (Exception ex)
+        {
+            OutputWindowLogger.Global.LogException("IdeDebugService.EnableBreakpointAsync", ex);
+            return new DebugResult { Ok = false, Reason = "Failed to change the breakpoint." };
+        }
+    }
+
     public async Task<DebugResult> RemoveBreakpointAsync(string filePath, int line)
     {
         await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeOutputService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeOutputService.cs
@@ -29,6 +29,10 @@ internal sealed class IdeOutputService
         public string Pane { get; set; }
         public string Content { get; set; }
         public int TotalLines { get; set; }
+
+        /// <summary>Lines matching the pattern, or null when there was none. Without it a short
+        /// answer reads as a short pane: 3 of 40000 lines and 3 lines total look the same.</summary>
+        public int? MatchedLines { get; set; }
         public bool Truncated { get; set; }
         public string[] AvailablePanes { get; set; } = [];
         public string Reason { get; set; }
@@ -150,9 +154,26 @@ internal sealed class IdeOutputService
     }
 
     /// <summary>Read a pane by name (case-insensitive). With no name, returns the list of
-    /// available pane names instead of content. tailLines caps the returned lines.</summary>
-    public async Task<OutputResult> ReadAsync(string paneName, int tailLines)
+    /// available pane names instead of content. tailLines caps the returned lines; pattern keeps
+    /// only the lines matching a regex.</summary>
+    public async Task<OutputResult> ReadAsync(string paneName, int tailLines, string pattern)
     {
+        System.Text.RegularExpressions.Regex rx = null;
+        if (!string.IsNullOrEmpty(pattern))
+        {
+            // Compiled before the thread switch: a bad pattern is the caller's mistake and should
+            // come back as one, not as an exception thrown from the middle of a UI-thread read.
+            try
+            {
+                rx = new System.Text.RegularExpressions.Regex(pattern,
+                    System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+            }
+            catch (ArgumentException ex)
+            {
+                return new OutputResult { Ok = false, Reason = $"Invalid pattern: {ex.Message}" };
+            }
+        }
+
         await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
         try
         {
@@ -199,10 +220,23 @@ internal sealed class IdeOutputService
                 ? []
                 : text.Replace("\r\n", "\n").TrimEnd('\n').Split('\n');
             var total = allLines.Length;
-            var truncated = tailLines > 0 && total > tailLines;
-            var content = truncated
-                ? string.Join("\n", allLines.Skip(total - tailLines))
-                : text;
+
+            // Filter first, then tail: "the last N lines that match" is what searching a long log
+            // wants. Tailing first would answer "the matches among the last N", which finds nothing
+            // whenever what is being looked for scrolled past.
+            var lines = allLines;
+            int? matched = null;
+            if (rx != null)
+            {
+                lines = [.. allLines.Where(l => rx.IsMatch(l))];
+                matched = lines.Length;
+            }
+
+            var truncated = tailLines > 0 && lines.Length > tailLines;
+            var kept = truncated ? lines.Skip(lines.Length - tailLines) : lines;
+            // Only re-join when something was dropped or filtered; otherwise the original text keeps
+            // whatever line endings the pane wrote.
+            var content = truncated || rx != null ? string.Join("\n", kept) : text;
 
             return new OutputResult
             {
@@ -210,6 +244,7 @@ internal sealed class IdeOutputService
                 Pane = pane.Name,
                 Content = content,
                 TotalLines = total,
+                MatchedLines = matched,
                 Truncated = truncated,
             };
         }

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/McpServerHost.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/McpServerHost.cs
@@ -231,6 +231,7 @@ internal sealed partial class McpServerHost
         yield return new Tools.SetBreakpointTool();
         yield return new Tools.SetFunctionBreakpointTool();
         yield return new Tools.RemoveBreakpointTool();
+        yield return new Tools.EnableBreakpointTool();
         yield return new Tools.ClearBreakpointsTool();
         yield return new Tools.ListBreakpointsTool();
         yield return new Tools.BreakDebugTool();

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/EnableBreakpointTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/EnableBreakpointTool.cs
@@ -1,0 +1,47 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using Corsinvest.VisualStudio.Agents.Ide;
+using System.ComponentModel.DataAnnotations;
+using System.Threading.Tasks;
+
+namespace Corsinvest.VisualStudio.Agents.Mcp.Tools;
+
+internal sealed class EnableBreakpointArgs
+{
+    [Description("Path to the file the breakpoint is on. With line, identifies a file breakpoint. Omit when using functionName.")]
+    public string FilePath { get; set; }
+
+    [Description("1-based line of the breakpoint. Goes with filePath.")]
+    public int Line { get; set; }
+
+    [Description("Name of the function breakpoint to change, e.g. \"MyClass.Calculate\". Use instead of filePath+line.")]
+    public string FunctionName { get; set; }
+
+    [Required, Description("true to enable, false to disable.")]
+    public bool Enabled { get; set; }
+}
+
+/// <summary>MCP tool: turn a breakpoint off without losing it. debug_remove_breakpoint is the
+/// destructive twin — it takes the condition and hit-count rule with it.</summary>
+internal sealed class EnableBreakpointTool : McpTool<EnableBreakpointArgs>
+{
+    public override string Name => "debug_enable_breakpoint";
+    public override string Description =>
+        "Enable or disable the breakpoint(s) at a file and 1-based line, or the ones on a function " +
+        "name. Disabling is how a breakpoint in hot code stops interrupting the session while you " +
+        "are trying to reach a different one — unlike debug_remove_breakpoint, which also throws " +
+        "away the condition and hit-count rule it was set with and cannot put them back. " +
+        "debug_list_breakpoints reports enabled for each. Works whether or not a session is running.";
+
+    public override bool Idempotent => true;
+
+    protected override async Task<object> InvokeAsync(EnableBreakpointArgs args)
+    {
+        var r = await IdeDebugService.Instance.EnableBreakpointAsync(
+            args.FilePath, args.Line, args.FunctionName, args.Enabled);
+        return new { ok = r.Ok, mode = r.Mode, reason = r.Reason };
+    }
+}

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Document/ReadDocumentBufferTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Document/ReadDocumentBufferTool.cs
@@ -13,8 +13,14 @@ internal sealed class ReadDocumentBufferArgs
     [Description("Path to an open file. Omit to read the document the user is currently looking at.")]
     public string FilePath { get; set; }
 
-    [Description("Max number of lines to return from the top of the file (default 2000, 0 for all).")]
+    [Description("Max number of lines to return from the top of the file (default 2000, 0 for all). Ignored when startLine/endLine are given.")]
     public int MaxLines { get; set; } = 2000;
+
+    [Description("Optional. 1-based first line to return. Use with endLine to read one region of a large file instead of everything above it.")]
+    public int StartLine { get; set; }
+
+    [Description("Optional. 1-based last line to return, inclusive. Defaults to the end of the file when startLine is given without it.")]
+    public int EndLine { get; set; }
 }
 
 /// <summary>MCP tool: read the editor buffer instead of the file on disk, so unsaved
@@ -28,14 +34,16 @@ internal sealed class ReadDocumentBufferTool : McpTool<ReadDocumentBufferArgs>
         "Read an open document's editor buffer, including changes the user hasn't saved. " +
         "Omit filePath to read the document they are currently looking at. Use the Read tool " +
         "instead for the version on disk, or when the file isn't open in the IDE. " +
-        "Returns isDirty so you can tell whether what you read differs from disk.";
+        "Returns isDirty so you can tell whether what you read differs from disk. " +
+        "startLine/endLine read one region: on a large file that is the difference between fifty " +
+        "lines and everything above them, and startLine comes back so the text can be placed.";
 
     public override bool ReadOnly => true;
     public override bool Idempotent => true;
 
     protected override async Task<object> InvokeAsync(ReadDocumentBufferArgs args)
     {
-        var r = await IdeContextService.Instance.ReadDocumentBufferAsync(args.FilePath, args.MaxLines);
+        var r = await IdeContextService.Instance.ReadDocumentBufferAsync(args.FilePath, args.MaxLines, args.StartLine, args.EndLine);
         if (!r.Ok) { return new { ok = false, reason = r.Reason }; }
         return new
         {
@@ -44,6 +52,7 @@ internal sealed class ReadDocumentBufferTool : McpTool<ReadDocumentBufferArgs>
             isDirty = r.IsDirty,
             content = r.Content,
             totalLines = r.TotalLines,
+            startLine = r.StartLine,
             truncated = r.Truncated,
         };
     }

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Ide/ReadOutputTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Ide/ReadOutputTool.cs
@@ -17,6 +17,9 @@ internal sealed class ReadOutputArgs
 
     [Description("Max number of lines to return from the end of the pane (default 200).")]
     public int TailLines { get; set; } = 200;
+
+    [Description("Optional regex (case-insensitive). Keeps only the lines that match, before tailLines is applied — so this is 'the last N matching lines', not 'the matches among the last N'.")]
+    public string Pattern { get; set; }
 }
 
 /// <summary>MCP tool: read text from a VS Output window pane (Build, Debug, the running
@@ -29,7 +32,10 @@ internal sealed class ReadOutputTool : McpTool<ReadOutputArgs>
         "running program's output). Omit 'pane' to list the available pane names first — note " +
         "those come back in the IDE's language ('Compilazione' for Build on an Italian VS), but " +
         "the built-in panes are also reachable under their English names. " +
-        "'tailLines' caps how many lines are returned from the end (default 200). Useful to " +
+        "'tailLines' caps how many lines are returned from the end (default 200), and 'pattern' — a " +
+        "case-insensitive regex — keeps only matching lines, which is how a specific message is " +
+        "found in a long build log without pulling all of it; matchedLines says how many there were. " +
+        "Useful to " +
         "see build/debug output or the debuggee's console writes that don't go through the " +
         "shell — including what a frozen thread stopped printing, which is how debug_freeze_thread " +
         "is checked. ide_clear_output first to read only what happens next, ide_activate_output to " +
@@ -40,7 +46,7 @@ internal sealed class ReadOutputTool : McpTool<ReadOutputArgs>
 
     protected override async Task<object> InvokeAsync(ReadOutputArgs args)
     {
-        var r = await IdeOutputService.Instance.ReadAsync(args.Pane, args.TailLines);
+        var r = await IdeOutputService.Instance.ReadAsync(args.Pane, args.TailLines, args.Pattern);
         if (!r.Ok) { return new { ok = false, reason = r.Reason, availablePanes = r.AvailablePanes }; }
         if (string.IsNullOrWhiteSpace(args.Pane))
         {
@@ -60,6 +66,7 @@ internal sealed class ReadOutputTool : McpTool<ReadOutputArgs>
                 requestedPane = args.Pane,
                 content = r.Content,
                 totalLines = r.TotalLines,
+                matchedLines = r.MatchedLines,
                 truncated = r.Truncated,
             };
         }
@@ -69,6 +76,7 @@ internal sealed class ReadOutputTool : McpTool<ReadOutputArgs>
             pane = r.Pane,
             content = r.Content,
             totalLines = r.TotalLines,
+            matchedLines = r.MatchedLines,
             truncated = r.Truncated,
         };
     }

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Solution/GetConfigurationTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Solution/GetConfigurationTool.cs
@@ -18,7 +18,10 @@ internal sealed class GetConfigurationTool : McpTool<NoArgs>
         "compile — plus every configuration that can be asked for ('Debug|Any CPU', " +
         "'Release|Any CPU', …). Takes no arguments and changes nothing. Use it to check what a " +
         "build will produce, or to see the valid names before solution_set_configuration, which is " +
-        "what actually switches it.";
+        "what actually switches it. " +
+        "Also reports startupProject — the one debug_start runs — under the name " +
+        "solution_set_startup_project takes, so it can be read before changing it and put back " +
+        "after. null when none is set, or when several are.";
 
     public override bool ReadOnly => true;
     public override bool Idempotent => true;
@@ -26,6 +29,6 @@ internal sealed class GetConfigurationTool : McpTool<NoArgs>
     protected override async Task<object> InvokeAsync(NoArgs args)
     {
         var r = await IdeContextService.Instance.GetConfigurationAsync();
-        return new { ok = r.Ok, configuration = r.Configuration, available = r.Available, reason = r.Reason };
+        return new { ok = r.Ok, configuration = r.Configuration, available = r.Available, startupProject = r.StartupProject, reason = r.Reason };
     }
 }


### PR DESCRIPTION
Four gaps across the document, output, solution and debug domains, one commit each, plus a fifth fixing two things the verification run turned up.

## 1. Reading a buffer said "not open" for the file most worth reading

`document_read_buffer` looked the document up through `DTE.Documents`, while `document_check_dirty` and `document_save` go through the shell's document-window frames. The comment on that enumeration says why it exists: DTE misses tabs whose buffer is not materialised yet, preview tabs among them.

So a file open in a preview tab had `check_dirty` answering "open, and dirty" while `read_buffer` answered *"not open in an editor; use the Read tool for the on-disk version"* — sending the caller to disk for exactly the file whose buffer differs from it, which is the one case the tool exists to serve.

Reading a region comes with it: only `maxLines` existed, counted from the top, so lines 400-450 of a large file meant pulling 450 and discarding 400.

## 2. Finding one line in a build log meant reading the whole thing

`ide_read_output` took a pane and a tail and nothing else. A `pattern` regex now filters, **before** the tail — "the last N matching lines", where "the matches among the last N" finds nothing whenever the thing being looked for has scrolled past. `matchedLines` comes with it, because three lines out of forty thousand and a three-line pane otherwise look the same.

Compiled before the UI-thread switch, so a malformed pattern is a plain error rather than an exception from mid-read.

## 3. The startup project could be set but never read

`solution_set_startup_project` changes which project `debug_start` runs, and nothing reported which one that was — so using it meant working blind, with no way to restore the previous one. It rides along in `solution_get_configuration`, which already answers "how is this solution set up", translating the unique name VS stores into the display name every other tool speaks.

## 4. Turning a breakpoint off meant losing it

The only way to stop a breakpoint firing was `debug_remove_breakpoint`, which takes the condition and hit-count rule with it. `debug_enable_breakpoint` sets `Enabled` instead, by file+line or function name. The read half already existed in `debug_list_breakpoints`.

## 5. Two things the verification found

**A range read reported itself truncated when nothing was cut.** Asked for lines 20-30 of a 106-line file, it returned all eleven and set `truncated` anyway — the flag was answering "there is more file after this" rather than "what you asked for was cut". Only the second is useful, since `truncated` exists to decide whether to ask again.

**`debug_enable_breakpoint` folded two cases into one message.** *"Nothing changed — no breakpoint there, or it was already disabled"* covers a situation that is fine and one that means the caller is aiming at nothing, and during the test it caused exactly that confusion. Now separate, and the "found nothing" branch says where to look.

## Verification

Manual, in the experimental instance:

| Check | Result |
|---|---|
| `check_dirty` + `read_buffer` on the same open file | both see it — no more "not open" |
| range 20-30 of 106 lines | 11 lines, `startLine: 20`, `truncated: false` |
| range 100-9999 | `truncated: true` — the range itself was clipped |
| `maxLines: 5` | 5 lines, `truncated: true` |
| `pattern` on the Build pane | `matchedLines: 5`, `totalLines: 7` — the pane's total, not the filtered one |
| pattern matching nothing | empty, `matchedLines: 0`, `totalLines` unchanged |
| malformed regex | `ok: false`, "Invalid pattern" — no exception |
| `startupProject` round-trip get→set | accepted, so the name read is the name set takes |
| enable/disable by line, and again when already off | `"Disabled 1"` then `"Already disabled: 1"` |
| enable/disable by function name | works, no crosstalk with the file breakpoint |
| breakpoint at a line with none | `"No breakpoint at ..."`, points at `debug_list_breakpoints` |

Build green, no WARN/ERROR from these tools.

**Not covered:** `read_buffer` against a buffer with genuinely unsaved edits — the agent cannot dirty one, and the manual attempt did not take (`isDirty: false` throughout). The structural change is confirmed (the tool answers `ok: true` where it used to refuse), but the dirty case itself is unverified.

## Found and left for later

Three things noted in the TODO rather than widened into this PR:

- `debug_set_breakpoint` does not report when VS **moves** the line — asked for `Seed.cs:78`, VS binds at 80, and the tool says `ok: true` with no mention. Every later call using the original line then fails silently, which happened during the test.
- `ide_read_output` has no character cap, only a line one — measured a pane answering with 51,974 characters on a single line.
- Closing a pane with a send in flight logs an `ObjectDisposedException` for what is a normal event.
