### PR TITLE
feat(chat): the mode that never asks was the one with no colour

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,12 @@ See [Options → Profiles](docs/options.md#profiles).
   unsupported).
 - **Model switcher & controls** — pick the model; toggle extended **Thinking**, **Fast mode**, an
   **Effort** slider, and auto-switch-on-flag.
+- **Permission mode** — Shift+Tab cycles it, and while the composer has focus its border takes the
+  mode's colour, so the change is visible where you are already looking. **Bypass permissions** —
+  the mode that runs everything without asking, dangerous commands included — is named in red on
+  the toolbar whether or not the composer has focus: it is the one worth noticing when you come
+  back to a pane and don't remember how you left it. It only appears at all if
+  [Allow dangerously skip permissions](docs/options.md) is on.
 - **Notice bar** — info/success/warning/error messages above the composer (e.g. rate-limit notices).
 
 ### Conversation

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-permission-selector.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-permission-selector.ts
@@ -31,6 +31,13 @@ export class CvPermissionSelector extends LitElement {
                 padding-inline: 8px;
                 min-width: 0;
             }
+            /* The one mode that asks nothing before running anything, said where the modes are
+             * named — the composer border only shows it while the composer has focus. On the span:
+             * the button is Fluent's, which takes layout from us and nothing else. */
+            .trigger .danger {
+                color: var(--colorPaletteRedForeground1);
+                font-weight: var(--fontWeightSemibold);
+            }
         `,
     ];
 
@@ -76,7 +83,9 @@ export class CvPermissionSelector extends LitElement {
                 size="small"
                 @click=${this._onClick}
             >
-                <span>${item.short}</span>
+                <span class=${this._current === 'bypassPermissions' ? 'danger' : ''}
+                    >${item.short}</span
+                >
             </fluent-button>
             <!-- The name of the control, not of the mode: three of the five modes are shown in full
                  on the button already (Manual, Plan, Auto), so echoing the label would be the same

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-prompt.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-prompt.ts
@@ -210,6 +210,9 @@ export class CvPrompt extends LitElement implements CommandHost {
             #box[data-permission-mode='auto'] #field:focus-within {
                 border-color: var(--colorPaletteRedBorderActive);
             }
+            #box[data-permission-mode='bypassPermissions'] #field:focus-within {
+                border-color: var(--colorPaletteRedBorderActive);
+            }
             /* The drop target is the whole composer (the handlers sit on #box), but the highlight
                goes on the field: it is the thing the file ends up in. */
             #box.drag-over #field {


### PR DESCRIPTION
## The gap

Four of the five permission modes tint the composer border while it has focus — `default` peach, `acceptEdits` neutral, `plan` brand, `auto` red. **`bypassPermissions` had no rule at all** and inherited the resting grey, so the mode that runs everything without asking — dangerous commands included — showed *less* than `auto` did.

## What changed

**Border** — `bypassPermissions` gets `auto`'s red, under `:focus-within` like the other four. Same kind of danger, same colour, no exception to the rule.

**Toolbar label** — the word "Bypass" is red and semibold, always, regardless of focus. This is the part that matters: the border only appears while you are typing, and the question worth answering is the one you have when you come back to a pane and cannot remember how you left it.

![the toolbar label in bypass](https://github.com/user-attachments/assets/placeholder)

## Two things deliberately not done

**Not the send button**, which would be the louder signal — `#send` already turns red for `is-busy` ("click to stop"), and one colour for two unrelated states reads as neither. The official VS Code extension does colour its send button for this mode, and can, because its Stop is not red.

**Not a stronger red.** `RedBorderActive` is already the strongest on the border scale, and a second red would not read as "more dangerous", only as "something else" — leaving the reader to guess which of the two is worse. What sets bypass apart is *when* it is visible, not what shade it is.

Also worth noting: the label colour sits on the inner `<span>`, not the `fluent-button`. Per CLAUDE.md, Fluent components take layout CSS from us and nothing else.

## Docs

The README's Composer section listed the model switcher, thinking, fast mode and the effort slider, but never the permission mode — the most consequential control in that row. It is documented now, including that Bypass only appears when *Allow dangerously skip permissions* is enabled.
