### PR TITLE
fix(chat): expanding a failed Agent hid the button explaining the failure

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/base.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/base.ts
@@ -190,7 +190,7 @@ export abstract class ToolRenderer {
                               >`
                             : nothing
                     }
-                    ${this.renderHeaderActions()}
+                    ${this.headerActions()}
                     ${
                         opts.chevron
                             ? html`<fluent-button
@@ -437,29 +437,43 @@ export abstract class ToolRenderer {
         ${removed ? html`<span class="cv-diff-count-del">−${removed}</span>` : nothing}`;
     }
 
-    /** The header actions this tool shows (right of the header, before the chevron). Default: an
-     *  error button on a failed tool, nothing otherwise. Renderers override to add their own. */
+    /** Everything in the header's action slot: the error button — an invariant of a failed row,
+     *  not something a renderer opts into — plus whatever the tool itself offers. Kept out of
+     *  renderHeaderActions() so a renderer that overrides it can't drop the error button by
+     *  forgetting to call super: on a failed Agent, expanding used to swap the error away for
+     *  copy/show-all exactly when the user went looking for what failed. */
+    private headerActions(): TemplateResult | typeof nothing {
+        const failed = this.host.status === 'error';
+        const own = this.renderHeaderActions();
+        if (!failed && own === nothing) {
+            return nothing;
+        }
+        return html`<div class="cv-tool-actions">
+            ${failed ? this.errorButton() : nothing}${own}
+        </div>`;
+    }
+
+    /** The tool's OWN header actions (right of the header, before the chevron). Default: none.
+     *  Renderers override to add theirs; the error button is added by headerActions(). */
     protected renderHeaderActions(): TemplateResult | typeof nothing {
-        return this.host.status === 'error' ? this.errorButton() : nothing;
+        return nothing;
     }
 
     /** The "show error details in VS" icon button. */
-    protected errorButton(): TemplateResult {
-        return html`<div class="cv-tool-actions">
-            <fluent-button
-                class="trigger cv-tool-actions-error"
-                appearance="subtle"
-                shape="rounded"
-                size="small"
-                icon-only
-                title="Show error details"
-                @click=${(e: Event) => {
-                    e.stopPropagation();
-                    this.host.openError();
-                }}
-            >
-                ${unsafeHTML(ErrorCircle16Regular)}
-            </fluent-button>
-        </div>`;
+    private errorButton(): TemplateResult {
+        return html`<fluent-button
+            class="trigger cv-tool-actions-error"
+            appearance="subtle"
+            shape="rounded"
+            size="small"
+            icon-only
+            title="Show error details"
+            @click=${(e: Event) => {
+                e.stopPropagation();
+                this.host.openError();
+            }}
+        >
+            ${unsafeHTML(ErrorCircle16Regular)}
+        </fluent-button>`;
     }
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/renderers.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/renderers.ts
@@ -275,11 +275,9 @@ export class AgentRenderer extends ToolRenderer {
         return this.body() !== null || this.host.agentId !== '' || this.host.childCount > 0;
     }
     protected override renderHeaderActions(): TemplateResult | typeof nothing {
-        // Copy-output + show-all only make sense once the transcript is open (same as before, when the
-        // slot was gated on `open`). Collapsed → just the error button, if any.
-        return this.host.expanded
-            ? this.host.componentHeaderActions()
-            : super.renderHeaderActions();
+        // Show-all only makes sense once the transcript is open. The error button isn't ours to
+        // render: headerActions() adds it on a failed row whatever we return here.
+        return this.host.expanded ? this.host.componentHeaderActions() : nothing;
     }
 }
 


### PR DESCRIPTION
A failed Agent row shows an error button that opens the full output in Visual Studio. **Expanding the row took it away.**

## Why

The header's action slot was `renderHeaderActions()`, and the base implementation *was* the error button:

```ts
protected renderHeaderActions() {
    return this.host.status === 'error' ? this.errorButton() : nothing;
}
```

`AgentRenderer` overrides that slot, because copy-output and show-all only make sense once the sub-agent transcript is open:

```ts
return this.host.expanded
    ? this.host.componentHeaderActions()   // ← replaces, not appends
    : super.renderHeaderActions();
```

An override replaces. So on an expanded failed row the error button was swapped for the copy/show-all pair — at the one moment the user is looking for what went wrong.

## The fix

The two are not the same kind of thing. The error button belongs to a failed row whatever renders it; copy-output and show-all are a tool's own offer.

The slot becomes `headerActions()` — private, not overridable — which puts the error button first and appends whatever `renderHeaderActions()` returns. That one now defaults to `nothing`: a renderer adds its own actions and cannot drop the error button, because it never had it to begin with.

Two things ride along:

- **The `.cv-tool-actions` wrapper moves up** into `headerActions()`, which returns `nothing` when there is neither an error nor a tool action — so the slot no longer renders an empty div on the rows that have nothing to put in it.
- **`errorButton()` is private**, now that only its own class calls it. It was `protected` for `diffActionButtons()`, which #167 removed.

## Verification

`npm run check` green — typecheck, lint (0 errors), format, 154 tests.

Manually in the experimental instance: fail an Agent (a sub-agent that errors, or interrupt one mid-run), then expand the row with the chevron. The error button stays. Before this, it vanished on expand.

Only `AgentRenderer` overrides the slot, so it is the only row where the bug could show.
