### PR TITLE
feat(chat): shell commands render as code, and no longer get cut off

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/base.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/base.ts
@@ -29,6 +29,14 @@ import { renderMarkdown } from '../../core/markdown';
 import { highlightCode } from '../../core/lang';
 import type { ToolHost } from './types';
 
+/** How a body cell treats the preview cap.
+ *  'always'  — clip even when the row is expanded (a long stdout stays a preview; the full
+ *              text is one click away in the editor, so the cell never has to hold it).
+ *  'preview' — clip until the row is expanded. The default for every tool.
+ *  'never'   — show it whole, cap or not: half a shell pipeline says nothing, where the
+ *              first lines of a log still do. */
+export type ClipMode = 'always' | 'preview' | 'never';
+
 export abstract class ToolRenderer {
     constructor(protected host: ToolHost) {}
 
@@ -47,7 +55,21 @@ export abstract class ToolRenderer {
 
     /** Body content. Default: the IN/OUT grid. null = no body. */
     body(): TemplateResult | null {
-        return this.ioGrid(this.inputText());
+        return this.ioGrid(this.inputText(), { highlightAs: this.highlightAs() });
+    }
+
+    /** Highlight language for the IN cell, '' for none — the OUT cell is never highlighted.
+     *  Default: no colouring, most tool input being a JSON dump rather than a language.
+     *  Mutually exclusive with a markdown body: ioGrid renders prose before it ever reaches
+     *  the highlighter. */
+    highlightAs(): string {
+        return '';
+    }
+
+    /** Clip mode for the IN cell. Default: whatever the row does with its output. A tool whose
+     *  input is the thing the user re-reads (a shell command) overrides this to 'never'. */
+    protected clipsInput(): ClipMode {
+        return this.host.clipsOutput ? 'always' : 'preview';
     }
 
     /** Name shown in the header. Default: the raw tool name. */
@@ -327,21 +349,24 @@ export abstract class ToolRenderer {
         // Markdown cells hold prose (an Agent's prompt and its report), so they render as rich
         // text and in full: clipping a paragraph mid-sentence hides the answer, and the preview
         // cap exists for tool output — logs, file dumps — where the first lines are enough.
-        const cell = (t: string, extra = '') => {
+        const cell = (t: string, clip: ClipMode, lang: string, extra = '') => {
             if (markdown) {
                 return html`<div class="cv-tool-body-md md" @click=${this.onMarkdownClick}>
                     ${unsafeHTML(renderMarkdown(t))}
                 </div>`;
             }
-            const shown = previewText(
-                t,
-                appState.ui.previewLines,
-                this.host.expanded,
-                this.host.clipsOutput,
-            );
-            // Highlight only what a caller asked to (Write's file content): tool OUTPUT is logs
-            // and dumps, where colouring guesses at structure that isn't there.
-            const code = highlightAs ? highlightCode(shown, highlightAs) : null;
+            // 'never' bypasses previewText: its only whole-text exit is gated on `expanded`,
+            // so no value of its `clip` flag can mean "uncapped while collapsed".
+            const shown =
+                clip === 'never'
+                    ? t
+                    : previewText(
+                          t,
+                          appState.ui.previewLines,
+                          this.host.expanded,
+                          clip === 'always',
+                      );
+            const code = lang ? highlightCode(shown, lang) : null;
             return code
                 ? html`<pre
                       class="cv-tool-body-pre hljs ${extra}"
@@ -370,7 +395,10 @@ export abstract class ToolRenderer {
                                           : nothing
                                   }
                                   <div class="cv-tool-body-cell">
-                                      ${cell(inText)}${copyBtn(inText, 'in')}
+                                      ${cell(inText, this.clipsInput(), highlightAs)}${copyBtn(
+                                          inText,
+                                          'in',
+                                      )}
                                   </div>
                               </div>`
                             : nothing
@@ -386,7 +414,15 @@ export abstract class ToolRenderer {
                                       >${this.host.status === 'error' ? 'ERR' : 'OUT'}</span
                                   >
                                   <div class="cv-tool-body-cell">
-                                      ${cell(outText, 'cv-tool-body-result')}${copyBtn(outText, 'out')}
+                                      <!-- Never highlighted, whatever the IN cell asked for: tool
+                                           output is logs and dumps, where colouring guesses at
+                                           structure that isn't there. -->
+                                      ${cell(
+                                          outText,
+                                          this.host.clipsOutput ? 'always' : 'preview',
+                                          '',
+                                          'cv-tool-body-result',
+                                      )}${copyBtn(outText, 'out')}
                                   </div>
                               </div>`
                             : nothing

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/renderers.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/renderers.ts
@@ -10,7 +10,7 @@ import { html, nothing, type TemplateResult } from 'lit';
 import { fileName } from '../../core/path';
 import { displayPathUi } from '../paths';
 import { truncate } from '../helpers/format';
-import { ToolRenderer } from './base';
+import { ToolRenderer, type ClipMode } from './base';
 import { state as appState } from '../../core/state';
 import { formatDuration, formatTokens } from '../helpers/format';
 import type { AskQuestion } from '../../core/types';
@@ -93,17 +93,20 @@ export class WriteRenderer extends ToolRenderer {
      *  so it is dropped too — an error still gets its row, being the one thing the header can't say.
      *  The body is a file, so it is highlighted as one, by its own extension. */
     override body(): TemplateResult | null {
+        return this.ioGrid(this.inputText(), {
+            showOut: this.host.status === 'error',
+            inLabel: '',
+            highlightAs: this.highlightAs(),
+        });
+    }
+    override highlightAs(): string {
         const name =
             String(this.host.input.file_path ?? '')
                 .split(/[\\/]/)
                 .pop() ?? '';
         const dot = name.lastIndexOf('.');
-        return this.ioGrid(this.inputText(), {
-            showOut: this.host.status === 'error',
-            inLabel: '',
-            // Extension only when there is one: an extensionless name is not its own language.
-            highlightAs: dot > 0 ? name.slice(dot + 1) : '',
-        });
+        // Extension only when there is one: an extensionless name is not its own language.
+        return dot > 0 ? name.slice(dot + 1) : '';
     }
 }
 
@@ -182,6 +185,16 @@ export class ShellRenderer extends ToolRenderer {
         super(host);
         this.host.clipsOutput = true;
     }
+    /** A command is code, and the thing that gets re-read most — pipes, redirections, quoting.
+     *  Both shells are hljs natives, so the language is what tells the two renderers apart. */
+    override highlightAs(): string {
+        return 'bash';
+    }
+    /** The command is never clipped, unlike the output it produces: half a pipeline says nothing,
+     *  where the first lines of a log still do. Cheap in practice — half the commands are one line. */
+    protected override clipsInput(): ClipMode {
+        return 'never';
+    }
     override header(): TemplateResult {
         const i = this.host.input;
         const cmd = String(i.command ?? i.script ?? i.code ?? '');
@@ -196,6 +209,9 @@ export class ShellRenderer extends ToolRenderer {
 
 export class PowerShellRenderer extends ShellRenderer {
     override readonly name = 'PowerShell';
+    override highlightAs(): string {
+        return 'powershell';
+    }
 }
 
 export class WebFetchRenderer extends ToolRenderer {


### PR DESCRIPTION
The IN cell of a `Bash` or `PowerShell` row was a flat `<pre>`. A shell command is code — and the thing that gets re-read most, for its pipes, redirections and quoting. It is now syntax-highlighted, and no longer truncated.

## What changed

- **`ShellRenderer` → `bash`, `PowerShellRenderer` → `powershell`.** The language is the field that already told the two classes apart. Both are hljs natives, so no entry in `lang.ts`'s alias map was needed.
- **The IN cell of a shell row is never clipped.** The OUT cell is unchanged — still capped in C# and in the cell, still one click from the full text in the editor.
- **`WriteRenderer` moves to the same shape**, its language becoming a `highlightAs()` override rather than an inline opts field.

## Two defects found while wiring it up

Both came from one value shared by two cells that want opposite policies — `cell()` is a single closure serving IN and OUT.

**`clipsOutput` also clipped the IN cell**, and did so even when the row was expanded. Opening a `Bash` row still showed a truncated command; the name says "output", the code did both. Clip policy is now per cell.

**`highlightAs` was a closure variable, so it coloured the OUT cell too.** Harmless until now — its only caller, `Write`, shows OUT on error alone — but shell rows always have output, and colouring a log guesses at structure that isn't there. The language is now a `cell()` parameter and OUT always gets `''`.

## Why `ClipMode` and not a boolean

`previewText`'s only whole-text exit is gated on `expanded`:

```ts
if (!clip && (expanded || previewLines <= 0)) return text;
```

so its flag can *suppress* the expanded exemption but never *grant* one — `false` still clipped while collapsed. Three states are reachable, two were expressible:

| mode | collapsed | expanded |
|---|---|---|
| `always` | clipped | clipped |
| `preview` | clipped | whole |
| `never` | **whole** | whole |

`ClipMode` also names what the old flag actually meant, which `true`/`false` did not.

## Cost

Measured over **6839** shell commands in this project's own transcripts: median **1 line**, p90 9, p99 28, max 61. **73 %** already fit inside the default three-line cap, so they render exactly as before; the rest grow by a few lines.

## Verification

`npm run typecheck` clean, `lint` 0 errors (7 pre-existing `no-explicit-any` warnings in `bridge.ts` / `cv-mic-button.ts`, untouched here), `format` unchanged, `build` green. The three clip modes were checked by running the real `previewText` against the table above.

Not covered by the build, and worth a look in the Exp instance: that the hljs token colours sit well on the dark IN cell, and that `.cv-tool-body-pre`'s `max-height: 200px` (`chat.css:420`) — which scrolls rather than truncates — reads acceptably for the rare command past ~13 lines.

Closes the "colour the shell tool command" item in `docs/internal/TODO.md`.
