### PR TITLE
feat(chat): the changed words in a diff keep their syntax colours

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/mark-ranges.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/mark-ranges.ts
@@ -1,0 +1,90 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+// Wrap character ranges of already-highlighted HTML in <mark>, without cutting its tags.
+
+/** Half-open [start, end) over the line's plain text. */
+export type Range = { start: number; end: number };
+
+/**
+ * Entities the highlighter emits. Each stands for one character of the source, which is what the
+ * ranges are counted in — advancing by their literal length would drift the offsets.
+ */
+const ENTITY = /^&(?:lt|gt|amp|quot|#x27|#39);/;
+
+/**
+ * `html` wrapped so every range is inside a <mark>, everything else untouched.
+ *
+ * A mark is closed and reopened around any tag that falls inside it: a <mark> spanning a
+ * `<span>` boundary would nest the two badly, and the browser's recovery moves the text.
+ *
+ * Ranges must be sorted and non-overlapping — what diffWords produces.
+ */
+export function markRanges(html: string, ranges: readonly Range[]): string {
+    if (!ranges.length) {
+        return html;
+    }
+    let out = '';
+    let pos = 0; // offset into the plain text, what the ranges are measured in
+    let i = 0; // read cursor into html
+    let r = 0; // range under consideration
+    let open: boolean = false;
+
+    const closeIfOpen = () => {
+        if (open) {
+            out += '</mark>';
+            open = false;
+        }
+    };
+
+    while (i < html.length) {
+        while (r < ranges.length && pos >= ranges[r].end) {
+            closeIfOpen();
+            r++;
+        }
+
+        if (html[i] === '<') {
+            const close = html.indexOf('>', i);
+            const end = close < 0 ? html.length : close + 1;
+            const wasOpen: boolean = open;
+            closeIfOpen();
+            out += html.slice(i, end);
+            open = wasOpen;
+            if (wasOpen) {
+                out += '<mark>';
+            }
+            i = end;
+            continue;
+        }
+
+        const inRange = r < ranges.length && pos >= ranges[r].start && pos < ranges[r].end;
+        if (inRange && !open) {
+            out += '<mark>';
+            open = true;
+        } else if (!inRange && open) {
+            closeIfOpen();
+        }
+
+        const entity = html[i] === '&' ? ENTITY.exec(html.slice(i)) : null;
+        const step = entity ? entity[0].length : 1;
+        out += html.slice(i, i + step);
+        i += step;
+        pos++;
+    }
+    closeIfOpen();
+    return out;
+}
+
+/** Ranges over the concatenated text of `segs`, one per changed segment. */
+export function rangesOf(segs: readonly { text: string; changed: boolean }[]): Range[] {
+    const ranges: Range[] = [];
+    let at = 0;
+    for (const seg of segs) {
+        if (seg.changed) {
+            ranges.push({ start: at, end: at + seg.text.length });
+        }
+        at += seg.text.length;
+    }
+    return ranges;
+}

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/mark-ranges.test.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/mark-ranges.test.ts
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright (C) 2026 Corsinvest Srl
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { markRanges, rangesOf } from '../core/mark-ranges.ts';
+
+test('markRanges: senza range restituisce l’html intatto', () => {
+    assert.equal(
+        markRanges('<span class="k">const</span> x', []),
+        '<span class="k">const</span> x',
+    );
+});
+
+test('markRanges: marca un tratto di testo semplice', () => {
+    assert.equal(markRanges('abcdef', [{ start: 2, end: 4 }]), 'ab<mark>cd</mark>ef');
+});
+
+test('markRanges: gli offset sono quelli del testo, non dell’html', () => {
+    // 'const x' con i primi cinque caratteri dentro uno span: il range 6..7 è la x.
+    const html = '<span class="hljs-keyword">const</span> x';
+    assert.equal(markRanges(html, [{ start: 6, end: 7 }]), `${html.slice(0, -1)}<mark>x</mark>`);
+});
+
+test('markRanges: un range dentro un tag lo marca senza toccare il tag', () => {
+    const html = '<span class="hljs-keyword">const</span>';
+    assert.equal(
+        markRanges(html, [{ start: 0, end: 5 }]),
+        '<span class="hljs-keyword"><mark>const</mark></span>',
+    );
+});
+
+test('markRanges: un range a cavallo di un tag chiude e riapre invece di annidare male', () => {
+    // 'ab' testo, poi <i>cd</i>: marcare 1..3 prende la b fuori e la c dentro.
+    const out = markRanges('ab<i>cd</i>', [{ start: 1, end: 3 }]);
+    assert.equal(out, 'a<mark>b</mark><i><mark>c</mark>d</i>');
+});
+
+test('markRanges: le entità valgono un carattere solo', () => {
+    // Testo sorgente: 'a<b' — '<' è &lt; e conta 1. Il range 1..2 è quel carattere.
+    assert.equal(markRanges('a&lt;b', [{ start: 1, end: 2 }]), 'a<mark>&lt;</mark>b');
+});
+
+test('markRanges: più range disgiunti sullo stesso html', () => {
+    assert.equal(
+        markRanges('abcdef', [
+            { start: 0, end: 1 },
+            { start: 4, end: 6 },
+        ]),
+        '<mark>a</mark>bcd<mark>ef</mark>',
+    );
+});
+
+test('markRanges: un range fino a fine riga chiude il mark', () => {
+    assert.equal(markRanges('abc', [{ start: 1, end: 3 }]), 'a<mark>bc</mark>');
+});
+
+test('rangesOf: gli offset seguono i segmenti concatenati', () => {
+    assert.deepEqual(
+        rangesOf([
+            { text: 'return ', changed: false },
+            { text: 'false', changed: true },
+            { text: ';', changed: false },
+        ]),
+        [{ start: 7, end: 12 }],
+    );
+});
+
+test('rangesOf: nessun segmento cambiato = nessun range', () => {
+    assert.deepEqual(rangesOf([{ text: 'const x = 1', changed: false }]), []);
+});

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-diff-preview.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-diff-preview.ts
@@ -8,6 +8,7 @@ import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { buildRows, rowsFromHunks, type Row, type Seg } from '../../core/diff-rows';
 import type { PatchHunkDto } from '../../core/generated/PatchHunkDto';
 import { highlightCode } from '../../core/lang';
+import { markRanges, rangesOf } from '../../core/mark-ranges';
 
 /** Unchanged lines kept around each change — what git and GitHub show. */
 const CONTEXT_LINES = 3;
@@ -18,10 +19,10 @@ const VISIBLE_ROWS = 12;
 /**
  * Inline diff preview for tool rows (Edit / Write / MultiEdit).
  *
- * Three layers that do not fight each other, applied in this order: the patch
- * says which rows changed, the word-diff which piece inside a row, the
- * highlighter what the code says. The order is a constraint — the highlighter
- * returns HTML, and feeding that to the word-diff would cut its tags in half.
+ * Three layers: the patch says which rows changed, the word-diff which piece inside a row, the
+ * highlighter what the code says. The highlighter needs the whole line — given a changed piece
+ * alone it sees a word out of context and returns `boolean` plain, not as a keyword — so it runs
+ * first and markRanges puts the marks over its HTML.
  */
 @customElement('cv-diff-preview')
 export class CvDiffPreview extends LitElement {
@@ -40,17 +41,20 @@ export class CvDiffPreview extends LitElement {
         return this;
     }
 
-    /** Highlight one segment. Null (unknown language, or hljs threw) renders
-     *  plain text, which is what an unhighlighted file should look like. */
-    private _seg(seg: Seg, lang: string): TemplateResult {
-        const hl = highlightCode(seg.text, lang);
-        const inner = hl ? unsafeHTML(hl) : seg.text;
-        return seg.changed ? html`<mark>${inner}</mark>` : html`${inner}`;
+    /** The row's text, highlighted whole and then marked. Null (unknown language, or hljs threw)
+     *  renders the segments plain, which is what an unhighlighted file should look like. */
+    private _text(segs: Seg[], lang: string): TemplateResult {
+        const line = segs.map((s) => s.text).join('');
+        const hl = highlightCode(line, lang);
+        if (!hl) {
+            return html`${segs.map((s) => (s.changed ? html`<mark>${s.text}</mark>` : s.text))}`;
+        }
+        return html`${unsafeHTML(markRanges(hl, rangesOf(segs)))}`;
     }
 
     private _row(row: Row, lang: string, numbered: boolean): TemplateResult {
         if (row.kind === 'hunk') {
-            return html`<div class="cv-diff-hunk">@@ ${row.oldNo} ${row.newNo} @@</div>`;
+            return html`<div class="cv-diff-hunk"></div>`;
         }
         const sign = row.kind === 'ins' ? '+' : row.kind === 'del' ? '-' : ' ';
         // One gutter: a '-' exists only in the old file and a '+' only in the new, so every
@@ -59,7 +63,7 @@ export class CvDiffPreview extends LitElement {
         return html`<div class="cv-diff-row cv-diff-${row.kind}">
             ${numbered ? html`<span class="cv-diff-ln">${no ?? ''}</span>` : nothing}
             <span class="cv-diff-sign">${sign}</span>
-            <span class="cv-diff-txt">${row.segs.map((s) => this._seg(s, lang))}</span>
+            <span class="cv-diff-txt">${this._text(row.segs, lang)}</span>
         </div>`;
     }
 
@@ -71,9 +75,12 @@ export class CvDiffPreview extends LitElement {
         // Diffing those is the best available answer, but their line numbers describe the fragment
         // and not the file — so that branch renders without a gutter rather than with a wrong one.
         const fromCli = !!this.patch?.length;
-        const rows = fromCli
+        const all = fromCli
             ? rowsFromHunks(this.patch)
             : buildRows(this.oldString, this.newString, this.filePath, CONTEXT_LINES);
+        // The leading hunk marker separates nothing. Dropped before the slice below, or it would
+        // still spend one of the visible rows.
+        const rows = all[0]?.kind === 'hunk' ? all.slice(1) : all;
         if (!rows.length) {
             return html`<div class="cv-diff-empty">No changes</div>`;
         }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-rewind-dialog.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-rewind-dialog.ts
@@ -112,8 +112,10 @@ export class CvRewindDialog extends CvDialogBase {
                 background: var(--colorNeutralBackground3);
                 font-size: var(--fontSizeBase200);
             }
+            /* A sentence now, not a count, so it wraps and needs the leading. */
             .summary {
                 color: var(--colorNeutralForeground2);
+                line-height: 1.4;
                 margin-bottom: 6px;
             }
             .ins {
@@ -310,7 +312,7 @@ export class CvRewindDialog extends CvDialogBase {
         const files = i.filesChanged ?? [];
         // Every user message is a valid target — that is the CLI's model, not an accident — so a
         // message that changed nothing answers canRewind:true with an empty list. Saying "the code
-        // has not changed" is the answer; "0 files · +0 −0" would look like a failed read.
+        // has not changed" is the answer; a sentence counting zero lines would look like a failed read.
         if (!files.length) {
             return html`<div class="impact muted">
                 The code has not changed since this message, so nothing would be restored.
@@ -318,9 +320,14 @@ export class CvRewindDialog extends CvDialogBase {
         }
         return html`<div class="impact">
             <div class="summary">
-                ${files.length} file${files.length === 1 ? '' : 's'} ·
-                <span class="ins">+${i.insertions}</span>
-                <span class="del">−${i.deletions}</span>
+                <!-- Spelled out, and in the future tense, because these count the rewind rather than
+                     the edits since the checkpoint: the CLI diffs the file on disk *towards* the
+                     snapshot (fileHistory.ts, diffLines(current, backup)), so its deletions are the
+                     lines this button would take away. As "+2 −5" they read as the opposite. -->
+                <span class="del">${i.deletions} line${i.deletions === 1 ? '' : 's'}</span>
+                will be removed and
+                <span class="ins">${i.insertions} line${i.insertions === 1 ? '' : 's'}</span>
+                added across ${files.length} file${files.length === 1 ? '' : 's'}:
             </div>
             <div class="files">
                 ${files.map(

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/diff.css
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/diff.css
@@ -36,14 +36,17 @@ cv-diff-preview {
  * nothing here owns a horizontal scroll. */
 .cv-diff-row {
     display: grid;
-    grid-template-columns: 2.6em 0.9em 1fr;
+    grid-template-columns: 3.4em 0.9em 1fr;
     font-family: var(--fontFamilyMonospace);
     font-size: var(--fontSizeBase200);
     line-height: 1.45;
 }
+/* Four digits plus the padding either side: a number that fills the column
+ * touches the row's left border. */
 .cv-diff-ln {
     color: var(--colorNeutralForeground4);
     text-align: right;
+    padding-left: 0.5em;
     padding-right: 0.5em;
     user-select: none;
 }
@@ -60,27 +63,47 @@ cv-diff-preview {
 .cv-diff-preview-wrap.no-gutter .cv-diff-row {
     grid-template-columns: 0.9em 1fr;
 }
+/* Between two hunks, and only there: the gutter numbers already say where each
+ * one starts, so the separator has nothing to spell out. */
 .cv-diff-hunk {
-    color: var(--colorNeutralForeground4);
-    font-family: var(--fontFamilyMonospace);
-    font-size: var(--fontSizeBase100);
-    padding: 2px 8px;
+    border-top: 1px solid var(--colorNeutralStroke2);
+    margin: 4px 0;
 }
 .cv-diff-more {
     color: var(--colorNeutralForeground4);
     font-size: var(--fontSizeBase100);
     padding: 2px 8px;
 }
-/* Row background says which line changed; <mark> says which piece inside it. */
+/* Row background says which line changed; <mark> says which piece inside it.
+ * Both stay weak, and the gutter takes the row's colour instead: a solid fill
+ * would be a second colour over the syntax highlighting, and the code loses. */
 .cv-diff-ins {
-    background: var(--colorPaletteGreenBackground1);
+    background: color-mix(in srgb, var(--colorPaletteGreenBackground1) 60%, transparent);
+    color: var(--colorPaletteGreenForeground1);
 }
 .cv-diff-del {
-    background: var(--colorPaletteRedBackground1);
+    background: color-mix(in srgb, var(--colorPaletteRedBackground1) 60%, transparent);
+    color: var(--colorPaletteRedForeground1);
 }
-.cv-diff-ins mark,
+.cv-diff-ins .cv-diff-ln,
+.cv-diff-del .cv-diff-ln,
+.cv-diff-ins .cv-diff-sign,
+.cv-diff-del .cv-diff-sign {
+    color: inherit;
+}
+.cv-diff-ins .cv-diff-txt,
+.cv-diff-del .cv-diff-txt {
+    color: var(--colorNeutralForeground1);
+}
+/* Translucent on purpose: an opaque fill hides the token colour underneath, and
+ * the changed word is the one place the highlighting is worth reading. */
+.cv-diff-ins mark {
+    background: color-mix(in srgb, var(--colorPaletteGreenBackground3) 45%, transparent);
+    color: inherit;
+    border-radius: 2px;
+}
 .cv-diff-del mark {
-    background: var(--colorPaletteYellowBackground2);
+    background: color-mix(in srgb, var(--colorPaletteRedBackground3) 40%, transparent);
     color: inherit;
     border-radius: 2px;
 }


### PR DESCRIPTION
## What

Two things in the inline diff preview, and one in the rewind dialog.

### The changed words in a diff keep their syntax colours

`_seg` highlighted each word-diff segment on its own. hljs given `boolean`
alone sees a word, not a keyword, and returns it plain — so the marked text,
the one place worth reading, was the only text in the row without colours.

The highlighter now runs on the whole line, and the new `core/mark-ranges.ts`
lays the marks over that HTML by character offset. It closes and reopens a
`<mark>` around any tag that falls inside it: a mark spanning a `<span>`
boundary nests badly and the browser's recovery moves the text. Entities count
as one character, since that is what the ranges are measured in.

10 unit tests cover the cases that are easy to get wrong — a range inside a
tag, across a tag, over an entity, several disjoint ranges, one running to the
end of the line.

### Row colours

Solid green/red fills plus a yellow `<mark>` meant three colours arguing over
the same line. Now: a weak tint, the line number and sign taking the row's
colour, and a translucent mark that lets the token colour through. Two signals
where there were four, which is also how Claude Code renders it.

The leading `@@ 10 10 @@` is gone: with one hunk it separates nothing, and it
spent one of the twelve visible rows saying so. Between two hunks it is now a
thin rule.

### The rewind dialog read its two counts backwards

`1 file · +2 −5` reads as what changed since the checkpoint. The CLI means the
opposite — `fileHistory.ts` does `diffLines(currentContent, backupContent)`,
diffing the file on disk *towards* the snapshot, so those are the lines the
button is about to add and remove.

Verified against the real `rewind_files` control_request on two checkpoints:

| checkpoint | CLI answers | `diff current backup` |
|---|---|---|
| 1 file  | `+2 −5`   | `+2 −5`   |
| 4 files | `+46 −77` | `+46 −77` |

VS Code words the same two fields as a sentence in the future tense, and this
now matches: *"5 lines will be removed and 2 lines added across 1 file"*.

## Verification

`npm run check` — typecheck, lint, format, 164/164 tests. The 7 lint warnings
are pre-existing in `cv-mic-button.ts`.

Rendering checked by reloading the chat in the Exp instance across several
diffs: multi-digit line numbers, prose-heavy edits, single- and multi-hunk.

## Not covered

The word-diff still marks most of a line when a comment block is rewritten —
it pairs lines that are only loosely related. That is `similarity()` and its
threshold in `diff-rows.ts`, untouched here.
