### PR TITLE
feat(chat): the IN/OUT copy button stops covering the code

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/chat.css
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/chat.css
@@ -448,17 +448,13 @@ body.sticky-user .cv-exchange > cv-message[msg-role="user"]:first-child .cv-mess
 .cv-tool-body-result {
     margin: 0;
 }
-/* Copy button on each IN/OUT cell of the tool body. `cv-copy-btn` is
- * display:contents, so we position its inner button via ::part. The button
- * sits ON TOP of the monospace pre — so it needs an opaque background to
- * mask the text behind it (otherwise the icon overlaps the code). */
+/* Copy button on each IN/OUT cell of the tool body. It shares the label's line
+ * rather than floating over the code: the cell scrolls, and a button anchored
+ * to its top corner leaves the viewport while the text is still being read.
+ * `cv-copy-btn` is display:contents, so its inner button is reached via ::part. */
 .cv-tool-body-copy-btn::part(button) {
-    position: absolute;
-    top: 0;
-    right: 0;
     opacity: 0;
     transition: opacity 0.15s;
-    background: var(--colorNeutralBackground1);
     border-radius: var(--borderRadiusSmall);
 }
 .cv-tool-body-row:hover .cv-tool-body-copy-btn::part(button) {
@@ -616,6 +612,23 @@ body.sticky-user .cv-exchange > cv-message[msg-role="user"]:first-child .cv-mess
 .cv-tool-body-cell {
     position: relative;
     min-width: 0;
+}
+/* The label's line, with the copy button at the far end. margin-left on the
+ * button rather than space-between: a labelless row (Write: the body IS the
+ * file) has only the button, and space-between would leave it on the left.
+ * The button is taller than the 10px label, so the row keeps the label's
+ * height and lets it overflow — otherwise every tool row grows by the
+ * difference. */
+.cv-tool-body-head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    height: 1.2em;
+}
+/* On ::part, not on the host: cv-copy-btn is display:contents, so the button
+ * itself is the flex item and the host has no box to push. */
+.cv-tool-body-head .cv-tool-body-copy-btn::part(button) {
+    margin-left: auto;
 }
 .cv-tool-body-label {
     font-family: var(--fontFamilyMonospace);

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/base.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/base.ts
@@ -389,16 +389,18 @@ export abstract class ToolRenderer {
                                   style="cursor:pointer"
                                   @click=${() => this.host.openOutput('in')}
                               >
-                                  ${
-                                      inLabel
-                                          ? html`<span class="cv-tool-body-label">${inLabel}</span>`
-                                          : nothing
-                                  }
+                                  <div class="cv-tool-body-head">
+                                      ${
+                                          inLabel
+                                              ? html`<span class="cv-tool-body-label"
+                                                    >${inLabel}</span
+                                                >`
+                                              : nothing
+                                      }
+                                      ${copyBtn(inText, 'in')}
+                                  </div>
                                   <div class="cv-tool-body-cell">
-                                      ${cell(inText, this.clipsInput(), highlightAs)}${copyBtn(
-                                          inText,
-                                          'in',
-                                      )}
+                                      ${cell(inText, this.clipsInput(), highlightAs)}
                                   </div>
                               </div>`
                             : nothing
@@ -410,9 +412,12 @@ export abstract class ToolRenderer {
                                   style="cursor:pointer"
                                   @click=${() => this.host.openOutput('out')}
                               >
-                                  <span class="cv-tool-body-label"
-                                      >${this.host.status === 'error' ? 'ERR' : 'OUT'}</span
-                                  >
+                                  <div class="cv-tool-body-head">
+                                      <span class="cv-tool-body-label"
+                                          >${this.host.status === 'error' ? 'ERR' : 'OUT'}</span
+                                      >
+                                      ${copyBtn(outText, 'out')}
+                                  </div>
                                   <div class="cv-tool-body-cell">
                                       <!-- Never highlighted, whatever the IN cell asked for: tool
                                            output is logs and dumps, where colouring guesses at
@@ -422,7 +427,7 @@ export abstract class ToolRenderer {
                                           this.host.clipsOutput ? 'always' : 'preview',
                                           '',
                                           'cv-tool-body-result',
-                                      )}${copyBtn(outText, 'out')}
+                                      )}
                                   </div>
                               </div>`
                             : nothing


### PR DESCRIPTION
## What

The copy button on a tool row's IN/OUT cell was `position: absolute` at the
cell's top-right corner — so it sat on the first line of the very text it
copies, and needed an opaque background to mask the characters behind it. On a
cell long enough to scroll, it left the viewport while the code was still
being read.

The label's line was empty to its right, so the button moves there: same row
as `IN` / `OUT` / `ERR`, aligned to the far end. Nothing overlaps the code any
more, and the button stays put whatever the cell does.

## Notes

- **`margin-left: auto`, not `space-between`** — a labelless row (Write, where
  the body *is* the file) has only the button, and `space-between` would leave
  it stranded on the left.
- **On `::part(button)`, not the host** — `cv-copy-btn` is `display: contents`,
  so the inner button is the flex item; a margin on the host has no box to push.
- **The header keeps the label's height** (`1.2em`) and lets the taller button
  overflow it, so no tool row grows.
- Click-through was already handled: `cv-copy-btn` stops propagation
  (`cv-copy-btn.ts:49`), so copying does not also open the output in VS.

## Verification

`npm run check` — typecheck, lint, format, 164/164 tests. The 7 lint warnings
are pre-existing in `cv-mic-button.ts`.

Checked by reloading the chat in the Exp instance: IN and OUT cells, an ERR
row, a labelless Write row, and a cell long enough to scroll.

## Related

The same complaint about markdown code blocks is a separate open TODO entry
(`docs/internal/TODO.md:1810`) — different component (`.cv-md-copy-btn`), and
there is no header to move the button into, so it needs its own fix.
