### PR TITLE
feat(chat): say when a newer Claude Code has been released

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
@@ -590,6 +590,28 @@ public partial class ChatPaneControl : PaneControlBase
         {
             SetComposerText(_startupPrompt, withIdeContext: !restoreState);
         }
+
+        // Detached from the startup path on purpose: it is a network call, and the chat must open
+        // at the same speed whether the registry answers in 50ms, in five seconds, or never.
+        ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+        {
+            var update = await Core.Client.ClaudeUpdateCheck.CheckAsync();
+            if (update == null) { return; }
+
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            _bridge?.Send(BridgeMessages.ToWebView.Chat.Notice, new Contracts.NoticeNotification
+            {
+                Key = "cli-update",
+                // Info, not warning: nothing is wrong and nothing is blocked — a newer release
+                // exists, which is worth saying once and colouring like a fact.
+                // Sticky all the same: the chat may well be opened and left alone for a while, and
+                // a row that fades after a few seconds is easy to miss entirely.
+                Severity = Contracts.NoticeVariantDto.Info,
+                Sticky = true,
+                Message = $"Claude Code {update.Value.Latest} is available (you have {update.Value.Local})",
+                Position = Contracts.NoticePositionDto.Top,
+            });
+        });
     }
 
     /// <summary>Writes text into the composer. <paramref name="withIdeContext"/> also re-opens the

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeInstall.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeInstall.cs
@@ -6,6 +6,7 @@
 using Corsinvest.VisualStudio.Agents.Options;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 
 namespace Corsinvest.VisualStudio.Agents.Core.Client;
@@ -97,21 +98,44 @@ public static class ClaudeInstall
         if (!string.IsNullOrEmpty(localAppData)) { yield return Path.Combine(localAppData, "npm"); }
     }
 
-    /// <summary>Installed CLI version from the npm package.json next to a node_modules binary
-    /// (<c>bin/claude.exe</c> → <c>../package.json</c>). Returns <c>null</c> for non-npm installs
-    /// (native/WinGet have no package.json) or when the field is missing.</summary>
+    /// <summary>Installed CLI version, or <c>null</c> if the binary can't be found or won't say.
+    ///
+    /// Asks the CLI rather than reading the npm <c>package.json</c> next to it: that manifest only
+    /// exists for an npm install, so the native installer, WinGet and a hand-set
+    /// <c>ClaudeExecutablePath</c> all came back "(unknown)". <c>--version</c> is a documented
+    /// flag and answers whatever the layout. Costs a process start, and the one caller is the
+    /// session-info dialog, opened by hand — no reason to cache it.</summary>
     public static string Version()
     {
         var exe = ResolveExecutable();
         if (exe == null) { return null; }
-        var pkg = Path.Combine(Path.GetDirectoryName(Path.GetDirectoryName(exe)), "package.json");
-        if (!File.Exists(pkg)) { return null; }
         try
         {
-            var json = Newtonsoft.Json.Linq.JObject.Parse(File.ReadAllText(pkg));
-            return (string)json["version"];
+            var psi = new ProcessStartInfo(exe)
+            {
+                Arguments = "--version",
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                StandardOutputEncoding = System.Text.Encoding.UTF8,
+            };
+            using var p = Process.Start(psi);
+            var stdout = p.StandardOutput.ReadToEndAsync();
+            if (!p.WaitForExit(5000))
+            {
+                try { p.Kill(); } catch { /* already gone */ }
+                OutputWindowLogger.Global.Warn("[cli] `claude --version` timed out");
+                return null;
+            }
+            // "2.1.245 (Claude Code)" — the version is the first token.
+            var first = stdout.Result?.Trim().Split(' ')[0];
+            return string.IsNullOrEmpty(first) ? null : first;
         }
-        catch { return null; }
+        catch (Exception ex)
+        {
+            OutputWindowLogger.Global.Warn($"[cli] could not read the CLI version from {exe}: {ex.Message}");
+            return null;
+        }
     }
 
     /// <summary>WPF panel explaining the CLI is not installed, with a button opening the setup page.

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeUpdateCheck.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeUpdateCheck.cs
@@ -1,0 +1,108 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Corsinvest.VisualStudio.Agents.Core.Client;
+
+/// <summary>
+/// <para>
+/// Tells the user a newer Claude Code exists. Only tells: the CLI is not ours, and updating it
+/// under a live session would break that session.
+/// </para>
+/// <para>
+/// The remote truth is the npm registry's dist-tags — the address the user installs from, so it
+/// does not move. The CLI's own updater also reads a GCS bucket holding a bare version string,
+/// which is lighter, but that is an internal detail of their updater and can change with a
+/// refactor of theirs; for a feature that only raises a notice it is not worth the coupling.
+/// </para>
+/// </summary>
+internal static class ClaudeUpdateCheck
+{
+    /// <summary>Just the tags, tens of bytes — as opposed to `/latest`, which answers with the
+    /// whole package.json to read one field out of it. No auth.</summary>
+    private const string DistTagsUrl =
+        "https://registry.npmjs.org/-/package/@anthropic-ai/claude-code/dist-tags";
+
+    /// <summary>`latest` is what `npm i -g` installs. `stable` trails it — comparing against that
+    /// one would announce an "update" to someone already ahead of it.</summary>
+    private const string Tag = "latest";
+
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(5);
+
+    /// <summary>Once per VS, on whichever chat opens first. Not persisted across restarts: the
+    /// user can act on the notice at a moment of their choosing, and telling them again next time
+    /// they start is the reminder. Not per pane either — the second chat of a session would be
+    /// repeating itself.</summary>
+    private static bool _told;
+
+    /// <summary>The newer version to announce, or <c>null</c> when there is nothing to say —
+    /// already current, already told this VS session, offline, unparseable.
+    /// <para>Never throws: a version check must not be able to break the pane that awaits it.</para></summary>
+    public static async Task<(string Latest, string Local)?> CheckAsync()
+    {
+        if (_told) { return null; }
+
+        var local = ClaudeInstall.Version();
+        if (string.IsNullOrEmpty(local)) { return null; }
+
+        var latest = await FetchLatestAsync();
+        if (string.IsNullOrEmpty(latest) || !IsNewer(latest, local)) { return null; }
+
+        _told = true;
+        return (latest, local);
+    }
+
+    private static async Task<string> FetchLatestAsync()
+    {
+        try
+        {
+            // VS runs on .NET Framework, whose default is still SSL3/TLS1.0 — the registry needs 1.2.
+            ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
+            using var http = new HttpClient { Timeout = Timeout };
+            // The registry asks callers to identify themselves; an anonymous one may be throttled.
+            http.DefaultRequestHeaders.Add("User-Agent", $"{AppConstants.AppId}/{BuildInfo.Version}");
+            var json = await http.GetStringAsync(DistTagsUrl);
+            return (string)Newtonsoft.Json.Linq.JObject.Parse(json)[Tag];
+        }
+        catch (Exception ex)
+        {
+            // Offline, proxy, registry down: the user asked for a chat, not for this.
+            OutputWindowLogger.Global.Warn($"[cli] update check failed: {ex.Message}");
+            return null;
+        }
+    }
+
+    /// <summary>SemVer compare on the numeric release, which is all the registry publishes.
+    /// A local build carries `+SHA` build metadata, which SemVer excludes from precedence — and
+    /// anyone running one is not waiting to be told about npm.</summary>
+    private static bool IsNewer(string latest, string local)
+    {
+        var a = Parse(latest);
+        var b = Parse(local);
+        if (a == null || b == null) { return false; }
+        for (var i = 0; i < 3; i++)
+        {
+            if (a[i] != b[i]) { return a[i] > b[i]; }
+        }
+        return false;
+    }
+
+    private static int[] Parse(string version)
+    {
+        // Drop build metadata and pre-release before splitting: "2.1.245+abc" / "2.1.245-beta.1".
+        var core = version.Split('+')[0].Split('-')[0].Split('.');
+        if (core.Length < 3) { return null; }
+        var parts = new int[3];
+        for (var i = 0; i < 3; i++)
+        {
+            if (!int.TryParse(core[i], out parts[i])) { return null; }
+        }
+        return parts;
+    }
+}

--- a/src/Corsinvest.VisualStudio.Agents/Corsinvest.VisualStudio.Agents.csproj
+++ b/src/Corsinvest.VisualStudio.Agents/Corsinvest.VisualStudio.Agents.csproj
@@ -245,6 +245,7 @@
     <Compile Include="Core\Panes\PaneRegistry.cs" />
     <Compile Include="Core\Panes\PaneControlBase.cs" />
     <Compile Include="Core\Client\ClaudeInstall.cs" />
+    <Compile Include="Core\Client\ClaudeUpdateCheck.cs" />
     <Compile Include="Core\Client\ClientMessages.cs" />
     <Compile Include="Core\Client\ClientOptions.cs" />
     <Compile Include="Core\Client\ContextUsage.cs" />


### PR DESCRIPTION
The chat raises a notice at the top when the npm registry has a release newer than the installed CLI.

> Claude Code 2.1.245 is available (you have 2.1.243)

It only says so — never installs. The CLI is not ours, and replacing it under a live session would break that session.

## Behaviour

- **Once per VS**, on whichever chat opens first. Not per pane (the second chat would be repeating itself), not persisted across restarts (the next start is the reminder).
- **Detached from startup**: the pane opens at the same speed whether the registry answers in 50ms, in five seconds, or never.
- **Silent on failure** (`Warn`): offline, proxy, registry down — the user asked for a chat, not for this.
- `Info` severity and sticky, so it does not fade before it is read.

## Why the npm registry

`latest` is the tag compared against: it is what `npm i -g` installs, and `stable` trails it far enough (2.1.231 vs 2.1.245 at the time of writing) to announce an "update" to someone already ahead of it.

The `dist-tags` endpoint answers in tens of bytes, unlike `/latest`, which returns the whole `package.json` to read one field out of it.

The CLI's own updater also reads a GCS bucket holding a bare version string — lighter still, but an internal detail of their updater that can change with a refactor of theirs. The registry is the address users install from, so it does not move.

## The local half was broken

`ClaudeInstall.Version()` walked two directories up from the executable and read the npm `package.json`. That manifest only exists for an npm install: the native installer, WinGet and a hand-set `ClaudeExecutablePath` all reported **"(unknown)"** in the session-info dialog — the common Windows case, and the one the comparison needs most.

It now asks the CLI. `--version` is a documented flag; the directory layout is not. The output is `2.1.245 (Claude Code)`, so the first token is taken. 5s timeout with a kill, and the two `catch`es now `Warn` instead of swallowing, per CLAUDE.md.

No cache: the one caller is the session-info dialog, opened by hand.

## Verification

Built green. Checked in the Exp instance with the CLI downgraded to 2.1.243 against a published 2.1.245 — the notice appears, with the right numbers, and stays until dismissed.

No test project covers this path.
