### PR TITLE
feat(chat): approving a plan asks which mode follows, and the selector keeps up

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.ClientEvents.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.ClientEvents.cs
@@ -41,6 +41,7 @@ public partial class ChatPaneControl
         c.ToolProgressReceived += OnToolProgress;
         c.SystemMessageReceived += OnSystemMessage;
         c.SessionIdChanged += OnSessionIdChanged;
+        c.PermissionModeChanged += OnPermissionModeChanged;
         c.ConversationReset += OnConversationReset;
         c.Error += OnClientError;
         c.ProcessStarted += OnProcessStarted;
@@ -65,6 +66,7 @@ public partial class ChatPaneControl
         c.ToolProgressReceived -= OnToolProgress;
         c.SystemMessageReceived -= OnSystemMessage;
         c.SessionIdChanged -= OnSessionIdChanged;
+        c.PermissionModeChanged -= OnPermissionModeChanged;
         c.Error -= OnClientError;
         c.ProcessStarted -= OnProcessStarted;
         c.ProcessExited -= OnProcessExited;
@@ -192,8 +194,10 @@ public partial class ChatPaneControl
                 {
                     // Empty model → the webview shows "Default"; get_settings usually fills it in.
                     Model = e.Model ?? "",
-                    // The CLI doesn't report permissionMode (it obeys the --permission-mode we passed);
-                    // it's carried on the event, captured at this startup so a respawn can't stale it.
+                    // The startup reply doesn't carry permissionMode — it's ours, passed as
+                    // --permission-mode — so it's read from the client here, captured at this
+                    // startup so a respawn can't stale it. Later changes DO come from the CLI,
+                    // on system/status (OnPermissionModeChanged).
                     PermissionMode = e.PermissionMode ?? "default",
                     EffortLevel = Enum.TryParse<Contracts.EffortLevelDto>(e.EffortLevel, ignoreCase: true, out var lvl) ? lvl : (Contracts.EffortLevelDto?)null,
                     AlwaysThinkingEnabled = e.AlwaysThinkingEnabled,
@@ -776,6 +780,14 @@ public partial class ChatPaneControl
             Entry.ActiveSessionId = id;
             RefreshTitleFromDisk();
         });
+
+    // Same channel the selector already listens on for the ack of its own change: from the
+    // WebView's side there is no difference between "your change went through" and "the CLI
+    // changed it without you".
+    private void OnPermissionModeChanged(object sender, string mode)
+        => Dispatcher.Invoke(() => _bridge?.Send(
+            BridgeMessages.ToWebView.Cli.PermissionModeChanged,
+            new Contracts.PermissionModeChangedNotification { Mode = mode }));
 
     // The CLI reset the conversation (/clear): empty the transcript now. The respawn's
     // StartupAsync re-seeds the UI (OnCliStateReceived); system/init updates the session id.

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/types.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/types.ts
@@ -191,7 +191,11 @@ export type { InitPayloadNotification } from './generated/InitPayloadNotificatio
 // once claude.exe has answered initialize + get_settings.
 export type { CliStateNotification } from './generated/CliStateNotification';
 
-export type PermissionMode = 'default' | 'acceptEdits' | 'plan' | 'auto' | 'bypassPermissions';
+/** The five modes the picker offers. The CLI reports others too (`dontAsk`, and whatever a future
+ *  version adds): they travel as their raw string rather than being coerced into one of these —
+ *  a mode shown wrong is worse than a mode shown ugly. `string & {}` keeps the completions. */
+export type PermissionMode =
+    'default' | 'acceptEdits' | 'plan' | 'auto' | 'bypassPermissions' | (string & {});
 
 // FromWebView input payloads (WebView → C#) — generated from C# (Contracts.*InputDto) by
 // TypeGen. Used to type the bridge.post(...) call sites so a payload that diverges from the

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-permission-banner.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-permission-banner.ts
@@ -8,7 +8,9 @@ import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import LockClosed16Regular from '@fluentui/svg-icons/icons/lock_closed_16_regular.svg';
 import QuestionCircle16Regular from '@fluentui/svg-icons/icons/question_circle_16_regular.svg';
 import Dismiss16Regular from '@fluentui/svg-icons/icons/dismiss_16_regular.svg';
+import ClipboardBulletListLtr16Regular from '@fluentui/svg-icons/icons/clipboard_bullet_list_ltr_16_regular.svg';
 import { iconStyles } from '../styles/shared';
+import { renderMarkdown } from '../../core/markdown';
 import { bridge } from '../../core/bridge';
 import { Msg } from '../../core/bridge-messages';
 import { state as appState } from '../../core/state';
@@ -18,6 +20,8 @@ import type {
     ToolPermissionNotification,
     ToolPermissionCancelNotification,
     RespondPermissionNotification,
+    SetPermissionModeNotification,
+    PermissionMode,
     AskQuestion,
 } from '../../core/types';
 
@@ -45,6 +49,11 @@ interface PermissionSuggestion {
 }
 
 const OTHER = 'Other';
+
+/** The tool the model calls to leave plan mode. Its request is a permission request like any
+ *  other, but the choice is not "may I run this" — it is which mode the session continues in,
+ *  so it gets its own wording (see _renderPlanPermission). */
+const EXIT_PLAN_MODE = 'ExitPlanMode';
 
 /** Scope destinations the "Yes, allow …" choice can cycle through. The order is
  *  narrowest-first, so the least far-reaching scope is the default. Clicking the
@@ -143,6 +152,24 @@ export class CvPermissionBanner extends LitElement {
                 white-space: pre-wrap;
                 max-height: 160px;
                 overflow-y: auto;
+            }
+            /* The plan is prose, not a command: rendered markdown, in the body font, and taller
+               than the command box — it is what the choice is about, so it is worth the room. */
+            #plan-body {
+                font-size: var(--fontSizeBase200);
+                color: var(--colorNeutralForeground2);
+                background: var(--colorNeutralBackground3);
+                border-radius: var(--borderRadiusMedium);
+                padding: 8px 10px;
+                margin-top: 6px;
+                max-height: 40vh;
+                overflow-y: auto;
+            }
+            #plan-body > :first-child {
+                margin-top: 0;
+            }
+            #plan-body > :last-child {
+                margin-bottom: 0;
             }
             /* Short single-line command shown inline: an expander would cost a click for one line. */
             #permission-detail-inline {
@@ -593,6 +620,16 @@ export class CvPermissionBanner extends LitElement {
      *  focus the deny field as the final number. */
     private _numberedActions(): Array<() => void> {
         const p = this._pending;
+        // The plan banner draws its own buttons, so its numbers have to be built the same way
+        // or the keys land on choices that aren't there.
+        if (p?.name === EXIT_PLAN_MODE) {
+            return [
+                () => this._onAcceptPlan('acceptEdits'),
+                () => this._onAcceptPlan('default'),
+                () => this._onDeny(),
+                () => this._focusDenyInput(),
+            ];
+        }
         const suggestion = (p?.permissionSuggestions ?? [])[0];
         const actions: Array<() => void> = [() => this._onAllow()];
         if (suggestion) {
@@ -955,9 +992,12 @@ export class CvPermissionBanner extends LitElement {
      *  For setMode suggestions this is the whole label (no scope cycle). */
     private _suggestionLabel(s: PermissionSuggestion): string {
         if (s.type === 'setMode') {
-            return s.mode === 'acceptEdits'
-                ? 'Yes, allow all edits this session'
-                : 'Yes, and don’t ask again';
+            if (s.mode === 'acceptEdits') {
+                return 'Yes, allow all edits this session';
+            }
+            // `default` asks about every edit again — the opposite of not asking, so it can't
+            // share the wording below.
+            return s.mode === 'default' ? 'Yes, return to normal mode' : 'Yes, and don’t ask again';
         }
         const rule = s.rules?.[0];
         // Prefer the specific rule pattern; fall back to the tool name.
@@ -1019,6 +1059,9 @@ export class CvPermissionBanner extends LitElement {
         }
         if (p.name === 'AskUserQuestion') {
             return this._renderQuestions();
+        }
+        if (p.name === EXIT_PLAN_MODE) {
+            return this._renderPlanPermission(p);
         }
         // At most THREE numbered choices — 1 Yes, 2 "allow … for this project"
         // (the suggestions collapsed into one), 3 No: more rows than that and the
@@ -1104,6 +1147,74 @@ export class CvPermissionBanner extends LitElement {
         );
         this._dismiss();
     };
+
+    /** Accept the plan and continue in `mode`. Two messages, in this order: the mode first, the
+     *  allow second — the turn resumes the moment the tool is allowed, so a mode arriving after
+     *  it would leave the first edit to be judged in plan mode, and blocked.
+     *
+     *  Not `updatedPermissions`: the CLI attaches no permission_suggestions to ExitPlanMode (its
+     *  checkPermissions returns a bare `ask`), and the terminal builds the setMode itself, in a
+     *  component the SDK channel never runs. set_permission_mode is the path the selector already
+     *  uses, so the mode is applied once, by the CLI. */
+    private _onAcceptPlan(mode: PermissionMode): void {
+        if (!this._pending) {
+            return;
+        }
+        // Optimistic, like the selector's own switch: the host echoes back what the CLI really
+        // holds (and system/status confirms it), so a refusal rolls this back.
+        appState.permissionMode = mode;
+        bridge.sendNotification<SetPermissionModeNotification>(
+            Msg.fromWebView.cli.setPermissionMode,
+            { mode },
+        );
+        this._respond(true);
+    }
+
+    /** Leaving plan mode: the question is not "may I run this tool" but which mode the session
+     *  continues in, so both answers are a yes and each says which mode follows. */
+    private _renderPlanPermission(p: ToolPermission) {
+        const plan = typeof p.input?.plan === 'string' ? p.input.plan : '';
+        return html`
+            <div id="permission-area">
+                <div id="permission-header">
+                    ${unsafeHTML(ClipboardBulletListLtr16Regular)}
+                    <span id="permission-title">Accept this plan?</span>
+                </div>
+                ${
+                    plan
+                        ? html`<div id="plan-body">${unsafeHTML(renderMarkdown(plan))}</div>`
+                        : nothing
+                }
+                <div id="permission-buttons">
+                    <fluent-button
+                        appearance="primary"
+                        @click=${() => this._onAcceptPlan('acceptEdits')}
+                    >
+                        <span class="num">1</span> Yes, and auto-accept
+                    </fluent-button>
+                    <fluent-button
+                        appearance="outline"
+                        @click=${() => this._onAcceptPlan('default')}
+                    >
+                        <span class="num">2</span>
+                        <span class="label">Yes, and manually approve edits</span>
+                    </fluent-button>
+                    <fluent-button appearance="outline" @click=${this._onDeny}>
+                        <span class="num">3</span> No, keep planning
+                    </fluent-button>
+                </div>
+                <fluent-textarea
+                    id="permission-deny-input"
+                    appearance="outline"
+                    auto-resize
+                    resize="none"
+                    placeholder="Tell Claude what to do instead…"
+                    @keydown=${this._onDenyInputKey}
+                ></fluent-textarea>
+                <div id="permission-hint">Esc to cancel</div>
+            </div>
+        `;
+    }
 
     /** Interactive AskUserQuestion UI: per-question tabs, radio/checkbox
      *  options, an "Other" free-text option, and a Submit footer. */

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-permission-selector.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-permission-selector.ts
@@ -72,8 +72,10 @@ export class CvPermissionSelector extends LitElement {
         // _models is read so the label re-resolves when the catalogue (and thus the
         // available modes) changes.
         void this._models;
-        const items = permissionItems();
-        const item = items.find((it) => it.value === this._current) ?? items[0];
+        // No fallback to the first item: the CLI can sit in a mode the picker doesn't list
+        // (`dontAsk`, or `auto`/`bypassPermissions` once filtered out), and labelling that
+        // "Manual" would state the opposite of what is in force. The raw value is ugly and true.
+        const item = permissionItems().find((it) => it.value === this._current);
         return html`
             <fluent-button
                 id="perm-trigger"
@@ -84,7 +86,7 @@ export class CvPermissionSelector extends LitElement {
                 @click=${this._onClick}
             >
                 <span class=${this._current === 'bypassPermissions' ? 'danger' : ''}
-                    >${item.short}</span
+                    >${item?.short ?? this._current}</span
                 >
             </fluent-button>
             <!-- The name of the control, not of the mode: three of the five modes are shown in full

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/init.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/init.ts
@@ -188,12 +188,14 @@ function wireBridgeHandlers(): void {
     });
 
     // Both selectors switch optimistically and the host echoes back what the CLI really holds —
-    // on success the same value, on failure the previous one, which rolls the UI back.
+    // on success the same value, on failure the previous one, which rolls the UI back. The
+    // permission one also arrives unprompted, when the CLI changes mode by itself (a plan
+    // approved, Shift+Tab from a remote terminal): same message, no caller waiting for it.
     bridge.onNotification<PermissionModeChangedNotification>(
         Msg.toWebView.cli.permissionModeChanged,
         (data) => {
             if (data?.mode) {
-                state.permissionMode = data.mode as PermissionMode;
+                state.permissionMode = data.mode;
             }
         },
     );

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/renderers.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/renderers.ts
@@ -360,10 +360,39 @@ export class EnterPlanModeRenderer extends HeaderOnlyRenderer {
     }
 }
 
-export class ExitPlanModeRenderer extends HeaderOnlyRenderer {
+export class ExitPlanModeRenderer extends ToolRenderer {
     readonly name = 'ExitPlanMode';
+    /** Same shape as Ask: the outcome IS the body, so no chevron — and nothing to show
+     *  while the banner is still up. */
+    override row(): TemplateResult {
+        const done = this.host.status !== 'pending';
+        return this.chrome({
+            body: done ? this.outcomeBody() : null,
+            open: done,
+            onClick: null,
+            chevron: false,
+        });
+    }
     override header(): TemplateResult {
-        return html`${this.nameSpan('ExitPlanMode')}`;
+        return html`${this.nameSpan("Claude's Plan")}`;
+    }
+    /** What the user decided, in the Ask answer's shape: a chip for the question, the
+     *  choice next to it. The plan itself was read in the banner and is in the approved-plan
+     *  message that follows — repeating it here would say the same thing three times. */
+    private outcomeBody(): TemplateResult {
+        const approved = this.host.status !== 'error';
+        return html`
+            <div class="cv-tool-body">
+                <div class="cv-question-list cv-question-compact">
+                    <div class="cv-question-answer">
+                        <span class="cv-question-chip">Plan</span>
+                        <span class="cv-question-answer-val"
+                            >${approved ? 'Approved' : 'Kept planning'}</span
+                        >
+                    </div>
+                </div>
+            </div>
+        `;
     }
 }
 

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.Protocol.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.Protocol.cs
@@ -334,6 +334,26 @@ internal sealed partial class ClaudeClient
                     break;
                 }
 
+            // Every mutation of the CLI's permission mode is announced here — the ExitPlanMode
+            // dialog approving a plan, Shift+Tab or /plan from a remote terminal, a rewind, our own
+            // set_permission_mode: the CLI registers a single listener on the mode diff, so no path
+            // escapes it. Approving a plan is the case that bites: the CLI leaves `plan` for
+            // acceptEdits by itself, and the selector would keep reading "Plan" while files are
+            // written. `break`, not `return`: the pane reads the same subtype for the compacting
+            // spinner. A change of ours arrives here after the ack already wrote the field, so the
+            // guard below keeps it silent.
+            case ClientMessages.SystemSubtype.Status:
+                {
+                    var mode = obj.Val("permissionMode");
+                    if (!string.IsNullOrEmpty(mode) && mode != PermissionMode)
+                    {
+                        _log.Debug(() => $"[client] permission mode {PermissionMode} → {mode}");
+                        PermissionMode = mode;
+                        PermissionModeChanged?.Invoke(this, mode);
+                    }
+                    break;
+                }
+
             case ClientMessages.SystemSubtype.BridgeState:
                 // Whole payload: the state values and the reconnect sequence are read from the
                 // CLI's source, never observed on the wire, and the event may carry fields we

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.cs
@@ -79,6 +79,7 @@ internal sealed partial class ClaudeClient : IClaudeClient
     public event EventHandler<ToolProgressEventArgs> ToolProgressReceived;
     public event EventHandler<JObject> SystemMessageReceived;
     public event EventHandler<string> SessionIdChanged;
+    public event EventHandler<string> PermissionModeChanged;
     /// <summary>The CLI reset the conversation (/clear). Arg = new_conversation_id.
     /// A fresh system/init with the new session_id follows.</summary>
     public event EventHandler<string> ConversationReset;

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/IClaudeClient.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/IClaudeClient.cs
@@ -131,6 +131,9 @@ public interface IClaudeClient : IDisposable
     event EventHandler<ToolProgressEventArgs> ToolProgressReceived;
     event EventHandler<JObject> SystemMessageReceived;
     event EventHandler<string> SessionIdChanged;
+    /// <summary>The CLI moved to another permission mode on its own: a plan approved from the
+    /// ExitPlanMode dialog, Shift+Tab or /plan from a remote terminal, a rewind. Arg = the new mode.</summary>
+    event EventHandler<string> PermissionModeChanged;
     event EventHandler<string> ConversationReset;
     event EventHandler<string> Error;
     event EventHandler<ProcessStartedEventArgs> ProcessStarted;


### PR DESCRIPTION
Leaving plan mode changes the permission mode, and neither half of that was visible.

Approve a plan and the selector kept reading **Plan** while files were being written — the one lie that control can't afford. And the banner offered a single "Yes" that let the CLI choose the mode by itself: measured, it chooses `auto`.

## The message was already there

The CLI announces every mode change on `system` / `subtype:"status"`:

```json
{ "type": "system", "subtype": "status", "status": null,
  "permissionMode": "acceptEdits", "uuid": "…", "session_id": "…" }
```

One listener on its side covers Shift+Tab, the ExitPlanMode dialog, `/plan`, rewind and our own `set_permission_mode`. `HandleSystem` had no case for it, so the field reached the pane and was thrown away — while a comment claimed *"The CLI doesn't report permissionMode"*, true only of the startup reply.

The client now reads it, the same way it already follows the CLI on `model_refusal_fallback`, and the pane forwards it on the channel the selector already listens to. No new message, no new DTO.

## The plan banner

`ExitPlanMode` gets its own branch in the permission banner, next to the one `AskUserQuestion` has: **"Accept this plan?"**, the plan rendered as markdown, and the three choices the terminal offers.

| button | sends |
| --- | --- |
| 1 · Yes, and auto-accept | `set_permission_mode: acceptEdits`, then `allow` |
| 2 · Yes, and manually approve edits | `set_permission_mode: default`, then `allow` |
| 3 · No, keep planning | `deny` — stays in `plan` |

**The order matters**: the turn resumes the moment the tool is permitted, so a mode arriving after it would leave the first edit judged in plan mode, and blocked.

**Why two messages and not `updatedPermissions`**: `ExitPlanModeV2Tool.checkPermissions` returns a bare `ask` with no `suggestions` — confirmed in the source and then on the wire. The terminal builds the `setMode` inside a React dialog the SDK channel never runs; VS Code, for the same reason, calls `set_permission_mode` too.

The transcript row now says what was decided — "Claude's Plan" with **Approved** or **Kept planning**, in the shape Ask uses for its answers.

## Two fixes found along the way

- A `setMode: default` suggestion was labelled *"Yes, and don't ask again"* — the opposite of what it does. Now "Yes, return to normal mode".
- The selector fell back to the first item for a mode it doesn't list (`dontAsk`, or `auto`/`bypassPermissions` once filtered out), showing **Manual** for a mode that is anything but. It now shows the raw value: ugly and true beats pretty and wrong on a control that decides whether a command runs unattended.

## Verification

No test project — MSBuild green, plus the wire measured in the Exp instance against CLI 2.1.245:

- **button 1** → `acceptEdits` acked, `status` confirms it, and the following `Write` goes through **without** a `can_use_tool`.
- **button 2** → `default` acked, `status` confirms it, and the following `Write` **does** ask.
- No later `status` overrides either — the `auto` the CLI picks on its own only happens when nothing tells it otherwise.
- A change made from the selector still logs one line, not two (the guard absorbs the echo), and compaction still shows "Compacting…" — the new case `break`s instead of `return`ing, so the pane keeps seeing the message.
