### PR TITLE
feat(chat): the spinner shows the answer growing, and drops the random verb

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-spinner.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-spinner.ts
@@ -4,9 +4,15 @@
  */
 import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
-import type { SpinnerVerbsConfigDto } from '../../core/types';
-import { formatDurationSec } from '../helpers/format';
+import type {
+    AssistantTextDeltaNotification,
+    SpinnerVerbsConfigDto,
+    ThinkingDeltaNotification,
+} from '../../core/types';
+import { formatDurationSec, formatTokens } from '../helpers/format';
 import { onTick, type UnsubscribeTick } from '../../core/tick';
+import { bridge } from '../../core/bridge';
+import { Msg } from '../../core/bridge-messages';
 
 // Verbs the spinner cycles; replace/extend via setVerbsConfig at runtime.
 const DEFAULT_VERBS: readonly string[] = [
@@ -83,6 +89,12 @@ const DEFAULT_VERBS: readonly string[] = [
     'Polishing',
 ];
 
+/** Show the cycling verb next to the frame. Off: the animation already says "working", and a
+ *  word that changes every few seconds draws the eye without telling anyone anything — the
+ *  elapsed time does that better. A known status (Compacting) still gets its label either way.
+ *  The pool and its CLI config stay wired up: flip this back to true to have them again. */
+const SHOW_RANDOM_VERBS = false;
+
 const STAR_GROW = ['·', '✢', '✳', '✶', '✻', '✽'];
 const FRAMES: readonly string[] = [...STAR_GROW, ...[...STAR_GROW].reverse()];
 const FRAME_INTERVAL_MS = 120;
@@ -115,8 +127,9 @@ function pickRandomVerb(): string {
 }
 
 /**
- * Working indicator: cycles a braille frame ~120ms, randomises the verb
- * every few seconds. Timers cleared in disconnectedCallback (no leaks).
+ * Working indicator: cycles a braille frame ~120ms plus the elapsed seconds, and a label for a
+ * known CLI status (Compacting). The random verb is behind SHOW_RANDOM_VERBS, off today.
+ * Timers cleared in disconnectedCallback (no leaks).
  *
  *   <cv-spinner></cv-spinner>
  */
@@ -132,27 +145,39 @@ export class CvSpinner extends LitElement {
             color: var(--colorNeutralForeground3);
             font-size: 12px;
         }
+        /* Brand blue: with no verb beside it the frame is the only thing saying "still
+           working", so it takes the accent rather than sitting in the muted body colour. */
         .icon {
             font-size: 14px;
             line-height: 1;
             display: inline-block;
             width: 16px;
             text-align: center;
+            color: var(--colorBrandBackground);
         }
+        /* The min-width reserves room for the longest verb, so the elapsed time doesn't jitter
+           left and right as the word changes. Only worth it while a word is actually there. */
         .text {
             font-size: 12px;
             opacity: 0.8;
             min-width: 120px;
         }
-        .elapsed {
+        .elapsed,
+        .tokens {
             font-size: 12px;
             opacity: 0.6;
             font-variant-numeric: tabular-nums;
         }
+        /* The wrap's gap already separates the row's parts; this pulls the count back towards the
+           seconds so the two read as one figure rather than as two unrelated badges. */
+        .tokens {
+            margin-left: -2px;
+        }
     `;
 
-    /** Raw CLI work status (appState.status). Known values map to a fixed label that overrides the
-     *  random verb; anything else (incl. "") falls back to the random working verb. */
+    /** Raw CLI work status (appState.status). Known values get a fixed label; anything else
+     *  (incl. "") leaves the frame to speak for itself — or falls back to the random verb
+     *  while SHOW_RANDOM_VERBS is on. */
     @property() status = '';
 
     /** Map a known CLI status to its spinner label. Add entries here as new statuses appear. */
@@ -163,14 +188,47 @@ export class CvSpinner extends LitElement {
     @state() private _frame = FRAMES[0];
     @state() private _verb = pickRandomVerb();
     @state() private _elapsedSec = 0;
+    /** Characters of answer text received so far this turn, turned into tokens at render. An
+     *  estimate, and deliberately so: the real count only exists once a model call is finished
+     *  (`message_delta`), which would leave the number frozen through the whole of a long answer.
+     *  The CLI's own spinner does the same (`responseLengthRef.current / 4`). Lives here for the
+     *  same reason the elapsed seconds do — born with the turn, dead with it, no reset needed. */
+    @state() private _answerChars = 0;
+    /** Thinking tokens, which the API DOES report as it goes (`estimated_tokens` on some
+     *  thinking_delta frames). Added to the estimate above: both are output the user is waiting on. */
+    @state() private _thinkingTokens = 0;
 
     private _frameTimer = 0;
     private _verbTimer = 0;
+    private _offs: Array<() => void> = [];
     private _unsubscribeTick?: UnsubscribeTick;
     private _startedAt = 0;
 
     override connectedCallback(): void {
         super.connectedCallback();
+        // Main thread only (parentToolUseId null): a sub-agent's own output is its chip's business,
+        // and counting it here would make the number jump for work this line isn't measuring.
+        this._offs.push(
+            bridge.onNotification<AssistantTextDeltaNotification>(
+                Msg.toWebView.chat.assistantTextDelta,
+                (d) => {
+                    if (d?.parentToolUseId) {
+                        return;
+                    }
+                    this._answerChars += d?.text?.length ?? 0;
+                },
+            ),
+            bridge.onNotification<ThinkingDeltaNotification>(
+                Msg.toWebView.chat.thinkingDelta,
+                (d) => {
+                    // -1 marks a frame that carries no estimate; most of them don't.
+                    if (d?.parentToolUseId || !d || d.estimatedTokens < 0) {
+                        return;
+                    }
+                    this._thinkingTokens += d.estimatedTokens;
+                },
+            ),
+        );
         let i = 0;
         // The frames stay on their own timer: at 120ms they are an animation, and rounding them to
         // the shared second would turn the spinner into a stutter.
@@ -196,11 +254,18 @@ export class CvSpinner extends LitElement {
         super.disconnectedCallback();
         clearInterval(this._frameTimer);
         clearTimeout(this._verbTimer);
+        this._offs.forEach((off) => off());
+        this._offs = [];
         this._unsubscribeTick?.();
         this._unsubscribeTick = undefined;
     }
 
     private _scheduleNextVerb(): void {
+        // Nothing reads _verb while the flag is off — re-rolling it would be a timer per pane
+        // waking up to change something invisible.
+        if (!SHOW_RANDOM_VERBS) {
+            return;
+        }
         const delay = VERB_MIN_MS + Math.random() * (VERB_MAX_MS - VERB_MIN_MS);
         this._verbTimer = window.setTimeout(() => {
             this._verb = pickRandomVerb();
@@ -215,11 +280,21 @@ export class CvSpinner extends LitElement {
             this._elapsedSec > 0
                 ? html`<span class="elapsed">${formatDurationSec(this._elapsedSec)}</span>`
                 : nothing;
+        // A known status always speaks; the random verb only when the flag lets it.
+        const label = CvSpinner.STATUS_LABELS[this.status] || (SHOW_RANDOM_VERBS ? this._verb : '');
+        // ~4 chars per token, the ratio the CLI's own spinner uses. An estimate: the exact figure
+        // arrives only when a model call ends, and waiting for it would leave this frozen for the
+        // whole of a long answer — the one moment it has something to say.
+        const estimated = Math.round(this._answerChars / 4) + this._thinkingTokens;
+        // After the seconds: the time is what the eye checks first, and this only starts moving
+        // once the model writes. `↓` for output, like the end-of-turn row and the CLI.
+        const tokens = estimated
+            ? html`<span class="tokens">↓ ${formatTokens(estimated)} tok</span>`
+            : nothing;
         return html`
             <div class="wrap">
                 <span class="icon">${this._frame}</span>
-                <span class="text">${CvSpinner.STATUS_LABELS[this.status] || this._verb}…</span>
-                ${elapsed}
+                ${label ? html`<span class="text">${label}…</span>` : nothing} ${elapsed}${tokens}
             </div>
         `;
     }


### PR DESCRIPTION
Three changes to the one line that speaks while a turn runs — all in `cv-spinner.ts`.

## A live token count

`✳ 14s ↓ 1.2k tok`

The exact figure only exists once a model call has finished (`message_delta`), which would leave the number frozen through the whole of a long answer — the one moment it has something to say. So:

| part | source | exact? |
| --- | --- | --- |
| answer text | characters from `chat_assistant_text_delta`, `/ 4` | estimated |
| thinking | `estimatedTokens` on `chat_thinking_delta` | reported by the API |

`~4 chars per token` is the ratio the CLI's own spinner uses (`SpinnerAnimationRow.tsx:160`: `Math.round(responseLengthRef.current / 4)`). Sub-agent deltas are skipped by `parentToolUseId`: their work belongs to their chip, and counting it here would make the line jump for something it isn't measuring.

The estimate is rough on code, where tokens are shorter than in prose. The exact total is one row below, in the end-of-turn figures, and this never contradicts it — it just gets there first.

**Measured**: "ciao" → 4 tok while the answer is still being written. Before, the number only appeared once the turn was over.

## The cycling verb is off

"Spelunking…" changing every few seconds drew the eye without telling anyone anything, and the elapsed time already answers the question it pretended to.

It sits behind `SHOW_RANDOM_VERBS` rather than being deleted — the verb pool, `setVerbsConfig` and the CLI's own config stay wired up, so flipping one constant brings it back.

Two details:
- **A known status still speaks.** Compaction can run long, and "Compacting…" is the difference between a wait that is explained and one that isn't. It comes from `STATUS_LABELS`, independent of the flag.
- **The verb timer returns early** when the flag is off, so a pane isn't waking up every 2–5s to change a value nothing reads.

## The frame is brand blue

With no word beside it, the frame is the only thing saying "still working", so it takes `--colorBrandBackground` instead of sitting in the muted body colour.

---

WebView only — no C#, so no VSIX reinstall: reloading the chat is enough. Typecheck, lint and prettier clean.
