### PR TITLE
fix(chat): an edit header always shows both change counts

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/base.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/base.ts
@@ -474,8 +474,8 @@ export abstract class ToolRenderer {
         if (!added && !removed) {
             return html`Modified`;
         }
-        return html`${added ? html`<span class="cv-diff-count-ins">+${added}</span>` : nothing}
-        ${removed ? html`<span class="cv-diff-count-del">−${removed}</span>` : nothing}`;
+        return html`<span class="cv-diff-count-ins">+${added}</span>
+            <span class="cv-diff-count-del">−${removed}</span>`;
     }
 
     /** Everything in the header's action slot: the error button — an invariant of a failed row,


### PR DESCRIPTION
## What

An edit row header showed only the non-zero side of the change count: a
deletions-only edit read `-20` with no `+0`, an additions-only one `+3`
alone. Both spans are now always rendered.

## Why

`diffSummary` in `ui/tool-renderers/base.ts` rendered each side behind a
truthiness check. The "both zero" case already returns `Modified` from an
earlier guard, so past that point at least one side is non-zero -- the
zero that vanished was information, not noise: it said the file had not
grown at all, which the reader otherwise had to infer from an absence.

## Verification

- `npm run typecheck` - clean
- `npm run lint` - 0 errors (7 pre-existing `no-explicit-any` warnings, unrelated)
- `npm run format` - applied
- `npm run build` - bundle built
