### PR TITLE
fix(debug): say why a breakpoint line was refused, and where one landed

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.Dtos.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.Dtos.cs
@@ -35,6 +35,13 @@ internal sealed partial class IdeDebugService
         /// session, where nothing has bound yet and 0 would read as a failure. 0 during a session
         /// means the breakpoint will not stop anything. Only set by the breakpoint tools.</summary>
         public int? Bound { get; set; }
+
+        /// <summary>Where the breakpoint landed. For a file breakpoint that is always the line asked
+        /// for — VS rejects a line it can't use rather than moving it — but for a function breakpoint
+        /// it is the only way the caller learns which file and line the name resolved to. A null line
+        /// means unresolved, which in design mode is normal. Only set by the breakpoint tools.</summary>
+        public string File { get; set; }
+        public int? Line { get; set; }
     }
 
     /// <summary>One breakpoint in the solution (file/line OR function, plus condition/enabled).</summary>

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.cs
@@ -278,6 +278,34 @@ internal sealed partial class IdeDebugService
         }
     }
 
+    /// <summary>Where the breakpoints just created by Breakpoints.Add actually sit. Falls back to
+    /// what was requested when the collection can't be read, so a failure here never turns a
+    /// breakpoint that VS did create into a reported failure — at worst the caller loses the
+    /// warning about a moved line. Must be called on the UI thread.</summary>
+    private static (string File, int? Line) LandedAt(Breakpoints added, string requestedFile)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        try
+        {
+            // One Add can produce several breakpoints (the same file/line in more than one project,
+            // e.g. a multi-targeted or shared-source project). They share the line, so the first
+            // answers "which line" for all of them; the count is the binding's business, not ours.
+            foreach (Breakpoint bp in added)
+            {
+                // FileLine is 0 for a function breakpoint the name has not resolved yet (the normal
+                // state in design mode). 0 is not a line: report it as "unknown", not as line zero.
+                return (string.IsNullOrEmpty(bp.File) ? requestedFile : bp.File,
+                        bp.FileLine > 0 ? bp.FileLine : (int?)null);
+            }
+            return (requestedFile, null);
+        }
+        catch (Exception ex)
+        {
+            OutputWindowLogger.Global.Warn($"[debug] could not read where a breakpoint landed: {ex.Message}");
+            return (requestedFile, null);
+        }
+    }
+
     private static int CountHits(Breakpoint bp)
     {
         ThreadHelper.ThrowIfNotOnUIThread();
@@ -354,7 +382,7 @@ internal sealed partial class IdeDebugService
             if (hitError != null) { return new DebugResult { Ok = false, Reason = hitError }; }
 
             var hasCond = !string.IsNullOrWhiteSpace(condition);
-            dbg.Breakpoints.Add(
+            var added = dbg.Breakpoints.Add(
                 Function: "",
                 File: filePath,
                 Line: line,
@@ -367,7 +395,35 @@ internal sealed partial class IdeDebugService
                 Address: "",
                 HitCount: Math.Max(0, hitCount),
                 HitCountType: hitType);
-            return new DebugResult { Ok = true, Mode = ModeToString(dbg.CurrentMode) };
+
+            // Report the line back so the caller can reason about the breakpoint it got rather than
+            // the one it asked for. Measured: for a file breakpoint the two always match — VS
+            // rejects a line it cannot use (see the catch) instead of moving it elsewhere.
+            var (landedFile, landedLine) = LandedAt(added, filePath);
+            return new DebugResult
+            {
+                Ok = true,
+                Mode = ModeToString(dbg.CurrentMode),
+                File = landedFile,
+                Line = landedLine,
+            };
+        }
+        // The one failure the caller can act on: VS refuses a line it cannot put a breakpoint on
+        // (blank, comment, a type declaration) instead of moving it to the next executable one.
+        // Under the generic message below it read as "the debugger is broken", when the fix is to
+        // pick another line. VS's own text is localized, so it goes to the log, not into Reason.
+        // Measured, against the obvious guess: a method's opening brace IS accepted — it carries the
+        // entry sequence point — and so is an expression-bodied member.
+        catch (System.Runtime.InteropServices.COMException ex)
+        {
+            OutputWindowLogger.Global.Warn(
+                $"[debug] breakpoint refused at {filePath}:{line}: {ex.Message}");
+            return new DebugResult
+            {
+                Ok = false,
+                Reason = $"Visual Studio will not put a breakpoint on line {line}: it has no " +
+                         "executable code. Pick a line with a statement on it.",
+            };
         }
         catch (Exception ex)
         {
@@ -396,7 +452,7 @@ internal sealed partial class IdeDebugService
             if (hitError != null) { return new DebugResult { Ok = false, Reason = hitError }; }
 
             var hasCond = !string.IsNullOrWhiteSpace(condition);
-            dbg.Breakpoints.Add(
+            var added = dbg.Breakpoints.Add(
                 Function: functionName,
                 File: "",
                 Line: 1,
@@ -409,7 +465,18 @@ internal sealed partial class IdeDebugService
                 Address: "",
                 HitCount: Math.Max(0, hitCount),
                 HitCountType: hitType);
-            return new DebugResult { Ok = true, Mode = ModeToString(dbg.CurrentMode) };
+
+            // Which file and line the name resolved to — the caller asked by name and has no other
+            // way to learn where it landed, and an overload or a same-named method in another type
+            // is exactly the case worth seeing. Both stay null until symbols load.
+            var (landedFile, landedLine) = LandedAt(added, null);
+            return new DebugResult
+            {
+                Ok = true,
+                Mode = ModeToString(dbg.CurrentMode),
+                File = landedFile,
+                Line = landedLine,
+            };
         }
         catch (Exception ex)
         {

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/SetBreakpointTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/SetBreakpointTool.cs
@@ -42,9 +42,12 @@ internal sealed class SetBreakpointTool : McpTool<SetBreakpointArgs>
         "— the way to stop on the 500th iteration of a loop without a counter variable to test. " +
         "Works whether or not a debug session is running. Combine with debug_start + " +
         "debug_get_state to pause execution at this point. " +
-        "Accepting the line does not mean the debugger can stop on it: binding happens later, and a " +
-        "line with no executable code binds to nothing. debug_list_breakpoints reports bound once " +
-        "the session is running, which is where \"why did it never stop\" gets answered.";
+        "A line with no executable code (blank, comment, a type declaration) is refused, not moved: " +
+        "ok=false and the reason says so, so retry on a line that has a statement. A method's " +
+        "opening brace is fine — it carries the entry sequence point. " +
+        "Accepting the line does not mean the debugger can stop on it either: binding happens later. " +
+        "debug_list_breakpoints reports bound once the session is running, which is where " +
+        "\"why did it never stop\" gets answered.";
 
     public override bool Idempotent => true;
 
@@ -52,6 +55,6 @@ internal sealed class SetBreakpointTool : McpTool<SetBreakpointArgs>
     {
         var r = await IdeDebugService.Instance.SetBreakpointAsync(
             args.FilePath, args.Line, args.Condition, args.HitCount, args.HitCountType);
-        return new { ok = r.Ok, mode = r.Mode, reason = r.Reason };
+        return new { ok = r.Ok, mode = r.Mode, reason = r.Reason, file = r.File, line = r.Line };
     }
 }

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/SetFunctionBreakpointTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/SetFunctionBreakpointTool.cs
@@ -43,7 +43,11 @@ internal sealed class SetFunctionBreakpointTool : McpTool<SetFunctionBreakpointA
         "session that will hit it. " +
         "A name that matches nothing is accepted just the same — it stays unresolved instead of " +
         "failing. debug_list_breakpoints reports bound once the session is running: 0 there means " +
-        "the name never matched, so check the spelling or how the type is qualified.";
+        "the name never matched, so check the spelling or how the type is qualified. " +
+        "The returned file and line say where the name resolved to, which is worth checking when the " +
+        "name is unqualified and an overload or a same-named method in another type could have " +
+        "matched. Both are null before a session is running: the name only resolves once symbols " +
+        "are loaded, so a null there is not a failure.";
 
     public override bool Idempotent => true;
 
@@ -51,6 +55,6 @@ internal sealed class SetFunctionBreakpointTool : McpTool<SetFunctionBreakpointA
     {
         var r = await IdeDebugService.Instance.SetFunctionBreakpointAsync(
             args.FunctionName, args.Condition, args.HitCount, args.HitCountType);
-        return new { ok = r.Ok, mode = r.Mode, reason = r.Reason };
+        return new { ok = r.Ok, mode = r.Mode, reason = r.Reason, file = r.File, line = r.Line };
     }
 }


### PR DESCRIPTION
## What

`debug_set_breakpoint` on a line with no executable code answered with a bare
`"Failed to set breakpoint."`. It now says which line was refused and why, and both
breakpoint tools return the `file` and `line` the breakpoint landed on.

## Why

`Breakpoints.Add` raises a `COMException` for a line that cannot hold a breakpoint,
and that exception carries the real reason. The generic catch replaced it with a
message that told the caller nothing: a bad line and a broken debugger looked
identical, and nothing hinted that retrying one line down would work. VS's own text
is localized, so it goes to the log and the caller gets our English reason.

The returned `file`/`line` matter most for `debug_set_function_breakpoint`: asking by
name, the caller had no way to learn where the name resolved, which is exactly the
case worth seeing when the name is unqualified and an overload could have matched.
A `FileLine` of 0 (unresolved -- the normal state in design mode) is reported as
`null`, since zero is not a line.

## Verification

Driven through the CLI against the extension in the experimental instance, on a real
file (`Calcolatrice.cs`):

| line | content | result |
|---|---|---|
| 15 | blank | `ok:false` + the new reason |
| 1 | class declaration | `ok:false` + the new reason |
| 3 | `=> a + b` (expression-bodied) | `ok:true`, line 3 |
| 10 | method's opening brace | `ok:true`, line 10 |
| 16 | `return a / b;` | `ok:true`, line 16 |

`debug_list_breakpoints` agrees with every line reported. The function breakpoint
returns `file:null, line:null` in design mode instead of the previous `line:0`.

Two things the test corrected, and the code now reflects: VS **refuses** a line it
cannot use rather than sliding the breakpoint down to the next one, and a method's
opening brace **is** accepted -- it carries the entry sequence point.

`msbuild` Debug is green (built through the IDE).
