### PR TITLE
fix(chat): keep the active permission mode in the picker, and name the modes once

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/permission-modes.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/permission-modes.ts
@@ -14,6 +14,7 @@ import Flash20Regular from '@fluentui/svg-icons/icons/flash_20_regular.svg';
 import ShieldDismiss20Regular from '@fluentui/svg-icons/icons/shield_dismiss_20_regular.svg';
 import { state as appState } from './state';
 import { resolveModelValue } from './ai-models';
+import { PERMISSION_MODE } from './types';
 import type { PermissionMode } from './types';
 
 export interface PermissionItem {
@@ -32,14 +33,14 @@ export const PERMISSION_ITEMS: PermissionItem[] = [
     // the spare width is better spent on the limits of each mode (verified in the CLI:
     // acceptEdits only auto-approves writes inside the working directory).
     {
-        value: 'default',
+        value: PERMISSION_MODE.default,
         label: 'Manual',
         short: 'Manual',
         description: 'Every edit and command waits for your approval',
         icon: HandRight20Regular,
     },
     {
-        value: 'acceptEdits',
+        value: PERMISSION_MODE.acceptEdits,
         label: 'Edit automatically',
         short: 'Auto-edit',
         description:
@@ -47,21 +48,21 @@ export const PERMISSION_ITEMS: PermissionItem[] = [
         icon: Code20Regular,
     },
     {
-        value: 'plan',
+        value: PERMISSION_MODE.plan,
         label: 'Plan',
         short: 'Plan',
         description: 'Reads and explores freely, then proposes a plan — no file is changed',
         icon: ClipboardBulletListLtr20Regular,
     },
     {
-        value: 'auto',
+        value: PERMISSION_MODE.auto,
         label: 'Auto',
         short: 'Auto',
         description: 'Decides per task when to act and when to ask, based on how risky it is',
         icon: Flash20Regular,
     },
     {
-        value: 'bypassPermissions',
+        value: PERMISSION_MODE.bypassPermissions,
         label: 'Bypass permissions',
         short: 'Bypass',
         description: 'Nothing is ever asked, including commands that can destroy data',
@@ -71,21 +72,24 @@ export const PERMISSION_ITEMS: PermissionItem[] = [
 
 /** Gate the optional modes: `auto` only when the current model supports it,
  *  `bypassPermissions` only when the option is enabled. Before the model catalogue
- *  arrives, keep `auto` shown. */
+ *  arrives we cannot know, and the two ways to be wrong are not equal: offering `auto`
+ *  to a model that refuses it makes the row vanish from under the cursor, while hiding
+ *  it costs nothing the user notices — unless it is the mode they are already in, which
+ *  is why that one case keeps it. */
 export function permissionItems(): PermissionItem[] {
     const value = resolveModelValue(appState.currentModel);
     const m = appState.models.find((x) => x.value === value);
-    const autoOk = m ? m.supportsAutoMode : true;
+    const autoOk = m ? m.supportsAutoMode : appState.permissionMode === PERMISSION_MODE.auto;
     // Two gates: our own VS option AND the CLI's effective settings — an org can
     // forbid the mode via managed settings. Without the second one we would offer a mode the CLI
     // then refuses. Note the different sources: `ui.*` is a VS Option, the other is CLI state.
     const bypassOk =
         appState.ui.allowDangerouslySkipPermissions && !appState.bypassPermissionsDisabled;
     return PERMISSION_ITEMS.filter((it) => {
-        if (it.value === 'auto') {
+        if (it.value === PERMISSION_MODE.auto) {
             return autoOk;
         }
-        if (it.value === 'bypassPermissions') {
+        if (it.value === PERMISSION_MODE.bypassPermissions) {
             return bypassOk;
         }
         return true;

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/state.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/state.ts
@@ -19,6 +19,7 @@ import type {
     Theme,
     VsOptionsDto,
 } from './types';
+import { PERMISSION_MODE } from './types';
 
 interface AppState {
     workingDirectory: string;
@@ -164,7 +165,7 @@ type Store<T extends object> = T & { on: OnFn<T> };
 const _impl = new StoreImpl<AppState>({
     workingDirectory: '',
     currentModel: null,
-    permissionMode: 'default',
+    permissionMode: PERMISSION_MODE.default,
     slashCommands: [],
     theme: 'dark',
     effortLevel: 'high',

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/types.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/types.ts
@@ -197,6 +197,17 @@ export type { CliStateNotification } from './generated/CliStateNotification';
 export type PermissionMode =
     'default' | 'acceptEdits' | 'plan' | 'auto' | 'bypassPermissions' | (string & {});
 
+/** The mode names as values. `string & {}` in the type above means a typo still compiles, so a
+ *  comparison written by hand is unchecked — these give the compiler something to check. The
+ *  strings are the CLI's, not ours: renaming one here renames nothing on the wire. */
+export const PERMISSION_MODE = {
+    default: 'default',
+    acceptEdits: 'acceptEdits',
+    plan: 'plan',
+    auto: 'auto',
+    bypassPermissions: 'bypassPermissions',
+} as const satisfies Record<string, PermissionMode>;
+
 // FromWebView input payloads (WebView → C#) — generated from C# (Contracts.*InputDto) by
 // TypeGen. Used to type the bridge.post(...) call sites so a payload that diverges from the
 // C# DTO fails at compile time. Opposite direction of the ToWebView DTOs above.

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-permission-banner.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-permission-banner.ts
@@ -15,6 +15,7 @@ import { bridge } from '../../core/bridge';
 import { Msg } from '../../core/bridge-messages';
 import { state as appState } from '../../core/state';
 import { PermissionQueue } from '../../core/permission-queue';
+import { PERMISSION_MODE } from '../../core/types';
 import type {
     ToolResultNotification,
     ToolPermissionNotification,
@@ -624,8 +625,8 @@ export class CvPermissionBanner extends LitElement {
         // or the keys land on choices that aren't there.
         if (p?.name === EXIT_PLAN_MODE) {
             return [
-                () => this._onAcceptPlan('acceptEdits'),
-                () => this._onAcceptPlan('default'),
+                () => this._onAcceptPlan(PERMISSION_MODE.acceptEdits),
+                () => this._onAcceptPlan(PERMISSION_MODE.default),
                 () => this._onDeny(),
                 () => this._focusDenyInput(),
             ];
@@ -992,12 +993,14 @@ export class CvPermissionBanner extends LitElement {
      *  For setMode suggestions this is the whole label (no scope cycle). */
     private _suggestionLabel(s: PermissionSuggestion): string {
         if (s.type === 'setMode') {
-            if (s.mode === 'acceptEdits') {
+            if (s.mode === PERMISSION_MODE.acceptEdits) {
                 return 'Yes, allow all edits this session';
             }
             // `default` asks about every edit again — the opposite of not asking, so it can't
             // share the wording below.
-            return s.mode === 'default' ? 'Yes, return to normal mode' : 'Yes, and don’t ask again';
+            return s.mode === PERMISSION_MODE.default
+                ? 'Yes, return to normal mode'
+                : 'Yes, and don’t ask again';
         }
         const rule = s.rules?.[0];
         // Prefer the specific rule pattern; fall back to the tool name.
@@ -1188,13 +1191,13 @@ export class CvPermissionBanner extends LitElement {
                 <div id="permission-buttons">
                     <fluent-button
                         appearance="primary"
-                        @click=${() => this._onAcceptPlan('acceptEdits')}
+                        @click=${() => this._onAcceptPlan(PERMISSION_MODE.acceptEdits)}
                     >
                         <span class="num">1</span> Yes, and auto-accept
                     </fluent-button>
                     <fluent-button
                         appearance="outline"
-                        @click=${() => this._onAcceptPlan('default')}
+                        @click=${() => this._onAcceptPlan(PERMISSION_MODE.default)}
                     >
                         <span class="num">2</span>
                         <span class="label">Yes, and manually approve edits</span>

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-permission-selector.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-permission-selector.ts
@@ -7,6 +7,7 @@ import { customElement, state } from 'lit/decorators.js';
 import { state as appState } from '../../core/state';
 import { tooltipStyles } from '../styles/shared';
 import type { PermissionMode } from '../../core/types';
+import { PERMISSION_MODE } from '../../core/types';
 import { permissionItems } from '../../core/permission-modes';
 
 /**
@@ -85,7 +86,7 @@ export class CvPermissionSelector extends LitElement {
                 size="small"
                 @click=${this._onClick}
             >
-                <span class=${this._current === 'bypassPermissions' ? 'danger' : ''}
+                <span class=${this._current === PERMISSION_MODE.bypassPermissions ? 'danger' : ''}
                     >${item?.short ?? this._current}</span
                 >
             </fluent-button>

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/init.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/init.ts
@@ -9,6 +9,7 @@ import { bridge } from '../core/bridge';
 import { Msg } from '../core/bridge-messages';
 import { state } from '../core/state';
 import type { IdeContextNotification } from '../core/types';
+import { PERMISSION_MODE } from '../core/types';
 import { normPath } from '../core/path';
 import { closeTopDialog } from '../core/dialog-focus';
 import { setExtraLinkableExtensions } from '../core/file-links';
@@ -92,7 +93,7 @@ function wireBridgeHandlers(): void {
             return;
         }
         state.currentModel = c.model;
-        state.permissionMode = (c.permissionMode as PermissionMode) || 'default';
+        state.permissionMode = (c.permissionMode as PermissionMode) || PERMISSION_MODE.default;
         if (c.effortLevel) {
             state.effortLevel = c.effortLevel;
         }


### PR DESCRIPTION
Two changes to the permission-mode picker, in the same place.

## The active mode no longer disappears

`permissionItems()` gated `auto` on `supportsAutoMode`, falling back to "show it"
whenever the model catalogue had not arrived yet. If the model then turned out not
to support the mode, the row vanished from a menu the user was already reading.

Before the catalogue arrives we still cannot know, but the two ways to be wrong are
not equal: hiding a row nobody was looking for costs nothing, while taking away the
mode currently in use does. The fallback now keeps `auto` only when it is already the
active mode — the same rule the VS Code extension applies through its three-state
`autoModeAvailability`.

## The mode names live in one place

The five names were written as bare string literals across six files. `PermissionMode`
ends in `(string & {})` — deliberately, so a mode the CLI adds later travels as its own
string instead of being coerced into one of ours — which means every hand-written
comparison is unchecked and a typo compiles.

`PERMISSION_MODE` in `types.ts` gives the compiler something to check, with `satisfies`
keeping each value at its literal type rather than widening it back to `PermissionMode`.
The strings remain the CLI's: renaming one here renames nothing on the wire.

Deliberately left as literals:

- the model id `'default'` in `ai-models.ts` and the `'plan'`/`'auto'` command aliases —
  unrelated names that only look the same
- the `[data-permission-mode='...']` CSS selectors in `cv-prompt.ts`, which no
  TypeScript constant can reach

## Verification

`npm run typecheck` clean, `npm run lint` 0 errors (7 pre-existing `no-explicit-any`
warnings, unrelated), `npm run format` applied, `npm run build` green.

The refactor is behaviour-preserving — the strings on the wire are unchanged. The `auto`
gate change is a real behaviour change, in a window that lasts until the catalogue
arrives; it needs a look in the experimental instance rather than a green build, since
this path has no automated tests.
