### PR TITLE
test(host): unit tests for the parts that fail without saying so

### DIFF
--- a/cv4vs-agents.sln
+++ b/cv4vs-agents.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
-VisualStudioVersion = 18.8.12021.73 stable
+VisualStudioVersion = 18.8.12021.73
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Corsinvest.VisualStudio.Agents", "src\Corsinvest.VisualStudio.Agents\Corsinvest.VisualStudio.Agents.csproj", "{D1E2F3A4-B5C6-7890-DEFA-AB1234567890}"
 EndProject
@@ -12,6 +12,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Corsinvest.VisualStudio.Agents.Contracts", "src\Corsinvest.VisualStudio.Agents.Contracts\Corsinvest.VisualStudio.Agents.Contracts.csproj", "{E617149F-E368-4C8B-B430-132D2F4CD298}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Corsinvest.VisualStudio.Agents.Tests", "tests\Corsinvest.VisualStudio.Agents.Tests\Corsinvest.VisualStudio.Agents.Tests.csproj", "{65105A61-0FA6-AE69-C838-0CD5B8E9CBBA}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{83F7F5CE-D7E6-4583-AEF3-CF70C67CF45C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -47,6 +51,18 @@ Global
 		{E617149F-E368-4C8B-B430-132D2F4CD298}.Release|x64.Build.0 = Release|Any CPU
 		{E617149F-E368-4C8B-B430-132D2F4CD298}.Release|x86.ActiveCfg = Release|Any CPU
 		{E617149F-E368-4C8B-B430-132D2F4CD298}.Release|x86.Build.0 = Release|Any CPU
+		{65105A61-0FA6-AE69-C838-0CD5B8E9CBBA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{65105A61-0FA6-AE69-C838-0CD5B8E9CBBA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{65105A61-0FA6-AE69-C838-0CD5B8E9CBBA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{65105A61-0FA6-AE69-C838-0CD5B8E9CBBA}.Debug|x64.Build.0 = Debug|Any CPU
+		{65105A61-0FA6-AE69-C838-0CD5B8E9CBBA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{65105A61-0FA6-AE69-C838-0CD5B8E9CBBA}.Debug|x86.Build.0 = Debug|Any CPU
+		{65105A61-0FA6-AE69-C838-0CD5B8E9CBBA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{65105A61-0FA6-AE69-C838-0CD5B8E9CBBA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{65105A61-0FA6-AE69-C838-0CD5B8E9CBBA}.Release|x64.ActiveCfg = Release|Any CPU
+		{65105A61-0FA6-AE69-C838-0CD5B8E9CBBA}.Release|x64.Build.0 = Release|Any CPU
+		{65105A61-0FA6-AE69-C838-0CD5B8E9CBBA}.Release|x86.ActiveCfg = Release|Any CPU
+		{65105A61-0FA6-AE69-C838-0CD5B8E9CBBA}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -54,5 +70,9 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{D1E2F3A4-B5C6-7890-DEFA-AB1234567890} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{E617149F-E368-4C8B-B430-132D2F4CD298} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{65105A61-0FA6-AE69-C838-0CD5B8E9CBBA} = {83F7F5CE-D7E6-4583-AEF3-CF70C67CF45C}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {D59AFC20-DC73-41DA-A9E2-ACCB70465AB9}
 	EndGlobalSection
 EndGlobal

--- a/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.cs
@@ -214,7 +214,7 @@ internal sealed partial class SessionManager(ClaudePaths paths, string workingDi
     /// <summary>True when the line's top-level "type" equals <paramref name="type"/>. Goes through
     /// FindJsonStringValue rather than matching a literal '"type":"x"' so a writer that pretty-prints
     /// (space after the colon) is read the same as the CLI's compact output.</summary>
-    private static bool IsType(string line, string type)
+    internal static bool IsType(string line, string type)
         => string.Equals(FindJsonStringValue(line, "type"), type, StringComparison.Ordinal);
 
     /// <summary>The field, when the line is of the wanted type. Takes the type the caller already

--- a/src/Corsinvest.VisualStudio.Agents/Corsinvest.VisualStudio.Agents.csproj
+++ b/src/Corsinvest.VisualStudio.Agents/Corsinvest.VisualStudio.Agents.csproj
@@ -120,6 +120,8 @@
          the VSIX (Private=True) since the DTOs are used at runtime. -->
     <ProjectReference Include="..\Corsinvest.VisualStudio.Agents.Contracts\Corsinvest.VisualStudio.Agents.Contracts.csproj">
       <Private>True</Private>
+      <Project>{E617149F-E368-4C8B-B430-132D2F4CD298}</Project>
+      <Name>Corsinvest.VisualStudio.Agents.Contracts</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Corsinvest.VisualStudio.Agents/Options/AgentsOptions.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Options/AgentsOptions.cs
@@ -15,15 +15,33 @@ public static class AgentsOptions
 
     internal static void RaiseApplied() => Applied?.Invoke();
 
-    public static AgentsGeneralPage General =>
-        Get<AgentsGeneralPage>() ?? new AgentsGeneralPage();
+    public static AgentsGeneralPage General => Get<AgentsGeneralPage>();
 
-    public static AgentsChatPage Chat =>
-        Get<AgentsChatPage>() ?? new AgentsChatPage();
+    public static AgentsChatPage Chat => Get<AgentsChatPage>();
 
-    public static AgentsDebugPage Debug =>
-        Get<AgentsDebugPage>() ?? new AgentsDebugPage();
+    public static AgentsDebugPage Debug => Get<AgentsDebugPage>();
 
-    private static T Get<T>() where T : Microsoft.VisualStudio.Shell.DialogPage =>
-        AgentsPackage.Instance?.GetDialogPage(typeof(T)) as T;
+    /// <summary>The live page when the package has one, otherwise a defaults-only stand-in.
+    /// <para>Never null: all 23 call sites read a property straight off these, on paths where a
+    /// missing setting must degrade to its default rather than throw.</para></summary>
+    private static T Get<T>() where T : Microsoft.VisualStudio.Shell.DialogPage, new()
+        => AgentsPackage.Instance?.GetDialogPage(typeof(T)) is T live ? live : Defaults<T>.Instance;
+
+    /// <summary>The stand-in, built once per page type.
+    /// <para>A <see cref="Microsoft.VisualStudio.Shell.DialogPage"/> constructor reaches through
+    /// ThreadHelper.JoinableTaskContext to the global service provider, which exists only when
+    /// Visual Studio is the host process. In a unit test that throws FileNotFoundException on
+    /// Microsoft.Internal.VisualStudio.Interop — so the construction is guarded, and what is handed
+    /// back instead is an instance whose property initialisers never ran: LogLevel.None and
+    /// EnablePerfLog false, which is what an unconfigured page would have said anyway.</para></summary>
+    private static class Defaults<T> where T : Microsoft.VisualStudio.Shell.DialogPage, new()
+    {
+        public static readonly T Instance = Build();
+
+        private static T Build()
+        {
+            try { return new T(); }
+            catch { return (T)System.Runtime.Serialization.FormatterServices.GetUninitializedObject(typeof(T)); }
+        }
+    }
 }

--- a/src/Corsinvest.VisualStudio.Agents/Properties/AssemblyInfo.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Properties/AssemblyInfo.cs
@@ -4,8 +4,13 @@
  */
 
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Windows;
+
+// The UI-free logic worth testing (the .jsonl scan, StatsAggregator, the path helpers) is internal,
+// and making it public to be reachable would widen the surface for one consumer that ships to nobody.
+[assembly: InternalsVisibleTo("Corsinvest.VisualStudio.Agents.Tests")]
 
 // Custom WPF controls (Core/Controls) resolve their default ControlTemplate from Themes/Generic.xaml
 // in this assembly. Required for CvExpander's chevron template to load.

--- a/tests/Corsinvest.VisualStudio.Agents.Tests/ClaudePathsTests.cs
+++ b/tests/Corsinvest.VisualStudio.Agents.Tests/ClaudePathsTests.cs
@@ -1,0 +1,50 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using System.IO;
+using Xunit;
+
+namespace Corsinvest.VisualStudio.Agents.Tests;
+
+/// <summary>Where the CLI's files live.
+/// <para><see cref="ClaudePaths.ProjectFolderName"/> mirrors a rule that belongs to the CLI, not to
+/// us: it resolves the cwd and replaces every non-alphanumeric character with a dash. Drift here
+/// does not throw — it points at a folder that does not exist, and the session list comes back
+/// empty as though the project had never been used.</para></summary>
+public class ClaudePathsTests
+{
+    [Theory]
+    // Every non-alphanumeric becomes a dash, case PRESERVED — including the dot in a username,
+    // which is the case that makes this look wrong until you check the CLI does the same.
+    [InlineData(@"C:\Users\jane.doe", "C--Users-jane-doe")]
+    [InlineData(@"C:\proj\demo", "C--proj-demo")]
+    [InlineData(@"K:\source\repos\OpenSource\cv4vs-agents", "K--source-repos-OpenSource-cv4vs-agents")]
+    // Existing dashes and digits survive; spaces do not.
+    [InlineData(@"C:\my-proj2\sub dir", "C--my-proj2-sub-dir")]
+    public void ProjectFolderName_mirrors_the_CLI_folder_naming(string workingDirectory, string expected)
+        => Assert.Equal(expected, ClaudePaths.ProjectFolderName(workingDirectory));
+
+    [Fact]
+    public void ProjectFolderName_resolves_a_relative_path_first()
+    {
+        // The CLI names the folder after the ABSOLUTE cwd, so a relative input must be resolved
+        // before the replace — otherwise the same project gets two folders.
+        var expected = ClaudePaths.ProjectFolderName(Directory.GetCurrentDirectory());
+
+        Assert.Equal(expected, ClaudePaths.ProjectFolderName("."));
+    }
+
+    [Fact]
+    public void The_folders_hang_off_the_config_dir_it_was_given()
+    {
+        var paths = new ClaudePaths(@"C:\cfg\claude");
+
+        Assert.Equal(@"C:\cfg\claude", paths.ClaudeFolder);
+        Assert.Equal(@"C:\cfg\claude\settings.json", paths.SettingsFile);
+        Assert.Equal(@"C:\cfg\claude\projects", paths.ProjectsFolder);
+        Assert.Equal(@"C:\cfg\claude\ide", paths.IdeFolder);
+        Assert.Equal(@"C:\cfg\claude\file-history", paths.FileHistoryFolder);
+    }
+}

--- a/tests/Corsinvest.VisualStudio.Agents.Tests/ContentBlockTranslatorTests.cs
+++ b/tests/Corsinvest.VisualStudio.Agents.Tests/ContentBlockTranslatorTests.cs
@@ -1,0 +1,198 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using Corsinvest.VisualStudio.Agents.Chat;
+using Corsinvest.VisualStudio.Agents.Chat.Host;
+using Corsinvest.VisualStudio.Agents.Contracts;
+using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Corsinvest.VisualStudio.Agents.Tests;
+
+/// <summary>Turning wire content blocks into what the WebView renders.
+/// <para>The failures here are all of the same kind: the chat still renders, just wrong. A block
+/// type nobody handles disappears without a trace, and usage attached to the wrong block makes the
+/// context gauge count one turn several times.</para></summary>
+public class ContentBlockTranslatorTests
+{
+    /// <summary>Collects what the translator emitted, in order.</summary>
+    private sealed class Sent
+    {
+        public List<(string Channel, object Payload)> All { get; } = [];
+
+        public void Send(string channel, object payload) => All.Add((channel, payload));
+
+        public IEnumerable<T> Of<T>() => All.Select(x => x.Payload).OfType<T>();
+    }
+
+    private static JArray Blocks(params JObject[] blocks) => new(blocks.Cast<object>().ToArray());
+
+    private static JObject Text(string text) => new()
+    {
+        ["type"] = "text",
+        ["text"] = text,
+    };
+
+    private static JObject ToolUse(string type, string id, string name) => new()
+    {
+        ["type"] = type,
+        ["id"] = id,
+        ["name"] = name,
+        ["input"] = new JObject { ["file_path"] = @"C:\proj\demo\Program.cs" },
+    };
+
+    private static JObject Usage(int input, int output, int cacheRead = 0, int cacheCreation = 0) => new()
+    {
+        ["input_tokens"] = input,
+        ["output_tokens"] = output,
+        ["cache_read_input_tokens"] = cacheRead,
+        ["cache_creation_input_tokens"] = cacheCreation,
+    };
+
+    [Fact]
+    public void EmitAssistant_turns_a_text_block_into_one_message()
+    {
+        var sent = new Sent();
+
+        ContentBlockTranslator.EmitAssistant(Blocks(Text("hello")), sent.Send, uuid: "a1");
+
+        var text = Assert.Single(sent.Of<AssistantTextNotification>());
+        Assert.Equal("hello", text.Text);
+        Assert.Equal("a1", text.Uuid);
+    }
+
+    [Fact]
+    public void EmitAssistant_gives_every_block_of_a_message_the_same_uuid()
+    {
+        // The uuid names the MESSAGE, not the block: the WebView groups by it.
+        var sent = new Sent();
+
+        ContentBlockTranslator.EmitAssistant(
+            Blocks(Text("one"), Text("two"), Text("three")), sent.Send, uuid: "a1");
+
+        Assert.All(sent.Of<AssistantTextNotification>(), t => Assert.Equal("a1", t.Uuid));
+    }
+
+    [Fact]
+    public void EmitAssistant_attaches_usage_to_the_first_block_only()
+    {
+        // The gauge adds up what it receives, so usage repeated on each block counts the turn twice.
+        var sent = new Sent();
+
+        ContentBlockTranslator.EmitAssistant(
+            Blocks(Text("one"), Text("two")), sent.Send, usage: Usage(100, 50));
+
+        var texts = sent.Of<AssistantTextNotification>().ToList();
+        Assert.Equal(2, texts.Count);
+        Assert.NotNull(texts[0].Usage);
+        Assert.Equal(100, texts[0].Usage.InputTokens);
+        Assert.Equal(50, texts[0].Usage.OutputTokens);
+        Assert.Null(texts[1].Usage);
+    }
+
+    [Fact]
+    public void EmitAssistant_reads_every_token_field_of_the_usage()
+    {
+        var sent = new Sent();
+
+        ContentBlockTranslator.EmitAssistant(
+            Blocks(Text("hi")), sent.Send, usage: Usage(10, 20, cacheRead: 30, cacheCreation: 40));
+
+        var usage = Assert.Single(sent.Of<AssistantTextNotification>()).Usage;
+        Assert.Equal(10, usage.InputTokens);
+        Assert.Equal(20, usage.OutputTokens);
+        Assert.Equal(30, usage.CacheReadTokens);
+        Assert.Equal(40, usage.CacheCreationTokens);
+    }
+
+    [Fact]
+    public void EmitAssistant_sends_no_usage_when_the_turn_carried_none()
+    {
+        var sent = new Sent();
+
+        ContentBlockTranslator.EmitAssistant(Blocks(Text("hi")), sent.Send);
+
+        Assert.Null(Assert.Single(sent.Of<AssistantTextNotification>()).Usage);
+    }
+
+    [Theory]
+    // All three carry the same {id,name,input} shape, so all three render as a tool row. Handling
+    // only "tool_use" would drop a web_search or an MCP call from the transcript silently.
+    [InlineData("tool_use")]
+    [InlineData("server_tool_use")]
+    [InlineData("mcp_tool_use")]
+    public void EmitAssistant_renders_every_tool_use_shape_as_a_tool_row(string type)
+    {
+        var sent = new Sent();
+
+        ContentBlockTranslator.EmitAssistant(
+            Blocks(ToolUse(type, "t1", "Read")), sent.Send);
+
+        Assert.Single(sent.Of<ToolPermissionNotification>());
+    }
+
+    [Fact]
+    public void EmitAssistant_moves_usage_onto_a_leading_tool_use_too()
+    {
+        // "First block of the turn" is about position, not about being text.
+        var sent = new Sent();
+
+        ContentBlockTranslator.EmitAssistant(
+            Blocks(ToolUse("tool_use", "t1", "Read"), Text("after")), sent.Send, usage: Usage(7, 3));
+
+        Assert.NotNull(Assert.Single(sent.Of<ToolPermissionNotification>()).Usage);
+        Assert.Null(Assert.Single(sent.Of<AssistantTextNotification>()).Usage);
+    }
+
+    [Fact]
+    public void EmitAssistant_closes_a_thinking_block_so_the_label_stops_streaming()
+    {
+        var sent = new Sent();
+
+        ContentBlockTranslator.EmitAssistant(
+            Blocks(new JObject { ["type"] = "thinking", ["thinking"] = "..." }), sent.Send);
+
+        var ended = Assert.Single(sent.Of<ThinkingEndedNotification>());
+        Assert.False(ended.Redacted);
+    }
+
+    [Fact]
+    public void EmitAssistant_marks_a_redacted_thinking_block_as_redacted()
+    {
+        // Cipher-only, no text to show: the WebView renders a static box rather than an empty one.
+        var sent = new Sent();
+
+        ContentBlockTranslator.EmitAssistant(
+            Blocks(new JObject { ["type"] = "redacted_thinking", ["data"] = "cipher" }), sent.Send);
+
+        Assert.True(Assert.Single(sent.Of<ThinkingEndedNotification>()).Redacted);
+    }
+
+    [Fact]
+    public void EmitAssistant_ignores_content_that_is_not_a_block_array()
+    {
+        // Assistant content is always an array in practice; anything else is bailed on rather than
+        // guessed at.
+        var sent = new Sent();
+
+        ContentBlockTranslator.EmitAssistant(JValue.CreateString("bare string"), sent.Send);
+
+        Assert.Empty(sent.All);
+    }
+
+    [Fact]
+    public void EmitAssistant_carries_the_error_onto_the_message()
+    {
+        // What colours the red dot on the bubble.
+        var sent = new Sent();
+
+        ContentBlockTranslator.EmitAssistant(
+            Blocks(Text("API Error: 529")), sent.Send, error: "overloaded");
+
+        Assert.Equal("overloaded", Assert.Single(sent.Of<AssistantTextNotification>()).Error);
+    }
+}

--- a/tests/Corsinvest.VisualStudio.Agents.Tests/Corsinvest.VisualStudio.Agents.Tests.csproj
+++ b/tests/Corsinvest.VisualStudio.Agents.Tests/Corsinvest.VisualStudio.Agents.Tests.csproj
@@ -1,0 +1,63 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Unit tests for the UI-free parts of the host: the .jsonl scan, StatsAggregator, the path
+    helpers. Deliberately OUTSIDE src/ and glob-based: the extension's own .csproj is legacy-style
+    with explicit <Compile> items, and a glob project living inside that tree invites the two
+    conventions to be confused.
+
+    net48 to match the assembly under test. Not packed, not shipped: the VSIX references the
+    extension, never this.
+  -->
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>disable</Nullable>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Corsinvest.VisualStudio.Agents.Tests</RootNamespace>
+    <!-- The extension project is a VSIX; nothing here should try to deploy one. -->
+    <DeployExtension>false</DeployExtension>
+    <!-- MSB3277: the extension drags in the VS SDK's own assemblies, several of which ship in more
+         than one version. VS itself resolves them at runtime and these tests never load them —
+         they exercise string and path helpers. Left on, the conflict list is hundreds of lines and
+         buries anything real, which is the failure mode the threading warnings already demonstrate. -->
+    <MSBuildWarningsAsMessages>MSB3277</MSBuildWarningsAsMessages>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <!-- 13.0.1 exactly: the version VS forces at runtime, so the tests read the DTOs through the
+         same Newtonsoft the extension will actually get. A higher one throws MissingMethodException
+         in the IDE (CLAUDE.md), and a test passing against a version that never ships proves nothing. -->
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+
+  <!--
+    The assembly under test, NOT a ProjectReference. The extension is a legacy-style VSIX whose
+    dependencies come from packages.config + <HintPath>; asking the modern SDK to rebuild it
+    resolves none of them and buries the run in CS0246 for JObject, DTE2 and CoreWebView2*.
+    Referencing what MSBuild already produced tests the shipped assembly and leaves the build of
+    the extension to the one tool that knows how to do it.
+
+    So: msbuild (or build_solution) first, dotnet test second. That order IS the gate.
+  -->
+  <ItemGroup>
+    <Reference Include="Corsinvest.VisualStudio.Agents">
+      <HintPath>..\..\src\Corsinvest.VisualStudio.Agents\bin\$(Configuration)\Corsinvest.VisualStudio.Agents.dll</HintPath>
+      <Private>true</Private>
+    </Reference>
+  </ItemGroup>
+
+  <!-- The wire DTOs. A ProjectReference would be fine here — this one is SDK-style and builds on
+       its own — but it is read from the same output folder as the assembly above so both always
+       come from the one build, rather than from two that could be a compile apart. -->
+  <ItemGroup>
+    <Reference Include="Corsinvest.VisualStudio.Agents.Contracts">
+      <HintPath>..\..\src\Corsinvest.VisualStudio.Agents\bin\$(Configuration)\Corsinvest.VisualStudio.Agents.Contracts.dll</HintPath>
+      <Private>true</Private>
+    </Reference>
+  </ItemGroup>
+
+</Project>

--- a/tests/Corsinvest.VisualStudio.Agents.Tests/HistoryReaderTests.cs
+++ b/tests/Corsinvest.VisualStudio.Agents.Tests/HistoryReaderTests.cs
@@ -1,0 +1,237 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Corsinvest.VisualStudio.Agents.Tests;
+
+/// <summary>The .jsonl readers, against a transcript on disk.
+/// <para>The Compact/Pretty pairs are the point of the file: the scan matches on strings for speed,
+/// so a writer that puts a space after the colon must be read identically. That rule is stated in
+/// CLAUDE.md and enforced by nothing else.</para></summary>
+public class HistoryReaderTests
+{
+    private static List<JObject> Conversation() =>
+    [
+        Jsonl.UserPrompt("u1", "first question"),
+        Jsonl.Assistant("a1", "first answer", "u1"),
+        Jsonl.UserPrompt("u2", "second question", "a1"),
+        Jsonl.Assistant("a2", "second answer", "u2"),
+        Jsonl.UserPrompt("u3", "third question", "a2"),
+        Jsonl.Assistant("a3", "third answer", "u3"),
+    ];
+
+    [Fact]
+    public void ReadHistoryRaw_returns_the_messages_oldest_first()
+    {
+        using var fx = SessionFixture.Compact(Conversation());
+
+        var page = fx.Manager().ReadHistoryRaw(fx.SessionId);
+
+        Assert.Equal(6, page.Messages.Count);
+        Assert.Equal("u1", page.Messages[0]["uuid"]?.Value<string>());
+        Assert.Equal("a3", page.Messages[5]["uuid"]?.Value<string>());
+    }
+
+    [Fact]
+    public void ReadHistoryRaw_reads_a_pretty_printed_transcript_the_same_way()
+    {
+        var conversation = Conversation();
+        using var compact = SessionFixture.Compact(conversation);
+        using var pretty = SessionFixture.Pretty(conversation);
+
+        var fromCompact = compact.Manager().ReadHistoryRaw(compact.SessionId);
+        var fromPretty = pretty.Manager().ReadHistoryRaw(pretty.SessionId);
+
+        Assert.Equal(fromCompact.Messages.Count, fromPretty.Messages.Count);
+        Assert.Equal(
+            fromCompact.Messages.Select(m => m["uuid"]?.Value<string>()),
+            fromPretty.Messages.Select(m => m["uuid"]?.Value<string>()));
+    }
+
+    [Fact]
+    public void ReadHistoryRaw_on_a_session_that_does_not_exist_is_empty_not_a_throw()
+    {
+        using var fx = SessionFixture.Compact(Conversation());
+
+        var page = fx.Manager().ReadHistoryRaw("11111111-2222-3333-4444-555555555555");
+
+        Assert.Empty(page.Messages);
+        Assert.Equal(-1, page.OldestOffset);
+    }
+
+    [Theory]
+    // A traversal token must not reach Path.Combine: it degrades to "no such session", never to
+    // whatever the walked-to path happens to hold.
+    [InlineData("../../etc/passwd")]
+    [InlineData(@"..\..\windows\system32\config")]
+    [InlineData("..")]
+    public void ReadHistoryRaw_refuses_a_traversal_id(string hostileId)
+    {
+        using var fx = SessionFixture.Compact(Conversation());
+
+        var page = fx.Manager().ReadHistoryRaw(hostileId);
+
+        Assert.Empty(page.Messages);
+    }
+
+    [Fact]
+    public void ReadHistoryRaw_pages_backwards_without_losing_or_repeating_a_message()
+    {
+        using var fx = SessionFixture.Compact(Conversation());
+        var mgr = fx.Manager();
+
+        // Two at a time, walking back from the end.
+        var first = mgr.ReadHistoryRaw(fx.SessionId, 2, -1, out var info);
+        Assert.Equal(2, first.Messages.Count);
+        Assert.True(first.HasMore);
+        Assert.NotNull(info);
+
+        var second = mgr.ReadHistoryRaw(fx.SessionId, 2, first.OldestOffset, out _);
+        Assert.Equal(2, second.Messages.Count);
+
+        var third = mgr.ReadHistoryRaw(fx.SessionId, 2, second.OldestOffset, out _);
+        Assert.Equal(2, third.Messages.Count);
+        Assert.False(third.HasMore);
+
+        // Every uuid exactly once, and in order once the pages are stitched back together.
+        var seen = third.Messages.Concat(second.Messages).Concat(first.Messages)
+                        .Select(m => m["uuid"]?.Value<string>()).ToList();
+        Assert.Equal(new[] { "u1", "a1", "u2", "a2", "u3", "a3" }, seen);
+    }
+
+    [Fact]
+    public void ReadHistoryRaw_walks_a_transcript_larger_than_one_64KB_chunk()
+    {
+        // The reverse read works in 64 KB chunks and prepends older ones so a split never lands
+        // mid-line. Padding each answer pushes the conversation well past one chunk, so the first
+        // and last messages sit in different chunks - where an off-by-one on the boundary shows.
+        var padding = new string('x', 4096);
+        var lines = new List<JObject>();
+        for (int i = 0; i < 40; i++)
+        {
+            lines.Add(Jsonl.UserPrompt($"u{i}", $"question {i}"));
+            lines.Add(Jsonl.Assistant($"a{i}", $"answer {i} {padding}", $"u{i}"));
+        }
+        using var fx = SessionFixture.Compact(lines);
+
+        var page = fx.Manager().ReadHistoryRaw(fx.SessionId, 80, -1, out _);
+
+        Assert.Equal(80, page.Messages.Count);
+        Assert.Equal("u0", page.Messages[0]["uuid"]?.Value<string>());
+        Assert.Equal("a39", page.Messages[79]["uuid"]?.Value<string>());
+        // Nothing garbled at a boundary: every line still carries the uuid it was written with.
+        Assert.Equal(
+            Enumerable.Range(0, 40).SelectMany(i => new[] { $"u{i}", $"a{i}" }),
+            page.Messages.Select(m => m["uuid"]?.Value<string>()));
+    }
+
+    [Fact]
+    public void ReadHistoryRaw_survives_a_multibyte_char_on_a_chunk_boundary()
+    {
+        // The window is decoded in one block precisely because a chunked backward scan split
+        // multi-byte UTF-8 at the boundary and garbled accented characters in titles. The padding
+        // is ASCII so it alone sets the byte offsets, and the accented text sits at both ends.
+        const string firstText = "café naïve résumé";          // Latin-1 range, 2 bytes each
+        const string lastText = "日本語 — emoji 😀";           // 3-byte CJK and a 4-byte pair
+        var padding = new string('a', 30000);
+        var lines = new List<JObject>
+        {
+            Jsonl.UserPrompt("u1", firstText),
+            Jsonl.Assistant("a1", "answer " + padding, "u1"),
+            Jsonl.UserPrompt("u2", lastText, "a1"),
+        };
+        using var fx = SessionFixture.Compact(lines);
+
+        var page = fx.Manager().ReadHistoryRaw(fx.SessionId, 10, -1, out _);
+
+        // What lands in Messages is each record's `message` object, with the line's uuid lifted
+        // onto it, so the text is at ["content"] rather than ["message"]["content"].
+        Assert.Equal(3, page.Messages.Count);
+        Assert.Equal(firstText, page.Messages[0]["content"]?.Value<string>());
+        Assert.Equal(lastText, page.Messages[2]["content"]?.Value<string>());
+    }
+
+    [Fact]
+    public void ReadUserPrompts_returns_only_the_user_turns_oldest_first()
+    {
+        using var fx = SessionFixture.Compact(Conversation());
+
+        var prompts = fx.Manager().ReadUserPrompts(fx.SessionId);
+
+        // Collected newest-first while walking backwards, then reversed for the WebView.
+        Assert.Equal(new[] { "first question", "second question", "third question" }, prompts);
+    }
+
+    [Fact]
+    public void ReadUserPrompts_reads_a_pretty_printed_transcript_the_same_way()
+    {
+        var conversation = Conversation();
+        using var compact = SessionFixture.Compact(conversation);
+        using var pretty = SessionFixture.Pretty(conversation);
+
+        Assert.Equal(
+            compact.Manager().ReadUserPrompts(compact.SessionId),
+            pretty.Manager().ReadUserPrompts(pretty.SessionId));
+    }
+
+    [Fact]
+    public void ReadRewindableUuids_keeps_only_the_snapshots_that_tracked_a_file()
+    {
+        var lines = Conversation();
+        lines.Add(Jsonl.FileHistorySnapshot("u2", @"C:\proj\demo\Program.cs"));
+        lines.Add(Jsonl.EmptySnapshot("u3"));
+        using var fx = SessionFixture.Compact(lines);
+
+        var rewindable = fx.Manager().ReadRewindableUuids(fx.SessionId);
+
+        Assert.Contains("u2", rewindable);
+        // A snapshot with no tracked backups restores nothing, so it is not a rewind point.
+        Assert.DoesNotContain("u3", rewindable);
+        Assert.DoesNotContain("u1", rewindable);
+    }
+
+    [Fact]
+    public void ReadRewindableUuids_reads_a_pretty_printed_transcript_the_same_way()
+    {
+        var lines = Conversation();
+        lines.Add(Jsonl.FileHistorySnapshot("u2", @"C:\proj\demo\Program.cs"));
+        using var compact = SessionFixture.Compact(lines);
+        using var pretty = SessionFixture.Pretty(lines);
+
+        Assert.Equal(
+            compact.Manager().ReadRewindableUuids(compact.SessionId).OrderBy(x => x),
+            pretty.Manager().ReadRewindableUuids(pretty.SessionId).OrderBy(x => x));
+    }
+
+    [Fact]
+    public void ReadMessageBlock_returns_the_block_at_the_index()
+    {
+        using var fx = SessionFixture.Compact(Conversation());
+
+        var block = fx.Manager().ReadMessageBlock(fx.SessionId, "a2", 0);
+
+        Assert.NotNull(block);
+        Assert.Equal("text", block["type"]?.Value<string>());
+        Assert.Equal("second answer", block["text"]?.Value<string>());
+    }
+
+    [Fact]
+    public void ReadMessageBlock_past_the_end_is_null_not_a_throw()
+    {
+        using var fx = SessionFixture.Compact(Conversation());
+        Assert.Null(fx.Manager().ReadMessageBlock(fx.SessionId, "a2", 9));
+    }
+
+    [Fact]
+    public void ReadMessageBlock_for_an_unknown_uuid_is_null()
+    {
+        using var fx = SessionFixture.Compact(Conversation());
+        Assert.Null(fx.Manager().ReadMessageBlock(fx.SessionId, "nope", 0));
+    }
+}

--- a/tests/Corsinvest.VisualStudio.Agents.Tests/MetaInjectionTests.cs
+++ b/tests/Corsinvest.VisualStudio.Agents.Tests/MetaInjectionTests.cs
@@ -1,0 +1,82 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using Corsinvest.VisualStudio.Agents.Chat;
+using Xunit;
+
+namespace Corsinvest.VisualStudio.Agents.Tests;
+
+/// <summary>The filter that keeps CLI-injected meta out of the transcript.
+/// <para>Both directions fail quietly. Miss a tag and machine noise renders as a user bubble;
+/// match one tag too many and a real turn disappears, with the conversation still reading as
+/// though the user never said it.</para></summary>
+public class MetaInjectionTests
+{
+    [Theory]
+    // The injections the CLI rides in on a role:user line. Hidden in Claude Code's own UI too.
+    [InlineData("<task-notification>agent finished</task-notification>")]
+    [InlineData("<system-reminder>remember the thing</system-reminder>")]
+    [InlineData("<local-command-caveat>caveat</local-command-caveat>")]
+    [InlineData("<bash-stdout>ls output</bash-stdout>")]
+    [InlineData("<bash-stderr>command not found</bash-stderr>")]
+    [InlineData("<tick>")]
+    [InlineData("<teammate-message>hi</teammate-message>")]
+    [InlineData("<post-tool-use-hook>hook said this</post-tool-use-hook>")]
+    // Leading whitespace does not smuggle one past the filter.
+    [InlineData("   <system-reminder>indented</system-reminder>")]
+    [InlineData("\n\t<tick>")]
+    public void IsMetaText_hides_a_CLI_injection(string text)
+        => Assert.True(MetaInjection.IsMetaText(text));
+
+    [Theory]
+    // A real turn, plain or carrying the editor context the composer prepends.
+    [InlineData("fix the bug in Program.cs")]
+    [InlineData("<ide_selection>lines 10-20 of Foo.cs</ide_selection>\nwhat does this do?")]
+    [InlineData("<ide_opened_file>Foo.cs</ide_opened_file>\nexplain")]
+    // An interrupt IS a real turn: it renders with an orange bar. Callers that must skip it
+    // (session titles) guard it themselves rather than having this call it meta.
+    [InlineData("[Request interrupted by user]")]
+    // The CLI's slash-command output is NOT filtered: the WebView renders it as a slash-result.
+    [InlineData("<local-command-stdout>Set model to opus</local-command-stdout>")]
+    [InlineData("<local-command-stderr>unknown command</local-command-stderr>")]
+    // A tag in the MIDDLE of a real message is the user quoting one, not an injection.
+    [InlineData("why does <system-reminder> show up in my logs?")]
+    // An unknown tag is not meta by virtue of being a tag.
+    [InlineData("<invoke name=\"Read\">")]
+    // Nothing to classify.
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void IsMetaText_leaves_a_real_turn_alone(string text)
+        => Assert.False(MetaInjection.IsMetaText(text));
+
+    [Theory]
+    // The composer prepends the editor context; the user's own words are what follows.
+    [InlineData("<ide_selection>Foo.cs:10-20</ide_selection>\nwhat does this do?", "what does this do?")]
+    [InlineData("<ide_opened_file>Foo.cs</ide_opened_file>\nexplain this", "explain this")]
+    // Multi-line context blocks: Singleline means the dot spans the newlines inside the block.
+    [InlineData("<ide_selection>line one\nline two</ide_selection>\nthe question", "the question")]
+    // Only the LEADING block goes: one quoted later in the message is the user's own text.
+    [InlineData("look at <ide_selection>this</ide_selection> please", "look at <ide_selection>this</ide_selection> please")]
+    // Nothing to strip.
+    [InlineData("plain question", "plain question")]
+    [InlineData("", "")]
+    [InlineData(null, null)]
+    public void StripIdeContext_removes_only_a_leading_context_block(string text, string expected)
+        => Assert.Equal(expected, MetaInjection.StripIdeContext(text));
+
+    [Fact]
+    public void StripIdeContext_leaves_a_prompt_that_does_not_start_with_one()
+    {
+        // The reason this matters: title generation rejects text starting with '<', so a message
+        // sent with editor context would otherwise be dropped and the session left untitled.
+        const string withContext = "<ide_selection>Foo.cs</ide_selection>\nrename this method";
+
+        var stripped = MetaInjection.StripIdeContext(withContext);
+
+        Assert.False(stripped.StartsWith("<"));
+        Assert.Equal("rename this method", stripped);
+    }
+}

--- a/tests/Corsinvest.VisualStudio.Agents.Tests/PathHelpersTests.cs
+++ b/tests/Corsinvest.VisualStudio.Agents.Tests/PathHelpersTests.cs
@@ -1,0 +1,77 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using Xunit;
+
+namespace Corsinvest.VisualStudio.Agents.Tests;
+
+/// <summary>The path shapes handed to the CLI.
+/// <para>These matter because the CLI compares strings, not paths: it matches its own
+/// <c>process.cwd()</c> against the lock file's <c>workspaceFolders</c> case-sensitively, so an
+/// upper-case drive letter does not fail loudly — IDE discovery just never happens.</para></summary>
+public class PathHelpersTests
+{
+    [Theory]
+    [InlineData(@"C:\proj\demo", @"C:\proj\demo\src\Program.cs", "src/Program.cs")]
+    // Either separator, mixed, and a trailing slash on the root: same answer.
+    [InlineData(@"C:/proj/demo", @"C:\proj\demo\src\Program.cs", "src/Program.cs")]
+    [InlineData(@"C:\proj\demo\", @"C:\proj\demo/src\Program.cs", "src/Program.cs")]
+    // Case-insensitive, because Windows is.
+    [InlineData(@"c:\proj\demo", @"C:\PROJ\Demo\src\Program.cs", "src/Program.cs")]
+    // The path IS the root.
+    [InlineData(@"C:\proj\demo", @"C:\proj\demo", "")]
+    [InlineData(@"C:\proj\demo", @"C:\proj\demo\", "")]
+    // Outside the root: handed back whole, only re-slashed. NOT walked up with "..".
+    [InlineData(@"C:\proj\demo", @"C:\other\File.cs", "C:/other/File.cs")]
+    // A sibling whose name merely STARTS with the root's: not inside it.
+    [InlineData(@"C:\proj\demo", @"C:\proj\demo2\File.cs", "C:/proj/demo2/File.cs")]
+    // Nothing to work with.
+    [InlineData(@"C:\proj\demo", "", "")]
+    [InlineData(@"C:\proj\demo", null, "")]
+    [InlineData("", @"C:\proj\demo\File.cs", "C:/proj/demo/File.cs")]
+    public void Relative_answers_in_forward_slashes(string root, string path, string expected)
+        => Assert.Equal(expected, PathHelpers.Relative(root, path));
+
+    [Theory]
+    [InlineData(@"C:\proj\demo", @"c:\proj\demo")]
+    [InlineData(@"K:\source\repos", @"k:\source\repos")]
+    // Already lower-case, and a path with no drive at all: untouched.
+    [InlineData(@"c:\proj\demo", @"c:\proj\demo")]
+    [InlineData(@"\\server\share\file.cs", @"\\server\share\file.cs")]
+    [InlineData("relative/path.cs", "relative/path.cs")]
+    [InlineData("", "")]
+    [InlineData(null, null)]
+    public void LowercaseDrive_lowers_only_the_drive_letter(string path, string expected)
+        => Assert.Equal(expected, PathHelpers.LowercaseDrive(path));
+
+    [Theory]
+    [InlineData(@"C:\proj\demo\File.cs", "file:///c:/proj/demo/File.cs")]
+    [InlineData(@"c:\proj\demo\File.cs", "file:///c:/proj/demo/File.cs")]
+    // Only the drive letter is lowered — the rest of the path keeps its case.
+    [InlineData(@"C:\Proj\Demo\MyFile.cs", "file:///c:/Proj/Demo/MyFile.cs")]
+    public void ToFileUri_produces_the_shape_the_CLI_expects(string path, string expected)
+        => Assert.Equal(expected, PathHelpers.ToFileUri(path));
+
+    [Fact]
+    public void ToFileUri_round_trips_through_FromFileUri()
+    {
+        const string path = @"C:\proj\demo\src\Program.cs";
+
+        var uri = PathHelpers.ToFileUri(path);
+
+        // Back as a Windows path, with the drive lowered on the way out and left that way.
+        Assert.Equal(@"c:\proj\demo\src\Program.cs", PathHelpers.FromFileUri(uri));
+    }
+
+    [Theory]
+    // The same file written the two ways the two sides of the wire write it.
+    [InlineData(@"C:\proj\demo\File.cs", @"c:\proj\demo\File.cs", true)]
+    [InlineData("file:///c:/proj/demo/File.cs", @"C:\proj\demo\File.cs", true)]
+    [InlineData("file:///C:/proj/demo/File.cs", "file:///c:/proj/demo/File.cs", true)]
+    // Genuinely different files.
+    [InlineData(@"C:\proj\demo\File.cs", @"C:\proj\demo\Other.cs", false)]
+    public void UrisEquivalent_ignores_the_spelling_not_the_file(string a, string b, bool expected)
+        => Assert.Equal(expected, PathHelpers.UrisEquivalent(a, b));
+}

--- a/tests/Corsinvest.VisualStudio.Agents.Tests/SchemaBuilderTests.cs
+++ b/tests/Corsinvest.VisualStudio.Agents.Tests/SchemaBuilderTests.cs
@@ -1,0 +1,123 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using Corsinvest.VisualStudio.Agents.Mcp;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Corsinvest.VisualStudio.Agents.Tests;
+
+/// <summary>The JSON Schema the CLI reads to learn how to call an MCP tool.
+/// <para>Wrong here means the model sends an argument under a name the tool never reads, or omits
+/// one it needs — and neither shows up as an error on our side: the tool simply behaves as though
+/// the caller had passed nothing.</para></summary>
+public class SchemaBuilderTests
+{
+    private sealed class SampleArgs
+    {
+        public string FilePath { get; set; }
+        public int Line { get; set; }
+        public bool? IncludeDetails { get; set; }
+        public string[] Tags { get; set; }
+
+        // The CLI uses snake_case on a few tools, so an explicit wire name has to win over the
+        // camelCase policy.
+        [JsonProperty("old_file_path")]
+        public string OldFilePath { get; set; }
+
+        // Read-only: nothing can be passed for it, so it has no business in the schema.
+        public string Computed => "x";
+    }
+
+    private static Dictionary<string, object> Schema()
+        => (Dictionary<string, object>)SchemaBuilder.For<SampleArgs>();
+
+    private static Dictionary<string, object> Properties()
+        => (Dictionary<string, object>)Schema()["properties"];
+
+    [Fact]
+    public void For_describes_an_object_with_its_writable_properties()
+    {
+        var schema = Schema();
+
+        Assert.Equal("object", schema["type"]);
+        Assert.Equal(
+            new[] { "filePath", "line", "includeDetails", "tags", "old_file_path" },
+            Properties().Keys);
+    }
+
+    [Fact]
+    public void For_leaves_out_a_property_nothing_can_be_passed_for()
+        => Assert.DoesNotContain("computed", Properties().Keys);
+
+    [Fact]
+    public void For_lets_an_explicit_JsonProperty_name_win_over_camelCase()
+    {
+        // Would be "oldFilePath" by policy; the attribute names the wire form the CLI sends.
+        Assert.Contains("old_file_path", Properties().Keys);
+        Assert.DoesNotContain("oldFilePath", Properties().Keys);
+    }
+
+    [Theory]
+    [InlineData("filePath", "string")]
+    [InlineData("line", "integer")]
+    [InlineData("includeDetails", "boolean")]
+    [InlineData("tags", "array")]
+    public void For_maps_a_property_to_its_JSON_type(string name, string expected)
+    {
+        var meta = (Dictionary<string, object>)Properties()[name];
+
+        Assert.Equal(expected, meta["type"]);
+    }
+
+    [Fact]
+    public void For_says_what_an_array_holds()
+    {
+        var tags = (Dictionary<string, object>)Properties()["tags"];
+        var items = (Dictionary<string, object>)tags["items"];
+
+        Assert.Equal("string", items["type"]);
+    }
+
+    [Fact]
+    public void For_returns_the_same_schema_object_on_a_second_call()
+    {
+        // Cached per type: the schema is rebuilt for every tool listing otherwise.
+        Assert.Same(SchemaBuilder.For<SampleArgs>(), SchemaBuilder.For<SampleArgs>());
+    }
+
+    [Theory]
+    [InlineData("FilePath", "filePath")]
+    [InlineData("Line", "line")]
+    [InlineData("URL", "url")]
+    [InlineData("HTTPSPort", "httpsPort")]
+    [InlineData("ID", "id")]
+    // Already camel, or nothing to case.
+    [InlineData("filePath", "filePath")]
+    [InlineData("", "")]
+    [InlineData(null, null)]
+    public void ToCamelCase_lowers_the_leading_run_of_capitals(string input, string expected)
+        => Assert.Equal(expected, SchemaBuilder.ToCamelCase(input));
+
+    [Theory]
+    // The schema and the wire have to agree, and the wire is Newtonsoft's resolver. Drift between
+    // the two is invisible: the model sends what the schema promised, under a name nothing binds.
+    [InlineData("FilePath")]
+    [InlineData("Line")]
+    [InlineData("URL")]
+    [InlineData("HTTPSPort")]
+    [InlineData("ID")]
+    [InlineData("OldFilePath")]
+    [InlineData("IncludeDetails")]
+    [InlineData("A")]
+    public void ToCamelCase_agrees_with_the_resolver_that_names_the_wire(string name)
+    {
+        var resolver = new CamelCasePropertyNamesContractResolver();
+
+        Assert.Equal(resolver.GetResolvedPropertyName(name), SchemaBuilder.ToCamelCase(name));
+    }
+}

--- a/tests/Corsinvest.VisualStudio.Agents.Tests/SessionFixture.cs
+++ b/tests/Corsinvest.VisualStudio.Agents.Tests/SessionFixture.cs
@@ -1,0 +1,148 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using Corsinvest.VisualStudio.Agents.Core.Sessions;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace Corsinvest.VisualStudio.Agents.Tests;
+
+/// <summary>A throwaway config-dir holding one session .jsonl, laid out where the CLI would put it.
+/// <para>The readers take the real filesystem — ClaudePaths and the working directory both arrive
+/// through the constructor, so a temp folder is all the isolation needed. No IFileSystem seam:
+/// these files are small, and an abstraction here would be tested instead of the code that ships.
+/// </para></summary>
+internal sealed class SessionFixture : IDisposable
+{
+    public string ConfigDir { get; }
+    public string WorkingDirectory { get; }
+    public ClaudePaths Paths { get; }
+    public string SessionId { get; }
+
+    private SessionFixture(string configDir, string workingDirectory, string sessionId)
+    {
+        ConfigDir = configDir;
+        WorkingDirectory = workingDirectory;
+        SessionId = sessionId;
+        Paths = new ClaudePaths(configDir);
+    }
+
+    public SessionManager Manager() => new(Paths, WorkingDirectory, OutputWindowLogger.Global);
+
+    /// <summary>Writes the lines as the CLI does: one compact JSON object per line, UTF-8, LF.</summary>
+    public static SessionFixture Compact(IEnumerable<JObject> lines)
+        => Write(lines, Formatting.None);
+
+    /// <summary>The same content through a pretty-printing writer. Still valid JSONL only if each
+    /// record stays on one line, so indentation goes INSIDE the object — which is the shape the
+    /// string-matching scan has to survive: '"type": "user"' with a space after the colon.</summary>
+    public static SessionFixture Pretty(IEnumerable<JObject> lines)
+        => Write(lines, Formatting.None, spaceAfterColon: true);
+
+    private static SessionFixture Write(IEnumerable<JObject> lines, Formatting formatting,
+                                        bool spaceAfterColon = false)
+    {
+        var configDir = Path.Combine(Path.GetTempPath(),
+            "cv4vs-tests-" + Guid.NewGuid().ToString("N"));
+        var workingDirectory = Path.Combine(configDir, "work");
+        Directory.CreateDirectory(workingDirectory);
+
+        var sessionId = Guid.NewGuid().ToString("D");
+        var folder = Path.Combine(configDir, "projects",
+            ClaudePaths.ProjectFolderName(workingDirectory));
+        Directory.CreateDirectory(folder);
+
+        var sb = new StringBuilder();
+        foreach (var line in lines)
+        {
+            var json = line.ToString(formatting);
+            // A writer that puts a space after every colon produces the same JSON and is what the
+            // scan must tolerate; done by re-serializing rather than by hand so the result stays
+            // parseable.
+            if (spaceAfterColon) { json = SpaceAfterColons(json); }
+            sb.Append(json).Append('\n');
+        }
+        File.WriteAllText(Path.Combine(folder, sessionId + ".jsonl"), sb.ToString(), new UTF8Encoding(false));
+        return new SessionFixture(configDir, workingDirectory, sessionId);
+    }
+
+    /// <summary>Adds a space after each colon that separates a key from its value, leaving colons
+    /// inside string values alone (a Windows path, a timestamp).</summary>
+    private static string SpaceAfterColons(string json)
+    {
+        var sb = new StringBuilder(json.Length + 32);
+        bool inString = false, escaped = false;
+        foreach (var c in json)
+        {
+            if (escaped) { sb.Append(c); escaped = false; continue; }
+            if (c == '\\' && inString) { sb.Append(c); escaped = true; continue; }
+            if (c == '"') { inString = !inString; sb.Append(c); continue; }
+            sb.Append(c);
+            if (c == ':' && !inString) { sb.Append(' '); }
+        }
+        return sb.ToString();
+    }
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(ConfigDir)) { Directory.Delete(ConfigDir, true); } }
+        catch { /* a temp folder the OS will reclaim; failing the test over it helps nobody */ }
+    }
+}
+
+/// <summary>The transcript records these tests care about, in the CLI's own shape.</summary>
+internal static class Jsonl
+{
+    public static JObject UserPrompt(string uuid, string text, string parent = null) => new()
+    {
+        ["type"] = "user",
+        ["uuid"] = uuid,
+        ["parentUuid"] = parent,
+        ["timestamp"] = "2026-08-26T10:00:00.000Z",
+        ["message"] = new JObject { ["role"] = "user", ["content"] = text },
+    };
+
+    public static JObject Assistant(string uuid, string text, string parent = null) => new()
+    {
+        ["type"] = "assistant",
+        ["uuid"] = uuid,
+        ["parentUuid"] = parent,
+        ["timestamp"] = "2026-08-26T10:00:01.000Z",
+        ["message"] = new JObject
+        {
+            ["role"] = "assistant",
+            ["model"] = "claude-opus-5",
+            ["content"] = new JArray { new JObject { ["type"] = "text", ["text"] = text } },
+        },
+    };
+
+    /// <summary>A rewindable point: a snapshot naming at least one tracked backup.</summary>
+    public static JObject FileHistorySnapshot(string messageId, params string[] files)
+    {
+        var backups = new JObject();
+        foreach (var f in files)
+        {
+            backups[f] = new JObject { ["backupFileName"] = "bk-" + Math.Abs(f.GetHashCode()) };
+        }
+        return new JObject
+        {
+            ["type"] = "file-history-snapshot",
+            ["messageId"] = messageId,
+            ["snapshot"] = new JObject { ["trackedFileBackups"] = backups },
+        };
+    }
+
+    /// <summary>A snapshot with nothing tracked — present in real transcripts, and NOT rewindable.</summary>
+    public static JObject EmptySnapshot(string messageId) => new()
+    {
+        ["type"] = "file-history-snapshot",
+        ["messageId"] = messageId,
+        ["snapshot"] = new JObject { ["trackedFileBackups"] = new JObject() },
+    };
+}

--- a/tests/Corsinvest.VisualStudio.Agents.Tests/SessionScanTests.cs
+++ b/tests/Corsinvest.VisualStudio.Agents.Tests/SessionScanTests.cs
@@ -1,0 +1,75 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using Corsinvest.VisualStudio.Agents.Core.Sessions;
+using Xunit;
+
+namespace Corsinvest.VisualStudio.Agents.Tests;
+
+/// <summary>The .jsonl scan matches on strings for speed, which makes it whitespace-sensitive
+/// unless it is written not to be. That rule is stated in CLAUDE.md and enforced by nothing:
+/// a literal '"type":"x"' compiles, passes a manual check against the CLI's compact output, and
+/// silently skips lines the day a pretty-printing writer produces the same JSON. These tests are
+/// the enforcement.</summary>
+public class SessionScanTests
+{
+    [Theory]
+    // The CLI's own compact output.
+    [InlineData("{\"isSidechain\":true}", "isSidechain", true)]
+    // A pretty-printer's space after the colon — same JSON, and it must read the same.
+    [InlineData("{\"isSidechain\": true}", "isSidechain", true)]
+    // Present but false, and absent: both are "not flagged".
+    [InlineData("{\"isSidechain\":false}", "isSidechain", false)]
+    [InlineData("{\"isSidechain\": false}", "isSidechain", false)]
+    [InlineData("{\"other\":true}", "isSidechain", false)]
+    [InlineData("{}", "isSidechain", false)]
+    public void IsFlagTrue_reads_the_flag_whatever_the_writer_did_with_spaces(
+        string line, string key, bool expected)
+        => Assert.Equal(expected, SessionManager.IsFlagTrue(line, key));
+
+    [Theory]
+    // The CLI writes compact; a pretty-printer writes the same JSON with a space after the colon.
+    // IsType decides whether a line is read at all, so getting this wrong SKIPS records rather
+    // than failing loudly - the exact bug the rule in CLAUDE.md exists to prevent.
+    [InlineData(@"{""type"":""user""}", "user", true)]
+    [InlineData(@"{""type"": ""user""}", "user", true)]
+    // NOT covered, deliberately: a space BEFORE the colon ({"type" : "user"}). FindJsonStringValue
+    // matches the two forms a writer actually emits, and no mainstream serializer produces that
+    // third one - Newtonsoft's Indented, JSON.stringify and json.dumps all put the space after.
+    // Widening the scan for a writer nobody uses costs a third IndexOf on every line of every read.
+    // The type is not the first key: the scan must find it wherever the writer put it.
+    [InlineData(@"{""uuid"":""u1"",""type"":""assistant""}", "assistant", true)]
+    [InlineData(@"{""uuid"":""u1"",""type"": ""assistant""}", "assistant", true)]
+    // Wrong type, and a line with no type at all.
+    [InlineData(@"{""type"":""assistant""}", "user", false)]
+    [InlineData(@"{""uuid"":""u1""}", "user", false)]
+    // A value that merely CONTAINS the wanted one is a different type.
+    [InlineData(@"{""type"":""user-something""}", "user", false)]
+    public void IsType_reads_the_type_whatever_the_writer_did_with_spaces(
+        string line, string type, bool expected)
+        => Assert.Equal(expected, SessionManager.IsType(line, type));
+
+    [Theory]
+    // Plain ids: what a session or agent id actually looks like.
+    [InlineData("e98457c0-1234-4abc-9def-000000000000", true)]
+    [InlineData("asidequestion-a1b2c3", true)]
+    [InlineData("abc_DEF-123", true)]
+    // Traversal and separators. These reach the reader straight off a WebView DTO, so a false
+    // here is what keeps Path.Combine from resolving out of the session folder.
+    [InlineData("..", false)]
+    [InlineData("../../etc/passwd", false)]
+    [InlineData(@"..\..\windows\system32", false)]
+    [InlineData("sub/dir", false)]
+    [InlineData(@"sub\dir", false)]
+    [InlineData("C:", false)]
+    // Nothing to build a path from.
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    // A dot is not in the allowed set: ".jsonl" is appended by the caller, never carried in the id.
+    [InlineData("session.jsonl", false)]
+    public void IsSafePathToken_accepts_plain_ids_and_rejects_everything_that_walks(
+        string token, bool expected)
+        => Assert.Equal(expected, SessionManager.IsSafePathToken(token));
+}

--- a/tests/Corsinvest.VisualStudio.Agents.Tests/StatsAggregatorTests.cs
+++ b/tests/Corsinvest.VisualStudio.Agents.Tests/StatsAggregatorTests.cs
@@ -1,0 +1,276 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using Corsinvest.VisualStudio.Agents.Core.Stats;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+namespace Corsinvest.VisualStudio.Agents.Tests;
+
+/// <summary>The usage numbers behind the Statistics tab.
+/// <para>Wrong arithmetic here is the quietest defect in the codebase: the dialog shows a number,
+/// it looks plausible, and nothing about it says it is off. There is no manual check that catches
+/// a total that is 3% low.</para></summary>
+public class StatsAggregatorTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(Path.GetTempPath(),
+        "cv4vs-stats-" + Guid.NewGuid().ToString("N"));
+
+    public StatsAggregatorTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_dir)) { Directory.Delete(_dir, true); } }
+        catch { /* temp folder; the OS reclaims it */ }
+    }
+
+    private string WriteJsonl(params JObject[] lines)
+    {
+        var path = Path.Combine(_dir, Guid.NewGuid().ToString("N") + ".jsonl");
+        var sb = new StringBuilder();
+        foreach (var line in lines) { sb.Append(line.ToString(Newtonsoft.Json.Formatting.None)).Append('\n'); }
+        File.WriteAllText(path, sb.ToString(), new UTF8Encoding(false));
+        return path;
+    }
+
+    private static JObject Assistant(string model, int input, int output,
+                                     int cacheRead = 0, int cacheCreation = 0,
+                                     string timestamp = "2026-08-26T10:00:00.000Z",
+                                     string cwd = @"C:\proj\demo") => new()
+    {
+        ["type"] = "assistant",
+        ["timestamp"] = timestamp,
+        ["cwd"] = cwd,
+        ["message"] = new JObject
+        {
+            ["role"] = "assistant",
+            ["model"] = model,
+            ["content"] = new JArray { new JObject { ["type"] = "text", ["text"] = "hi" } },
+            ["usage"] = new JObject
+            {
+                ["input_tokens"] = input,
+                ["output_tokens"] = output,
+                ["cache_read_input_tokens"] = cacheRead,
+                ["cache_creation_input_tokens"] = cacheCreation,
+            },
+        },
+    };
+
+    private static JObject UserWithBlocks(string timestamp, params string[] blockTypes)
+    {
+        var content = new JArray();
+        foreach (var t in blockTypes) { content.Add(new JObject { ["type"] = t }); }
+        return new JObject
+        {
+            ["type"] = "user",
+            ["timestamp"] = timestamp,
+            ["cwd"] = @"C:\proj\demo",
+            ["message"] = new JObject { ["role"] = "user", ["content"] = content },
+        };
+    }
+
+    [Fact]
+    public void AggregateFile_sums_tokens_per_model()
+    {
+        var path = WriteJsonl(
+            Assistant("claude-opus-5", input: 100, output: 50, cacheRead: 10, cacheCreation: 5),
+            Assistant("claude-opus-5", input: 200, output: 75),
+            Assistant("claude-sonnet-5", input: 30, output: 20));
+
+        var result = StatsAggregator.AggregateFile(path, isSubagent: false, fromOffset: 0, seed: null);
+
+        Assert.NotNull(result);
+        var agg = result.Value.agg;
+        Assert.Equal(3, agg.Messages);
+
+        var opus = agg.ModelUsage["claude-opus-5"];
+        Assert.Equal(300, opus.InputTokens);
+        Assert.Equal(125, opus.OutputTokens);
+        Assert.Equal(10, opus.CacheReadTokens);
+        Assert.Equal(5, opus.CacheCreationTokens);
+
+        var sonnet = agg.ModelUsage["claude-sonnet-5"];
+        Assert.Equal(30, sonnet.InputTokens);
+        Assert.Equal(20, sonnet.OutputTokens);
+    }
+
+    [Fact]
+    public void AggregateFile_keeps_the_raw_model_id()
+    {
+        // Deliberately provider-agnostic: a GLM or z.ai id set through env must survive as written,
+        // so the id is never rewritten into a display name here.
+        var path = WriteJsonl(Assistant("glm-4.6", input: 10, output: 5));
+
+        var agg = StatsAggregator.AggregateFile(path, false, 0, null).Value.agg;
+
+        Assert.True(agg.ModelUsage.ContainsKey("glm-4.6"));
+    }
+
+    [Fact]
+    public void AggregateFile_counts_both_roles_as_messages_and_reads_the_cwd()
+    {
+        var path = WriteJsonl(
+            UserWithBlocks("2026-08-26T10:00:00.000Z", "text"),
+            Assistant("claude-opus-5", 10, 5));
+
+        var result = StatsAggregator.AggregateFile(path, false, 0, null).Value;
+
+        Assert.Equal(2, result.agg.Messages);
+        Assert.Equal(@"C:\proj\demo", result.cwd);
+    }
+
+    [Fact]
+    public void AggregateFile_takes_the_LAST_cwd_because_a_session_can_cd()
+    {
+        var path = WriteJsonl(
+            Assistant("claude-opus-5", 10, 5, cwd: @"C:\proj\first"),
+            Assistant("claude-opus-5", 10, 5, cwd: @"C:\proj\second"));
+
+        Assert.Equal(@"C:\proj\second",
+            StatsAggregator.AggregateFile(path, false, 0, null).Value.cwd);
+    }
+
+    [Fact]
+    public void AggregateFile_counts_attachments_on_user_turns()
+    {
+        var path = WriteJsonl(
+            UserWithBlocks("2026-08-26T10:00:00.000Z", "text", "image", "image", "document"));
+
+        var agg = StatsAggregator.AggregateFile(path, false, 0, null).Value.agg;
+
+        Assert.Equal(2, agg.ImageCount);
+        Assert.Equal(1, agg.FileCount);
+    }
+
+    [Fact]
+    public void AggregateFile_skips_sidechain_turns_in_a_main_transcript()
+    {
+        // Sub-agent turns inside a main transcript are counted in their own file, not twice here.
+        var sidechain = Assistant("claude-opus-5", 999, 999);
+        sidechain["isSidechain"] = true;
+        var path = WriteJsonl(Assistant("claude-opus-5", 10, 5), sidechain);
+
+        var agg = StatsAggregator.AggregateFile(path, isSubagent: false, 0, null).Value.agg;
+
+        Assert.Equal(1, agg.Messages);
+        Assert.Equal(10, agg.ModelUsage["claude-opus-5"].InputTokens);
+    }
+
+    [Fact]
+    public void AggregateFile_counts_sidechain_turns_when_the_file_IS_the_subagent()
+    {
+        var sidechain = Assistant("claude-opus-5", 42, 7);
+        sidechain["isSidechain"] = true;
+        var path = WriteJsonl(sidechain);
+
+        var agg = StatsAggregator.AggregateFile(path, isSubagent: true, 0, null).Value.agg;
+
+        Assert.Equal(1, agg.Messages);
+        Assert.Equal(42, agg.ModelUsage["claude-opus-5"].InputTokens);
+    }
+
+    [Fact]
+    public void AggregateFile_adds_to_the_seed_rather_than_starting_over()
+    {
+        // How the cache resumes: re-reading only the bytes appended since last time, on top of
+        // what was already counted. Double-counting here inflates every historical total.
+        var path = WriteJsonl(Assistant("claude-opus-5", 100, 50));
+        var first = StatsAggregator.AggregateFile(path, false, 0, null).Value;
+
+        var second = StatsAggregator.AggregateFile(path, false, first.newSize, first.agg).Value;
+
+        // Nothing was appended, so the seed comes back unchanged.
+        Assert.Equal(1, second.agg.Messages);
+        Assert.Equal(100, second.agg.ModelUsage["claude-opus-5"].InputTokens);
+    }
+
+    [Fact]
+    public void AggregateFile_on_a_missing_file_is_null_not_a_throw()
+        => Assert.Null(StatsAggregator.AggregateFile(
+            Path.Combine(_dir, "nope.jsonl"), false, 0, null));
+
+    [Fact]
+    public void AggregateFile_ignores_a_line_that_is_not_valid_json()
+    {
+        var path = Path.Combine(_dir, "broken.jsonl");
+        File.WriteAllText(path,
+            Assistant("claude-opus-5", 10, 5).ToString(Newtonsoft.Json.Formatting.None) + "\n"
+            + "{\"type\":\"assistant\" this is not json\n"
+            + Assistant("claude-opus-5", 20, 10).ToString(Newtonsoft.Json.Formatting.None) + "\n",
+            new UTF8Encoding(false));
+
+        var agg = StatsAggregator.AggregateFile(path, false, 0, null).Value.agg;
+
+        // The broken line is dropped; the ones around it are still counted.
+        Assert.Equal(2, agg.Messages);
+        Assert.Equal(30, agg.ModelUsage["claude-opus-5"].InputTokens);
+    }
+
+    [Fact]
+    public void ReadCwd_finds_the_working_directory_without_parsing_the_whole_file()
+    {
+        var path = WriteJsonl(
+            Assistant("claude-opus-5", 10, 5, cwd: @"C:\proj\demo"),
+            Assistant("claude-opus-5", 10, 5, cwd: @"C:\proj\demo"));
+
+        Assert.Equal(@"C:\proj\demo", StatsAggregator.ReadCwd(path));
+    }
+
+    [Fact]
+    public void ReadCwd_on_a_file_with_no_cwd_is_empty_not_a_throw()
+    {
+        var noCwd = Assistant("claude-opus-5", 10, 5);
+        noCwd.Remove("cwd");
+        var path = WriteJsonl(noCwd);
+
+        Assert.True(string.IsNullOrEmpty(StatsAggregator.ReadCwd(path)));
+    }
+
+    [Theory]
+    // The day-bucket key. Producer and readers only agree as long as both go through DateKey —
+    // change one and lookups return nothing: empty heatmap, no exception.
+    [InlineData(2026, 8, 26, "2026-08-26")]
+    [InlineData(2026, 1, 1, "2026-01-01")]
+    [InlineData(2026, 12, 31, "2026-12-31")]
+    public void DateKey_is_invariant_yyyy_MM_dd(int y, int m, int d, string expected)
+        => Assert.Equal(expected, StatsAggregator.DateKey(new DateTime(y, m, d)));
+
+    [Fact]
+    public void DateKey_does_not_follow_the_thread_culture()
+    {
+        // An Italian locale formats dates as dd/MM/yyyy. If the key picked up the current culture
+        // the buckets written on one machine would be unreadable on another.
+        var original = Thread.CurrentThread.CurrentCulture;
+        try
+        {
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("it-IT");
+            Assert.Equal("2026-08-26", StatsAggregator.DateKey(new DateTime(2026, 8, 26)));
+        }
+        finally { Thread.CurrentThread.CurrentCulture = original; }
+    }
+
+    [Fact]
+    public void TryParseDateKey_round_trips_what_DateKey_wrote()
+    {
+        var day = new DateTime(2026, 8, 26);
+
+        Assert.True(StatsAggregator.TryParseDateKey(StatsAggregator.DateKey(day), out var parsed));
+        Assert.Equal(day, parsed);
+    }
+
+    [Theory]
+    [InlineData("unknown")]
+    [InlineData("26/08/2026")]
+    [InlineData("2026-8-26")]
+    [InlineData("")]
+    public void TryParseDateKey_refuses_anything_DateKey_did_not_write(string key)
+        => Assert.False(StatsAggregator.TryParseDateKey(key, out _));
+}

--- a/tests/Corsinvest.VisualStudio.Agents.Tests/StringHelpersTests.cs
+++ b/tests/Corsinvest.VisualStudio.Agents.Tests/StringHelpersTests.cs
@@ -1,0 +1,62 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using Corsinvest.VisualStudio.Agents.Helpers;
+using Xunit;
+
+namespace Corsinvest.VisualStudio.Agents.Tests;
+
+/// <summary>The shorteners behind menu rows, tab captions and list items.
+/// <para>A session title falls back to the last prompt, which is a whole message — newlines and
+/// all. One of those in a MenuItem breaks the row instead of wrapping, and the break looks like a
+/// layout bug rather than a string that was never collapsed.</para></summary>
+public class StringHelpersTests
+{
+    [Theory]
+    [InlineData("short", 10, "short")]
+    // Exactly at the limit is not truncated: the ellipsis would claim something was dropped.
+    [InlineData("exactly-10", 10, "exactly-10")]
+    [InlineData("this is far too long", 7, "this is…")]
+    [InlineData("", 5, "")]
+    [InlineData(null, 5, null)]
+    public void Truncate_only_cuts_past_the_limit(string s, int max, string expected)
+        => Assert.Equal(expected, StringHelpers.Truncate(s, max));
+
+    [Fact]
+    public void Truncate_marks_the_cut_so_the_reader_knows_there_was_more()
+    {
+        var result = StringHelpers.Truncate(new string('x', 600));
+
+        Assert.EndsWith("…", result);
+        Assert.Equal(501, result.Length); // 500 kept plus the one-char ellipsis
+    }
+
+    [Theory]
+    // Newlines become spaces, and each line is trimmed on the way.
+    [InlineData("first\nsecond", 100, "first second")]
+    [InlineData("first\r\nsecond", 100, "first second")]
+    [InlineData("  first  \n  second  ", 100, "first second")]
+    // Blank lines collapse away rather than leaving double spaces.
+    [InlineData("first\n\n\nsecond", 100, "first second")]
+    // Collapse happens BEFORE the cut: truncating first would land inside line one and drop the
+    // rest silently, which is the bug this function exists to avoid.
+    [InlineData("first line\nsecond line", 12, "first line s…")]
+    [InlineData("", 10, "")]
+    [InlineData("   ", 10, "   ")]
+    [InlineData(null, 10, null)]
+    public void ToSingleLine_collapses_then_truncates(string s, int max, string expected)
+        => Assert.Equal(expected, StringHelpers.ToSingleLine(s, max));
+
+    [Theory]
+    [InlineData("one\ntwo\nthree", 3)]
+    // Empty lines are not counted; a trailing newline does not invent one.
+    [InlineData("one\n\ntwo", 2)]
+    [InlineData("one\n", 1)]
+    [InlineData("single", 1)]
+    [InlineData("", 0)]
+    [InlineData(null, 0)]
+    public void NonEmptyLineCount_counts_the_lines_that_hold_something(string text, int expected)
+        => Assert.Equal(expected, StringHelpers.NonEmptyLineCount(text));
+}

--- a/tests/Corsinvest.VisualStudio.Agents.Tests/ToolResultExtrasTests.cs
+++ b/tests/Corsinvest.VisualStudio.Agents.Tests/ToolResultExtrasTests.cs
@@ -1,0 +1,174 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using Corsinvest.VisualStudio.Agents.Chat;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Corsinvest.VisualStudio.Agents.Tests;
+
+/// <summary>The extras that ride along with a tool result: an edit's hunks, an Agent run's totals.
+/// <para>Two sources have to agree — the live <c>toolUseResult</c> and the fields history lifts onto
+/// the message — because the same row is built from one or the other depending on whether you are
+/// watching it happen or reopening the session. Drift between them shows up as a diff that renders
+/// live and vanishes on reload.</para></summary>
+public class ToolResultExtrasTests
+{
+    private static JObject Hunk() => new()
+    {
+        ["oldStart"] = 10,
+        ["oldLines"] = 2,
+        ["newStart"] = 10,
+        ["newLines"] = 3,
+        ["lines"] = new JArray { "-old line", "+new line", "+added line" },
+    };
+
+    [Fact]
+    public void FromToolUseResult_reads_the_patch_the_CLI_computed()
+    {
+        var result = new JObject { ["structuredPatch"] = new JArray { Hunk() } };
+
+        var extras = ToolResultExtras.FromToolUseResult(result);
+
+        Assert.NotNull(extras.Patch);
+        var hunk = Assert.Single(extras.Patch);
+        Assert.Equal(10, hunk.OldStart);
+        Assert.Equal(3, hunk.NewLines);
+    }
+
+    [Fact]
+    public void FromToolUseResult_treats_an_empty_patch_as_no_patch()
+    {
+        // How "nothing changed" arrives. Rendering it would draw an empty diff box.
+        var result = new JObject { ["structuredPatch"] = new JArray() };
+
+        Assert.Null(ToolResultExtras.FromToolUseResult(result).Patch);
+    }
+
+    [Fact]
+    public void FromToolUseResult_has_no_patch_when_the_tool_reported_none()
+    {
+        // A Write to a new file has nothing to diff against.
+        Assert.Null(ToolResultExtras.FromToolUseResult(new JObject()).Patch);
+    }
+
+    [Fact]
+    public void FromToolUseResult_reads_an_agent_runs_totals()
+    {
+        var result = new JObject
+        {
+            ["totalDurationMs"] = 4200L,
+            ["totalTokens"] = 15000L,
+            ["totalToolUseCount"] = 7,
+        };
+
+        var totals = ToolResultExtras.FromToolUseResult(result).AgentTotals;
+
+        Assert.NotNull(totals);
+        Assert.Equal(4200, totals.DurationMs);
+        Assert.Equal(15000, totals.Tokens);
+        Assert.Equal(7, totals.ToolUses);
+    }
+
+    [Fact]
+    public void FromToolUseResult_reports_no_totals_when_the_duration_is_zero()
+    {
+        // A zero duration is how both sources say "nothing to report" — a running agent, an
+        // interrupted one, any other tool. A DTO full of zeros would claim the run took no time.
+        var result = new JObject
+        {
+            ["totalDurationMs"] = 0L,
+            ["totalTokens"] = 0L,
+            ["totalToolUseCount"] = 0,
+        };
+
+        Assert.Null(ToolResultExtras.FromToolUseResult(result).AgentTotals);
+    }
+
+    [Fact]
+    public void FromToolUseResult_survives_a_null_result()
+    {
+        // The object is a bare string on an error result, which reaches here as null.
+        var extras = ToolResultExtras.FromToolUseResult(null);
+
+        Assert.Null(extras.Patch);
+        Assert.Null(extras.AgentTotals);
+    }
+
+    [Fact]
+    public void FromMessage_reads_back_what_history_lifted_onto_the_message()
+    {
+        // Replay: toolUseResult does not survive into the transcript, so the pieces travel flat on
+        // the message — except the patch, which stays the CLI's own JSON.
+        var msg = new JObject
+        {
+            ["diffPatch"] = new JArray { Hunk() },
+            ["agentDurationMs"] = 4200L,
+            ["agentTokens"] = 15000L,
+            ["agentToolUses"] = 7,
+        };
+
+        var extras = ToolResultExtras.FromMessage(msg);
+
+        Assert.Single(extras.Patch);
+        Assert.Equal(4200, extras.AgentTotals.DurationMs);
+        Assert.Equal(15000, extras.AgentTotals.Tokens);
+        Assert.Equal(7, extras.AgentTotals.ToolUses);
+    }
+
+    [Fact]
+    public void FromMessage_and_FromToolUseResult_agree_on_the_same_run()
+    {
+        // The same row, built live and rebuilt from history: if these two drift the diff renders
+        // while you watch and disappears when you reopen the session.
+        var live = ToolResultExtras.FromToolUseResult(new JObject
+        {
+            ["structuredPatch"] = new JArray { Hunk() },
+            ["totalDurationMs"] = 4200L,
+            ["totalTokens"] = 15000L,
+            ["totalToolUseCount"] = 7,
+        });
+        var replayed = ToolResultExtras.FromMessage(new JObject
+        {
+            ["diffPatch"] = new JArray { Hunk() },
+            ["agentDurationMs"] = 4200L,
+            ["agentTokens"] = 15000L,
+            ["agentToolUses"] = 7,
+        });
+
+        Assert.Equal(live.Patch.Length, replayed.Patch.Length);
+        Assert.Equal(live.Patch[0].OldStart, replayed.Patch[0].OldStart);
+        Assert.Equal(live.AgentTotals.DurationMs, replayed.AgentTotals.DurationMs);
+        Assert.Equal(live.AgentTotals.Tokens, replayed.AgentTotals.Tokens);
+        Assert.Equal(live.AgentTotals.ToolUses, replayed.AgentTotals.ToolUses);
+    }
+
+    [Fact]
+    public void FromMessage_on_a_message_carrying_neither_reports_neither()
+    {
+        var extras = ToolResultExtras.FromMessage(new JObject());
+
+        Assert.Null(extras.Patch);
+        Assert.Null(extras.AgentTotals);
+    }
+
+    [Fact]
+    public void ToDto_is_null_when_there_is_nothing_to_report()
+    {
+        // So the WebView tests for presence rather than for a zero that could also mean "ran for 0ms".
+        Assert.Null(new ToolResultExtras().ToDto());
+    }
+
+    [Fact]
+    public void ToDto_carries_whichever_group_the_tool_reported()
+    {
+        var patchOnly = ToolResultExtras.FromToolUseResult(
+            new JObject { ["structuredPatch"] = new JArray { Hunk() } }).ToDto();
+
+        Assert.NotNull(patchOnly);
+        Assert.NotNull(patchOnly.Patch);
+        Assert.Null(patchOnly.AgentTotals);
+    }
+}


### PR DESCRIPTION
The WebView half has had tests for a while — 11 files, `npm run check`. The host half had none, and `CLAUDE.md` still said *"No test project"* for both. The gate was a green build plus a manual pass in the Exp instance, which catches what you can see (a broken pane, a missing menu entry) and catches nothing at all when a parser quietly returns a slightly wrong answer.

**192 tests**, ~800ms, over the logic that has no UI to give it away.

## What is covered

| Suite | What it pins |
|---|---|
| `SessionScanTests` | `IsType`, `IsFlagTrue`, `IsSafePathToken` |
| `HistoryReaderTests` | `ReadHistoryRaw`, `ReadUserPrompts`, `ReadRewindableUuids`, `ReadMessageBlock` |
| `StatsAggregatorTests` | tokens per model, cwd, sidechain, seeded resume, `DateKey` |
| `PathHelpersTests` | `Relative`, `LowercaseDrive`, `ToFileUri`, `UrisEquivalent` |
| `ClaudePathsTests` | `ProjectFolderName` — the CLI's folder-naming rule |
| `MetaInjectionTests` | the filter that keeps CLI injections out of the transcript |
| `SchemaBuilderTests` | the JSON Schema the CLI reads to call an MCP tool |
| `ContentBlockTranslatorTests` | wire content blocks → what the WebView renders |
| `ToolResultExtrasTests` | an edit's hunks and an Agent run's totals |

The rule worth the most is the one `CLAUDE.md` states and nothing enforces: the scan matches on strings, so it has to read `{"type": "user"}` from a pretty-printing writer the same as the CLI's compact output. Break it and the build stays green while history skips records.

## Each suite was verified by breaking the code

A test that cannot fail is worse than no test. Every suite was checked by putting the defect in and watching it get caught:

| Defect injected | Tests turned red |
|---|---|
| `IsType` back to a literal `"type":"x"` match | 4 (2 unit, 2 through the readers) |
| `<bash-stderr>` dropped from the meta tags | 1 |
| explicit `[JsonProperty]` name ignored in the schema | 2 |
| `usage` moved onto every content block, not the first | 2 — the context gauge would count a turn twice |

All four reverted; 192/192 green on the committed state.

## Three changes to shipping code

Needed to reach the logic, and one of them is a fix in its own right:

- **`AgentsOptions`** — the `?? new AgentsDebugPage()` fallback could not do its job. A `DialogPage` constructor reaches `ThreadHelper.JoinableTaskContext`, so outside the VS process it throws `FileNotFoundException` rather than yielding defaults — which is exactly what every settings read on a non-UI path was relying on. The construction is now guarded and memoised per page type.
- **`SessionManager.IsType`** — `private` → `internal`. It decides whether a line is read at all, so it is the one that most needs the pretty-print cases pinned.
- **`AssemblyInfo`** — `InternalsVisibleTo`. The logic worth testing is internal; making it public to reach it would widen the surface for a consumer that ships to nobody.

The `.csproj` hunk is not mine — Visual Studio wrote `<Project>`/`<Name>` onto the existing `ProjectReference` when it saved the solution. Kept rather than reverted, because it comes back on the next save either way.

## How it builds, and why the order matters

The test project sits outside `src/` and globs its files. It does **not** use a `ProjectReference`: the extension is a legacy-style VSIX whose dependencies come from `packages.config` and `<HintPath>`, and asking the modern SDK to rebuild it resolves none of them — the first attempt drowned in `CS0246` for `JObject`, `DTE2` and `CoreWebView2*`. It reads the assembly MSBuild already produced instead, so the tests run against what actually ships.

That makes the order part of the gate rather than a preference:

```
msbuild (or build_solution)   →   dotnet test
```

`dotnet test` alone will happily run against a stale DLL and report green.

Newtonsoft is pinned to **13.0.1** here too, for the reason it is pinned in the extension: that is the version VS forces at runtime, and a test passing against one that never ships proves nothing.

## Left out on purpose

- **The editor context** (`IdeContextService`) — `ThreadHelper.ThrowIfNotOnUIThread` + `IVsTextManager` + `IVsWindowFrame`. Testing it means mocking half the VS shell; the Exp instance stays the right gate there.
- **The big services** — `StatsService`, `ClaudeClient`, `FileSuggestions`, `McpServerHost`. Pure by their `using`s, but they hold state and talk to the CLI process. They need scaffolding, not fixtures.
- **`{"type" : "user"}`** (space *before* the colon). `FindJsonStringValue` handles the two forms writers actually emit; no mainstream serializer produces the third. Documented in the test rather than widened for.

## Not wired into CI yet

Deliberately a separate step — this PR is the project and the tests. The WebView side already chains everything into one command (`npm run check`); the host equivalent is `msbuild` + `dotnet test`, in that order.

`CLAUDE.md` says *"No test project"* in two places and is now wrong on both counts. Left for a follow-up so this diff stays what it says it is.
