### PR TITLE
feat(chat): tool rows can be folded away, and the chevron closes them again

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,8 +433,8 @@ gauge in the composer shows how much room is left before the CLI compacts the co
 
 Most of what looks like a saving isn't. **A setting that changes what the chat draws changes nothing
 about what was sent**: by the time a tool result is on screen it has already been through the model.
-Preview lines, Compact Ask answers, Show tool errors inline, the diff options — all rendering. These
-four are the ones that reach the wire:
+Preview lines, Collapse tool results, Compact Ask answers, Show tool errors inline — all rendering.
+These four are the ones that reach the wire:
 
 | | Where | Default | What it does |
 |---|---|---|---|

--- a/docs/chat/context-and-usage.md
+++ b/docs/chat/context-and-usage.md
@@ -94,9 +94,9 @@ The gauge tells you the window is filling; this is what you can actually do abou
 
 Worth saying first, because most of the Chat options page looks like it belongs here and does not:
 **a setting that changes what the chat draws changes nothing about what was sent.** By the time the
-tool result is on screen, it has already been through the model. Preview lines, Compact Ask answers,
-Show tool errors inline, the diff options — every one of those is a rendering choice. The knobs
-below are the ones that reach the wire.
+tool result is on screen, it has already been through the model. Preview lines, Collapse tool
+results, Compact Ask answers, Show tool errors inline — every one of those is a rendering choice.
+The knobs below are the ones that reach the wire.
 
 ### What travels with every message
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -21,7 +21,8 @@ go to `%LOCALAPPDATA%` — see [Settings and data](settings-and-data.md).
 | Show cost and duration | bool | `false` | Show cost (USD) and duration after each response. |
 | Show relative paths in tool rows | bool | `true` | File paths relative to the working directory (full path if outside it). |
 | Select lines when opening file | bool | `true` | When opening a file from a tool row, select the relevant lines in the editor. |
-| Preview lines | int | `3` | Lines shown in preview areas (tool output, user messages). `0` = no preview. |
+| Preview lines | int | `3` | Lines shown in preview areas (tool output, user messages) before a body is clipped. `0` shows an open row whole, however long it is. |
+| Collapse tool results | bool | `false` | Start every tool row closed, so a long session reads as what Claude did rather than how it got there. The chevron opens one when you want it; a failed row still shows its dot and the button that opens the full output. |
 | Chat font size | int (px) | `13` | Font size of the chat message text. |
 | Show WebView developer entries | bool | `false` | Add "WebView DevTools" and "WebView task manager" to the chat toolbar's "More" (…) menu — the browser console/DOM/network on the chat itself, and the browser's processes with their memory and CPU. Pre-release builds always offer both. |
 | Autosave before Claude reads/writes | bool | `true` | Save a dirty file before Claude reads/writes it, so it sees your in-editor edits, not the stale on-disk version. |

--- a/src/Corsinvest.VisualStudio.Agents.Contracts/ToWebViewDtos.cs
+++ b/src/Corsinvest.VisualStudio.Agents.Contracts/ToWebViewDtos.cs
@@ -607,6 +607,7 @@ public class VsOptionsDto
 {
     public bool ShowCostAndDuration { get; set; }
     public int PreviewLines { get; set; }
+    public bool CollapseTools { get; set; }
     public int ChatFontSize { get; set; }
     public bool ShowRelativePaths { get; set; }
     public bool StickyUserMessages { get; set; }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.Payloads.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.Payloads.cs
@@ -30,6 +30,7 @@ internal sealed partial class WebViewBridge
         {
             ShowCostAndDuration = chat.ShowCostAndDuration,
             PreviewLines = chat.PreviewLines,
+            CollapseTools = chat.CollapseTools,
             ChatFontSize = chat.ChatFontSize,
             ShowRelativePaths = chat.ShowRelativePaths,
             StickyUserMessages = chat.StickyUserMessages,

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated/VsOptionsDto.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated/VsOptionsDto.ts
@@ -6,6 +6,7 @@
 export interface VsOptionsDto {
     showCostAndDuration: boolean;
     previewLines: number;
+    collapseTools: boolean;
     chatFontSize: number;
     showRelativePaths: boolean;
     stickyUserMessages: boolean;

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/state.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/state.ts
@@ -199,6 +199,7 @@ const _impl = new StoreImpl<AppState>({
     ui: {
         showCostAndDuration: false,
         previewLines: 3,
+        collapseTools: false,
         chatFontSize: 13,
         showRelativePaths: true,
         stickyUserMessages: true,

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/base.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/base.ts
@@ -9,8 +9,11 @@
 // row(ctx):    the entire row (chrome + content). Pick a layout building block
 //              (rowStandard / rowDiff / rowCount / rowHeaderOnly) or build your
 //              own. Default: rowStandard (header + collapsible IN/OUT body).
-// header():    the row label — name span + optional secondary detail.
+// header():    the row label — name span + optional secondary detail. Unchanged whether the body
+//              is open or folded: a title that rewrites itself on a click reads as a different row.
 // body():      the collapsible content. Default: the IN/OUT grid.
+// autoOpen():  whether that body shows without a click. Errors always do; the rest follow the
+//              "Collapse tool results" option. isOpen() turns it into the rendered state.
 //
 // Pure helpers (cleanResult/preview/diff summary/link markup/row layout) live
 // here. Only actions that touch the app go through this.host.
@@ -97,25 +100,39 @@ export abstract class ToolRenderer {
         return '';
     }
 
+    /** Is this row's body showing? Answers for every layout that has one, so the rule lives in a
+     *  single place rather than in each row*() helper.
+     *
+     *  `expanded` on the host means "the user clicked the chevron", NOT "is open": it FLIPS the
+     *  resting state. That is what lets a row which starts open be folded away — an OR would have
+     *  let the resting state win every time, leaving the chevron toggling a value nothing reads.
+     *
+     *  The resting state itself is the renderer's to decide, through the two hooks it already has:
+     *  `defaultCollapsed()` (Agent: closed whatever the options say) and `autoOpen()` (everything
+     *  else: errors, and the "Collapse tool results" option). */
+    protected isOpen(): boolean {
+        const opensAtRest = !this.defaultCollapsed() && this.autoOpen();
+        return opensAtRest !== this.host.expanded;
+    }
+
     /** Header + collapsible IN/OUT body (the common case). */
     protected rowStandard(): TemplateResult {
         const body = this.body();
         // "Something to expand into": a body, or (Agent) live sub-agent children. Not gated on the
         // pending status, so the Agent chevron appears while the sub-agent runs.
         const expandable = this.hasExpandableContent();
-        // Only defaultCollapsed rows (Agent) are collapsible: they start closed regardless of
-        // the preview setting and show a chevron (kept visible at rest) to toggle. Every other
-        // tool opens per autoOpen and shows no chevron — its body just stays open.
-        const collapsed = this.defaultCollapsed();
-        const open =
-            expandable && (collapsed ? this.host.expanded : this.autoOpen() || this.host.expanded);
         return this.chrome({
             body,
-            open,
+            open: expandable && this.isOpen(),
             // No explicit onClick: chrome's rowClick falls back to toggleExpanded when there's a chevron.
             onClick: null,
-            chevron: expandable && collapsed,
-            chevronAlwaysShown: collapsed,
+            // A chevron wherever there is a body, open or shut: it toggles, so a row that starts
+            // open needs it to close as much as one that starts shut needs it to open. Gating it on
+            // "starts closed" was enough while Agent was the only such row.
+            chevron: expandable,
+            // Agent keeps its chevron visible at rest, so a row holding a whole transcript reads as
+            // expandable before it is hovered.
+            chevronAlwaysShown: this.defaultCollapsed(),
         });
     }
 
@@ -147,14 +164,22 @@ export abstract class ToolRenderer {
     }
 
     /** Diff tools (Edit/Write/MultiEdit): body shows even while pending, the row
-     *  click opens the file at the edit, the header gets the VS/error buttons. */
+     *  click opens the file at the edit, the header gets the VS/error buttons.
+     *
+     *  Same open/toggle rule as rowStandard, so "Collapse tool results" reaches the diff too — it
+     *  is the tallest body in the transcript, and an option that folded everything except the
+     *  thing taking the most room would not be worth turning on. The row click still opens the
+     *  file: the chevron stops propagation, so the two never fight. */
     protected rowDiff(): TemplateResult {
         const fp = String(this.host.input.file_path ?? this.host.input.path ?? '');
+        // diffBody(), not hasExpandableContent(): that one asks body(), which an Edit inherits from
+        // the base (the IN/OUT grid) and never renders — it would answer about a body that isn't there.
+        const body = this.diffBody();
         return this.chrome({
-            body: this.diffBody(),
-            open: true,
+            body,
+            open: body !== null && this.isOpen(),
             onClick: () => this.host.openFileAtEdit(fp),
-            chevron: false,
+            chevron: body !== null,
         });
     }
 
@@ -165,10 +190,16 @@ export abstract class ToolRenderer {
         return this.body() !== null;
     }
 
-    /** Whether a standard body opens without a click. Default: error rows, or
-     *  when previews are on. */
+    /** Whether a standard body opens without a click: the "Collapse tool results" option, and
+     *  nothing else. Separate from previewLines, which caps a body that is already open and used
+     *  to double as this switch by being set to 0.
+     *
+     *  No exception for failures: a closed row still shows its red dot and the error button that
+     *  opens the whole output in Visual Studio — more than the three-line preview would have — so
+     *  forcing it open would only mean the option quietly stops working on the turns that went
+     *  wrong, which are the ones with the most rows to fold. */
     protected autoOpen(): boolean {
-        return this.host.status === 'error' || appState.ui.previewLines > 0;
+        return !appState.ui.collapseTools;
     }
 
     /** Whether this row starts collapsed, ignoring the preview auto-open setting.
@@ -189,9 +220,9 @@ export abstract class ToolRenderer {
         chevron: boolean;
         chevronAlwaysShown?: boolean;
     }): TemplateResult {
-        // A custom onClick wins (e.g. Edit opens the file); otherwise a chevron makes the WHOLE row
-        // the toggle target (accordion-style). The chevron button stopPropagation()s, so clicking it
-        // and clicking the row can't double-fire.
+        // What clicking the ROW does: a custom onClick wins (Edit opens the file), otherwise a
+        // chevron makes the whole row the toggle target (accordion-style). The chevron itself
+        // always toggles — see its handler — and stopPropagation()s so the two can't double-fire.
         const rowClick = opts.onClick ?? (opts.chevron ? () => this.host.toggleExpanded() : null);
         const clickable = rowClick !== null;
         const elapsed = this.host.elapsedSec;
@@ -225,8 +256,11 @@ export abstract class ToolRenderer {
                                   icon-only
                                   title=${opts.open ? 'Collapse' : 'Expand'}
                                   @click=${(e: Event) => {
+                                      // Always the toggle, never rowClick: a row with an onClick of
+                                      // its own (Edit opens the file) would otherwise have a chevron
+                                      // that opens the file instead of folding the row.
                                       e.stopPropagation();
-                                      rowClick?.();
+                                      this.host.toggleExpanded();
                                   }}
                               >
                                   ${unsafeHTML(ChevronDown16Regular)}

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/renderers.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/renderers.ts
@@ -222,9 +222,6 @@ export class WebFetchRenderer extends ToolRenderer {
         const detail = /^https?:\/\//.test(url) ? this.urlLink(url, text) : text;
         return html`${this.nameSpan('Web Fetch')}${this.detailSpan(detail)}`;
     }
-    protected override autoOpen(): boolean {
-        return true;
-    }
     override inputText(): string {
         return String(this.host.input.prompt ?? '');
     }

--- a/src/Corsinvest.VisualStudio.Agents/Options/AgentsChatPage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Options/AgentsChatPage.cs
@@ -52,8 +52,13 @@ public class AgentsChatPage : AgentsOptionsPage
 
     [Category("Display")]
     [DisplayName("Preview lines")]
-    [Description("Number of lines shown in preview areas (tool output and user messages). 0 turns previews off: tool rows start collapsed (the chevron opens them in full) and user bubbles keep a short 3-line preview.")]
+    [Description("Number of lines shown in preview areas (tool output and user messages) before a body is clipped. 0 shows an open row whole, however long it is. To start rows closed instead, use Collapse tool results below.")]
     public int PreviewLines { get; set; } = 3;
+
+    [Category("Display")]
+    [DisplayName("Collapse tool results")]
+    [Description("Start every tool row closed, so a long session reads as what Claude did rather than how it got there. The chevron opens one when you want it, and a failed tool stays open either way. Separate from Preview lines, which decides how much of an OPEN row is shown.")]
+    public bool CollapseTools { get; set; }
 
     [Category("File links")]
     [DisplayName("Extra linkable extensions")]


### PR DESCRIPTION
A long session reads as *how* Claude got somewhere rather than *what it did*: every tool row shows its body, and the diffs — the tallest thing in a transcript — show it whether or not anyone is reading them.

## The option

**Options → Chat → Collapse tool results**, off by default. It changes how the whole transcript looks, which is the user's call rather than one to spring on them.

It is a **separate option**, not a meaning bolted onto *Preview lines*. Setting that to `0` used to do this, which made "I want short bodies" and "I want them closed" the same switch — and whoever wanted the second lost the preview on everything they later opened. *Preview lines* now caps an open body and nothing else, which is what its name says.

## Two bugs surfaced, both older than the option

**A row that started open had no chevron**, so it could never be closed. The chevron was gated on "starts collapsed", which was enough while the Agent row was the only one that ever did.

It now appears wherever there is a body, and `expanded` on the host **flips** the resting state instead of being ORed with it:

```ts
const opensAtRest = !this.defaultCollapsed() && this.autoOpen();
return opensAtRest !== this.host.expanded;
```

An OR let `autoOpen` win every time, leaving the chevron toggling a value nothing read.

**The chevron ran the ROW's click handler.** On an Edit that opens the file — so clicking the chevron opened the file instead of folding the diff. It now always toggles, and still stops propagation so the row's own click never double-fires.

## No exception for failed rows

`autoOpen()` used to force them open. A closed one still shows its **red dot** and the **error button that opens the whole output in Visual Studio** — more than the three-line preview would have — so forcing it open only meant the option quietly stopped working on the turns that went wrong, which are the ones with the most rows to fold.

`WebFetch`'s own `autoOpen: true` goes for the same reason: no comment explained it, and its body is the prompt, not the fetched page.

## What it reaches

| layout | tools | folds? |
| --- | --- | --- |
| `rowStandard` | Bash, PowerShell, Write, NotebookEdit, WebFetch, Skill, Agent | yes |
| `rowDiff` | Edit, MultiEdit | yes — the tallest body, and the reason the option is worth turning on |
| `rowCount` | Grep, Glob, WebSearch | no — one line, already clickable |
| `rowHeaderOnly` | Read, ToolSearch, worktree/plan tools | no — no body at all |
| `open: done` | ExitPlanMode, TodoWrite, AskUserQuestion | no — interactive: closing hides the answer, not an output |

## Considered and dropped

A `headerCollapsed()` hook, so Bash could show its command instead of its description while folded. Written, then removed: **a title that rewrites itself on a click reads as a different row**, and with Bash gone the hook had no consumer left. The reasoning is now a line in `base.ts` so it isn't rediscovered.

## Verified

MSBuild green, typecheck, lint, prettier, and 164/164 WebView tests.
