### PR TITLE
feat(debug): a bar over the file when you stop, one press from asking

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ own.
 - **[70+ MCP tools](docs/mcp-tools.md)** — Visual Studio's own navigation, references, rename,
   diagnostics, build and the **live debugger** (breakpoints, stepping, locals, evaluate) handed to
   the agent. Not text search over source: the IDE's semantic, running view of your program.
+- **[It offers when you break](docs/options.md#asking-about-a-break)** — stop on an exception and a
+  bar appears over that file: one press asks about the break, and the agent reads the live stack and
+  locals rather than guessing from the source. Breakpoints are opt-in, steps never ask.
 - **[Review changes in VS's own diff](docs/chat/diff.md)** — every Edit/Write shows as an inline diff,
   and opens in Visual Studio's native, **editable** side-by-side diff: **save (Ctrl+S) to accept** or
   **close to reject**, the CLI applies it only if you saved.
@@ -154,7 +157,7 @@ own.
 - **[Restore panes on solution open](docs/options.md#general)** *(opt-in)* — reopen the panes you
   had for a solution, each back on its own session. Off by default: opening a solution shouldn't
   start agents you didn't ask for.
-- **[Tune it to your taste](docs/options.md)** — 26 options across General, Chat and Debug: what
+- **[Tune it to your taste](docs/options.md)** — 27 options across General, Chat and Debug: what
   the chat shows, how diffs render, which keys send, the starting permission mode, autosave,
   file checkpoints, upload and `@`-picker filters, log verbosity.
 - **[It tells you when it needs you](#pane-attention-notifications)** — with several panes working

--- a/docs/marketplace-overview.md
+++ b/docs/marketplace-overview.md
@@ -28,7 +28,7 @@ Visual Studio **2022 and 2026**. Free, GPL-3.0.
 |---|---|
 | **Build** | build and rebuild, with the errors handed straight back |
 | **Diagnostics** | errors and warnings from the live language service, including the ones an edit just introduced |
-| **Debugger** | breakpoints, stepping, locals, call stack |
+| **Debugger** | breakpoints, stepping, locals, call stack — and it offers to look when you stop on an exception |
 | **Tests** | discovery and runs |
 | **Navigation** | go to definition, find references, symbol search |
 | **Editor** | active document, selection, open files |
@@ -38,6 +38,10 @@ The chat panel and the diff viewer are the easy part. Compiler diagnostics are n
 structured model behind the Error List, not as text in a buffer. Reaching them means going through
 Visual Studio's own APIs — which is what these tools do, via Roslyn's per-document language
 services and `EnvDTE` rather than a C#-only path, so they keep working in C++, F# and TypeScript.
+
+And it offers before you ask. Stop on an exception and a bar appears over that file — one press asks
+about the break, and the answer comes from the live call stack and locals rather than a guess at the
+source. Breakpoints are opt-in (you placed it, you know why you are there) and stepping never asks.
 
 ---
 
@@ -160,7 +164,7 @@ The things people keep asking for, and where they are:
 | Native diff review inside VS, not a terminal text stream | inline in the chat, click to open the file at the line |
 | Build errors passed to Claude automatically | the build tools return them as file/line/message |
 | A dockable chat panel, not a detached terminal | a real tool window — and a CLI pane too, if you want both |
-| Breakpoint and debug state visible to Claude | the debugger tools: breakpoints, stepping, locals, call stack |
+| Breakpoint and debug state visible to Claude | the debugger tools: breakpoints, stepping, locals, call stack — and a bar over the file when you stop on an exception, one press from asking about it |
 | Crash dumps, profiling, VS diagnostic tools | not yet — [open an issue](https://github.com/Corsinvest/cv4vs-agents/issues/new?template=feature_request.yml) if you need it |
 | Works with a Max subscription | it drives your own `claude.exe`, so whatever you are signed in with |
 | **Visual Studio 2022** | supported, not just 2026 |

--- a/docs/options.md
+++ b/docs/options.md
@@ -11,8 +11,35 @@ go to `%LOCALAPPDATA%` — see [Settings and data](settings-and-data.md).
 | Setting | Type | Default | Description |
 |---|---|---|---|
 | Restore panes on solution open | bool | `false` | Reopen the panes (with their sessions) that were open for a solution when it is reopened. |
+| Offer to ask when the debugger pauses | `Never` / `Exceptions only` / `Exceptions and breakpoints` | `Exceptions only` | Show an InfoBar over the file the debugger stopped in, with an "Ask cv4vs Agents" button that asks a chat pane about the break. See [Asking about a break](#asking-about-a-break). |
 | Default new session | `Chat` / `CLI` | `Chat` | Which kind the "New" button creates by default (the dropdown still lets you pick the other). |
 | Claude executable path | file path | *(empty)* | Override auto-detection with a specific `claude.exe` (browse with `…`). Empty = auto-detect via PATH / native installer / npm. Must be the real `.exe` — `.cmd`/`.bat`/`.ps1` shims can't be launched. |
+
+### Asking about a break
+
+When the debugger stops, an InfoBar appears over the file it stopped in:
+
+> ⚠ Debugger paused on `DivideByZeroException` at `Calcolatrice.cs:13`.  **[Ask cv4vs Agents]**
+
+Pressing the button activates the last chat pane you used and asks it about the break. Nothing is
+sent until you press it, and the bar goes away on its own when execution resumes.
+
+The message names neither the file nor the exception type. Both are right there, but the debug
+[MCP tools](mcp-tools.md#debug) read them live and read more besides — the call stack, the locals,
+any expression — so naming a type up front would only anchor the answer on the outermost exception
+when the cause is usually an `InnerException` two levels down. What the message does say is to
+leave the debugger where it is: those same tools can step and continue, and you are standing in
+that break looking at it.
+
+Which pauses are worth an offer differs by kind, which is why the setting has three values rather
+than a checkbox:
+
+- **Exceptions** are a surprise, and the default.
+- **Breakpoints** are not — you placed it and know why you are there — so they are opt-in.
+- **Steps** never raise a bar at any setting: one per F10 is noise.
+
+A break landing where the previous one did is skipped too, so a breakpoint inside a loop raises one
+bar rather than one per iteration.
 
 ## Chat
 

--- a/src/Corsinvest.VisualStudio.Agents.Contracts/ToWebViewDtos.cs
+++ b/src/Corsinvest.VisualStudio.Agents.Contracts/ToWebViewDtos.cs
@@ -425,6 +425,10 @@ public class SetComposerNotification
     /// context menu is about the file it was picked in, and asking about this code outranks the
     /// session's standing preference.</summary>
     public bool EnableIdeContext { get; set; }
+
+    /// <summary>Send the text instead of leaving it in the composer, for a prompt the user asked
+    /// for by pressing a button of its own. Otherwise it is a pre-fill they can still edit.</summary>
+    public bool Send { get; set; }
 }
 
 /// <summary>A keystroke the host claimed on the WebView's behalf (ui_host_key).

--- a/src/Corsinvest.VisualStudio.Agents/AgentsPackage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/AgentsPackage.cs
@@ -67,6 +67,9 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
     private uint _debuggerEventsCookie;
     private IVsDebugger _debugger;
 
+    // A field, not a local: the sink is COM, and a collected one silently stops delivering.
+    private EnvDTE.DebuggerEvents _dteDebuggerEvents;
+
     // Solution reload watch. VS models a reload as close-then-open and no event tells the two apart
     // from a plain close, so the close is deferred and the panes are kept until we know which it was.
     private System.Threading.Timer _reloadWatch;
@@ -303,6 +306,29 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
         });
     }
 
+    /// <summary>Break mode, with the reason attached. Deferred off the event: reading the location
+    /// goes back through a debugger still settling into the break.</summary>
+    private void OnEnterBreakMode(EnvDTE.dbgEventReason reason, ref EnvDTE.dbgExecutionAction action)
+    {
+        try
+        {
+            var notify = AgentsOptions.General.NotifyOnDebugBreak;
+            if (notify == DebugBreakNotify.Never) { return; }
+            if (reason == EnvDTE.dbgEventReason.dbgEventReasonStep) { return; }
+
+            var notifyOnBreakpoint = notify == DebugBreakNotify.ExceptionsAndBreakpoints;
+            _ = JoinableTaskFactory.RunAsync(async () =>
+            {
+                try { await DebugBreakService.NotifyBreakAsync(notifyOnBreakpoint); }
+                catch (Exception ex) { OutputWindowLogger.Global.LogException("Pkg.OnEnterBreakMode.Notify", ex); }
+            });
+        }
+        catch (Exception ex)
+        {
+            OutputWindowLogger.Global.LogException("Pkg.OnEnterBreakMode", ex);
+        }
+    }
+
     /// <summary>Debugger mode changed. VS keeps window layouts per mode, so panes opened at design
     /// time are absent from the run-time layout and look as though the debugger closed them — the
     /// frames are still there, just not shown. Bring back the ones the registry knows are open.
@@ -314,6 +340,9 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
     {
         try
         {
+            // Left break mode: whatever the break InfoBar was pointing at is over.
+            if (dbgmodeNew != DBGMODE.DBGMODE_Break) { DebugBreakService.Clear(); }
+
             if (Core.Panes.PaneRegistry.Instance.Entries.Count == 0) { return VSConstants.S_OK; }
             _ = JoinableTaskFactory.StartOnIdle(() =>
             {
@@ -406,6 +435,22 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
         _debugger = await GetServiceAsync(typeof(SVsShellDebugger)) as IVsDebugger;
         _debugger?.AdviseDebuggerEvents(this, out _debuggerEventsCookie);
 
+        // Only DTE reports why the debugger stopped: OnModeChange above sees a step, a breakpoint
+        // and a thrown exception all as DBGMODE_Break. Best effort — without it the panes still
+        // follow the layout, there is just never a break offer.
+        try
+        {
+            if (await GetServiceAsync(typeof(EnvDTE.DTE)) is EnvDTE.DTE dte && dte.Events != null)
+            {
+                _dteDebuggerEvents = dte.Events.DebuggerEvents;
+                _dteDebuggerEvents.OnEnterBreakMode += OnEnterBreakMode;
+            }
+        }
+        catch (Exception ex)
+        {
+            OutputWindowLogger.Global.LogException("Pkg.AdviseDteDebuggerEvents", ex);
+        }
+
         // Prime from current state: VS may already have a solution — or, in Open Folder mode, a
         // folder — open before our package activates, so we'd miss OnAfterOpenSolution/
         // OnAfterOpenFolder. VSPROPID_IsSolutionOpen is documented as tracking a .sln file
@@ -435,6 +480,11 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
             {
                 _debugger?.UnadviseDebuggerEvents(_debuggerEventsCookie);
                 _debuggerEventsCookie = 0;
+            }
+            if (_dteDebuggerEvents != null)
+            {
+                _dteDebuggerEvents.OnEnterBreakMode -= OnEnterBreakMode;
+                _dteDebuggerEvents = null;
             }
             _reloadWatch?.Dispose();
             _reloadWatch = null;

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
@@ -401,7 +401,7 @@ public partial class ChatPaneControl : PaneControlBase
             SendTheme();
             // Re-push the caption: RegisterInstance runs before VS wires IVsWindowFrame, so the earlier set can no-op.
             RepushCaption();
-            Entry.SetComposerAction = text => SetComposerText(text, withIdeContext: true);
+            Entry.SetComposerAction = (text, send) => SetComposerText(text, true, send);
 
             AgentsOptions.Applied += OnOptionsApplied;
             VSColorTheme.ThemeChanged += OnVsThemeChanged;
@@ -588,7 +588,7 @@ public partial class ChatPaneControl : PaneControlBase
         // is also what tells the two apart, a fork always brings the session it forked.
         if (!string.IsNullOrEmpty(_startupPrompt))
         {
-            SetComposerText(_startupPrompt, withIdeContext: !restoreState);
+            SetComposerText(_startupPrompt, !restoreState, false);
         }
 
         // Detached from the startup path on purpose: it is a network call, and the chat must open
@@ -616,18 +616,19 @@ public partial class ChatPaneControl : PaneControlBase
 
     /// <summary>Writes text into the composer. <paramref name="withIdeContext"/> also re-opens the
     /// IDE-context eye: a prompt picked from the editor context menu is about the file it came
-    /// from, and with the eye shut the CLI is never told which file that is.</summary>
-    private void SetComposerText(string text, bool withIdeContext)
+    /// from, and with the eye shut the CLI is never told which file that is.
+    /// <paramref name="send"/> sends it instead of leaving it there to edit.</summary>
+    private void SetComposerText(string text, bool withIdeContext, bool send)
         => Dispatcher.Invoke(() =>
         {
-            if (withIdeContext && Entry != null && !Entry.Options.SendSelection)
+            if (withIdeContext && Entry?.Options.SendSelection == false)
             {
                 Entry.Options.SendSelection = true;
-                Ide.IdeContextService.Instance.ForceEmitCurrentContext();
+                IdeContextService.Instance.ForceEmitCurrentContext();
             }
             _bridge?.Send(
                 BridgeMessages.ToWebView.Ui.SetComposer,
-                new Contracts.SetComposerNotification { Text = text, EnableIdeContext = withIdeContext });
+                new Contracts.SetComposerNotification { Text = text, EnableIdeContext = withIdeContext, Send = send });
         });
 
     /// <summary>Creates the single ClaudeClient instance on demand (once per tool window lifetime).</summary>

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated/SetComposerNotification.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/generated/SetComposerNotification.ts
@@ -6,4 +6,5 @@
 export interface SetComposerNotification {
     text: string;
     enableIdeContext: boolean;
+    send: boolean;
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/init.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/init.ts
@@ -148,7 +148,12 @@ function wireBridgeHandlers(): void {
         }
         const input = document.querySelector('cv-prompt') as
             import('./components/cv-prompt').CvPrompt | null;
-        input?.setComposerText(data?.text ?? '');
+        const text = data?.text ?? '';
+        if (data?.send && text) {
+            input?.sendPrompt(text, true);
+        } else {
+            input?.setComposerText(text);
+        }
     });
 
     // A key the composition control dropped, claimed by the pane on our behalf — see host-keys.ts.

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/DebugBreakInfoBar.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/DebugBreakInfoBar.cs
@@ -1,0 +1,99 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Imaging;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using System;
+
+namespace Corsinvest.VisualStudio.Agents.Core.Panes;
+
+/// <summary>A debugger-break InfoBar: "Paused on &lt;exception&gt; at &lt;file&gt;:&lt;line&gt;" with an
+/// "Ask cv4vs Agents" action. Hosted on the window frame of the file the break happened in — the user is
+/// looking at that editor, not at the top of the shell — and falls back to the main window when
+/// that document isn't open. <see cref="DebugBreakService"/> decides when one is worth raising.</summary>
+internal sealed class DebugBreakInfoBar : IVsInfoBarUIEvents
+{
+    private readonly Action _onAsk;
+    private readonly object _ask = new();
+    private IVsInfoBarUIElement _element;
+    private uint _cookie;
+    private Action _onClosedExternal;
+
+    private DebugBreakInfoBar(Action onAsk) => _onAsk = onAsk;
+
+    /// <summary>Create + attach the bar. Returns null (no-op) when no InfoBar host or factory is
+    /// available. <paramref name="filePath"/> selects the document frame to host it on;
+    /// <paramref name="onAsk"/> runs on the ask click, <paramref name="onClosed"/> lets the
+    /// caller drop its reference once the bar goes away.</summary>
+    public static DebugBreakInfoBar TryShow(string message, string filePath, Action onAsk, Action onClosed)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        try
+        {
+            if (!TryGetInfoBarHost(filePath, out var host)) { return null; }
+            if (Package.GetGlobalService(typeof(SVsInfoBarUIFactory)) is not IVsInfoBarUIFactory factory) { return null; }
+
+            var bar = new DebugBreakInfoBar(onAsk) { _onClosedExternal = onClosed };
+            var model = new InfoBarModel(
+                textSpans: [new InfoBarTextSpan(message + " ")],
+                actionItems: [new InfoBarButton($"Ask {AppConstants.AppName}", bar._ask)],
+                image: KnownMonikers.StatusWarning,
+                isCloseButtonVisible: true);
+
+            bar._element = factory.CreateInfoBar(model);
+            bar._element.Advise(bar, out bar._cookie);
+            host.AddInfoBar(bar._element);
+            return bar;
+        }
+        catch (Exception ex)
+        {
+            OutputWindowLogger.Global.LogException("DebugBreakInfoBar.TryShow", ex);
+            return null;
+        }
+    }
+
+    public void Close()
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        try { _element?.Close(); } catch { /* best effort */ }
+    }
+
+    /// <summary>The InfoBar host of the frame showing <paramref name="filePath"/>, or the main
+    /// window's when the file isn't open. Deliberately does not open the document: a break can land
+    /// in a file the user never asked to see, and opening tabs mid-debug moves ground under them.</summary>
+    private static bool TryGetInfoBarHost(string filePath, out IVsInfoBarHost host)
+    {
+        host = null;
+        if (!string.IsNullOrEmpty(filePath)
+            && VsShellUtilities.IsDocumentOpen(
+                ServiceProvider.GlobalProvider, filePath, Guid.Empty, out _, out _, out var frame)
+            && frame?.GetProperty((int)__VSFPROPID7.VSFPROPID_InfoBarHost, out var frameHost) == VSConstants.S_OK)
+        {
+            host = frameHost as IVsInfoBarHost;
+            if (host != null) { return true; }
+        }
+
+        if (Package.GetGlobalService(typeof(SVsShell)) is not IVsShell shell) { return false; }
+        if (shell.GetProperty((int)__VSSPROPID7.VSSPROPID_MainWindowInfoBarHost, out var hostObj) != VSConstants.S_OK) { return false; }
+        host = hostObj as IVsInfoBarHost;
+        return host != null;
+    }
+
+    void IVsInfoBarUIEvents.OnActionItemClicked(IVsInfoBarUIElement infoBarUIElement, IVsInfoBarActionItem actionItem)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        if (ReferenceEquals(actionItem.ActionContext, _ask)) { _onAsk?.Invoke(); }
+        try { infoBarUIElement.Close(); } catch { /* best effort */ }
+    }
+
+    void IVsInfoBarUIEvents.OnClosed(IVsInfoBarUIElement infoBarUIElement)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        try { infoBarUIElement.Unadvise(_cookie); } catch { /* best effort */ }
+        _onClosedExternal?.Invoke();
+    }
+}

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/DebugBreakService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/DebugBreakService.cs
@@ -1,0 +1,163 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using Corsinvest.VisualStudio.Agents.Core.Profiles;
+using Corsinvest.VisualStudio.Agents.Ide;
+using Microsoft.VisualStudio.Shell;
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Corsinvest.VisualStudio.Agents.Core.Panes;
+
+/// <summary>Offers a chat when the debugger stops on something the user didn't plan for. Raises the
+/// break InfoBar over the file it happened in; pressing it asks a chat pane about the break. The
+/// press is the consent — nothing here starts a turn on its own.
+/// <para>An exception is a surprise and worth an offer. A breakpoint is not: the user placed it and
+/// knows why they are there, so it is opt-in. Steps never notify — one bar per F10 is noise — and a
+/// break landing where the previous one did is dropped, or a breakpoint inside a loop raises the
+/// same bar on every iteration.</para></summary>
+internal static class DebugBreakService
+{
+    private static DebugBreakInfoBar _bar;
+    private static string _lastKey;
+
+    // Bumped by every resume, so a read that outlives its break can tell and drop its answer.
+    private static int _generation;
+
+    /// <summary>The debugger entered break mode on something other than a step. Reads the location
+    /// through <see cref="IdeDebugService"/> — the same view the debug tools report — so the bar and
+    /// the model can't disagree. A break carrying no exception is a breakpoint.</summary>
+    public static async Task NotifyBreakAsync(bool notifyOnBreakpoint)
+    {
+        var generation = _generation;
+        var state = await ReadSettledStateAsync(generation);
+        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+        // Resumed while the location was being read — this answer is about a break already over.
+        if (generation != _generation) { return; }
+        if (state == null || !string.Equals(state.Mode, "break", StringComparison.Ordinal)) { return; }
+
+        var isException = !string.IsNullOrEmpty(state.ExceptionType);
+        if (!isException && !notifyOnBreakpoint) { return; }
+
+        // Same place as the break before it: the user is already looking at that bar.
+        var key = $"{state.CurrentFile}|{state.CurrentLine}|{state.ExceptionType}";
+        if (string.Equals(key, _lastKey, StringComparison.Ordinal)) { return; }
+
+        CloseBar();
+        _lastKey = key;
+
+        _bar = DebugBreakInfoBar.TryShow(
+            Describe(state),
+            state.CurrentFile,
+            onAsk: () => Ask(state),
+            onClosed: () => _bar = null);
+    }
+
+    /// <summary>The break location, once the debugger agrees with itself about it. Asked the instant
+    /// the event fires it answers mid-settle — the opening brace rather than the throwing line, and
+    /// no $exception yet, which reads as "no exception" and would drop the very break worth
+    /// offering. So it retries briefly, and takes the first answer carrying one.</summary>
+    private static async Task<IdeDebugService.DebugState> ReadSettledStateAsync(int generation)
+    {
+        const int attempts = 5;
+        const int delayMs = 120;
+
+        IdeDebugService.DebugState last = null;
+        for (var i = 0; i < attempts; i++)
+        {
+            if (generation != _generation) { return last; }
+
+            last = await IdeDebugService.Instance.GetStateAsync();
+            if (last == null || !string.Equals(last.Mode, "break", StringComparison.Ordinal)) { return last; }
+            if (!string.IsNullOrEmpty(last.ExceptionType)) { return last; }
+
+            if (i < attempts - 1) { await Task.Delay(delayMs); }
+        }
+        return last;
+    }
+
+    /// <summary>Execution resumed, or the session ended. Clears the de-dup key too: stopping at the
+    /// same line after running on is a new event, unlike the same line reported twice without ever
+    /// leaving break mode.</summary>
+    public static void Clear()
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        _generation++;
+        _lastKey = null;
+        CloseBar();
+    }
+
+    private static void CloseBar()
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        if (_bar == null) { return; }
+        _bar.Close();
+        _bar = null;
+    }
+
+    private static string Describe(IdeDebugService.DebugState state)
+        => string.IsNullOrEmpty(state.ExceptionType)
+            ? $"Debugger paused{Where(state)}."
+            : $"Debugger paused on {Short(state.ExceptionType)}{Where(state)}.";
+
+    private static string Where(IdeDebugService.DebugState state)
+    {
+        if (string.IsNullOrEmpty(state.CurrentFile)) { return string.Empty; }
+        var name = Path.GetFileName(state.CurrentFile);
+        return state.CurrentLine > 0 ? $" at {name}:{state.CurrentLine}" : $" in {name}";
+    }
+
+    /// <summary>Last segment of a namespace-qualified type — the bar has one line to spend, and
+    /// "DivideByZeroException" identifies it as well as the full name does.</summary>
+    private static string Short(string type)
+    {
+        var dot = type.LastIndexOf('.');
+        return dot >= 0 && dot < type.Length - 1 ? type.Substring(dot + 1) : type;
+    }
+
+    /// <summary>Hands the question to a chat pane the way the editor prompts do: the last activated
+    /// one, brought forward first, or the answer arrives in a tab nobody is looking at.</summary>
+    private static void Ask(IdeDebugService.DebugState state)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        try
+        {
+            var prompt = Prompt(state);
+            var target = PaneRegistry.Instance.OfKind(PaneKind.Chat).LastOrDefault(e => e.SetComposerAction != null);
+            if (target == null)
+            {
+                // First profile = the native "Claude" that ProfileStore prepends.
+                var profile = ProfileStore.Load(forEdit: false).FirstOrDefault();
+                if (profile != null) { PaneLauncher.OpenNew(PaneKind.Chat, profile, initialPrompt: prompt); }
+                return;
+            }
+
+            target.ActivateAction?.Invoke();
+            target.SetComposerAction(prompt, true);
+        }
+        catch (Exception ex)
+        {
+            OutputWindowLogger.Global.LogException("DebugBreakService.Ask", ex);
+        }
+    }
+
+    /// <summary>Says a break is there to look at, and nothing the debug tools would read better.
+    /// <para>Naming the type up front anchors the answer on the outermost exception, where the
+    /// cause is usually an InnerException two levels down. The second line is the one worth
+    /// spending: those same tools step and continue, and nothing tells them the user is standing
+    /// in this break watching it.</para></summary>
+    private static string Prompt(IdeDebugService.DebugState state)
+    {
+        // On a breakpoint "why did this happen" answers itself — the user put it there.
+        var ask = string.IsNullOrEmpty(state.ExceptionType)
+            ? "The debugger is paused. Look at it and tell me what is going on here."
+            : "The debugger is paused on an exception. Look at it and tell me why.";
+
+        return $"{ask}\nDo not move the debugger — I am looking at this break.";
+    }
+}

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneEntry.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneEntry.cs
@@ -97,9 +97,10 @@ public sealed class PaneEntry
     /// VS routes Esc through IOleCommandTarget, so it never reaches the popup on its own.</summary>
     internal Func<bool> DismissHistoryAction { get; set; }
 
-    /// <summary>Writes text into this pane's composer, for the editor context menu. Chat panes
-    /// only — the CLI pane has no composer of ours to fill.</summary>
-    internal Action<string> SetComposerAction { get; set; }
+    /// <summary>Writes text into this pane's composer, for the editor context menu and the
+    /// debugger-break offer; the flag sends it outright. Chat panes only — the CLI pane has no
+    /// composer of ours to fill.</summary>
+    internal Action<string, bool> SetComposerAction { get; set; }
 
     /// <summary>The single-source display title, used by BOTH the pane caption and the toolbar's
     /// open-panes list: e.g. "Chat 3 (Claude)". Computed once in the ctor (all inputs immutable).

--- a/src/Corsinvest.VisualStudio.Agents/Corsinvest.VisualStudio.Agents.csproj
+++ b/src/Corsinvest.VisualStudio.Agents/Corsinvest.VisualStudio.Agents.csproj
@@ -237,6 +237,8 @@
       <DependentUpon>CvLoadingOverlay.xaml</DependentUpon>
     </Compile>
     <Compile Include="Core\Panes\IPaneControl.cs" />
+    <Compile Include="Core\Panes\DebugBreakInfoBar.cs" />
+    <Compile Include="Core\Panes\DebugBreakService.cs" />
     <Compile Include="Core\Panes\PaneAttentionInfoBar.cs" />
     <Compile Include="Core\Panes\PaneAttentionService.cs" />
     <Compile Include="Core\Panes\PaneWindowBase.cs" />

--- a/src/Corsinvest.VisualStudio.Agents/Editor/EditorPromptsMenuCommand.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Editor/EditorPromptsMenuCommand.cs
@@ -97,7 +97,7 @@ internal sealed class EditorPromptsMenuCommand : OleMenuCommand
         }
 
         target.ActivateAction?.Invoke();
-        target.SetComposerAction(prompt);
+        target.SetComposerAction(prompt, false);
     }
 
     private static int GetIndex(EditorPromptsMenuCommand cmd)

--- a/src/Corsinvest.VisualStudio.Agents/Options/AgentsGeneralPage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Options/AgentsGeneralPage.cs
@@ -19,6 +19,21 @@ public enum NewSessionKind
     Cli,
 }
 
+/// <summary>Which debugger pauses are worth offering a chat on. An exception is a surprise; a
+/// breakpoint is not — the user placed it and knows why they are there — so the two are separate
+/// steps rather than one switch. Steps never notify at any setting.</summary>
+public enum DebugBreakNotify
+{
+    [Description("Never")]
+    Never,
+
+    [Description("Exceptions only")]
+    Exceptions,
+
+    [Description("Exceptions and breakpoints")]
+    ExceptionsAndBreakpoints,
+}
+
 /// <summary>File picker limited to executables — the CLI path must be a real .exe (see the
 /// ClaudeExecutablePath comment). The filter only guides the dialog; a hand-typed path is still
 /// validated by the resolver.</summary>
@@ -39,6 +54,10 @@ public class AgentsGeneralPage : AgentsOptionsPage
     [DisplayName("Restore panes on solution open")]
     [Description("Reopen the panes (with their sessions) that were open for a solution when it is reopened.")]
     public bool RestorePanesOnSolutionOpen { get; set; } = false;
+
+    [DisplayName("Offer to ask when the debugger pauses")]
+    [Description("Show an InfoBar over the file the debugger stopped in, with an \"Ask cv4vs Agents\" action that asks a chat pane about the break. Nothing is sent unless you press it.")]
+    public DebugBreakNotify NotifyOnDebugBreak { get; set; } = DebugBreakNotify.Exceptions;
 
     [DisplayName("Default new session")]
     [Description("Which kind of session the \"New\" button creates by default (the dropdown still lets you pick the other).")]


### PR DESCRIPTION
Stopping on an exception raised nothing. The debug tools were there, but nothing told the model a break was happening — so a question typed mid-session got answered from the source instead of from the running program.

Now the break raises an InfoBar on the frame of the file it happened in, and its button asks the last chat pane about it.

> ⚠ Debugger paused on `DivideByZeroException` at `Calcolatrice.cs:13`.  **[Ask cv4vs Agents]**

The press is the consent — nothing starts a turn on its own, and the bar goes away when execution resumes.

## What it sends

Two lines, naming neither the file nor the exception type:

```
The debugger is paused on an exception. Look at it and tell me why.
Do not move the debugger — I am looking at this break.
```

Both are right there, but the debug tools read them live and read more besides, and a type named up front anchors the answer on the outermost exception when the cause is usually an `InnerException` two levels down. What it does say is the one thing no tool description carries: those same tools step and continue, and none of them knows the user is standing in that break watching it.

## Which pauses ask

Three values rather than a checkbox, because the kinds differ:

- **Exceptions** — a surprise, and the default.
- **Breakpoints** — you placed it and know why you are there, so opt-in.
- **Steps** — never, at any setting.

A break landing where the previous one did is dropped, or a breakpoint inside a loop would raise one bar per iteration.

## The settle problem

Asked the instant the event fires, the debugger answers mid-settle: the method's opening brace rather than the throwing line, and no `$exception` yet — which reads as "no exception" and would drop the very break worth offering. Found in testing, before it shipped. The location is now retried briefly, and a resume bumps a token the read checks on its way back, so a program that ran on can't leave a bar describing a break already over.

## Notes

- `SetComposerNotification` grows a `Send` flag. Editor prompts still pre-fill a composer the user can edit; a button that already means "ask this" sends.
- `EnvDTE.DebuggerEvents.OnEnterBreakMode` is a second sink because `IVsDebuggerEvents.OnModeChange` reports the mode alone — a step, a breakpoint and a throw all arrive as `DBGMODE_Break`. Held in a field: a collected COM sink stops delivering silently.
- The bar attaches to the document's own `IVsInfoBarHost` and falls back to the main window when the file isn't open. It never opens the document — a break can land in a file the user never asked to see.

## Verified

Manually in the experimental instance, on `ConsoleApp3`:

| Case | Result |
|---|---|
| Exception → bar names type and line | pass |
| Press → turn sent, model reads call stack / locals / evaluates live | pass |
| Model leaves the debugger where it is | pass |
| Bar clears when execution resumes | pass |
| Stepping (F10 ×5) raises nothing | pass |
| Breakpoint in a 1000-iteration loop raises one bar | pass |
| Nested exception — model reaches the inner cause | pass |

Build green, no warnings. TypeScript typecheck and `format:check` clean.

Docs: `docs/options.md` (setting + "Asking about a break"), `README.md`, `docs/marketplace-overview.md`.
