### PR TITLE
feat(menu): ask about a build failure from where you are reading it

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,10 +129,14 @@ own.
   selection) rides along with the prompt, shown as a chip you can click to jump back to it. One
   toggle turns the sharing off when you'd rather it didn't.
 - **Ask from the editor** — right-click code and the **cv4vs Agents** submenu offers Explain,
-  Review, Find bugs, Write tests, Simplify. The prompt lands in the composer rather than being
-  sent, so you can add the half line that matters; the file and selection travel with it, so the
-  prompt itself is just the instruction. The list is yours to edit in Options → Editor prompts —
-  title, text, and whether the entry needs a selection to be enabled.
+  Review, Find bugs, Write tests, Simplify. The prompt lands in the composer, so you can add the
+  half line that matters; the file and selection travel with it, so the prompt itself is just the
+  instruction. The list is yours to edit in Options → Editor prompts — title, text, whether the
+  entry needs a selection, and whether it sends on click instead of waiting.
+- **Ask about a failure** — right-click in the **Output window** or the **Error List** and pick
+  **Explain in cv4vs Agents**. In the Error List it takes the rows you selected, with their file,
+  line and project; in the Output window your selection, or the tail of the pane when you selected
+  nothing — a build error is worth asking about without highlighting it first.
 - **Jump between panes** — a toolbar list of every open pane, Chat and CLI together, each with its
   title and kind. Docked panes hide each other behind tabs; this is how you find the one you want.
 - **[Sub-agent panel](docs/chat/sub-agents.md)** — a chip shows how many sub-agents are running; click it

--- a/docs/options.md
+++ b/docs/options.md
@@ -130,6 +130,7 @@ add the half line that matters before it goes.
 | Title | What the menu item reads. |
 | Prompt | What reaches the composer. The instruction alone: which file and which lines travel with it through the IDE context, and Claude reads the symbol itself with the `nav_*` tools, so pasting code in here only duplicates what the pane already points at. |
 | Needs selection | Greys the entry out when nothing is selected, the way Copilot greys "Optimize selection". Leave it off for prompts that read fine against the whole file. |
+| Send on click | Sends the turn right away, exactly as pressing the send button would — file and selection included. Off by default: the prompt waits in the composer so you can add the half line that matters. |
 
 Rows appear in the menu in the order listed, so the one you reach for most belongs at the top;
 **Restore defaults** puts back the prompts the extension ships with.

--- a/docs/settings-and-data.md
+++ b/docs/settings-and-data.md
@@ -43,7 +43,7 @@ Root: `%LOCALAPPDATA%\Corsinvest\cv4vs-agents\`
 
 ```
 profiles.json                       environment profiles (name, enabled, env vars)
-editor-prompts.json                 editor context-menu prompts (title, prompt, needs-selection)
+editor-prompts.json                 editor context-menu prompts (title, prompt, needs-selection, send-on-click)
 picker-ignore.gitignore             extra `@` picker ignore rules, on top of the workspace's own
 WebView2/                           WebView2 user-data (chat UI cache/storage)
 icons/                              file-type icons rasterised from VS KnownMonikers

--- a/src/Corsinvest.VisualStudio.Agents/AgentsPackage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/AgentsPackage.cs
@@ -412,6 +412,7 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
         await ProfilesMenuCommand.InitializeAsync(this);
         await ActiveSessionsMenuCommand.InitializeAsync(this);
         await Editor.EditorPromptsMenuCommand.InitializeAsync(this);
+        await Editor.ExplainMenuCommand.InitializeAsync(this);
         await GlobalMenuCommands.InitializeAsync(this);
         // Lazy MCP lifecycle: server runs only while >=1 session is open,
         // driven by PaneRegistry's 0->1 / ->0 transitions.

--- a/src/Corsinvest.VisualStudio.Agents/AgentsPackage.vsct
+++ b/src/Corsinvest.VisualStudio.Agents/AgentsPackage.vsct
@@ -129,6 +129,21 @@
       <Group guid="guidAgentsCommandSet" id="EditorPromptsGroup" priority="0x0100">
         <Parent guid="guidAgentsCommandSet" id="EditorPromptsSubMenu"/>
       </Group>
+      <!-- Explain, in the two windows that show a failure. A flat entry rather than the editor's
+           submenu: there is one thing to ask of a build log, and a submenu holding a single item
+           is a click spent on nothing. Same low priority, for the same reason — it is reached
+           without hunting.
+           The Output pane's context menu is IDM_VS_CTXT_RESULTSLIST, which does not read like it:
+           vsshlids.h has no IDM_VS_CTXT_OUTPUTWINDOW, and the groups inside this one are the
+           IDG_VS_RESULTSLIST* block it heads "Output Window Pane Context menu groups".
+           IDM_VS_TOOL_OUTPUTWINDOW is NOT it — that is the window's toolbar, and anchoring there
+           puts the entry somewhere the right-click never shows. -->
+      <Group guid="guidAgentsCommandSet" id="OutputContextGroup" priority="0x0050">
+        <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_RESULTSLIST"/>
+      </Group>
+      <Group guid="guidAgentsCommandSet" id="ErrorListContextGroup" priority="0x0050">
+        <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_ERRORLIST"/>
+      </Group>
       <Group guid="guidAgentsCommandSet" id="HelpDocsGroup" priority="0x0100">
         <Parent guid="guidAgentsCommandSet" id="HelpSubMenu"/>
       </Group>
@@ -179,6 +194,15 @@
         <Strings>
           <ButtonText>Prompt</ButtonText>
         </Strings>
+      </Button>
+
+      <!-- DynamicVisibility so BeforeQueryStatus can grey it when there is nothing to explain.
+           The Error List placement is the CommandPlacement below: a Button carries one Parent. -->
+      <Button guid="guidAgentsCommandSet" id="ExplainCommandId" priority="0x0100" type="Button">
+        <Parent guid="guidAgentsCommandSet" id="OutputContextGroup"/>
+        <Icon guid="guidImages" id="bmpPic1"/>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <Strings><ButtonText>Explain in cv4vs Agents</ButtonText></Strings>
       </Button>
 
       <Button guid="guidAgentsCommandSet" id="SettingsCommandId" priority="0x0100" type="Button">
@@ -260,6 +284,13 @@
     </Bitmaps>
   </Commands>
 
+  <CommandPlacements>
+    <!-- The same command placed again, not a second one to keep in step. -->
+    <CommandPlacement guid="guidAgentsCommandSet" id="ExplainCommandId" priority="0x0100">
+      <Parent guid="guidAgentsCommandSet" id="ErrorListContextGroup"/>
+    </CommandPlacement>
+  </CommandPlacements>
+
   <Symbols>
     <GuidSymbol name="guidAgentsPackage" value="{b1c2d3e4-f5a6-7890-bcde-fa1234567890}" />
     <GuidSymbol name="guidAgentsCommandSet" value="{a2b3c4d5-e6f7-8901-cdef-ab1234567890}">
@@ -280,6 +311,8 @@
       <IDSymbol name="EditorContextGroup" value="0x1077" />
       <IDSymbol name="EditorPromptsSubMenu" value="0x1078" />
       <IDSymbol name="EditorPromptsGroup" value="0x1079" />
+      <IDSymbol name="OutputContextGroup" value="0x107A" />
+      <IDSymbol name="ErrorListContextGroup" value="0x107B" />
       <IDSymbol name="HelpDocsGroup" value="0x1080" />
       <IDSymbol name="HelpContactGroup" value="0x1090" />
       <!-- Must match PackageIds.cs — a mismatch is silent: the entry just never appears. -->
@@ -296,6 +329,7 @@
       <IDSymbol name="StatisticsCommandId" value="0x0209" />
       <IDSymbol name="UsageCommandId" value="0x020A" />
       <IDSymbol name="ContextUsageCommandId" value="0x020B" />
+      <IDSymbol name="ExplainCommandId" value="0x020C" />
       <!-- Seed of the open-panes dynamic range. Its own 0x03xx block: the range grows with the
            number of open panes and must not run into the fixed ids above. -->
       <IDSymbol name="ActiveSessionCommandId" value="0x0300" />

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
@@ -313,15 +313,18 @@ public partial class ChatPaneControl : PaneControlBase
     private string _startupSessionId;
     // Forked-at message text to pre-fill in the composer once the fork loads.
     private string _startupPrompt;
+    private bool _startupPromptSend;
 
     /// <summary>Make this pane start resumed on <paramref name="sessionId"/> rather
     /// than fresh, pre-filling the composer with <paramref name="initialPrompt"/>.
     /// Must be called before the pane's Loaded fires (PaneLauncher does this right
-    /// after creating the window, like AssignPaneId).</summary>
-    internal void SetStartupSession(string sessionId, string initialPrompt)
+    /// after creating the window, like AssignPaneId).
+    /// <paramref name="sendPrompt"/> runs it on load instead of leaving it there; a fork waits.</summary>
+    internal void SetStartupSession(string sessionId, string initialPrompt, bool sendPrompt)
     {
         _startupSessionId = sessionId;
         _startupPrompt = initialPrompt;
+        _startupPromptSend = sendPrompt;
     }
 
     public ChatPaneControl()
@@ -588,7 +591,7 @@ public partial class ChatPaneControl : PaneControlBase
         // is also what tells the two apart, a fork always brings the session it forked.
         if (!string.IsNullOrEmpty(_startupPrompt))
         {
-            SetComposerText(_startupPrompt, !restoreState, false);
+            SetComposerText(_startupPrompt, !restoreState, _startupPromptSend);
         }
 
         // Detached from the startup path on purpose: it is a network call, and the chat must open

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneWindow.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneWindow.cs
@@ -55,9 +55,9 @@ public sealed class ChatPaneWindow : PaneWindowBase, IOleCommandTarget
 
     /// <summary>Forward to the hosted control so the launcher can seed a forked
     /// session before the pane loads (Content is a DockPanel, not the control).</summary>
-    internal void SetStartupSession(string sessionId, string initialPrompt)
+    internal void SetStartupSession(string sessionId, string initialPrompt, bool sendPrompt)
     {
-        if (PaneControl is ChatPaneControl ctl) { ctl.SetStartupSession(sessionId, initialPrompt); }
+        if (PaneControl is ChatPaneControl ctl) { ctl.SetStartupSession(sessionId, initialPrompt, sendPrompt); }
     }
 
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-prompt.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-prompt.ts
@@ -599,6 +599,19 @@ export class CvPrompt extends LitElement implements CommandHost {
         ta.setSelectionRange(text.length, text.length);
     }
 
+    /**
+     * Fill the composer and submit it, exactly as pressing the button would.
+     *
+     * Through `_submit` rather than `sendPrompt`, which looks like the shorter route and is not
+     * the same one: it mints its own payload with no attachments and echoes a bubble with no IDE
+     * refs, so the turn would go without the file/selection chip that the very same text typed by
+     * hand would carry.
+     */
+    setComposerTextAndSubmit(text: string): void {
+        this.setComposerText(text);
+        this._submit();
+    }
+
     /** Clear the textarea and reset its height. */
     clear(): void {
         if (!this._ta) {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/init.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/init.ts
@@ -150,7 +150,7 @@ function wireBridgeHandlers(): void {
             import('./components/cv-prompt').CvPrompt | null;
         const text = data?.text ?? '';
         if (data?.send && text) {
-            input?.sendPrompt(text, true);
+            input?.setComposerTextAndSubmit(text);
         } else {
             input?.setComposerText(text);
         }

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/DebugBreakService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/DebugBreakService.cs
@@ -3,12 +3,10 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
-using Corsinvest.VisualStudio.Agents.Core.Profiles;
 using Corsinvest.VisualStudio.Agents.Ide;
 using Microsoft.VisualStudio.Shell;
 using System;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace Corsinvest.VisualStudio.Agents.Core.Panes;
@@ -120,25 +118,15 @@ internal static class DebugBreakService
         return dot >= 0 && dot < type.Length - 1 ? type.Substring(dot + 1) : type;
     }
 
-    /// <summary>Hands the question to a chat pane the way the editor prompts do: the last activated
-    /// one, brought forward first, or the answer arrives in a tab nobody is looking at.</summary>
+    /// <summary>Hands the question to a chat pane the way the editor prompts do.</summary>
     private static void Ask(IdeDebugService.DebugState state)
     {
         ThreadHelper.ThrowIfNotOnUIThread();
         try
         {
-            var prompt = Prompt(state);
-            var target = PaneRegistry.Instance.OfKind(PaneKind.Chat).LastOrDefault(e => e.SetComposerAction != null);
-            if (target == null)
-            {
-                // First profile = the native "Claude" that ProfileStore prepends.
-                var profile = ProfileStore.Load(forEdit: false).FirstOrDefault();
-                if (profile != null) { PaneLauncher.OpenNew(PaneKind.Chat, profile, initialPrompt: prompt); }
-                return;
-            }
-
-            target.ActivateAction?.Invoke();
-            target.SetComposerAction(prompt, true);
+            // The prompt is complete the moment the break happens — exception, file, line — so it
+            // runs rather than waiting on an Enter that has nothing left to add.
+            Editor.PromptDispatcher.Send(Prompt(state), sendImmediately: true);
         }
         catch (Exception ex)
         {

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneLauncher.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneLauncher.cs
@@ -132,8 +132,11 @@ internal static class PaneLauncher
     /// <paramref name="initialPrompt"/> (the forked-at message). When
     /// <paramref name="resumeSessionId"/> is set (workspace restore, either kind), the new
     /// pane opens resumed on that session instead of fresh — a separate case from the fork,
-    /// with no pre-filled prompt.</summary>
-    public static void OpenNew(PaneKind kind, Profile profile, string forkSessionId = null, string initialPrompt = null, string resumeSessionId = null)
+    /// with no pre-filled prompt.
+    /// <paramref name="initialPromptSend"/> runs that prompt once the pane loads instead of
+    /// leaving it in the composer; it only means anything alongside a fresh
+    /// <paramref name="initialPrompt"/>, since a fork is there to be edited.</summary>
+    public static void OpenNew(PaneKind kind, Profile profile, string forkSessionId = null, string initialPrompt = null, string resumeSessionId = null, bool initialPromptSend = false)
     {
         var pkg = AgentsPackage.Instance;
         if (pkg == null) { OutputWindowLogger.Global.Warn("PaneLauncher: package not yet initialized"); return; }
@@ -172,13 +175,13 @@ internal static class PaneLauncher
                     var isFork = pane is ChatPaneWindow && !string.IsNullOrEmpty(forkSessionId);
                     if (isFork)
                     {
-                        ((ChatPaneWindow)pane).SetStartupSession(forkSessionId, initialPrompt);
+                        ((ChatPaneWindow)pane).SetStartupSession(forkSessionId, initialPrompt, sendPrompt: false);
                     }
                     else if (!string.IsNullOrEmpty(resumeSessionId))
                     {
                         if (pane is ChatPaneWindow chatPane)
                         {
-                            chatPane.SetStartupSession(resumeSessionId, null);
+                            chatPane.SetStartupSession(resumeSessionId, null, sendPrompt: false);
                         }
                         else if (pane is CliPaneWindow cliPane)
                         {
@@ -192,7 +195,7 @@ internal static class PaneLauncher
                     {
                         // A prompt with no session to start from — the editor context menu. Both
                         // branches above need one, so without this the prompt would be dropped.
-                        freshChat.SetStartupSession(null, initialPrompt);
+                        freshChat.SetStartupSession(null, initialPrompt, initialPromptSend);
                     }
                     if (pane.Frame is IVsWindowFrame frame) { ErrorHandler.ThrowOnFailure(frame.Show()); }
 

--- a/src/Corsinvest.VisualStudio.Agents/Corsinvest.VisualStudio.Agents.csproj
+++ b/src/Corsinvest.VisualStudio.Agents/Corsinvest.VisualStudio.Agents.csproj
@@ -136,6 +136,7 @@
     <Compile Include="Ide\IdeContextService.Operations.cs" />
     <Compile Include="Ide\IdeContextService.Common.cs" />
     <Compile Include="Ide\IdeDiagnosticsTracker.cs" />
+    <Compile Include="Ide\IdeErrorListService.cs" />
     <Compile Include="Ide\IdeDebugService.cs" />
     <Compile Include="Ide\IdeDebugService.Dtos.cs" />
     <Compile Include="Ide\IdeDebugService.Inspection.cs" />
@@ -311,6 +312,8 @@
     <Compile Include="Editor\EditorPrompt.cs" />
     <Compile Include="Editor\EditorPromptStore.cs" />
     <Compile Include="Editor\EditorPromptsMenuCommand.cs" />
+    <Compile Include="Editor\ExplainMenuCommand.cs" />
+    <Compile Include="Editor\PromptDispatcher.cs" />
     <Compile Include="Core\Panes\PaneLauncher.cs" />
     <Compile Include="AgentsPackage.cs" />
     <Compile Include="Core\Sessions\SessionInfo.cs" />

--- a/src/Corsinvest.VisualStudio.Agents/Editor/EditorPrompt.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Editor/EditorPrompt.cs
@@ -17,5 +17,9 @@ public sealed class EditorPrompt
     /// <summary>Greyed out without a selection, the way Copilot greys "Optimize selection".</summary>
     public bool RequiresSelection { get; set; }
 
+    /// <summary>Sends the turn on click instead of leaving the text in the composer. Off for a
+    /// prompt written as an opening line the user means to finish typing first.</summary>
+    public bool SendImmediately { get; set; }
+
     public EditorPrompt Clone() => (EditorPrompt)MemberwiseClone();
 }

--- a/src/Corsinvest.VisualStudio.Agents/Editor/EditorPromptsMenuCommand.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Editor/EditorPromptsMenuCommand.cs
@@ -3,13 +3,10 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
-using Corsinvest.VisualStudio.Agents.Core.Panes;
-using Corsinvest.VisualStudio.Agents.Core.Profiles;
 using Corsinvest.VisualStudio.Agents.Ide;
 using Microsoft.VisualStudio.Shell;
 using System;
 using System.ComponentModel.Design;
-using System.Linq;
 using Task = System.Threading.Tasks.Task;
 
 namespace Corsinvest.VisualStudio.Agents.Editor;
@@ -79,25 +76,7 @@ internal sealed class EditorPromptsMenuCommand : OleMenuCommand
         cmd.MatchedCommandId = 0;
         if (index < 0 || index >= items.Count) { return; }
 
-        Send(items[index].Prompt);
-    }
-
-    /// <summary>Delivers the prompt to a chat pane. With several open it goes to the last
-    /// activated — the one being worked in, where the first by SeqNo would just be the oldest —
-    /// and brings it forward, or the prompt lands in a tool window nobody is looking at.</summary>
-    private static void Send(string prompt)
-    {
-        var target = PaneRegistry.Instance.OfKind(PaneKind.Chat).LastOrDefault(e => e.SetComposerAction != null);
-        if (target == null)
-        {
-            // First profile = the native "Claude" that ProfileStore prepends.
-            var profile = ProfileStore.Load(forEdit: false).FirstOrDefault();
-            if (profile != null) { PaneLauncher.OpenNew(PaneKind.Chat, profile, initialPrompt: prompt); }
-            return;
-        }
-
-        target.ActivateAction?.Invoke();
-        target.SetComposerAction(prompt, false);
+        PromptDispatcher.Send(items[index].Prompt, items[index].SendImmediately);
     }
 
     private static int GetIndex(EditorPromptsMenuCommand cmd)

--- a/src/Corsinvest.VisualStudio.Agents/Editor/ExplainMenuCommand.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Editor/ExplainMenuCommand.cs
@@ -1,0 +1,106 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using Corsinvest.VisualStudio.Agents.Ide;
+using Microsoft.VisualStudio.Shell;
+using System;
+using System.ComponentModel.Design;
+using Task = System.Threading.Tasks.Task;
+
+namespace Corsinvest.VisualStudio.Agents.Editor;
+
+/// <summary><para>"Explain in cv4vs Agents", in the Output window's and the Error List's context menus.</para>
+/// <para>
+/// One command on two placements rather than one per window. VS routes a context menu command
+/// without saying which menu it came from, so the window is worked out from the active one.
+/// </para>
+/// <para>
+/// Unlike the editor prompts, the text is carried in the prompt itself: neither window is part of
+/// the IDE context a chat pane sends (that is editor documents only), so a bare instruction would
+/// reach the agent with nothing to explain.
+/// </para></summary>
+internal static class ExplainMenuCommand
+{
+    /// <summary>Enough of a build log to hold the error and the lines that led to it, when the
+    /// user has selected nothing. Long enough for an MSBuild failure to be in it, short enough
+    /// not to spend a turn's context on a pane that has been running all day.</summary>
+    private const int OutputTailLines = 80;
+
+    public static async Task InitializeAsync(AsyncPackage package)
+    {
+        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+        var commandService = await package.GetServiceAsync(typeof(IMenuCommandService)) as OleMenuCommandService;
+
+        var id = new CommandID(PackageGuids.AgentsCommandSet, PackageIds.ExplainCommandId);
+        var cmd = new OleMenuCommand(OnInvoke, id);
+        cmd.BeforeQueryStatus += OnBeforeQueryStatus;
+        commandService?.AddCommand(cmd);
+    }
+
+    /// <summary>Greyed out rather than hidden when there is nothing to explain — an entry that
+    /// comes and goes reads as a bug, the same call the editor prompts make.</summary>
+    private static void OnBeforeQueryStatus(object sender, EventArgs e)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        var cmd = (OleMenuCommand)sender;
+        cmd.Visible = true;
+        cmd.Enabled = GetText() != null;
+    }
+
+    private static void OnInvoke(object sender, EventArgs e)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        var prompt = GetText();
+        if (prompt != null) { PromptDispatcher.Send(prompt, sendImmediately: true); }
+    }
+
+    /// <summary><para>The whole prompt, or null when there is nothing to explain.</para>
+    /// <para>
+    /// Asks the window the menu was opened over, not whichever has something to say: with errors
+    /// selected in the Error List and the menu opened in the Output window, going by content alone
+    /// would explain the errors and never the log the user right-clicked. Falls back to trying
+    /// both when the active window is neither — the menu cannot have come from anywhere else, so
+    /// this is the docked-and-unfocused case, not a wrong guess.
+    /// </para></summary>
+    private static string GetText()
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+
+        // By the automation object's type, not by Window.ObjectKind: EnvDTE.Constants predates the
+        // Error List and has no window-kind field for it (see docs/internal/envdte-guids.md), so
+        // that comparison could only be an unverified GUID literal.
+        object active = null;
+        try { active = (Package.GetGlobalService(typeof(EnvDTE.DTE)) as EnvDTE.DTE)?.ActiveWindow?.Object; }
+        catch (Exception ex) { OutputWindowLogger.Global.Warn($"[ide] could not read the active window: {ex.Message}"); }
+
+        if (active is EnvDTE80.ErrorList) { return FromErrorList(); }
+        if (active is EnvDTE.OutputWindow) { return FromOutput(); }
+        return FromErrorList() ?? FromOutput();
+    }
+
+    /// <summary>No fence: the rows are already one structured line each, and a fence would turn
+    /// them into an opaque block.</summary>
+    private static string FromErrorList()
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        var text = IdeErrorListService.Instance.GetSelectedText();
+        return string.IsNullOrWhiteSpace(text)
+            ? null
+            : $"What is causing these errors, and how do I fix them?\n\n{text}";
+    }
+
+    /// <summary>Fenced, unlike the Error List: a log is full of dashes and asterisks that markdown
+    /// would eat. And asked flat — the active pane is as likely to be Debug or the program's own
+    /// output as a failed build, so naming a failure would invent one where there is none, and
+    /// where there is one, explaining it covers the cause without being told to.</summary>
+    private static string FromOutput()
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        var text = IdeOutputService.Instance.GetActivePaneText(OutputTailLines);
+        return string.IsNullOrWhiteSpace(text)
+            ? null
+            : $"Explain this output.\n\n```\n{text}\n```";
+    }
+}

--- a/src/Corsinvest.VisualStudio.Agents/Editor/PromptDispatcher.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Editor/PromptDispatcher.cs
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using Corsinvest.VisualStudio.Agents.Core.Panes;
+using Corsinvest.VisualStudio.Agents.Core.Profiles;
+using System.Linq;
+
+namespace Corsinvest.VisualStudio.Agents.Editor;
+
+/// <summary>Puts a prompt in front of the user: into an open chat pane's composer, or into a new
+/// pane when none is open. Shared by every context-menu entry that hands text to the agent.</summary>
+internal static class PromptDispatcher
+{
+    /// <summary>With several panes open it goes to the last activated — the one being worked in,
+    /// where the first by SeqNo would just be the oldest — and brings it forward, or the prompt
+    /// lands in a tool window nobody is looking at.
+    ///
+    /// <paramref name="sendImmediately"/> submits the composer the way the send button does, IDE
+    /// context and all.</summary>
+    public static void Send(string prompt, bool sendImmediately)
+    {
+        var target = PaneRegistry.Instance.OfKind(PaneKind.Chat).LastOrDefault(e => e.SetComposerAction != null);
+        if (target == null)
+        {
+            // First profile = the native "Claude" that ProfileStore prepends.
+            var profile = ProfileStore.Load(forEdit: false).FirstOrDefault();
+            if (profile != null)
+            {
+                PaneLauncher.OpenNew(PaneKind.Chat, profile, initialPrompt: prompt, initialPromptSend: sendImmediately);
+            }
+            return;
+        }
+
+        // Text first, activation second. Bringing the pane forward makes it the active window, and
+        // the IDE context that rides along with the turn is read from the active document — so
+        // activating first sends the prompt with no file behind it.
+        target.SetComposerAction(prompt, sendImmediately);
+        target.ActivateAction?.Invoke();
+    }
+}

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.Operations.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.Operations.cs
@@ -1107,7 +1107,7 @@ internal sealed partial class IdeContextService
         return result;
     }
 
-    private static string SeverityToLsp(vsBuildErrorLevel level) => level switch
+    internal static string SeverityToLsp(vsBuildErrorLevel level) => level switch
     {
         vsBuildErrorLevel.vsBuildErrorLevelHigh => "Error",
         vsBuildErrorLevel.vsBuildErrorLevelMedium => "Warning",

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeErrorListService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeErrorListService.cs
@@ -1,0 +1,146 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using EnvDTE;
+using EnvDTE80;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using System;
+using System.Collections.Generic;
+
+namespace Corsinvest.VisualStudio.Agents.Ide;
+
+/// <summary>Reads the rows the user has selected in the Error List, via the public EnvDTE80 API.
+/// Unlike the Output window this is not text but records — severity, file, line, project are
+/// separate fields — so the caller gets them formatted rather than scraped.</summary>
+internal sealed class IdeErrorListService
+{
+    public static IdeErrorListService Instance { get; } = new();
+
+    /// <summary>Cap on how many rows go into one prompt: selecting the whole list of a broken
+    /// build is one Ctrl+A, and the first rows are the ones worth asking about — the rest are
+    /// usually knock-on errors.</summary>
+    private const int MaxRows = 40;
+
+    /// <summary><para>
+    /// The selected rows, one per line, as "Error in Foo.cs:12 (MyProj): text". Null when
+    /// nothing is selected — the entry greys out rather than explaining rows the user did not pick.
+    /// </para>
+    /// <para>
+    /// UI thread; never throws — it runs from a menu query, where an exception would take the
+    /// context menu down with it.
+    /// </para></summary>
+    public string GetSelectedText()
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        try
+        {
+            var errorList = (Package.GetGlobalService(typeof(DTE)) as DTE2)?.ToolWindows?.ErrorList;
+            if (errorList == null) { return null; }
+
+            var selected = errorList.SelectedItems;
+            var text = Format(selected as System.Collections.IEnumerable);
+            if (text != null) { return text; }
+
+            OutputWindowLogger.Global.Debug(
+                () => $"[ide] Error List: DTE SelectedItems is {selected?.GetType().FullName ?? "null"}, asking the task list");
+            return SelectedViaTaskList();
+        }
+        catch (Exception ex)
+        {
+            OutputWindowLogger.Global.Warn($"[ide] could not read the Error List selection: {ex.Message}");
+            return null;
+        }
+    }
+
+    /// <summary>One line per row, or null when there is nothing readable in there.</summary>
+    private static string Format(System.Collections.IEnumerable items)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        if (items == null) { return null; }
+
+        var lines = new List<string>();
+        foreach (var item in items)
+        {
+            if (lines.Count >= MaxRows) { break; }
+            // Per row, like GetDiagnosticsAsync: every ErrorItem member is a COM call that can
+            // fail on a row the Error List is rebuilding underneath us, and half a line read out
+            // of one that is going away is worth less than skipping it.
+            try { if (item is ErrorItem err) { lines.Add(Format(err)); } }
+            catch (Exception) { /* row went away mid-read */ }
+        }
+        return lines.Count == 0 ? null : string.Join("\n", lines);
+    }
+
+    /// <summary><para>
+    /// The selection straight from the shell's task list, for when DTE's SelectedItems
+    /// answers with nothing. It is the window itself rather than the automation layer over it, so
+    /// it reports what is highlighted even when SelectedItems does not.
+    /// </para>
+    /// <para>
+    /// Text only: an IVsTaskItem carries its own columns and no ErrorItem behind it, so this loses
+    /// the project name that the DTE path prints. The row's own text is what the user selected.
+    /// </para></summary>
+    private static string SelectedViaTaskList()
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+
+        if (Package.GetGlobalService(typeof(SVsErrorList)) is not IVsTaskList2 list) { return null; }
+        if (list.EnumSelectedItems(out var items) != VSConstants.S_OK || items == null) { return null; }
+
+        var lines = new List<string>();
+        var one = new IVsTaskItem[1];
+        while (lines.Count < MaxRows && items.Next(1, one, null) == VSConstants.S_OK && one[0] != null)
+        {
+            try
+            {
+                one[0].Document(out var file);
+                one[0].Line(out var line);
+                one[0].get_Text(out var description);
+
+                var severity = one[0] is IVsErrorItem e && e.GetCategory(out var cat) == VSConstants.S_OK
+                    ? SeverityOf(cat)
+                    : "Item";
+                var where = string.IsNullOrEmpty(file)
+                    ? ""
+                    // IVsTaskItem lines are 0-based, unlike ErrorItem.Line.
+                    : $" in {file}:{line + 1}";
+                lines.Add($"{severity}{where}: {System.Net.WebUtility.HtmlDecode(description ?? "")}");
+            }
+            catch (Exception) { /* row went away mid-read */ }
+        }
+
+        return lines.Count == 0 ? null : string.Join("\n", lines);
+    }
+
+    private static string SeverityOf(uint category) => category switch
+    {
+        (uint)__VSERRORCATEGORY.EC_ERROR => "Error",
+        (uint)__VSERRORCATEGORY.EC_WARNING => "Warning",
+        _ => "Message",
+    };
+
+    private static string Format(ErrorItem err)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+
+        var parts = new List<string> { IdeContextService.SeverityToLsp(err.ErrorLevel) };
+
+        // A row can have no file behind it — a project-level error, as GetDiagnosticsAsync found.
+        var file = err.FileName;
+        if (!string.IsNullOrEmpty(file))
+        {
+            parts.Add(err.Line > 0 ? $"in {file}:{err.Line}" : $"in {file}");
+        }
+
+        if (!string.IsNullOrEmpty(err.Project)) { parts.Add($"({err.Project})"); }
+
+        // HTML-decode for the same reason GetDiagnosticsAsync does it: the Error List sometimes
+        // returns XAML-prepared descriptions, and `&quot;` reads as itself to the model.
+        var description = System.Net.WebUtility.HtmlDecode(err.Description ?? "");
+        return $"{string.Join(" ", parts)}: {description}";
+    }
+}

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeOutputService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeOutputService.cs
@@ -153,6 +153,42 @@ internal sealed class IdeOutputService
         }
     }
 
+    /// <summary>The text the user is looking at in the Output window: their selection, or the last
+    /// <paramref name="tailLines"/> lines of the active pane when they selected nothing — a build
+    /// error is read without being selected first, and a menu entry that greys out unless you
+    /// highlight something would be useless exactly when it is wanted.
+    ///
+    /// Returns null when there is nothing to read. UI thread; never throws — it runs from a menu
+    /// query, where an exception would take the context menu down with it.</summary>
+    public string GetActivePaneText(int tailLines)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        try
+        {
+            var pane = GetOutputWindow()?.ActivePane;
+            if (pane == null) { return null; }
+
+            var td = GetTextDocument(pane);
+            if (td == null) { return null; }
+
+            var selected = td.Selection?.Text;
+            if (!string.IsNullOrWhiteSpace(selected)) { return selected; }
+
+            // Same EditPoint read as ReadAsync, and for the same reason: selecting all would take
+            // away the caret and highlight the user left in the pane.
+            var text = td.StartPoint.CreateEditPoint().GetText(td.EndPoint) ?? "";
+            if (string.IsNullOrWhiteSpace(text)) { return null; }
+
+            var lines = text.Replace("\r\n", "\n").TrimEnd('\n').Split('\n');
+            return string.Join("\n", lines.Length > tailLines ? lines.Skip(lines.Length - tailLines) : lines);
+        }
+        catch (Exception ex)
+        {
+            OutputWindowLogger.Global.Warn($"[ide] could not read the active output pane: {ex.Message}");
+            return null;
+        }
+    }
+
     /// <summary>Read a pane by name (case-insensitive). With no name, returns the list of
     /// available pane names instead of content. tailLines caps the returned lines; pattern keeps
     /// only the lines matching a regex.</summary>

--- a/src/Corsinvest.VisualStudio.Agents/Options/EditorPromptsControl.xaml
+++ b/src/Corsinvest.VisualStudio.Agents/Options/EditorPromptsControl.xaml
@@ -11,9 +11,9 @@
     </Grid.RowDefinitions>
 
     <TextBlock Grid.Row="0" TextWrapping="Wrap" Margin="0,0,0,6"
-               Text="Prompts offered when you right-click code, under &quot;cv4vs Agents&quot;. Picking one writes it into a chat pane's composer — the file and selection are sent with it, so the prompt is the instruction alone. Rows appear in the menu in this order." />
+               Text="Prompts offered when you right-click code, under &quot;cv4vs Agents&quot;. Picking one hands it to a chat pane — the file and selection are sent with it, so the prompt is the instruction alone. &quot;Send on click&quot; runs it straight away; clear it for a prompt you mean to finish typing first. Rows appear in the menu in this order." />
 
-    <!-- One grid, not the master/detail the profiles page needs: three fields per row fit in it. -->
+    <!-- One grid, not the master/detail the profiles page needs: four fields per row fit in it. -->
     <DataGrid Grid.Row="1" x:Name="PromptsGrid"
               AutoGenerateColumns="False"
               CanUserAddRows="False"
@@ -26,6 +26,8 @@
                             Binding="{Binding Prompt, UpdateSourceTrigger=PropertyChanged}" />
         <DataGridCheckBoxColumn Header="Needs selection" Width="Auto"
                                 Binding="{Binding RequiresSelection, UpdateSourceTrigger=PropertyChanged}" />
+        <DataGridCheckBoxColumn Header="Send on click" Width="Auto"
+                                Binding="{Binding SendImmediately, UpdateSourceTrigger=PropertyChanged}" />
       </DataGrid.Columns>
     </DataGrid>
 

--- a/src/Corsinvest.VisualStudio.Agents/PackageGuids.cs
+++ b/src/Corsinvest.VisualStudio.Agents/PackageGuids.cs
@@ -34,6 +34,7 @@ internal static class PackageIds
     public const int StatisticsCommandId = 0x0209;
     public const int UsageCommandId = 0x020A;
     public const int ContextUsageCommandId = 0x020B;
+    public const int ExplainCommandId = 0x020C;
 
     // Seeds the dynamic open-panes range, which grows with the number of open panes — its own
     // 0x0300 block, clear of the fixed ids above.


### PR DESCRIPTION
Right-clicking the **Output window** or the **Error List** offers **Explain in cv4vs Agents** — the failure you are already looking at, handed to the agent without retyping it.

- **Error List** — the rows you selected, with severity, file, line and project.
- **Output window** — your selection, or the tail of the active pane when you selected nothing. A build error is worth asking about without highlighting it first.

Unlike the editor prompts, the text rides in the prompt itself: neither window is part of the IDE context a chat pane sends, so a bare instruction would reach the agent with nothing to explain.

Editor prompts gain a **Send on click** column, off by default — the prompt still lands in the composer so you can add the half line that matters.

## Along the way

- `PromptDispatcher` replaces three copies of "find a chat pane, or open one" — editor prompts, debug break, and now Explain.
- A pane opened *by* a prompt honours that flag too. Before, it always pre-filled and waited, while an already-open pane would send — the same entry behaving differently depending on what happened to be open.
- Sending from the host now goes through the composer's own `_submit`, the way the send button does. `sendPrompt()` mints its own payload and echoes a bubble with no IDE refs, so the turn went **without the file/selection chip** that the same text typed by hand carries.

## Two shell ids that do not read like what they are

Both verified against `vsshlids.h` / `EnvDTE.dll` and written down in `docs/internal/envdte-guids.md`:

- The Output pane's context menu is **`IDM_VS_CTXT_RESULTSLIST`**. There is no `IDM_VS_CTXT_OUTPUTWINDOW`, and `IDM_VS_TOOL_OUTPUTWINDOW` is the window's *toolbar* — anchoring there builds green, installs, and puts the entry somewhere the right-click never shows. Caught only by trying it.
- `EnvDTE.Constants` has **no `vsWindowKindErrorList`** (it postdates those constants), so the two windows are told apart by the type of their automation object rather than by a GUID literal nothing verifies.

## Testing

Manually in the experimental instance: both context menus, with and without a selection, and the editor prompts unchanged. `msbuild` green, `npm run typecheck` / `lint` / `format` clean.

Known: reading the Error List selection falls back to `IVsTaskList2.EnumSelectedItems` when DTE's `SelectedItems` answers empty, which it does. That path has no error code or project name — `TableManager` would fix it for this and for `ide_get_diagnostics` at once, and is noted in the internal TODO.
