### PR TITLE
feat(chat): a markdown table copies as markdown, from a button on its corner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **A table has a Copy button.** Hover a markdown table and it appears over its top-right corner,
+  the way a code block's already did. It copies the markdown the model wrote — pipes, alignment row
+  and empty cells — so what you paste parses back as the same table. The DOM could not supply it:
+  a `<table>`'s text content is the cells run together, with no pipes and no line breaks, which is
+  why the fence's approach of reading the rendered element does not carry over.
+
 ## [1.6.0] - 2026-08-26
 
 The inline diff was rebuilt around the patch the CLI already sends, so it shows the file's real line

--- a/README.md
+++ b/README.md
@@ -315,8 +315,9 @@ See [Options → Profiles](docs/options.md#profiles).
   saved.
 - **Full Markdown rendering** — tables, lists, blockquotes, links, and fenced code blocks rendered
   with **syntax highlighting** (highlight.js) across all common languages.
-- **Everything is copyable** — a copy button on every message, tool row and code block, so any part
-  of the conversation can be lifted out as plain text.
+- **Everything is copyable** — a copy button on every message, tool row, code block and table, so
+  any part of the conversation can be lifted out. A table copies as markdown, pipes and alignment
+  included, so it parses back as the same table wherever you paste it.
 - **Image lightbox** and a **welcome screen** for empty chats.
 - **Cost and elapsed time, per turn** — the spinner counts the seconds while the turn runs (and
   while it is thinking); when it lands, the hover-actions row carries what the turn cost. Agent rows

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/markdown.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/markdown.ts
@@ -22,6 +22,7 @@ const renderer = new marked.Renderer() as Renderer & {
     code: (token: Tokens.Code) => string;
     link: (token: Tokens.Link) => string;
     codespan: (token: Tokens.Codespan) => string;
+    table: (token: Tokens.Table) => string;
 };
 
 // Inline `code` that is a file reference and nothing else becomes a link inside the span. marked
@@ -43,6 +44,20 @@ renderer.code = function (token: Tokens.Code): string {
         `<div class="cv-md-code-wrap">` +
         `<pre><code class="hljs language-${language}">${hl ?? escapeHtml(code)}</code></pre>` +
         `<cv-copy-btn class="cv-md-copy-btn" frompre="1" title="Copy"></cv-copy-btn>` +
+        `</div>`
+    );
+};
+
+// The button carries the markdown source: unlike a fence, a table's textContent is the cells run
+// together with no pipes or newlines, so there is nothing in the DOM to copy.
+// `.call(this)`, never `.bind`: the base renderer reaches its cells through `this.parser`, which
+// marked injects on the instance it parses with, not on the one built here.
+const baseTable = renderer.table;
+renderer.table = function (this: Renderer, token: Tokens.Table): string {
+    return (
+        `<div class="cv-md-table-wrap">` +
+        baseTable.call(this, token) +
+        `<cv-copy-btn class="cv-md-table-copy-btn" text="${escapeHtml(token.raw.trim())}" title="Copy table"></cv-copy-btn>` +
         `</div>`
     );
 };
@@ -174,7 +189,8 @@ export function renderMarkdown(text: string | undefined | null): string {
         out = DOMPurify.sanitize(html, {
             // data-line-end is what makes a range select rather than just scroll. It was missing
             // here while the renderer emitted it, so "x.cs:35-48" opened at 35 and selected nothing.
-            ADD_ATTR: ['target', 'frompre', 'data-file', 'data-line', 'data-line-end'],
+            // 'text' carries the table's markdown to its copy button: dropped here, it copies nothing.
+            ADD_ATTR: ['target', 'frompre', 'text', 'data-file', 'data-line', 'data-line-end'],
             ADD_TAGS: ['cv-copy-btn'],
         });
     } catch (err) {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/markdown.test.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/markdown.test.ts
@@ -63,6 +63,20 @@ test('fence: il pulsante Copia resta, e legge dal pre', () => {
     assert.match(html, /<cv-copy-btn[^>]*frompre="1"/);
 });
 
+test('tabella: il pulsante Copia porta il markdown sorgente, non il DOM', () => {
+    // Pipe e riga di allineamento devono sopravvivere: e' cio' che rende il paste ri-parsabile.
+    const src = '| a | b |\n|:--|--:|\n| 1 | 2 |';
+    const html = md(src + '\n');
+    assert.match(html, /<div class="cv-md-table-wrap">/);
+    assert.match(html, /<cv-copy-btn[^>]*class="cv-md-table-copy-btn"/);
+    const text = /<cv-copy-btn[^>]*text="([^"]*)"/.exec(html)?.[1] ?? '';
+    assert.equal(text.replace(/&quot;/g, '"').replace(/&amp;/g, '&'), src);
+});
+
+test('tabella: le celle restano renderizzate da marked', () => {
+    assert.equal(links(md('| file |\n|---|\n| ClientEvents.cs:208 |\n')), 1);
+});
+
 // Gli attributi che il host legge al click. Non passano da DOMPurify qui, ma la ADD_ATTR di
 // markdown.ts deve elencarli tutti: data-line-end mancava mentre il renderer lo emetteva da sempre,
 // e l'intervallo apriva senza selezionare.

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/markdown.css
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/markdown.css
@@ -139,6 +139,26 @@
 .cv-md-code-wrap:hover .cv-md-copy-btn::part(button) {
     opacity: 1;
 }
+
+/* Same hover-reveal over a table. inline-block keeps the wrapper as wide as the table and not as
+ * the bubble, or the button lands far right of a narrow one; the background is what keeps it
+ * readable over the header row it sits on. */
+.cv-md-table-wrap {
+    position: relative;
+    display: inline-block;
+    max-width: 100%;
+}
+.cv-md-table-copy-btn::part(button) {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    opacity: 0;
+    background: var(--colorNeutralBackground1);
+    transition: opacity 0.15s;
+}
+.cv-md-table-wrap:hover .cv-md-table-copy-btn::part(button) {
+    opacity: 1;
+}
 .md blockquote {
     border-left: 3px solid var(--colorNeutralStroke1);
     padding-left: 10px;


### PR DESCRIPTION
A code block has had a Copy button since it existed; a table — the other thing in an answer you want to lift out whole — had none. Hovering one now reveals the same button over its top-right corner.

## What it copies

The markdown the model wrote (`token.raw`): pipes, alignment row, empty cells. A paste parses back as the same table, in a README, an issue, or the chat itself.

It cannot copy the way the fence does. `frompre` reads the rendered `<pre>`, whose text content *is* the source; a `<table>`'s text content is the cells run together with no pipes and no line breaks. So the button carries the source in an attribute instead of reading the DOM.

## Two silent failures, and the tests that hold them

- **DOMPurify drops any attribute not in `ADD_ATTR`.** Without `text` listed there the button copies an empty string — no error, nothing to see. There was already a test comparing what the renderers emit against that allow-list; it covers the new attribute too.
- **`.bind` breaks every table.** The base renderer reaches its cells through `this.parser`, which marked injects on the instance it actually parses with. Binding the base method to the renderer built in `markdown.ts` freezes `this` on an instance where `parser` is `undefined` — `Cannot read properties of undefined (reading 'parseInline')` on any table. It is `.call(this, token)`. The test caught this before it ever ran in the pane.

The override only wraps, so the cells stay marked's own work: a file reference inside a cell is still a link.

## Not in scope

`.md table` has no `overflow-x`, so a wide table still overflows the bubble. Fixing it means a scroll container, and the button has to stay outside it or it scrolls away with the content — a separate change.

## Verification

- `npm test` — 166/166 pass, two new cases (source survives the attribute round-trip; cells still render as links)
- `npm run typecheck` — clean
- `npm run lint` — 0 errors (7 pre-existing warnings in `bridge.ts` / `cv-mic-button.ts`, untouched)
- `npm run build` — clean
- Checked in the Exp instance against tables with escaped pipes, quotes and `&`, wide tables, tables in lists, and a fence containing a table (no button, correctly)
