### PR TITLE
refactor(chat): say re-render with requestUpdate, and hold subscriptions in a controller

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents.Contracts/ToWebViewDtos.cs
+++ b/src/Corsinvest.VisualStudio.Agents.Contracts/ToWebViewDtos.cs
@@ -238,13 +238,16 @@ public class PatchHunkDto
     public string[] Lines { get; set; }
 }
 
-/// <summary>The fields only one tool family reads, grouped so adding another one touches this class
+/// <summary><para>
+/// The fields only one tool family reads, grouped so adding another one touches this class
 /// and its renderer instead of widening the notification, the entry, the host and two call sites.
 /// Null when the tool reports none — which is most of them.
-///
+/// </para>
+/// <para>
 /// agentId and fullLineCount deliberately stay OUT: the first is routing (the transcript lookup and
 /// the sub-agent fetch use it, not the renderer) and arrives at launch rather than at the end; the
-/// second is computed for every tool_result and describes `result`, like isError.</summary>
+/// second is computed for every tool_result and describes `result`, like isError.
+/// </para></summary>
 public class ToolResultExtrasDto
 {
     public AgentRunTotalsDto AgentTotals { get; set; }
@@ -572,13 +575,16 @@ public class AssistantTextNotification
     public long? Timestamp { get; set; }
 }
 
-/// <summary>Messages the CLI retracted (chat_evict_messages): they were delivered to us but are no
+/// <summary><para>
+/// Messages the CLI retracted (chat_evict_messages): they were delivered to us but are no
 /// longer part of the conversation, so the model does not have them. Leaving them on screen is what
 /// makes the transcript diverge from the model's context — the user reads a partial answer and
 /// reasons about it, while the model never saw it.
-///
+/// </para>
+/// <para>
 /// Matching is by uuid equality and nothing else, which is what makes it safe to apply blind: a
-/// uuid naming nothing on screen removes nothing.</summary>
+/// uuid naming nothing on screen removes nothing.
+/// </para></summary>
 public class EvictMessagesNotification
 {
     public string[] Uuids { get; set; }

--- a/src/Corsinvest.VisualStudio.Agents/AgentsPackage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/AgentsPackage.cs
@@ -329,13 +329,16 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
         }
     }
 
-    /// <summary>Debugger mode changed. VS keeps window layouts per mode, so panes opened at design
+    /// <summary><para>
+    /// Debugger mode changed. VS keeps window layouts per mode, so panes opened at design
     /// time are absent from the run-time layout and look as though the debugger closed them — the
     /// frames are still there, just not shown. Bring back the ones the registry knows are open.
-    ///
+    /// </para>
+    /// <para>
     /// Only ever shows what was already open: a pane the user closed stays closed, because it is
     /// not in the registry. StartOnIdle for the same reason as the solution-open restore — the
-    /// shell is mid-transition and showing a frame from inside its event freezes it.</summary>
+    /// shell is mid-transition and showing a frame from inside its event freezes it.
+    /// </para></summary>
     public int OnModeChange(DBGMODE dbgmodeNew)
     {
         try

--- a/src/Corsinvest.VisualStudio.Agents/Chat/ContentBlockTranslator.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/ContentBlockTranslator.cs
@@ -13,13 +13,16 @@ using System.Linq;
 namespace Corsinvest.VisualStudio.Agents.Chat;
 
 /// <summary>
+/// <para>
 /// The per-tool fields the CLI writes on a tool_result, gathered in one place instead of one
 /// EmitUser parameter each — every tool that reports something of its own would otherwise widen
 /// that signature, and both callers would grow another extraction.
-///
+/// </para>
+/// <para>
 /// Built from the toolUseResult where there is one (live), or from the fields history lifted onto
 /// the message (replay): toolUseResult itself does not survive into the replay, so what the
 /// translator needs has to travel on the message.
+/// </para>
 /// </summary>
 internal sealed class ToolResultExtras
 {
@@ -71,16 +74,13 @@ internal sealed class ToolResultExtras
     /// <summary>The wire shape: each group present only when the tool reported it, and the whole
     /// object null when it reported neither — so the WebView tests for presence, never for a zero
     /// that could also mean "ran for 0ms".</summary>
-    public Contracts.ToolResultExtrasDto ToDto()
-    {
-        return AgentTotals == null && Patch == null
+    public Contracts.ToolResultExtrasDto ToDto() => AgentTotals == null && Patch == null
             ? null
             : new Contracts.ToolResultExtrasDto
             {
                 AgentTotals = AgentTotals,
                 Patch = Patch,
             };
-    }
 }
 
 /// <summary>

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/FileSuggestions.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/FileSuggestions.cs
@@ -366,13 +366,12 @@ internal sealed class GitIgnore
 
     private GitIgnore(List<Pattern> patterns)
     {
-        _excludes = patterns.Where(p => !p.Negate).ToList();
-        _negations = patterns.Where(p => p.Negate).ToList();
-        _negatedPrefixes = _negations
+        _excludes = [.. patterns.Where(p => !p.Negate)];
+        _negations = [.. patterns.Where(p => p.Negate)];
+        _negatedPrefixes = [.. _negations
             .Select(p => LiteralPrefix(p.Glob))
             .Where(s => s.Length > 0)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToList();
+            .Distinct(StringComparer.OrdinalIgnoreCase)];
     }
 
     /// <summary>The part of a glob before its first wildcard, trimmed to whole path segments —

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Chat.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Chat.cs
@@ -205,12 +205,10 @@ internal sealed partial class WebViewMessageHandler
         if (!string.IsNullOrEmpty(toolUseId)) { _ = client?.DetachTaskAsync(toolUseId); }
     }
 
-    private void HandleSubagentCancelAll(JObject data, int? id)
-    {
+    private void HandleSubagentCancelAll(JObject data, int? id) =>
         // The UI knows the active taskIds; it sends one cancel per id. As a fallback,
         // a bare cancel_all maps to interrupt (stops the whole turn).
         _ = client?.InterruptAsync();
-    }
 
     private void HandleGetHistory(JObject data, int? id)
     {
@@ -243,49 +241,43 @@ internal sealed partial class WebViewMessageHandler
         }).FileAndForget(nameof(WebViewMessageHandler));
     }
 
-    private void HandleOpenDocument(JObject data, int? id)
-    {
-        ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
-        {
-            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-            var p = data.ToObject<Contracts.OpenDocumentNotification>();
-            var uuid = p.Uuid ?? "";
-            var blockIdx = p.BlockIdx;
-            var sessionId = p.SessionId ?? client.SessionId;
-            if (string.IsNullOrEmpty(uuid) || blockIdx < 0) { return; }
-            var block = Sessions.ReadMessageBlock(sessionId, uuid, blockIdx);
-            if (block?.Val("type") != "document") { return; }
-            var source = block["source"] as JObject;
-            var content = source.Val("data", "");
-            var title = block.Val("title", "file");
-            var mediaType = source.Val("media_type", "text/plain");
-            // source.type (Anthropic content block): "text" carries raw UTF-8 in `data`,
-            // "base64" carries base64 (PDF and other binaries).
-            var sourceType = source.Val("type", "text");
-            WriteTempAndOpen(title, content, mediaType, sourceType == "base64");
-        }).FileAndForget(nameof(WebViewMessageHandler));
-    }
+    private void HandleOpenDocument(JObject data, int? id) => ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                                                                   {
+                                                                       await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                                                                       var p = data.ToObject<Contracts.OpenDocumentNotification>();
+                                                                       var uuid = p.Uuid ?? "";
+                                                                       var blockIdx = p.BlockIdx;
+                                                                       var sessionId = p.SessionId ?? client.SessionId;
+                                                                       if (string.IsNullOrEmpty(uuid) || blockIdx < 0) { return; }
+                                                                       var block = Sessions.ReadMessageBlock(sessionId, uuid, blockIdx);
+                                                                       if (block?.Val("type") != "document") { return; }
+                                                                       var source = block["source"] as JObject;
+                                                                       var content = source.Val("data", "");
+                                                                       var title = block.Val("title", "file");
+                                                                       var mediaType = source.Val("media_type", "text/plain");
+                                                                       // source.type (Anthropic content block): "text" carries raw UTF-8 in `data`,
+                                                                       // "base64" carries base64 (PDF and other binaries).
+                                                                       var sourceType = source.Val("type", "text");
+                                                                       WriteTempAndOpen(title, content, mediaType, sourceType == "base64");
+                                                                   }).FileAndForget(nameof(WebViewMessageHandler));
 
-    private void HandleOpenAttachment(JObject data, int? id)
-    {
-        ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
-        {
-            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-            var p = data.ToObject<Contracts.OpenAttachmentNotification>();
-            var name = p.Name ?? "";
-            var base64 = p.Base64 ?? "";
-            if (string.IsNullOrEmpty(name) || string.IsNullOrEmpty(base64)) { return; }
-            try
-            {
-                // The composer reads every attachment as base64 (one code path), text files
-                // included — so the bytes are never written back out as text.
-                WriteTempAndOpen(name, base64, p.MediaType ?? "", isBase64: true);
-            }
-            catch (Exception ex)
-            {
-                // Nothing opens and the click looks dead otherwise — say why.
-                log.LogException($"[chat] open attachment '{name}'", ex);
-            }
-        }).FileAndForget(nameof(WebViewMessageHandler));
-    }
+    private void HandleOpenAttachment(JObject data, int? id) => ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                                                                     {
+                                                                         await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                                                                         var p = data.ToObject<Contracts.OpenAttachmentNotification>();
+                                                                         var name = p.Name ?? "";
+                                                                         var base64 = p.Base64 ?? "";
+                                                                         if (string.IsNullOrEmpty(name) || string.IsNullOrEmpty(base64)) { return; }
+                                                                         try
+                                                                         {
+                                                                             // The composer reads every attachment as base64 (one code path), text files
+                                                                             // included — so the bytes are never written back out as text.
+                                                                             WriteTempAndOpen(name, base64, p.MediaType ?? "", isBase64: true);
+                                                                         }
+                                                                         catch (Exception ex)
+                                                                         {
+                                                                             // Nothing opens and the click looks dead otherwise — say why.
+                                                                             log.LogException($"[chat] open attachment '{name}'", ex);
+                                                                         }
+                                                                     }).FileAndForget(nameof(WebViewMessageHandler));
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Cli.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Cli.cs
@@ -89,13 +89,11 @@ internal sealed partial class WebViewMessageHandler
         _ = client.SetMaxThinkingTokensAsync(p.MaxThinkingTokens, p.Display);
     }
 
-    private void HandleStop(JObject data, int? id)
-    {
+    private void HandleStop(JObject data, int? id) =>
         // Fire and forget: the WebView frees itself the moment it asks, since it can't wait on a
         // wedged CLI. InterruptAsync logs its own failure — there is nothing to roll back here,
         // unlike the model and permission handlers below.
         _ = client.InterruptAsync();
-    }
 
     private void HandleSetPermissionMode(JObject data, int? id)
     {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Helpers.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Helpers.cs
@@ -203,13 +203,16 @@ internal sealed partial class WebViewMessageHandler
         return safe.Length > 40 ? safe.Substring(0, 40) : safe;
     }
 
-    /// <summary>Name for the temp file a tool's IN/OUT is opened from — readable in the tab, and
+    /// <summary><para>
+    /// Name for the temp file a tool's IN/OUT is opened from — readable in the tab, and
     /// carrying an extension the editor can colour.
-    ///
+    /// </para>
+    /// <para>
     /// The temp is the right thing to open here and not a stand-in for the real file: clicking the
     /// row's TITLE already goes to the file. Clicking the content asks a different question — what
     /// was written in THAT turn — and the file on disk answers it wrongly three turns later, while
-    /// a temp cannot change under you.</summary>
+    /// a temp cannot change under you.
+    /// </para></summary>
     private static string TempFileName(string toolName, string which, string filePath, string toolUseId)
     {
         // Last few chars of the tool_use_id: enough to keep two temps apart — two writes to

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Open.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Open.cs
@@ -16,95 +16,89 @@ namespace Corsinvest.VisualStudio.Agents.Chat.Host;
 /// <summary>WebViewMessageHandler: Open-namespace message handlers (jump to file/edit, tool output, diff, external url, options, CLI terminal).</summary>
 internal sealed partial class WebViewMessageHandler
 {
-    private void HandleIdeFile(JObject data, int? id)
-    {
-        ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
-        {
-            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-            var p = data.ToObject<Contracts.IdeFileNotification>();
-            var raw = p.FilePath ?? "";
-            var filePath = ResolveFilePath(raw);
-            if (filePath == null)
-            {
-                // Nothing was found anywhere ResolveFilePath looks, so name the path the link
-                // carried rather than one we resolved — that is what the user can act on. The
-                // reason stays open: moved, renamed, deleted, or a temp file Windows cleared out
-                // are all the same miss from here.
-                NoticeOpenFailed(raw, "not found");
-                return;
-            }
-            // endLine defaults to startLine when the WebView omits it (single-line open).
-            var endLine = p.EndLine != 0 ? p.EndLine : p.StartLine;
-            await OpenFileInEditorAsync(filePath, p.StartLine, endLine);
-        }).FileAndForget(nameof(WebViewMessageHandler));
-    }
+    private void HandleIdeFile(JObject data, int? id) => ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                                                              {
+                                                                  await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                                                                  var p = data.ToObject<Contracts.IdeFileNotification>();
+                                                                  var raw = p.FilePath ?? "";
+                                                                  var filePath = ResolveFilePath(raw);
+                                                                  if (filePath == null)
+                                                                  {
+                                                                      // Nothing was found anywhere ResolveFilePath looks, so name the path the link
+                                                                      // carried rather than one we resolved — that is what the user can act on. The
+                                                                      // reason stays open: moved, renamed, deleted, or a temp file Windows cleared out
+                                                                      // are all the same miss from here.
+                                                                      NoticeOpenFailed(raw, "not found");
+                                                                      return;
+                                                                  }
+                                                                  // endLine defaults to startLine when the WebView omits it (single-line open).
+                                                                  var endLine = p.EndLine != 0 ? p.EndLine : p.StartLine;
+                                                                  await OpenFileInEditorAsync(filePath, p.StartLine, endLine);
+                                                              }).FileAndForget(nameof(WebViewMessageHandler));
 
-    private void HandleToolOutput(JObject data, int? id)
-    {
-        ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
-        {
-            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-            var p = data.ToObject<Contracts.ToolOutputNotification>();
-            var toolUseId = p.ToolUseId ?? "";
-            var which = p.Which ?? "out";
-            var agentId = p.AgentId;
-            var toolName = p.ToolName ?? "";
-            if (string.IsNullOrEmpty(toolUseId)) { return; }
-            // Read full content from the JSONL — the WebView only holds preview-capped text, so
-            // this gives the untruncated output. The fallback below is for the Agent ROW: it
-            // carries an agentId (it needs one to fetch its children) while its OWN result lives
-            // in the main transcript, so the sub-agent file has no match for it.
-            var paths = PaneClaudePaths;
-            string content = null;
-            // Only the IN side names a file. OUT for a Write is "File created successfully at: …",
-            // which is not the file and must not lend the temp its extension.
-            string filePath = null;
-            // The sub-agent transcript first when there is one, then the main file. Same call, and
-            // the agentId is what picks the file it reads.
-            foreach (var lookIn in string.IsNullOrEmpty(agentId) ? [null] : new[] { agentId, null })
-            {
-                if (which == "in")
-                {
-                    (content, filePath) = FindToolInput(client.WorkingDirectory, client.SessionId, toolUseId, paths, toolName, lookIn);
-                }
-                else
-                {
-                    content = FindToolResult(client.WorkingDirectory, client.SessionId, toolUseId, paths, lookIn);
-                }
-                if (!string.IsNullOrEmpty(content)) { break; }
-            }
+    private void HandleToolOutput(JObject data, int? id) => ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                                                                 {
+                                                                     await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                                                                     var p = data.ToObject<Contracts.ToolOutputNotification>();
+                                                                     var toolUseId = p.ToolUseId ?? "";
+                                                                     var which = p.Which ?? "out";
+                                                                     var agentId = p.AgentId;
+                                                                     var toolName = p.ToolName ?? "";
+                                                                     if (string.IsNullOrEmpty(toolUseId)) { return; }
+                                                                     // Read full content from the JSONL — the WebView only holds preview-capped text, so
+                                                                     // this gives the untruncated output. The fallback below is for the Agent ROW: it
+                                                                     // carries an agentId (it needs one to fetch its children) while its OWN result lives
+                                                                     // in the main transcript, so the sub-agent file has no match for it.
+                                                                     var paths = PaneClaudePaths;
+                                                                     string content = null;
+                                                                     // Only the IN side names a file. OUT for a Write is "File created successfully at: …",
+                                                                     // which is not the file and must not lend the temp its extension.
+                                                                     string filePath = null;
+                                                                     // The sub-agent transcript first when there is one, then the main file. Same call, and
+                                                                     // the agentId is what picks the file it reads.
+                                                                     foreach (var lookIn in string.IsNullOrEmpty(agentId) ? [null] : new[] { agentId, null })
+                                                                     {
+                                                                         if (which == "in")
+                                                                         {
+                                                                             (content, filePath) = FindToolInput(client.WorkingDirectory, client.SessionId, toolUseId, paths, toolName, lookIn);
+                                                                         }
+                                                                         else
+                                                                         {
+                                                                             content = FindToolResult(client.WorkingDirectory, client.SessionId, toolUseId, paths, lookIn);
+                                                                         }
+                                                                         if (!string.IsNullOrEmpty(content)) { break; }
+                                                                     }
 
-            if (string.IsNullOrEmpty(content))
-            {
-                log.Debug(() => $"[open-output] no content found for tool_use_id={toolUseId}");
-                return;
-            }
+                                                                     if (string.IsNullOrEmpty(content))
+                                                                     {
+                                                                         log.Debug(() => $"[open-output] no content found for tool_use_id={toolUseId}");
+                                                                         return;
+                                                                     }
 
-            // Strip the CLI's <tool_use_error> wrapper (protocol detail).
-            // Same regex as the WebView's `_cleanResult`.
-            var m = System.Text.RegularExpressions.Regex.Match(content,
-                                                              @"<tool_use_error>([\s\S]*?)</tool_use_error>",
-                                                              System.Text.RegularExpressions.RegexOptions.IgnoreCase);
-            if (m.Success) { content = m.Groups[1].Value.Trim(); }
-            var tmpPath = Path.Combine(Path.GetTempPath(), TempFileName(toolName, which, filePath, toolUseId));
-            // Clear the flag before rewriting: a previous open left the file read-only, and
-            // WriteAllText would throw on it.
-            try
-            {
-                if (File.Exists(tmpPath)) { File.SetAttributes(tmpPath, FileAttributes.Normal); }
-            }
-            catch (Exception ex) { log.Warn($"[open-output] could not clear read-only on {tmpPath}: {ex.Message}"); }
-            File.WriteAllText(tmpPath, content, System.Text.Encoding.UTF8);
-            // Read-only on purpose: this is a copy of what the tool wrote at that turn, and now that
-            // it carries the real extension it looks even more like the source file. Editing it
-            // would change nothing on disk, which is worth making obvious rather than discovering.
-            try { File.SetAttributes(tmpPath, FileAttributes.ReadOnly); }
-            catch (Exception ex) { log.Warn($"[open-output] could not mark {tmpPath} read-only: {ex.Message}"); }
-            VsShellUtilities.OpenDocument(ServiceProvider.GlobalProvider, tmpPath,
-                Microsoft.VisualStudio.VSConstants.LOGVIEWID.TextView_guid, out _, out _, out var frame);
-            frame?.Show();
-        }).FileAndForget(nameof(WebViewMessageHandler));
-    }
+                                                                     // Strip the CLI's <tool_use_error> wrapper (protocol detail).
+                                                                     // Same regex as the WebView's `_cleanResult`.
+                                                                     var m = System.Text.RegularExpressions.Regex.Match(content,
+                                                                                                                       @"<tool_use_error>([\s\S]*?)</tool_use_error>",
+                                                                                                                       System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+                                                                     if (m.Success) { content = m.Groups[1].Value.Trim(); }
+                                                                     var tmpPath = Path.Combine(Path.GetTempPath(), TempFileName(toolName, which, filePath, toolUseId));
+                                                                     // Clear the flag before rewriting: a previous open left the file read-only, and
+                                                                     // WriteAllText would throw on it.
+                                                                     try
+                                                                     {
+                                                                         if (File.Exists(tmpPath)) { File.SetAttributes(tmpPath, FileAttributes.Normal); }
+                                                                     }
+                                                                     catch (Exception ex) { log.Warn($"[open-output] could not clear read-only on {tmpPath}: {ex.Message}"); }
+                                                                     File.WriteAllText(tmpPath, content, System.Text.Encoding.UTF8);
+                                                                     // Read-only on purpose: this is a copy of what the tool wrote at that turn, and now that
+                                                                     // it carries the real extension it looks even more like the source file. Editing it
+                                                                     // would change nothing on disk, which is worth making obvious rather than discovering.
+                                                                     try { File.SetAttributes(tmpPath, FileAttributes.ReadOnly); }
+                                                                     catch (Exception ex) { log.Warn($"[open-output] could not mark {tmpPath} read-only: {ex.Message}"); }
+                                                                     VsShellUtilities.OpenDocument(ServiceProvider.GlobalProvider, tmpPath,
+                                                                         Microsoft.VisualStudio.VSConstants.LOGVIEWID.TextView_guid, out _, out _, out var frame);
+                                                                     frame?.Show();
+                                                                 }).FileAndForget(nameof(WebViewMessageHandler));
 
     private void HandleDiffDialog(JObject data, int? id)
     {
@@ -138,15 +132,9 @@ internal sealed partial class WebViewMessageHandler
             leftLabel: "Original", rightLabel: "Proposed");
     }
 
-    private void HandleIdeOutputWindow(JObject data, int? id)
-    {
-        OutputWindowLogger.ActivatePane();
-    }
+    private void HandleIdeOutputWindow(JObject data, int? id) => OutputWindowLogger.ActivatePane();
 
-    private void HandleExternalUrl(JObject data, int? id)
-    {
-        ShellHelpers.OpenExternal(data.ToObject<Contracts.ExternalUrlNotification>().Url ?? "");
-    }
+    private void HandleExternalUrl(JObject data, int? id) => ShellHelpers.OpenExternal(data.ToObject<Contracts.ExternalUrlNotification>().Url ?? "");
 
     private void HandleOptions(JObject data, int? id)
     {
@@ -160,22 +148,17 @@ internal sealed partial class WebViewMessageHandler
         });
     }
 
-    private void HandleCliTerminal(JObject data, int? id)
-    {
+    private void HandleCliTerminal(JObject data, int? id) =>
         // Same as the toolbar "+" for CLI: a fresh interactive terminal pane, inheriting
         // this chat's profile.
         Core.Panes.PaneLauncher.OpenNew(PaneKind.Cli, entry.Profile);
-    }
 
-    private void HandleChatPane(JObject data, int? id)
-    {
+    private void HandleChatPane(JObject data, int? id) =>
         // Same as the toolbar "+" for Chat: a new pane on its own session, inheriting this
         // chat's profile. Distinct from /clear, which restarts the conversation in place.
         Core.Panes.PaneLauncher.OpenNew(PaneKind.Chat, entry.Profile);
-    }
 
-    private void HandleSessionHistory(JObject data, int? id)
-    {
+    private void HandleSessionHistory(JObject data, int? id) =>
         // The picker is WPF and lives in the toolbar; the entry carries the callback so the
         // command opens the very same popup as the History button.
         ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
@@ -183,5 +166,4 @@ internal sealed partial class WebViewMessageHandler
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
             entry.ShowHistoryAction?.Invoke();
         }).FileAndForget(nameof(WebViewMessageHandler));
-    }
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Plugins.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Plugins.cs
@@ -32,26 +32,20 @@ internal sealed partial class WebViewMessageHandler
             "plugin", p.Enabled ? "enable" : "disable", p.PluginId);
     }
 
-    private void HandleMarketplaceAdd(JObject data, int? id)
-    {
+    private void HandleMarketplaceAdd(JObject data, int? id) =>
         // Adding a marketplace only changes what's installable, not the active plugins.
         HandlePluginOp("marketplace-add", affectsActive: false,
             "plugin", "marketplace", "add", data.ToObject<Contracts.MarketplaceAddNotification>().Source);
-    }
 
-    private void HandleMarketplaceRemove(JObject data, int? id)
-    {
+    private void HandleMarketplaceRemove(JObject data, int? id) =>
         // Removing a marketplace also disables its plugins → touches active plugins.
         HandlePluginOp("marketplace-remove", affectsActive: true,
             "plugin", "marketplace", "remove", data.ToObject<Contracts.MarketplaceRemoveNotification>().Name);
-    }
 
-    private void HandleMarketplaceRefresh(JObject data, int? id)
-    {
+    private void HandleMarketplaceRefresh(JObject data, int? id) =>
         // Refresh re-fetches a marketplace's catalog; installed/active plugins are untouched.
         HandlePluginOp("marketplace-refresh", affectsActive: false,
             "plugin", "marketplace", "update", data.ToObject<Contracts.MarketplaceRefreshNotification>().Name);
-    }
 
     private void HandlePluginList(int? id)
     {
@@ -77,22 +71,19 @@ internal sealed partial class WebViewMessageHandler
         }).FileAndForget(nameof(WebViewMessageHandler));
     }
 
-    private void HandlePluginOp(string op, bool affectsActive, params string[] args)
-    {
-        ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
-        {
-            var (ok, message) = await Core.Plugins.PluginService.RunOpAsync(args);
-            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-            bridge.Send(BridgeMessages.ToWebView.Plugins.OpResult, new Contracts.PluginOpResultNotification
-            {
-                Op = op,
-                Ok = ok,
-                Message = message,
-                AffectsActive = affectsActive && ok,
-            });
-            // Only this pane hears about it: a plugin change affects every live chat, but there is
-            // no broadcast channel yet, so the others find out on their next reload.
-            if (ok && affectsActive) { bridge.Send(BridgeMessages.ToWebView.Plugins.Changed, null); }
-        }).FileAndForget(nameof(WebViewMessageHandler));
-    }
+    private void HandlePluginOp(string op, bool affectsActive, params string[] args) => ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                                                                                             {
+                                                                                                 var (ok, message) = await Core.Plugins.PluginService.RunOpAsync(args);
+                                                                                                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                                                                                                 bridge.Send(BridgeMessages.ToWebView.Plugins.OpResult, new Contracts.PluginOpResultNotification
+                                                                                                 {
+                                                                                                     Op = op,
+                                                                                                     Ok = ok,
+                                                                                                     Message = message,
+                                                                                                     AffectsActive = affectsActive && ok,
+                                                                                                 });
+                                                                                                 // Only this pane hears about it: a plugin change affects every live chat, but there is
+                                                                                                 // no broadcast channel yet, so the others find out on their next reload.
+                                                                                                 if (ok && affectsActive) { bridge.Send(BridgeMessages.ToWebView.Plugins.Changed, null); }
+                                                                                             }).FileAndForget(nameof(WebViewMessageHandler));
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.ClientEvents.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.ClientEvents.cs
@@ -798,20 +798,24 @@ public partial class ChatPaneControl
             SetSessionTitle(null);
         });
 
-    /// <summary>A line the CLI wrote on stderr. It reaches the chat only if the process is gone —
+    /// <summary><para>
+    /// A line the CLI wrote on stderr. It reaches the chat only if the process is gone —
     /// a CLI that is still running is warning, not failing, and rendering that as the red banner
     /// says the session broke when it didn't.
-    ///
+    /// </para>
+    /// <para>
     /// Measured 2026-08-06 on an untrusted workspace: the CLI writes "Ignoring 1 permissions.allow
     /// entry … this workspace has not been trusted", carries on, and answers the turn normally —
     /// while we showed an error over a working chat. Node's own DeprecationWarnings came out the
     /// same way. VS Code reads the child's stderr into a 2KB diagnostic tail and never surfaces it
     /// (verified in the SDK's ProcessTransport), which is why the same warning is invisible there.
-    ///
+    /// </para>
+    /// <para>
     /// Deliberately not a match on the message text: that would mean chasing the CLI's wording
     /// release by release. Whether the process survived is the CLI's own verdict on how bad the
     /// line was. Nothing is lost either way — every line is already logged as Warn by
-    /// NdjsonTransport, and a process that dies raises its own banner through OnProcessExited.</summary>
+    /// NdjsonTransport, and a process that dies raises its own banner through OnProcessExited.
+    /// </para></summary>
     private void OnClientError(object sender, string msg)
     {
         if (_client?.IsRunning == true) { return; }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
@@ -379,7 +379,7 @@ public partial class ChatPaneControl : PaneControlBase
         if (files.Count > 0)
         {
             _bridge.Send(BridgeMessages.ToWebView.Ui.FilesDropped,
-                         new Contracts.FilesDroppedNotification { Files = files.ToArray() });
+                         new Contracts.FilesDroppedNotification { Files = [.. files] });
         }
     }
 

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/state-subscriptions.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/state-subscriptions.ts
@@ -1,0 +1,45 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+import type { ReactiveController, ReactiveControllerHost } from 'lit';
+import { state as appState, type AppState } from './state';
+
+/**
+ * Holds a component's appState subscriptions and drops them when it leaves the DOM.
+ *
+ * Lit reconnects a host that is moved rather than destroyed, so the subscriptions are
+ * re-established on hostConnected: an element that survives a re-parent keeps working.
+ */
+export class StateSubscriptions implements ReactiveController {
+    private readonly _pending: Array<() => () => void> = [];
+    private _offs: Array<() => void> = [];
+
+    private readonly _host: ReactiveControllerHost;
+
+    constructor(host: ReactiveControllerHost) {
+        this._host = host;
+        host.addController(this);
+    }
+
+    /** Subscribe for as long as the host is connected. */
+    on<K extends keyof AppState>(key: K, fn: (value: AppState[K]) => void): void {
+        this._pending.push(() => appState.on(key, fn));
+    }
+
+    /** Subscribe to re-render only, for a render that reads appState itself. */
+    rerenderOn(...keys: Array<keyof AppState>): void {
+        for (const key of keys) {
+            this.on(key, () => this._host.requestUpdate());
+        }
+    }
+
+    hostConnected(): void {
+        this._offs = this._pending.map((subscribe) => subscribe());
+    }
+
+    hostDisconnected(): void {
+        this._offs.forEach((off) => off());
+        this._offs = [];
+    }
+}

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/state.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/state.ts
@@ -21,7 +21,7 @@ import type {
 } from './types';
 import { PERMISSION_MODE } from './types';
 
-interface AppState {
+export interface AppState {
     workingDirectory: string;
     currentModel: string | null;
     permissionMode: PermissionMode;

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/state-subscriptions.test.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/state-subscriptions.test.ts
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright (C) 2026 Corsinvest Srl
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import type { ReactiveController, ReactiveControllerHost } from 'lit';
+import { StateSubscriptions } from '../core/state-subscriptions.ts';
+import { state as appState } from '../core/state.ts';
+
+/**
+ * Stand-in for a LitElement: enough of ReactiveControllerHost to drive the lifecycle by hand,
+ * following what ReactiveElement itself does — connectedCallback calls hostConnected on every
+ * controller, disconnectedCallback calls hostDisconnected.
+ */
+class FakeHost implements ReactiveControllerHost {
+    readonly controllers: ReactiveController[] = [];
+    updateCount = 0;
+
+    addController(c: ReactiveController): void {
+        this.controllers.push(c);
+    }
+    removeController(c: ReactiveController): void {
+        const i = this.controllers.indexOf(c);
+        if (i >= 0) {
+            this.controllers.splice(i, 1);
+        }
+    }
+    requestUpdate(): void {
+        this.updateCount++;
+    }
+    get updateComplete(): Promise<boolean> {
+        return Promise.resolve(true);
+    }
+
+    connect(): void {
+        this.controllers.forEach((c) => c.hostConnected?.());
+    }
+    disconnect(): void {
+        this.controllers.forEach((c) => c.hostDisconnected?.());
+    }
+}
+
+/** Quante callback lo store tiene vive per una chiave: l'unica misura che vede una
+ *  sottoscrizione rimasta appesa, che contare le chiamate non rivelerebbe. */
+function liveListeners(key: string): number {
+    const subs = (appState as unknown as { _subs?: Map<string, Set<unknown>> })._subs;
+    return subs?.get(key)?.size ?? 0;
+}
+
+test('il controller si registra sull host alla costruzione', () => {
+    const host = new FakeHost();
+    const subs = new StateSubscriptions(host);
+
+    assert.deepEqual(host.controllers, [subs]);
+});
+
+test('nessuna sottoscrizione è viva prima del connect', () => {
+    const host = new FakeHost();
+    const subs = new StateSubscriptions(host);
+    const seen: string[] = [];
+    subs.on('workingDirectory', (v) => seen.push(v));
+
+    appState.workingDirectory = 'k:/before-connect';
+
+    assert.deepEqual(seen, []);
+});
+
+test('dopo il connect la callback riceve i cambi', () => {
+    const host = new FakeHost();
+    const subs = new StateSubscriptions(host);
+    const seen: string[] = [];
+    subs.on('workingDirectory', (v) => seen.push(v));
+    host.connect();
+
+    appState.workingDirectory = 'k:/one';
+    appState.workingDirectory = 'k:/two';
+
+    assert.deepEqual(seen, ['k:/one', 'k:/two']);
+});
+
+test('il disconnect stacca tutto', () => {
+    const host = new FakeHost();
+    const subs = new StateSubscriptions(host);
+    const seen: string[] = [];
+    subs.on('workingDirectory', (v) => seen.push(v));
+    host.connect();
+    appState.workingDirectory = 'k:/live';
+    host.disconnect();
+
+    appState.workingDirectory = 'k:/after-disconnect';
+
+    assert.deepEqual(seen, ['k:/live']);
+});
+
+test('un host rimosso e reinserito torna a ricevere i cambi', () => {
+    const host = new FakeHost();
+    const subs = new StateSubscriptions(host);
+    const seen: string[] = [];
+    subs.on('workingDirectory', (v) => seen.push(v));
+
+    host.connect();
+    appState.workingDirectory = 'k:/first';
+    host.disconnect();
+    appState.workingDirectory = 'k:/while-detached';
+    host.connect();
+    appState.workingDirectory = 'k:/second';
+
+    assert.deepEqual(seen, ['k:/first', 'k:/second']);
+});
+
+// Il caso che perderebbe memoria: due connect di fila senza disconnect in mezzo. Lit chiama
+// hostConnected a ogni connectedCallback, e addController lo chiama subito se l'host è già
+// connesso. Se il secondo giro sovrascrivesse la lista di unsubscribe, il primo resterebbe
+// appeso — invisibile contando le chiamate, perché lo store tiene i listener in un Set che
+// deduplica la stessa funzione. Va misurato lo store, non la callback: dopo il disconnect
+// deve tornare esattamente al numero di partenza.
+test('un connect ripetuto non lascia sottoscrizioni appese nello store', () => {
+    const host = new FakeHost();
+    const subs = new StateSubscriptions(host);
+    // Una chiusura nuova a ogni giro: due sottoscrizioni distinte, che un Set non può fondere.
+    subs.on('workingDirectory', (v) => void v);
+    subs.on('workingDirectory', (v) => void v);
+    const before = liveListeners('workingDirectory');
+
+    host.connect();
+    host.connect();
+    host.disconnect();
+
+    assert.equal(liveListeners('workingDirectory'), before);
+});
+
+test('un connect ripetuto non fa scattare la callback due volte', () => {
+    const host = new FakeHost();
+    const subs = new StateSubscriptions(host);
+    const seen: string[] = [];
+    subs.on('workingDirectory', (v) => seen.push(v));
+
+    host.connect();
+    host.connect();
+    appState.workingDirectory = 'k:/once';
+
+    assert.deepEqual(seen, ['k:/once']);
+});
+
+test('rerenderOn chiede un update per ogni chiave, senza leggere il valore', () => {
+    const host = new FakeHost();
+    const subs = new StateSubscriptions(host);
+    subs.rerenderOn('currentModel', 'permissionMode');
+    host.connect();
+
+    appState.currentModel = 'opus';
+    appState.permissionMode = 'plan';
+
+    assert.equal(host.updateCount, 2);
+});
+
+test('rerenderOn smette di chiedere update dopo il disconnect', () => {
+    const host = new FakeHost();
+    const subs = new StateSubscriptions(host);
+    subs.rerenderOn('currentModel');
+    host.connect();
+    appState.currentModel = 'sonnet';
+    host.disconnect();
+
+    appState.currentModel = 'haiku';
+
+    assert.equal(host.updateCount, 1);
+});
+
+test('due host indipendenti non si disturbano', () => {
+    const a = new FakeHost();
+    const b = new FakeHost();
+    const subsA = new StateSubscriptions(a);
+    const subsB = new StateSubscriptions(b);
+    subsA.rerenderOn('currentModel');
+    subsB.rerenderOn('currentModel');
+    a.connect();
+    b.connect();
+
+    appState.currentModel = 'first';
+    a.disconnect();
+    appState.currentModel = 'second';
+
+    assert.equal(a.updateCount, 1);
+    assert.equal(b.updateCount, 2);
+});
+
+// Tutte le chiamate a on() dei componenti stanno nel constructor, quindi prima del primo
+// connect. Se una arrivasse dopo, resterebbe muta fino al reinserimento nel DOM: il
+// controller sottoscrive solo in hostConnected. Fissato qui perché è il limite del
+// contratto, non un dettaglio implementativo.
+test('on() dopo il connect non ha effetto fino al reinserimento', () => {
+    const host = new FakeHost();
+    const subs = new StateSubscriptions(host);
+    host.connect();
+
+    const seen: string[] = [];
+    subs.on('workingDirectory', (v) => seen.push(v));
+    appState.workingDirectory = 'k:/late-subscription';
+
+    assert.deepEqual(seen, [], 'una on() tardiva non parte da sola');
+
+    host.disconnect();
+    host.connect();
+    appState.workingDirectory = 'k:/after-reconnect';
+
+    assert.deepEqual(seen, ['k:/after-reconnect']);
+});

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-app.ts
@@ -35,6 +35,7 @@ import './cv-permission-banner';
 import './cv-spinner';
 import './cv-tool-row';
 import { state as appState } from '../../core/state';
+import { StateSubscriptions } from '../../core/state-subscriptions';
 import type {
     SubagentTask,
     UiEntry,
@@ -129,6 +130,8 @@ export class CvApp extends LitElement {
     private _jumpRaf = 0;
     @query('#system-notices') private _systemNotices!: CvNoticeStack | null;
 
+    private readonly _subs = new StateSubscriptions(this);
+    /** Bridge notification handlers; the appState subscriptions live in _subs. */
     private _offs: Array<() => void> = [];
     /**
      * Currently-streaming assistant message, keyed by parent tool_use_id
@@ -206,15 +209,19 @@ export class CvApp extends LitElement {
         return this;
     }
 
+    constructor() {
+        super();
+        this._subs.on('isBusy', (v) => (this._isBusy = v));
+        this._subs.on('queuedUuids', (v) => (this._queuedUuids = new Set(v)));
+        this._subs.on('status', (v) => (this._status = v));
+        this._subs.on('pendingPermission', (v) => (this._awaitingUser = v != null));
+    }
+
     override connectedCallback(): void {
         super.connectedCallback();
         // Wired here rather than at the field: the initializer runs before `this` is usable.
         this._transcript.onRemoved = (ids) => this._dropRemovedIds(ids);
         this._transcript.onCleared = () => this._dropAllIds();
-        this._offs.push(appState.on('isBusy', (v) => (this._isBusy = v)));
-        this._offs.push(appState.on('queuedUuids', (v) => (this._queuedUuids = new Set(v))));
-        this._offs.push(appState.on('status', (v) => (this._status = v)));
-        this._offs.push(appState.on('pendingPermission', (v) => (this._awaitingUser = v != null)));
         // Global Esc-to-stop: interrupt generation regardless of focus, so stopping
         // never depends on where the caret is. Skipped when a permission/Ask prompt
         // is open — there Esc cancels the prompt (the banner handles it, with stopPropagation).

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-context-gauge.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-context-gauge.ts
@@ -13,6 +13,7 @@ import DataPie16Regular from '@fluentui/svg-icons/icons/data_pie_16_regular.svg'
 import { iconForCommandName } from '../../core/commands/command-icons';
 import { iconStyles, tooltipStyles } from '../styles/shared';
 import { state as appState } from '../../core/state';
+import { StateSubscriptions } from '../../core/state-subscriptions';
 import { bridge } from '../../core/bridge';
 import { Msg } from '../../core/bridge-messages';
 import {
@@ -134,23 +135,16 @@ export class CvContextGauge extends LitElement {
     @state() private _usage: ContextUsageDto | null = appState.contextUsage;
     @state() private _window = appState.contextWindow;
 
-    private _offUsage?: () => void;
-    private _offWindow?: () => void;
+    private readonly _subs = new StateSubscriptions(this);
 
-    override connectedCallback(): void {
-        super.connectedCallback();
-        this._offUsage = appState.on('contextUsage', (v) => {
+    constructor() {
+        super();
+        this._subs.on('contextUsage', (v) => {
             this._usage = v;
         });
-        this._offWindow = appState.on('contextWindow', (v) => {
+        this._subs.on('contextWindow', (v) => {
             this._window = v;
         });
-    }
-
-    override disconnectedCallback(): void {
-        super.disconnectedCallback();
-        this._offUsage?.();
-        this._offWindow?.();
     }
 
     /** Compact the conversation via the CLI's `/compact` command (mirrors cv-prompt._dispatch). */

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-effort-selector.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-effort-selector.ts
@@ -5,6 +5,7 @@
 import { LitElement, html, css, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { state as appState } from '../../core/state';
+import { StateSubscriptions } from '../../core/state-subscriptions';
 import { tooltipStyles } from '../styles/shared';
 import { currentEffortLevels } from '../../core/commands/model-controls';
 import { effortLabel } from '../../core/types';
@@ -37,26 +38,17 @@ export class CvEffortSelector extends LitElement {
     @state() private _effort = appState.effortLevel;
     @state() private _ultracode = appState.ultracodeEnabled;
 
-    private _offs: Array<() => void> = [];
+    private readonly _subs = new StateSubscriptions(this);
 
-    override connectedCallback(): void {
-        super.connectedCallback();
-        this._offs = [
-            appState.on('effortLevel', (v) => {
-                this._effort = v;
-            }),
-            appState.on('ultracodeEnabled', (v) => {
-                this._ultracode = v;
-            }),
-            appState.on('models', () => this.requestUpdate()),
-            appState.on('currentModel', () => this.requestUpdate()),
-        ];
-    }
-
-    override disconnectedCallback(): void {
-        super.disconnectedCallback();
-        this._offs.forEach((off) => off());
-        this._offs = [];
+    constructor() {
+        super();
+        this._subs.on('effortLevel', (v) => {
+            this._effort = v;
+        });
+        this._subs.on('ultracodeEnabled', (v) => {
+            this._ultracode = v;
+        });
+        this._subs.rerenderOn('models', 'currentModel');
     }
 
     private _onClick = (): void => {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-effort-selector.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-effort-selector.ts
@@ -36,9 +36,6 @@ export class CvEffortSelector extends LitElement {
 
     @state() private _effort = appState.effortLevel;
     @state() private _ultracode = appState.ultracodeEnabled;
-    // The catalogue decides whether this model has effort at all.
-    @state() private _models = appState.models;
-    @state() private _current = appState.currentModel;
 
     private _offs: Array<() => void> = [];
 
@@ -51,12 +48,8 @@ export class CvEffortSelector extends LitElement {
             appState.on('ultracodeEnabled', (v) => {
                 this._ultracode = v;
             }),
-            appState.on('models', (v) => {
-                this._models = v;
-            }),
-            appState.on('currentModel', (v) => {
-                this._current = v;
-            }),
+            appState.on('models', () => this.requestUpdate()),
+            appState.on('currentModel', () => this.requestUpdate()),
         ];
     }
 
@@ -71,9 +64,6 @@ export class CvEffortSelector extends LitElement {
     };
 
     override render() {
-        // Read so the availability check re-runs when either changes.
-        void this._models;
-        void this._current;
         if (currentEffortLevels() === null) {
             return nothing;
         }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-ide-context-badge.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-ide-context-badge.ts
@@ -9,6 +9,7 @@ import EyeOff16Regular from '@fluentui/svg-icons/icons/eye_off_16_regular.svg';
 import Bookmark16Regular from '@fluentui/svg-icons/icons/bookmark_16_regular.svg';
 import CodeBlock16Regular from '@fluentui/svg-icons/icons/code_block_16_regular.svg';
 import { state as appState } from '../../core/state';
+import { StateSubscriptions } from '../../core/state-subscriptions';
 import type { IdeContextNotification, SetSendSelectionNotification } from '../../core/types';
 import { bridge } from '../../core/bridge';
 import { Msg } from '../../core/bridge-messages';
@@ -120,28 +121,19 @@ export class CvIdeContextBadge extends LitElement {
      *  block while the chat is open, and the chip has to follow it. */
     @state() private _withText = appState.ui.sendSelectionText;
 
-    private _offCtx?: () => void;
-    private _offEnabled?: () => void;
-    private _offUi?: () => void;
+    private readonly _subs = new StateSubscriptions(this);
 
-    override connectedCallback(): void {
-        super.connectedCallback();
-        this._offCtx = appState.on('ideContext', (v) => {
+    constructor() {
+        super();
+        this._subs.on('ideContext', (v) => {
             this._ctx = v;
         });
-        this._offEnabled = appState.on('ideContextEnabled', (v) => {
+        this._subs.on('ideContextEnabled', (v) => {
             this._enabled = v;
         });
-        this._offUi = appState.on('ui', (v) => {
+        this._subs.on('ui', (v) => {
             this._withText = v.sendSelectionText;
         });
-    }
-
-    override disconnectedCallback(): void {
-        super.disconnectedCallback();
-        this._offCtx?.();
-        this._offEnabled?.();
-        this._offUi?.();
     }
 
     private _onToggleEye = (e: Event): void => {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-message.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-message.ts
@@ -15,6 +15,7 @@ import { bridge } from '../../core/bridge';
 import { Msg } from '../../core/bridge-messages';
 import { fetchChatImage, openChatDocument } from '../../core/lazy';
 import { state as appState } from '../../core/state';
+import { StateSubscriptions } from '../../core/state-subscriptions';
 import { iconUrl } from '../../core/icon-url';
 import { fileName } from '../../core/path';
 import { formatTokenCount } from '../helpers/format';
@@ -73,7 +74,7 @@ export class CvMessage extends LitElement {
     // Re-measure the truncation on width changes: text re-wraps, so the px cap and the "Show more"
     // decision must be recomputed. updated() alone fires on property change, not on resize.
     private _unobserve?: () => void;
-    private _offUi?: () => void;
+    private readonly _subs = new StateSubscriptions(this);
     // Last observed width — the observer fires on our own max-height writes too, so re-measure only
     // when the WIDTH actually changed (that's what re-wraps the text). Avoids a feedback loop.
     private _lastWidth = 0;
@@ -154,16 +155,14 @@ export class CvMessage extends LitElement {
         return this;
     }
 
-    override connectedCallback(): void {
-        super.connectedCallback();
+    constructor() {
+        super();
         // previewLines IS the cap, so a change to it changes the truncation of every bubble.
-        this._offUi = appState.on('ui', () => this._measure());
+        this._subs.on('ui', () => this._measure());
     }
 
     override disconnectedCallback(): void {
         super.disconnectedCallback();
-        this._offUi?.();
-        this._offUi = undefined;
         if (this._streamTimer) {
             clearTimeout(this._streamTimer);
             this._streamTimer = undefined;

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-model-list.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-model-list.ts
@@ -7,6 +7,7 @@ import { customElement, property, query, state } from 'lit/decorators.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import Checkmark16Regular from '@fluentui/svg-icons/icons/checkmark_16_regular.svg';
 import { state as appState } from '../../core/state';
+import { StateSubscriptions } from '../../core/state-subscriptions';
 import { displayModels, resolveModelValue } from '../../core/ai-models';
 import type { ModelInfoDto } from '../../core/types';
 import './cv-popover-list';
@@ -27,8 +28,7 @@ export class CvModelList extends LitElement {
     @state() private _models = displayModels(appState.models);
     @state() private _current = appState.currentModel;
 
-    private _offModels?: () => void;
-    private _offCurrent?: () => void;
+    private readonly _subs = new StateSubscriptions(this);
 
     @query('cv-popover-list') private _list?: CvPopoverList;
 
@@ -37,20 +37,14 @@ export class CvModelList extends LitElement {
         return this;
     }
 
-    override connectedCallback(): void {
-        super.connectedCallback();
-        this._offModels = appState.on('models', (v) => {
+    constructor() {
+        super();
+        this._subs.on('models', (v) => {
             this._models = displayModels(v);
         });
-        this._offCurrent = appState.on('currentModel', (v) => {
+        this._subs.on('currentModel', (v) => {
             this._current = v;
         });
-    }
-
-    override disconnectedCallback(): void {
-        super.disconnectedCallback();
-        this._offModels?.();
-        this._offCurrent?.();
     }
 
     override willUpdate(changed: Map<string, unknown>): void {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-model-selector.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-model-selector.ts
@@ -50,7 +50,6 @@ export class CvModelSelector extends LitElement {
     ];
 
     @state() private _current = appState.currentModel;
-    @state() private _models = appState.models;
 
     private _off?: () => void;
     private _offModels?: () => void;
@@ -60,10 +59,7 @@ export class CvModelSelector extends LitElement {
         this._off = appState.on('currentModel', (v) => {
             this._current = v;
         });
-        // The label comes from the catalogue, so it resolves only once that has arrived.
-        this._offModels = appState.on('models', (v) => {
-            this._models = v;
-        });
+        this._offModels = appState.on('models', () => this.requestUpdate());
     }
 
     override disconnectedCallback(): void {
@@ -77,8 +73,6 @@ export class CvModelSelector extends LitElement {
     };
 
     override render() {
-        // Read so the label re-resolves when the catalogue lands (it maps value → displayName).
-        void this._models;
         // fluent-tooltip, not a title attribute: the native one is drawn by the OS, so it follows
         // Windows' light/dark rather than the theme VS is in — and VS has themes (Blue, third-party
         // ones) that neither of the two settings a WebView2 profile can be put in would match.

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-model-selector.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-model-selector.ts
@@ -5,6 +5,7 @@
 import { LitElement, html, css } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { state as appState } from '../../core/state';
+import { StateSubscriptions } from '../../core/state-subscriptions';
 import { iconStyles, tooltipStyles } from '../styles/shared';
 import { modelLabelShort } from '../../core/ai-models';
 
@@ -51,21 +52,14 @@ export class CvModelSelector extends LitElement {
 
     @state() private _current = appState.currentModel;
 
-    private _off?: () => void;
-    private _offModels?: () => void;
+    private readonly _subs = new StateSubscriptions(this);
 
-    override connectedCallback(): void {
-        super.connectedCallback();
-        this._off = appState.on('currentModel', (v) => {
+    constructor() {
+        super();
+        this._subs.on('currentModel', (v) => {
             this._current = v;
         });
-        this._offModels = appState.on('models', () => this.requestUpdate());
-    }
-
-    override disconnectedCallback(): void {
-        super.disconnectedCallback();
-        this._off?.();
-        this._offModels?.();
+        this._subs.rerenderOn('models');
     }
 
     private _onClick = (): void => {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-permission-list.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-permission-list.ts
@@ -7,6 +7,7 @@ import { customElement, property, query, state } from 'lit/decorators.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import Checkmark16Regular from '@fluentui/svg-icons/icons/checkmark_16_regular.svg';
 import { state as appState } from '../../core/state';
+import { StateSubscriptions } from '../../core/state-subscriptions';
 import { permissionItems, type PermissionItem } from '../../core/permission-modes';
 import type { PermissionMode } from '../../core/types';
 import './cv-popover-list';
@@ -27,8 +28,7 @@ export class CvPermissionList extends LitElement {
     @state() private _current: PermissionMode = appState.permissionMode;
     @state() private _items: PermissionItem[] = permissionItems();
 
-    private _off?: () => void;
-    private _offModels?: () => void;
+    private readonly _subs = new StateSubscriptions(this);
 
     @query('cv-popover-list') private _list?: CvPopoverList;
 
@@ -37,21 +37,15 @@ export class CvPermissionList extends LitElement {
         return this;
     }
 
-    override connectedCallback(): void {
-        super.connectedCallback();
-        this._off = appState.on('permissionMode', (v) => {
+    constructor() {
+        super();
+        this._subs.on('permissionMode', (v) => {
             this._current = v;
         });
         // The available modes depend on the model (supportsAutoMode).
-        this._offModels = appState.on('models', () => {
+        this._subs.on('models', () => {
             this._items = permissionItems();
         });
-    }
-
-    override disconnectedCallback(): void {
-        super.disconnectedCallback();
-        this._off?.();
-        this._offModels?.();
     }
 
     override willUpdate(changed: Map<string, unknown>): void {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-permission-selector.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-permission-selector.ts
@@ -5,6 +5,7 @@
 import { LitElement, html, css } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { state as appState } from '../../core/state';
+import { StateSubscriptions } from '../../core/state-subscriptions';
 import { tooltipStyles } from '../styles/shared';
 import type { PermissionMode } from '../../core/types';
 import { PERMISSION_MODE } from '../../core/types';
@@ -44,21 +45,14 @@ export class CvPermissionSelector extends LitElement {
 
     @state() private _current: PermissionMode = appState.permissionMode;
 
-    private _off?: () => void;
-    private _offModels?: () => void;
+    private readonly _subs = new StateSubscriptions(this);
 
-    override connectedCallback(): void {
-        super.connectedCallback();
-        this._off = appState.on('permissionMode', (v) => {
+    constructor() {
+        super();
+        this._subs.on('permissionMode', (v) => {
             this._current = v;
         });
-        this._offModels = appState.on('models', () => this.requestUpdate());
-    }
-
-    override disconnectedCallback(): void {
-        super.disconnectedCallback();
-        this._off?.();
-        this._offModels?.();
+        this._subs.rerenderOn('models');
     }
 
     private _onClick = (): void => {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-permission-selector.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-permission-selector.ts
@@ -43,7 +43,6 @@ export class CvPermissionSelector extends LitElement {
     ];
 
     @state() private _current: PermissionMode = appState.permissionMode;
-    @state() private _models = appState.models;
 
     private _off?: () => void;
     private _offModels?: () => void;
@@ -53,10 +52,7 @@ export class CvPermissionSelector extends LitElement {
         this._off = appState.on('permissionMode', (v) => {
             this._current = v;
         });
-        // The label's item list is model-dependent (supportsAutoMode).
-        this._offModels = appState.on('models', (v) => {
-            this._models = v;
-        });
+        this._offModels = appState.on('models', () => this.requestUpdate());
     }
 
     override disconnectedCallback(): void {
@@ -70,9 +66,6 @@ export class CvPermissionSelector extends LitElement {
     };
 
     override render() {
-        // _models is read so the label re-resolves when the catalogue (and thus the
-        // available modes) changes.
-        void this._models;
         // No fallback to the first item: the CLI can sit in a mode the picker doesn't list
         // (`dontAsk`, or `auto`/`bypassPermissions` once filtered out), and labelling that
         // "Manual" would state the opposite of what is in force. The raw value is ugly and true.

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-prompt.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-prompt.ts
@@ -10,6 +10,7 @@ import Send16Filled from '@fluentui/svg-icons/icons/send_16_filled.svg';
 import Stop16Filled from '@fluentui/svg-icons/icons/stop_16_filled.svg';
 import { iconUrl } from '../../core/icon-url';
 import { state as appState } from '../../core/state';
+import { StateSubscriptions } from '../../core/state-subscriptions';
 import { bridge } from '../../core/bridge';
 import { Msg } from '../../core/bridge-messages';
 import type {
@@ -361,14 +362,12 @@ export class CvPrompt extends LitElement implements CommandHost {
     @query('cv-permission-list')
     private _permissionList?: import('./cv-permission-list').CvPermissionList;
 
-    private _offBusy?: () => void;
-    private _offPerm?: () => void;
-    private _offPending?: () => void;
+    private readonly _subs = new StateSubscriptions(this);
+
     private _offHistory?: () => void;
     private _offCleared?: () => void;
     private _offRate?: () => void;
     private _offNotice?: () => void;
-    private _offSubagentTasks?: () => void;
 
     // Input ↑/↓ prompt history (shell-style). Oldest first; the typed prompts of
     // the current conversation. Seeded from the loaded session, appended on send.
@@ -379,21 +378,27 @@ export class CvPrompt extends LitElement implements CommandHost {
     // The live draft saved when entering history, restored on ↓ past the newest.
     private _historyDraft = '';
 
-    override connectedCallback(): void {
-        super.connectedCallback();
-        this._offBusy = appState.on('isBusy', (v) => {
+    constructor() {
+        super();
+        this._subs.on('isBusy', (v) => {
             this._isBusy = v;
             if (!v) {
                 queueMicrotask(() => this._flushQueue());
             }
         });
-        this._offPerm = appState.on('permissionMode', (v) => {
+        this._subs.on('permissionMode', (v) => {
             this._permissionMode = v;
         });
-        this._offPending = appState.on('pendingPermission', (v) => {
+        this._subs.on('pendingPermission', (v) => {
             this._pendingPermission = v != null;
         });
+        this._subs.on('subagentTasks', (v) => {
+            this._subagentTasks = v;
+        });
+    }
 
+    override connectedCallback(): void {
+        super.connectedCallback();
         // Seed the ↑/↓ prompt history. The host loads it in the background after
         // the initial render and pushes it via chat_prompt_history. Replace, not
         // append — the history is per-session.
@@ -468,10 +473,6 @@ export class CvPrompt extends LitElement implements CommandHost {
             },
         );
 
-        this._offSubagentTasks = appState.on('subagentTasks', (v) => {
-            this._subagentTasks = v;
-        });
-
         // Close a menu-opened palette on an outside click. (The `/`-opened
         // one closes on textarea blur; this covers the searchable case, whose
         // focus lives in the menu's own search box.)
@@ -484,14 +485,10 @@ export class CvPrompt extends LitElement implements CommandHost {
 
     override disconnectedCallback(): void {
         super.disconnectedCallback();
-        this._offBusy?.();
-        this._offPerm?.();
-        this._offPending?.();
         this._offHistory?.();
         this._offCleared?.();
         this._offRate?.();
         this._offNotice?.();
-        this._offSubagentTasks?.();
         document.removeEventListener('pointerdown', this._onDocPointerDown, true);
         document.removeEventListener('keydown', this._onDocKeyDown, true);
     }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-remote-chip.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-remote-chip.ts
@@ -11,6 +11,7 @@ import { REMOTE_CONTROL_ICON } from '../../core/commands/builtin-commands';
 import { bridge } from '../../core/bridge';
 import { Msg } from '../../core/bridge-messages';
 import { state as appState } from '../../core/state';
+import { StateSubscriptions } from '../../core/state-subscriptions';
 import { iconStyles, iconTriggerStyles, tooltipStyles } from '../styles/shared';
 
 /**
@@ -62,19 +63,19 @@ export class CvRemoteChip extends LitElement {
 
     @state() private accessor _status = appState.remoteControl.status;
 
-    private _unsubscribe?: () => void;
+    private readonly _subs = new StateSubscriptions(this);
 
-    override connectedCallback(): void {
-        super.connectedCallback();
-        this._status = appState.remoteControl.status;
-        this._unsubscribe = appState.on('remoteControl', (v) => {
+    constructor() {
+        super();
+        this._subs.on('remoteControl', (v) => {
             this._status = v.status;
         });
     }
 
-    override disconnectedCallback(): void {
-        super.disconnectedCallback();
-        this._unsubscribe?.();
+    override connectedCallback(): void {
+        super.connectedCallback();
+        // Catch up on what was missed while detached: the subscription only reports changes.
+        this._status = appState.remoteControl.status;
     }
 
     private _onShowLink = (): void => {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-thinking-toggle.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-thinking-toggle.ts
@@ -47,9 +47,6 @@ export class CvThinkingToggle extends LitElement {
     @property({ attribute: false }) host!: CommandHost;
 
     @state() private _enabled = appState.thinkingEnabled;
-    // The catalogue decides whether this model thinks at all.
-    @state() private _models = appState.models;
-    @state() private _current = appState.currentModel;
 
     private _offs: Array<() => void> = [];
     private readonly _command = new ThinkingCommand();
@@ -60,12 +57,8 @@ export class CvThinkingToggle extends LitElement {
             appState.on('thinkingEnabled', (v) => {
                 this._enabled = v;
             }),
-            appState.on('models', (v) => {
-                this._models = v;
-            }),
-            appState.on('currentModel', (v) => {
-                this._current = v;
-            }),
+            appState.on('models', () => this.requestUpdate()),
+            appState.on('currentModel', () => this.requestUpdate()),
         ];
     }
 
@@ -82,9 +75,6 @@ export class CvThinkingToggle extends LitElement {
     };
 
     override render() {
-        // Read so the availability check re-runs when either changes.
-        void this._models;
-        void this._current;
         // Hidden on models without adaptive thinking, on the same condition as the menu row.
         if (!this._command.isEnabled()) {
             return nothing;

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-thinking-toggle.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-thinking-toggle.ts
@@ -10,6 +10,7 @@ import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import Lightbulb16Filled from '@fluentui/svg-icons/icons/lightbulb_16_filled.svg';
 import Lightbulb16Regular from '@fluentui/svg-icons/icons/lightbulb_16_regular.svg';
 import { state as appState } from '../../core/state';
+import { StateSubscriptions } from '../../core/state-subscriptions';
 import { iconStyles, tooltipStyles } from '../styles/shared';
 import { ThinkingCommand } from '../../core/commands/model-controls';
 import type { CommandHost } from '../../core/commands/base';
@@ -48,24 +49,15 @@ export class CvThinkingToggle extends LitElement {
 
     @state() private _enabled = appState.thinkingEnabled;
 
-    private _offs: Array<() => void> = [];
+    private readonly _subs = new StateSubscriptions(this);
     private readonly _command = new ThinkingCommand();
 
-    override connectedCallback(): void {
-        super.connectedCallback();
-        this._offs = [
-            appState.on('thinkingEnabled', (v) => {
-                this._enabled = v;
-            }),
-            appState.on('models', () => this.requestUpdate()),
-            appState.on('currentModel', () => this.requestUpdate()),
-        ];
-    }
-
-    override disconnectedCallback(): void {
-        super.disconnectedCallback();
-        this._offs.forEach((off) => off());
-        this._offs = [];
+    constructor() {
+        super();
+        this._subs.on('thinkingEnabled', (v) => {
+            this._enabled = v;
+        });
+        this._subs.rerenderOn('models', 'currentModel');
     }
 
     private _onClick = (): void => {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-tool-row.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-tool-row.ts
@@ -17,7 +17,7 @@ import { EMPTY } from '../../core/types';
 import { makeRenderer } from '../tool-renderers';
 import { BridgeToolHost, cleanResult } from '../tool-renderers/tool-host';
 import type { ToolRowState } from '../tool-renderers/types';
-import { state as appState } from '../../core/state';
+import { StateSubscriptions } from '../../core/state-subscriptions';
 import { renderActionsRow } from '../helpers/actions-row';
 
 // Re-export so existing consumers (e.g. cv-app) can keep importing from here.
@@ -61,7 +61,13 @@ export class CvToolRow extends LitElement implements ToolRowState {
     // Guards the one-shot lazy preview fetch (history Agent expanded with no children yet).
     private _previewRequested = false;
 
-    private _unsubSubagentTasks?: () => void;
+    // Re-render when subagentTasks changes so AgentRenderer.header() picks up the active task.
+    private readonly _subs = new StateSubscriptions(this);
+
+    constructor() {
+        super();
+        this._subs.rerenderOn('subagentTasks');
+    }
 
     get expanded(): boolean {
         return this._expanded;
@@ -76,18 +82,6 @@ export class CvToolRow extends LitElement implements ToolRowState {
 
     override createRenderRoot() {
         return this;
-    }
-
-    override connectedCallback() {
-        super.connectedCallback();
-        // Re-render when subagentTasks changes so AgentRenderer.header() picks up the active task.
-        this._unsubSubagentTasks = appState.on('subagentTasks', () => this.requestUpdate());
-    }
-
-    override disconnectedCallback() {
-        super.disconnectedCallback();
-        this._unsubSubagentTasks?.();
-        this._unsubSubagentTasks = undefined;
     }
 
     override render() {

--- a/src/Corsinvest.VisualStudio.Agents/Cli/Pane/CliPaneControl.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Cli/Pane/CliPaneControl.cs
@@ -295,8 +295,7 @@ internal class CliPaneControl : PaneControlBase, ITerminalConnection, IDisposabl
         Content = ClaudeInstall.BuildMissingPanel();
     }
 
-    private void OnProcessExited()
-    {
+    private void OnProcessExited() =>
         // claude.exe ended (exit/Ctrl-C/crash). The pane is only a view onto that process,
         // so auto-close it: process gone means the terminal pane goes too.
 
@@ -308,7 +307,6 @@ internal class CliPaneControl : PaneControlBase, ITerminalConnection, IDisposabl
             _log.Info("[cli] claude.exe exited — auto-closing pane");
             Pane?.ClosePane();
         }));
-    }
 
     private void OnThemeChanged(ThemeChangedEventArgs e)
     {
@@ -359,13 +357,11 @@ internal class CliPaneControl : PaneControlBase, ITerminalConnection, IDisposabl
         if (_started) { _ = StartOrRestartAsync(); }
     }
 
-    private void OnLoaded(object sender, RoutedEventArgs e)
-    {
+    private void OnLoaded(object sender, RoutedEventArgs e) =>
         // Real start happens on the first Resize (needs cols/rows). Re-push the
         // caption here: RegisterInstance runs before the IVsWindowFrame is wired, so
         // the earlier OwnerCaption set may have no-op'd silently.
         RepushCaption();
-    }
 
     protected override void DisposeCore()
     {

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.cs
@@ -307,14 +307,12 @@ internal sealed partial class ClaudeClient : IClaudeClient
     public const string DiagBaselineHookId = "cv_diag_baseline";
     public const string DiagCheckHookId = "cv_diag_check";
 
-    private void SendInitializeHooks()
-    {
+    private void SendInitializeHooks() =>
         // `initialize` carries the model catalogue + rich slash commands (→ ModelsReceived) and the
         // fast-mode state; get_settings adds the model + Model-menu toggles. Together they seed the UI
         // WITHOUT a user turn — system/init only arrives on the first turn, too late to enable the
         // toolbar. Fired on every StartProcess (open + respawn).
         _ = StartupAsync();
-    }
 
     private async Task StartupAsync()
     {

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeInstall.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeInstall.cs
@@ -98,13 +98,14 @@ public static class ClaudeInstall
         if (!string.IsNullOrEmpty(localAppData)) { yield return Path.Combine(localAppData, "npm"); }
     }
 
-    /// <summary>Installed CLI version, or <c>null</c> if the binary can't be found or won't say.
-    ///
+    /// <summary><para>Installed CLI version, or <c>null</c> if the binary can't be found or won't say.</para>
+    /// <para>
     /// Asks the CLI rather than reading the npm <c>package.json</c> next to it: that manifest only
     /// exists for an npm install, so the native installer, WinGet and a hand-set
     /// <c>ClaudeExecutablePath</c> all came back "(unknown)". <c>--version</c> is a documented
     /// flag and answers whatever the layout. Costs a process start, and the one caller is the
-    /// session-info dialog, opened by hand — no reason to cache it.</summary>
+    /// session-info dialog, opened by hand — no reason to cache it.
+    /// </para></summary>
     public static string Version()
     {
         var exe = ResolveExecutable();

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/Events.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/Events.cs
@@ -60,24 +60,27 @@ public sealed class AssistantMessageEventArgs
     /// other, so acting on both is safe. Null when the message replaces nothing, which is nearly
     /// always.</summary>
     public string[] Supersedes { get; set; }
-    /// <summary>Why the API call failed, when it did. An API failure doesn't arrive as an error on
+    /// <summary><para>
+    /// Why the API call failed, when it did. An API failure doesn't arrive as an error on
     /// the wire: the CLI fabricates a synthetic assistant whose TEXT is the error
     /// (`utils/messages.ts:445-457`), so without this field it reads as an ordinary answer — which
     /// is why one turn can show up twice, once as a grey-dot reply and once as the red notice the
     /// `result` raises.
-    ///
+    /// </para>
+    /// <para>
     /// A closed enum, not free text: `SDKAssistantMessageError` (`sdk.d.ts:2846`) is
     /// authentication_failed | oauth_org_not_allowed | billing_error | rate_limit | overloaded |
     /// invalid_request | model_not_found | server_error | unknown | max_output_tokens. So it says
     /// WHICH failure, not just that there was one — a notice can name the rate limit instead of
     /// saying "API error".
-    ///
+    /// </para>
+    /// <para>
     /// Measured 2026-08-06 by pointing the CLI at an invalid token: the wrapper came back with
     /// `error: "authentication_failed"`, and a normal turn carries no such field. The same frame
     /// also had `is_api_error_message: true`, which is NOT in the SDK types (0 hits in a file that
     /// declares everything else we use) — emitted without a contract, so not something to build on.
-    ///
-    /// Read and logged, not acted on: the double-rendering fix is a separate change.</summary>
+    /// </para>
+    /// <para>Read and logged, not acted on: the double-rendering fix is a separate change.</para></summary>
     public string Error { get; set; }
     /// <summary>Message time (epoch ms) parsed from the wire `timestamp`; null when absent.</summary>
     public long? Timestamp { get; set; }

--- a/src/Corsinvest.VisualStudio.Agents/Core/Context/ContextUsageControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Context/ContextUsageControl.xaml.cs
@@ -164,15 +164,12 @@ public partial class ContextUsageControl : UserControl
         RefreshButtons.IsEnabled = !running;
     }
 
-    private void OnIndexingCompleted()
-    {
-        _ = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
-        {
-            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-            SetIndexing(false);
-            BuildTree();
-        });
-    }
+    private void OnIndexingCompleted() => _ = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                                               {
+                                                   await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                                                   SetIndexing(false);
+                                                   BuildTree();
+                                               });
 
     // The panel prompt shown for intermediate nodes / before any session is picked.
     private void ShowSelectPrompt()

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneLauncher.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneLauncher.cs
@@ -53,15 +53,18 @@ internal static class PaneLauncher
         }
     }
 
-    /// <summary>Re-show the panes the registry already knows about, without creating any. VS holds a
+    /// <summary><para>
+    /// Re-show the panes the registry already knows about, without creating any. VS holds a
     /// separate window layout for design time and run time, so panes opened while writing code are
     /// missing from the run-time one and look closed when the debugger starts — the frames are alive,
     /// they are simply not in that layout. Called on debugger mode changes, and after a solution
     /// reload to bring back what <see cref="HideExisting"/> put away.
-    ///
+    /// </para>
+    /// <para>
     /// create: false throughout: a pane the user closed is gone from the registry and must stay
     /// closed, and a frame we cannot find is not one to conjure up.
-    /// Main thread only — IVsWindowFrame is not free-threaded.</summary>
+    /// Main thread only — IVsWindowFrame is not free-threaded.
+    /// </para></summary>
     public static void ShowExisting()
     {
         ThreadHelper.ThrowIfNotOnUIThread();

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneWindowBase.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneWindowBase.cs
@@ -140,13 +140,11 @@ public abstract class PaneWindowBase : ToolWindowPane
 
     /// <summary>Set the pane caption from the entry's single-source <see cref="PaneEntry.Title"/>
     /// (e.g. "Chat 3 (z.ai)"), the same text the toolbar's open-panes list shows.</summary>
-    internal void SetSessionCaption(PaneEntry entry)
-    {
+    internal void SetSessionCaption(PaneEntry entry) =>
         // Sets the pane title only. The docked TAB caption can't be changed here:
         // VS derives it from the window name + instance number and ignores every
         // frame caption property (Caption/ShortCaption/Owner/Editor/OverrideCaption).
         Caption = entry.Title;
-    }
 
     public override void OnToolWindowCreated()
     {
@@ -168,13 +166,16 @@ public abstract class PaneWindowBase : ToolWindowPane
         HookFrameShow();
     }
 
-    /// <summary>Focus the input when the frame is shown. Clicking a docked pane's TAB goes through
+    /// <summary><para>
+    /// Focus the input when the frame is shown. Clicking a docked pane's TAB goes through
     /// neither path that already focuses — ActivatePane (InfoBar, toast, the toolbar's pane list)
     /// and the toolbar buttons — so focus landed on the first focusable child, the More button, and
     /// Space opened a menu instead of typing.
-    ///
+    /// </para>
+    /// <para>
     /// VSFPROPID_ViewHelper is the frame's single notify slot: read what is already there and
-    /// forward to it, so this doesn't silently displace another listener.</summary>
+    /// forward to it, so this doesn't silently displace another listener.
+    /// </para></summary>
     private void HookFrameShow()
     {
         if (Frame is not IVsWindowFrame frame) { return; }
@@ -219,9 +220,7 @@ public abstract class PaneWindowBase : ToolWindowPane
     /// <summary>Focus the input, but only if this pane is the one the user is actually looking at.
     /// OnShow also fires when a pane merely becomes visible (a dock group opening, another tab
     /// closing); focusing then would pull the caret out of whatever the user was typing in.</summary>
-    private void FocusInputIfActive()
-    {
-        _ = Application.Current?.Dispatcher.BeginInvoke(
+    private void FocusInputIfActive() => _ = Application.Current?.Dispatcher.BeginInvoke(
             new System.Action(() =>
             {
                 ThreadHelper.ThrowIfNotOnUIThread();
@@ -236,7 +235,6 @@ public abstract class PaneWindowBase : ToolWindowPane
                 }
             }),
             System.Windows.Threading.DispatcherPriority.Background);
-    }
 
     /// <summary>Bring THIS pane to the front and focus its input. Keyed off the
     /// live pane instance, not a PaneId (VS recycles ids, so id-based lookup can
@@ -267,19 +265,19 @@ public abstract class PaneWindowBase : ToolWindowPane
         FocusInputWhenShellSettles();
     }
 
-    /// <summary>Focus the pane's input once the shell has finished activating the frame.
-    ///
+    /// <summary><para>Focus the pane's input once the shell has finished activating the frame.</para>
+    /// <para>
     /// The delay is the whole point. Focusing inline works on a pane that is already visible —
     /// Show() does no real work there — which is why this defect only ever showed on a HIDDEN pane:
     /// there the activation is real, and VS gives focus to the frame's first focusable child (the
     /// toolbar's More button) when it completes, overwriting ours. Yielding to Background puts our
     /// focus last. The same applies to any other caller that focuses around an activation.
-    ///
+    /// </para>
+    /// <para>
     /// Application.Current.Dispatcher, not this.Dispatcher: ToolWindowPane isn't a
-    /// DispatcherObject. Same UI thread either way.</summary>
-    private void FocusInputWhenShellSettles()
-    {
-        _ = Application.Current?.Dispatcher.BeginInvoke(
+    /// DispatcherObject. Same UI thread either way.
+    /// </para></summary>
+    private void FocusInputWhenShellSettles() => _ = Application.Current?.Dispatcher.BeginInvoke(
             new System.Action(() =>
             {
                 try
@@ -296,7 +294,6 @@ public abstract class PaneWindowBase : ToolWindowPane
                 }
             }),
             System.Windows.Threading.DispatcherPriority.Background);
-    }
 
     /// <summary>Wire a freshly-created instance entry to this pane: set the
     /// close/activate callbacks, add it to the registry, push the caption.

--- a/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManagerControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManagerControl.xaml.cs
@@ -230,15 +230,13 @@ public partial class SessionManagerControl : UserControl
 
     /// <summary>Focus the search box. Call AFTER the popup is laid out —
     /// Focus() on a non-visible element silently fails.</summary>
-    public void FocusSearch()
-    {
+    public void FocusSearch() =>
         // Render priority: the popup is up and the TextBox visible by then.
         Dispatcher.BeginInvoke(System.Windows.Threading.DispatcherPriority.Render, new Action(() =>
         {
             SearchBox.Focus();
             Keyboard.Focus(SearchBox);
         }));
-    }
 
     private void OnRow_Click(object sender, MouseButtonEventArgs e)
     {

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatisticsControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatisticsControl.xaml.cs
@@ -174,8 +174,7 @@ public partial class StatisticsControl : UserControl
         RefreshButtons.IsEnabled = !running;
     }
 
-    private void OnIndexingCompleted()
-    {
+    private void OnIndexingCompleted() =>
         // Raised on a background thread — marshal to the UI, restore the buttons, rebuild the tree
         // (new sessions may have appeared) preserving the selection, then re-read.
         _ = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
@@ -185,7 +184,6 @@ public partial class StatisticsControl : UserControl
             BuildTree();
             await ReloadAsync();
         });
-    }
 
     private async Task ReloadAsync()
     {

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsAggregator.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsAggregator.cs
@@ -221,15 +221,12 @@ internal static class StatsAggregator
         return m;
     }
 
-    private static long ParseTimestampMs(string iso)
-    {
-        return string.IsNullOrEmpty(iso)
+    private static long ParseTimestampMs(string iso) => string.IsNullOrEmpty(iso)
             ? 0
             : DateTimeOffset.TryParse(iso, CultureInfo.InvariantCulture,
             DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var dto)
             ? dto.ToUnixTimeMilliseconds()
             : 0;
-    }
 
     // yyyy-MM-dd in LOCAL time (the heatmap/day buckets are per local calendar day, like the CLI).
     private static string DateKey(long tsMs)

--- a/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Stats/StatsService.cs
@@ -105,14 +105,11 @@ internal static class StatsService
     /// share the same ~/.claude, hence the same .jsonl. They'd otherwise be double-counted in All
     /// and appear as duplicate tree nodes. Returns one entry per distinct config-dir: a representative
     /// profile (any of the group — same paths) and a label joining every profile name that uses it.</summary>
-    private static IEnumerable<(Profile profile, string label)> DistinctConfigs()
-    {
-        return ProfileStore.Load(forEdit: false)
+    private static IEnumerable<(Profile profile, string label)> DistinctConfigs() => ProfileStore.Load(forEdit: false)
             .GroupBy(p => ClaudePaths.ForProfile(p).ConfigId, StringComparer.OrdinalIgnoreCase)
             .Select(g => (
                 profile: g.First(),
                 label: string.Join(", ", g.Select(p => string.IsNullOrEmpty(p.Name) ? "(profile)" : p.Name))));
-    }
 
     /// <summary>Build the navigation tree (All → Profile → Folder… → Project → Day → Session),
     /// reading only the filesystem/cache — no .jsonl parse. The range hides sessions (and the days /

--- a/src/Corsinvest.VisualStudio.Agents/Core/Workspace/ProjectStore.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Workspace/ProjectStore.cs
@@ -98,7 +98,7 @@ internal static class ProjectStore
             : [];
 
     private static string Sanitize(string name)
-        => new(name.Select(c => char.IsLetterOrDigit(c) ? c : '-').ToArray());
+        => new([.. name.Select(c => char.IsLetterOrDigit(c) ? c : '-')]);
 
     /// <summary>Lower-cased before hashing: Windows paths are case-insensitive, so K:\Source and
     /// k:\source are one project and have to reach one folder.</summary>

--- a/src/Corsinvest.VisualStudio.Agents/Editor/PromptDispatcher.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Editor/PromptDispatcher.cs
@@ -13,12 +13,15 @@ namespace Corsinvest.VisualStudio.Agents.Editor;
 /// pane when none is open. Shared by every context-menu entry that hands text to the agent.</summary>
 internal static class PromptDispatcher
 {
-    /// <summary>With several panes open it goes to the last activated — the one being worked in,
+    /// <summary><para>
+    /// With several panes open it goes to the last activated — the one being worked in,
     /// where the first by SeqNo would just be the oldest — and brings it forward, or the prompt
     /// lands in a tool window nobody is looking at.
-    ///
+    /// </para>
+    /// <para>
     /// <paramref name="sendImmediately"/> submits the composer the way the send button does, IDE
-    /// context and all.</summary>
+    /// context and all.
+    /// </para></summary>
     public static void Send(string prompt, bool sendImmediately)
     {
         var target = PaneRegistry.Instance.OfKind(PaneKind.Chat).LastOrDefault(e => e.SetComposerAction != null);

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeConsoleService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeConsoleService.cs
@@ -14,16 +14,19 @@ using System.Threading.Tasks;
 namespace Corsinvest.VisualStudio.Agents.Ide;
 
 /// <summary>
+/// <para>
 /// The real console of a debugged console application — what the program wrote to stdout and what
 /// it is waiting to read from stdin. Not the Debug output pane: that only carries what goes through
 /// Debug.WriteLine, so a Console.WriteLine prompt, and the fact that the program is blocked on
 /// Console.ReadLine, are invisible there.
-///
+/// </para>
+/// <para>
 /// Everything here goes through AttachConsole, which is a PER-PROCESS switch: while devenv is
 /// attached to the debuggee's console it is detached from its own. That is why every call holds a
 /// lock for the whole attach → act → detach sequence, why the detach sits in a finally, and why
 /// nothing inside that sequence awaits — a continuation resuming elsewhere would leave Visual
 /// Studio without a console.
+/// </para>
 /// </summary>
 internal sealed class IdeConsoleService
 {
@@ -259,15 +262,18 @@ internal sealed class IdeConsoleService
 
     private const ushort VkReturn = 0x0D;
 
-    /// <summary>Named keys a caller can send, each with the character the console should read for
+    /// <summary><para>
+    /// Named keys a caller can send, each with the character the console should read for
     /// it. Deliberately small: the point is answering a prompt, not driving a full-screen console
     /// UI.
-    ///
+    /// </para>
+    /// <para>
     /// The character is what matters. A key record carrying only a virtual-key code and a NUL
     /// UnicodeChar is delivered and counted — WriteConsoleInput reports success — but a program
     /// blocked in Console.ReadLine never sees it, because ReadLine reads characters. The arrow keys
     /// have no character, which is why they are the ones that only work against a program reading
-    /// keys rather than lines.</summary>
+    /// keys rather than lines.
+    /// </para></summary>
     private static readonly Dictionary<string, (ushort Vk, char Ch)> KeyCodes = new(StringComparer.OrdinalIgnoreCase)
     {
         ["enter"] = (VkReturn, '\r'),

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.Operations.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.Operations.cs
@@ -67,24 +67,29 @@ internal sealed partial class IdeContextService
 
     //  Build (MCP buildSolution / buildProject)
 
-    /// <summary>Wait for a build/clean kicked with WaitFor…=false, yielding the UI thread between
+    /// <summary><para>
+    /// Wait for a build/clean kicked with WaitFor…=false, yielding the UI thread between
     /// polls.
-    ///
+    /// </para>
+    /// <para>
     /// The blocking overloads (WaitForBuildToFinish: true) are a synchronous COM call that never
     /// pumps: called from the UI thread — which every DTE access has to be — they freeze the whole
     /// IDE for the length of the build. Ctrl+Shift+B doesn't, which is what gives it away as a
     /// defect rather than a constraint. The tool still can't return until the build ends (it owes
     /// the caller LastBuildInfo plus the Error List); what changes is that the user no longer waits
     /// with it.
-    ///
+    /// </para>
+    /// <para>
     /// The await is what does the work: leaving the UI thread lets VS pump again, and
     /// SwitchToMainThreadAsync takes it back for the next read of BuildState, which is itself a DTE
     /// call. 200ms is short enough to not add a visible tail to a fast build and long enough to cost
     /// nothing on a long one.
-    ///
+    /// </para>
+    /// <para>
     /// Returns false if BuildState never left vsBuildStateInProgress within the cap. Without one a
     /// wedged build (MSBuild zombie, a target that never closes) leaves the MCP call pending
-    /// forever, and the caller has no way to tell that from a build that is merely slow.</summary>
+    /// forever, and the caller has no way to tell that from a build that is merely slow.
+    /// </para></summary>
     private static async Task<bool> WaitForBuildAsync(SolutionBuild sb)
     {
         // Poll at least once before testing: BuildState can still read vsBuildStateDone on the first
@@ -218,20 +223,23 @@ internal sealed partial class IdeContextService
         }
     }
 
-    /// <summary>Ask the running build to stop and wait for it to actually stop.
-    ///
+    /// <summary><para>Ask the running build to stop and wait for it to actually stop.</para>
+    /// <para>
     /// The cancel goes through <c>IVsSolutionBuildManager</c>: <c>EnvDTE.SolutionBuild</c> can start,
     /// clean and query a build but has no way to stop one — there is no <c>Cancel</c> anywhere in
     /// EnvDTE, not on <c>SolutionBuild2</c> either. State is still read from <c>SolutionBuild</c>,
     /// which is what the rest of this file polls.
-    ///
+    /// </para>
+    /// <para>
     /// Cancelling only requests the stop: MSBuild finishes the targets already in flight before the
     /// state leaves <c>vsBuildStateInProgress</c>, so returning right after the call would report a
     /// stop that hasn't happened. Polling here is what lets the caller learn whether the IDE is free
     /// again — otherwise the next build stacks on top of one still running.
-    ///
+    /// </para>
+    /// <para>
     /// The wait is capped far below <see cref="BuildPollMaxTries"/>: a cancel that hasn't taken
-    /// within seconds is a wedged build, and reporting that is more useful than blocking on it.</summary>
+    /// within seconds is a wedged build, and reporting that is more useful than blocking on it.
+    /// </para></summary>
     public async Task<BuildResult> CancelBuildAsync()
     {
         await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
@@ -389,14 +397,17 @@ internal sealed partial class IdeContextService
         return (true, match.Name, null);
     }
 
-    /// <summary>Switch the active solution configuration (Debug, Release, …), the one an
+    /// <summary><para>
+    /// Switch the active solution configuration (Debug, Release, …), the one an
     /// argument-less build compiles. Accepts either the bare name ("Release") or the name with its
     /// platform ("Release|Any CPU"); the bare form matches the first platform offered for it.
-    ///
+    /// </para>
+    /// <para>
     /// This changes the IDE for the user, not just for the call: the toolbar dropdown moves and
     /// stays moved, and their next manual build follows it. That is why it is a tool of its own
     /// rather than an argument on build_solution — a build that quietly flipped the configuration
-    /// and left it there would be a side effect nobody asked for.</summary>
+    /// and left it there would be a side effect nobody asked for.
+    /// </para></summary>
     public async Task<(bool Ok, string Configuration, string Reason)> SetConfigurationAsync(string configuration)
     {
         await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
@@ -489,12 +500,15 @@ internal sealed partial class IdeContextService
         return null;
     }
 
-    /// <summary>The solution's configurations as sorted "name|platform" strings, and — when
+    /// <summary><para>
+    /// The solution's configurations as sorted "name|platform" strings, and — when
     /// <paramref name="wanted"/> is given — the one matching it, by full form or by bare name.
-    ///
+    /// </para>
+    /// <para>
     /// The set is not a tidying-up: SolutionConfigurations repeats a configuration once per
     /// project that defines it, so a three-project solution offers "Debug|Any CPU" three times.
-    /// Must be called on the UI thread.</summary>
+    /// Must be called on the UI thread.
+    /// </para></summary>
     private static SortedSet<string> CollectConfigurations(SolutionBuild sb, string wanted, out SolutionConfiguration match)
     {
         ThreadHelper.ThrowIfNotOnUIThread();
@@ -570,13 +584,16 @@ internal sealed partial class IdeContextService
         }
     }
 
-    /// <summary>Add an existing file on disk to a project, the way Solution Explorer's "Add →
+    /// <summary><para>
+    /// Add an existing file on disk to a project, the way Solution Explorer's "Add →
     /// Existing Item" does. Only for projects that list their files: an SDK-style project globs
     /// them in already, and is reported as such rather than being handed a duplicate item.
-    ///
+    /// </para>
+    /// <para>
     /// The file must exist — this includes, it does not create. Writing the file and telling the
     /// project about it are separate steps, and merging them would give two ways to write a
-    /// file.</summary>
+    /// file.
+    /// </para></summary>
     public async Task<(bool Ok, string Project, string Reason)> AddFileToProjectAsync(string projectName, string filePath)
     {
         await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
@@ -822,14 +839,17 @@ internal sealed partial class IdeContextService
     // no real project, but its ProjectItems may nest sub-projects, so recurse.
     private const string SolutionFolderKind = "{66A26720-8FB5-11D2-AA7E-00C04F688DDE}";
 
-    /// <summary>"Miscellaneous Files" — where VS files anything opened from outside the solution
+    /// <summary><para>
+    /// "Miscellaneous Files" — where VS files anything opened from outside the solution
     /// (decompiled sources, the temp files a diff runs on). A Project by type, but not one anybody
     /// can build or add to, so it is no use as an answer to "which project did you mean".
-    ///
+    /// </para>
+    /// <para>
     /// Both are checked because the display name is localised ("File esterni" on an Italian IDE)
     /// and the kind alone has burnt us once: vsProjectKindMisc ends 671D, one digit from
     /// vsProjectKindSolutionItems' 6720. Values read from EnvDTE.Constants rather than written
-    /// from memory.</summary>
+    /// from memory.
+    /// </para></summary>
     private const string MiscellaneousFilesKind = "{66A2671D-8FB5-11D2-AA7E-00C04F688DDE}";
     private const string MiscellaneousFilesUniqueName = "<MiscFiles>";
 

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.Common.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.Common.cs
@@ -150,7 +150,5 @@ internal sealed partial class IdeDebugService
     /// <summary>The debugger renders string values wrapped in quotes (e.g. "boom"); strip a single
     /// surrounding pair so the model gets the bare message.</summary>
     private static string Unquote(string s)
-    {
-        return s?.Length >= 2 && s[0] == '"' && s[s.Length - 1] == '"' ? s.Substring(1, s.Length - 2) : s;
-    }
+        => s?.Length >= 2 && s[0] == '"' && s[s.Length - 1] == '"' ? s.Substring(1, s.Length - 2) : s;
 }

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.cs
@@ -248,13 +248,14 @@ internal sealed partial class IdeDebugService
         }
     }
 
-    /// <summary>How many times a breakpoint has actually been hit.
-    ///
+    /// <summary><para>How many times a breakpoint has actually been hit.</para>
+    /// <para>
     /// The breakpoint in <c>Debugger.Breakpoints</c> is the one that was *asked for*; when the
     /// debugger binds it, the hits land on the bound children it creates — one per address the
     /// location resolved to. Reading the parent's own CurrentHits therefore answers 0 for a
     /// breakpoint that has been hit five hundred times, which is worse than not reporting it at
-    /// all. Must be called on the UI thread.</summary>
+    /// all. Must be called on the UI thread.
+    /// </para></summary>
     /// <summary>How many code locations a breakpoint resolved to, or null outside a session.
     /// <para>Children is the binding: one child per address the debugger resolved. Read here rather
     /// than after Breakpoints.Add because binding is asynchronous — measured, every breakpoint reads

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.References.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.References.cs
@@ -57,15 +57,16 @@ internal sealed partial class IdeNavigationService
         return args;
     }
 
-    /// <summary>One of IFindUsagesService's two entry points, by name.
-    ///
+    /// <summary><para>One of IFindUsagesService's two entry points, by name.</para>
+    /// <para>
     /// Deliberately not pinned to an arity. It used to require exactly five parameters, and when
     /// one of the two grew a sixth the tool reported "not available in this Visual Studio" — which
     /// reads as an edition limit and sent everyone looking in the wrong place, while its sibling
     /// went on working from the same interface. If the shape ever changes for real, the invoke
     /// below fails with a message naming the mismatch, which is a better account than a probe that
     /// quietly answers no. Overloads are ordered so the widest wins: extra parameters are the ones
-    /// that get added.</summary>
+    /// that get added.
+    /// </para></summary>
     private MethodInfo FindUsagesMethod(string name)
         => _findUsagesServiceType.GetMethods()
             .Where(m => m.Name == name)

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeOutputService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeOutputService.cs
@@ -57,13 +57,16 @@ internal sealed class IdeOutputService
         ["Build Order"] = VSConstants.OutputWindowPaneGuid.SortedBuildOutputPane_guid,
     };
 
-    /// <summary>Resolve a built-in pane by GUID. The DTE pane object carries its own Guid as a
+    /// <summary><para>
+    /// Resolve a built-in pane by GUID. The DTE pane object carries its own Guid as a
     /// string, so the match is on identity and never on the localised display name.
-    ///
+    /// </para>
+    /// <para>
     /// The IVsOutputWindow round-trip is only there for the pane that does not exist yet — VS
     /// creates them lazily, and CreatePane materialises one without bringing the window forward.
     /// Returns null for panes with no stable GUID; those are found by name. Must be called on the
-    /// UI thread.</summary>
+    /// UI thread.
+    /// </para></summary>
     private static OutputWindowPane FindWellKnownPane(OutputWindow ow, string paneName)
     {
         ThreadHelper.ThrowIfNotOnUIThread();
@@ -120,15 +123,15 @@ internal sealed class IdeOutputService
         return match;
     }
 
-    /// <summary>Get the pane's TextDocument, the only way EnvDTE offers to read its text.
-    ///
+    /// <summary><para>Get the pane's TextDocument, the only way EnvDTE offers to read its text.</para>
+    /// <para>
     /// A pane that has never been shown answers E_FAIL here: it is listed, and it holds the text
     /// the build wrote, but the document behind it is realised together with the window. Activating
     /// the pane realises it, so the failure is retried once that way rather than reported — the
     /// alternative is a caller that cannot tell "no output" from "output you haven't looked at".
     /// Activating brings the Output window forward, which is why it is done only on that branch.
-    ///
-    /// Returns null when even the retry fails. Must be called on the UI thread.</summary>
+    /// </para>
+    /// <para>Returns null when even the retry fails. Must be called on the UI thread.</para></summary>
     private static TextDocument GetTextDocument(OutputWindowPane pane)
     {
         ThreadHelper.ThrowIfNotOnUIThread();
@@ -153,13 +156,16 @@ internal sealed class IdeOutputService
         }
     }
 
-    /// <summary>The text the user is looking at in the Output window: their selection, or the last
+    /// <summary><para>
+    /// The text the user is looking at in the Output window: their selection, or the last
     /// <paramref name="tailLines"/> lines of the active pane when they selected nothing — a build
     /// error is read without being selected first, and a menu entry that greys out unless you
     /// highlight something would be useless exactly when it is wanted.
-    ///
+    /// </para>
+    /// <para>
     /// Returns null when there is nothing to read. UI thread; never throws — it runs from a menu
-    /// query, where an exception would take the context menu down with it.</summary>
+    /// query, where an exception would take the context menu down with it.
+    /// </para></summary>
     public string GetActivePaneText(int tailLines)
     {
         ThreadHelper.ThrowIfNotOnUIThread();

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/IMcpTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/IMcpTool.cs
@@ -38,14 +38,17 @@ internal interface IMcpTool
     /// Use sparingly: ~50 tokens of context per turn. Default false.</summary>
     bool AlwaysLoad { get; }
 
-    /// <summary>MCP <c>readOnlyHint</c>: the tool changes nothing — no file written, no IDE state
+    /// <summary><para>
+    /// MCP <c>readOnlyHint</c>: the tool changes nothing — no file written, no IDE state
     /// touched, no process affected — so a client may run it without asking. The three hints are
     /// independent axes, not levels: a tool can be read-only AND idempotent, or destructive AND
     /// idempotent.
-    ///
+    /// </para>
+    /// <para>
     /// Getting it wrong is asymmetric, which is why every default is false: an unmarked read-only
     /// tool merely costs the user a permission prompt, while an unmarked-as-writing tool that
-    /// actually writes would be auto-approved. When in doubt, leave it false.</summary>
+    /// actually writes would be auto-approved. When in doubt, leave it false.
+    /// </para></summary>
     bool ReadOnly { get; }
 
     /// <summary>MCP <c>destructiveHint</c>: the tool can destroy or interrupt something the user

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/JsonRpcDispatcher.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/JsonRpcDispatcher.cs
@@ -266,25 +266,19 @@ internal sealed class JsonRpcDispatcher
     // Use SerializeObject(anonymous), not JObject.ToString(Formatting): VS loads its own
     // Newtonsoft.Json that may lack that overload and throw MissingMethodException.
 
-    private static string Result(JToken id, object result)
+    private static string Result(JToken id, object result) => Newtonsoft.Json.JsonConvert.SerializeObject(new
     {
-        return Newtonsoft.Json.JsonConvert.SerializeObject(new
-        {
-            jsonrpc = "2.0",
-            id,
-            result,
-        }, CamelCaseSettings);
-    }
+        jsonrpc = "2.0",
+        id,
+        result,
+    }, CamelCaseSettings);
 
-    private static string Error(JToken id, int code, string message)
+    private static string Error(JToken id, int code, string message) => Newtonsoft.Json.JsonConvert.SerializeObject(new
     {
-        return Newtonsoft.Json.JsonConvert.SerializeObject(new
-        {
-            jsonrpc = "2.0",
-            id,
-            error = new { code, message },
-        }, CamelCaseSettings);
-    }
+        jsonrpc = "2.0",
+        id,
+        error = new { code, message },
+    }, CamelCaseSettings);
 }
 
 /// <summary>Tool-side validation failure. Surfaced to the CLI as an

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/McpServerHost.LockFile.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/McpServerHost.LockFile.cs
@@ -62,23 +62,18 @@ internal sealed partial class McpServerHost
     /// that was already alive — which an instance field's initialiser does not, under Hot Reload.</summary>
     private static readonly object _writeGate = new();
 
-    private static string[] ResolveWorkspaceFoldersBlocking()
-    {
+    private static string[] ResolveWorkspaceFoldersBlocking() =>
         // Sync entry point for off-UI-thread callers; JTF avoids COM deadlocks in DTE.
-        return Microsoft.VisualStudio.Shell.ThreadHelper.JoinableTaskFactory.Run(async () =>
+        Microsoft.VisualStudio.Shell.ThreadHelper.JoinableTaskFactory.Run(async () =>
         {
             var f = await IdeContextService.Instance.GetWorkspaceFoldersAsync();
             var arr = new string[f.Count];
             for (int i = 0; i < f.Count; i++) { arr[i] = f[i]; }
             return arr;
         });
-    }
 
-    private static string ResolveIdeNameBlocking()
-    {
-        return Microsoft.VisualStudio.Shell.ThreadHelper.JoinableTaskFactory.Run(
+    private static string ResolveIdeNameBlocking() => Microsoft.VisualStudio.Shell.ThreadHelper.JoinableTaskFactory.Run(
             async () => await IdeContextService.Instance.GetIdeNameAsync());
-    }
 
     private void DeleteAllLockFiles()
     {

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/McpServerHost.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/McpServerHost.cs
@@ -463,9 +463,7 @@ internal sealed partial class McpServerHost
 
     private static string BuildSelectionNotification(
         string text, string filePath, string fileUrl,
-        int startLine, int startChar, int endLine, int endChar, bool isEmpty)
-    {
-        return JsonConvert.SerializeObject(new
+        int startLine, int startChar, int endLine, int endChar, bool isEmpty) => JsonConvert.SerializeObject(new
         {
             jsonrpc = "2.0",
             method = "selection_changed",
@@ -482,7 +480,6 @@ internal sealed partial class McpServerHost
                 },
             },
         }, JsonRpcDispatcher.CamelCaseSettings);
-    }
 
     private void BroadcastNotification(string json)
     {

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/SchemaBuilder.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/SchemaBuilder.cs
@@ -130,12 +130,10 @@ internal static class SchemaBuilder
         return generic?.GetGenericArguments()[0];
     }
 
-    private static bool IsRequired(PropertyInfo prop)
-    {
+    private static bool IsRequired(PropertyInfo prop) =>
         // Only [Required] marks a property required; value types and
         // reference types are otherwise optional (don't force every flag).
-        return prop.GetCustomAttribute<RequiredAttribute>() != null;
-    }
+        prop.GetCustomAttribute<RequiredAttribute>() != null;
 
     /// <summary>VS-friendly camelCase: <c>FilePath → filePath</c>,
     /// <c>URL → url</c>, <c>HTTPSPort → httpsPort</c> (best-effort).

--- a/src/Corsinvest.VisualStudio.Agents/Menu/ActiveSessionsMenuCommand.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Menu/ActiveSessionsMenuCommand.cs
@@ -13,15 +13,18 @@ using Task = System.Threading.Tasks.Task;
 namespace Corsinvest.VisualStudio.Agents.Menu;
 
 /// <summary>
+/// <para>
 /// View-menu entry point: one item per open pane, listed under an "Active sessions" submenu, to
 /// bring that pane forward. VS's own Window list mixes tool windows in with every open document,
 /// and the docked tab caption is stuck at "Chat 1"/"Chat 2" — VS derives it from the window name
 /// and ignores every caption property — so with several panes open this is the only place their
 /// full titles (session and profile) are visible together.
-///
+/// </para>
+/// <para>
 /// Same DynamicItemStart mechanism as <see cref="ProfilesMenuCommand"/>, minus its cache: the
 /// entries come from PaneRegistry, which is already in memory, so VS's constant polling costs
 /// nothing to serve.
+/// </para>
 /// </summary>
 internal sealed class ActiveSessionsMenuCommand : OleMenuCommand
 {

--- a/src/Corsinvest.VisualStudio.Agents/Options/ProfilesControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Options/ProfilesControl.xaml.cs
@@ -153,12 +153,10 @@ public partial class ProfilesControl : UserControl
         }
     }
 
-    private void OnProfileEnabledClick(object sender, RoutedEventArgs e)
-    {
+    private void OnProfileEnabledClick(object sender, RoutedEventArgs e) =>
         // The list checkbox is TwoWay-bound directly to Profile.Enabled, so the value
         // is already updated by the time this fires — just persist it.
         PersistProfiles();
-    }
 
     private void OnNameChanged(object sender, TextChangedEventArgs e)
     {

--- a/tests/Corsinvest.VisualStudio.Agents.Tests/ContentBlockTranslatorTests.cs
+++ b/tests/Corsinvest.VisualStudio.Agents.Tests/ContentBlockTranslatorTests.cs
@@ -4,7 +4,6 @@
  */
 
 using Corsinvest.VisualStudio.Agents.Chat;
-using Corsinvest.VisualStudio.Agents.Chat.Host;
 using Corsinvest.VisualStudio.Agents.Contracts;
 using Newtonsoft.Json.Linq;
 using System.Collections.Generic;

--- a/tests/Corsinvest.VisualStudio.Agents.Tests/SchemaBuilderTests.cs
+++ b/tests/Corsinvest.VisualStudio.Agents.Tests/SchemaBuilderTests.cs
@@ -84,11 +84,9 @@ public class SchemaBuilderTests
     }
 
     [Fact]
-    public void For_returns_the_same_schema_object_on_a_second_call()
-    {
+    public void For_returns_the_same_schema_object_on_a_second_call() =>
         // Cached per type: the schema is rebuilt for every tool listing otherwise.
         Assert.Same(SchemaBuilder.For<SampleArgs>(), SchemaBuilder.For<SampleArgs>());
-    }
 
     [Theory]
     [InlineData("FilePath", "filePath")]

--- a/tests/Corsinvest.VisualStudio.Agents.Tests/StatsAggregatorTests.cs
+++ b/tests/Corsinvest.VisualStudio.Agents.Tests/StatsAggregatorTests.cs
@@ -6,7 +6,6 @@
 using Corsinvest.VisualStudio.Agents.Core.Stats;
 using Newtonsoft.Json.Linq;
 using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Text;

--- a/tests/Corsinvest.VisualStudio.Agents.Tests/ToolResultExtrasTests.cs
+++ b/tests/Corsinvest.VisualStudio.Agents.Tests/ToolResultExtrasTests.cs
@@ -48,11 +48,9 @@ public class ToolResultExtrasTests
     }
 
     [Fact]
-    public void FromToolUseResult_has_no_patch_when_the_tool_reported_none()
-    {
+    public void FromToolUseResult_has_no_patch_when_the_tool_reported_none() =>
         // A Write to a new file has nothing to diff against.
         Assert.Null(ToolResultExtras.FromToolUseResult(new JObject()).Patch);
-    }
 
     [Fact]
     public void FromToolUseResult_reads_an_agent_runs_totals()
@@ -155,11 +153,9 @@ public class ToolResultExtrasTests
     }
 
     [Fact]
-    public void ToDto_is_null_when_there_is_nothing_to_report()
-    {
+    public void ToDto_is_null_when_there_is_nothing_to_report() =>
         // So the WebView tests for presence rather than for a zero that could also mean "ran for 0ms".
         Assert.Null(new ToolResultExtras().ToDto());
-    }
 
     [Fact]
     public void ToDto_carries_whichever_group_the_tool_reported()


### PR DESCRIPTION
Three passes over code that had grown a way of saying things the language already says. No behaviour changes.

## The `void this._models` mirrors (5f712c1)

Four composer controls kept an `@state()` copy of `appState.models` — two of them of `currentModel` as well — that no render ever read. The label and the availability check call `permissionItems()`, `modelLabelShort()` and `currentEffortLevels()`, which reach `appState` themselves. The copy existed to make Lit re-render; the `void this._models` under it existed to keep ESLint quiet about a field assigned and never used, which reads like a mistake.

`appState.on(k, () => this.requestUpdate())` says it directly, the way `cv-tool-row` already did for `subagentTasks`. Six mirrors and six `void` lines go. `_current` stays where the render does read it.

## The subscription bookkeeping (898608e)

Thirteen components each kept their own version of *stay subscribed while connected, drop it on the way out*, in two dialects that had grown side by side: an `_offs` array in five, one `_offX` field per subscription in the rest. `cv-prompt` had reached eight fields, eight assignments and eight `?.()` calls.

`StateSubscriptions` is a `ReactiveController` — the first in this codebase — that collects the subscriptions and drops them in `hostDisconnected`. Components now declare what they listen to and nothing else; seven lose `disconnectedCallback` entirely.

Left alone deliberately: the `_offs` arrays in `cv-spinner` and `cv-permission-banner`, and what remains of them in `cv-app` and `cv-prompt` — those hold `bridge.onNotification` handlers, a different channel. `cv-remote-chip` keeps its `connectedCallback`: `remoteControl` is replaced wholesale and `on` reports only future changes, so re-reading it on connect is what keeps a re-attached chip honest.

## The C# cleanup (58936c7)

A Code Cleanup pass that came in through the IDE, kept separate so it doesn't obscure the two above: single-`return` bodies become expression-bodied, `.Where(...).ToList()` becomes `[.. ...]`, doc comments get `<para>` where a blank line separated paragraphs, two unused `using` go.

## Verification

- `npm run check` — typecheck, lint, format, **177/177 tests**.
- 11 new tests in `tests/state-subscriptions.test.ts` pin the controller's lifecycle: nothing live before connect, delivery after it, teardown on disconnect, a re-attached host that works again, a repeated connect that leaves nothing dangling in the store, and the limit — an `on()` after connect stays quiet until the host is re-inserted. Their diagnostic power was checked by breaking the controller four ways and watching each mutation fail.
- The 17 subscribed keys were diffed against `master` per file: identical in all 13 components.
- `build_solution` on Debug: no errors.
- Checked in the experimental instance: effort and thinking disappear on haiku and come back on sonnet — the path that has no value to read, so the one that would break first.

## Not done, on purpose

The two remaining items from the TODO entry that started this — `cv-app._status` passed to `<cv-spinner>` and `cv-prompt._subagentTasks` passed to `<cv-subagent-chip>`. Both would trade a property for a subscription and couple two leaf components to the global store to save three lines each. The entry's premise for the first one is also wrong: it says the spinner already subscribes to `appState`, but the spinner never imports it — its token deltas come from `bridge`.
