### PR TITLE
feat(debug,mcp): say why a walk truncated, and name the valid alternatives on three errors

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.Operations.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeContextService.Operations.cs
@@ -654,7 +654,9 @@ internal sealed partial class IdeContextService
             var item = FindProjectItem(proj.ProjectItems, filePath);
             if (item == null)
             {
-                return (false, proj.Name, $"'{filePath}' is not an item of '{proj.Name}'.");
+                // The project name was validated just above, so reaching here means the project is
+                // right and the file is wrong — the one case where naming the items settles it.
+                return (false, proj.Name, $"'{filePath}' is not an item of '{proj.Name}'. {ItemsHint(proj, filePath)}");
             }
             item.Remove();
             proj.Save();
@@ -689,6 +691,58 @@ internal sealed partial class IdeContextService
     {
         ThreadHelper.ThrowIfNotOnUIThread();
         return FindProjectItem(proj.ProjectItems, filePath) != null;
+    }
+
+    /// <summary>What the project does hold, for a file that was not in it. Narrowed to the same
+    /// extension first: a project runs to hundreds of items, and a caller who got the path wrong
+    /// almost always got it wrong for a file of the kind they were after.</summary>
+    private static string ItemsHint(Project proj, string filePath)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        var all = new List<string>();
+        CollectProjectItemPaths(proj.ProjectItems, all);
+        if (all.Count == 0) { return "The project has no file items."; }
+
+        var ext = System.IO.Path.GetExtension(filePath);
+        var pool = all.FindAll(f => string.Equals(System.IO.Path.GetExtension(f), ext, StringComparison.OrdinalIgnoreCase));
+        var sameExt = pool.Count > 0;
+        if (!sameExt) { pool = all; }
+
+        pool.Sort(StringComparer.OrdinalIgnoreCase);
+        var shown = pool.Count > ItemsHintSample ? pool.GetRange(0, ItemsHintSample) : pool;
+        var names = string.Join(", ", shown.ConvertAll(f => $"'{System.IO.Path.GetFileName(f)}'"));
+        var more = pool.Count > shown.Count ? $" … and {pool.Count - shown.Count} more" : "";
+        return sameExt
+            ? $"{ext} items in it: {names}{more}."
+            : $"It holds {all.Count} item(s), none of them {ext}: {names}{more}.";
+    }
+
+    /// <summary>How many items an ItemsHint names. A project has hundreds; this is enough to spot
+    /// the one that was nearly right.</summary>
+    private const int ItemsHintSample = 12;
+
+    /// <summary>Every file an item tree holds, flattened. Mirrors FindProjectItem's walk — same
+    /// depth guard, same tolerance for an item that will not report its files.</summary>
+    private static void CollectProjectItemPaths(ProjectItems items, List<string> into, int depth = 0)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        if (items == null || depth > MaxProjectDepth) { return; }
+        foreach (ProjectItem item in items)
+        {
+            try
+            {
+                for (short i = 1; i <= item.FileCount; i++)
+                {
+                    // A folder is a ProjectItem too and reports its own path: it is not something
+                    // the caller could have meant to remove by file name.
+                    var path = item.FileNames[i];
+                    if (!System.IO.Directory.Exists(path)) { into.Add(path); }
+                }
+            }
+            catch { /* an item that won't report its files has nothing to add */ }
+
+            CollectProjectItemPaths(item.ProjectItems, into, depth + 1);
+        }
     }
 
     /// <summary>Locate a ProjectItem by file path, recursing into folders. Compares the item's own

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.Dtos.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.Dtos.cs
@@ -116,8 +116,16 @@ internal sealed partial class IdeDebugService
         public bool InBreak { get; set; }   // false ⇒ not paused; the model should poll debug_get_state
         public string FunctionName { get; set; }
         public LocalInfo[] Locals { get; set; } = [];
-        /// <summary>Set when a walked level hit the member cap — only possible with depth &gt; 0.</summary>
+        /// <summary>Set when the walk stopped short — a level over the member cap, or the capture
+        /// running out of time. TruncatedReason says which.</summary>
         public bool Truncated { get; set; }
+
+        /// <summary>Which limit stopped the walk: "budget" (out of time) or "maxMembers" (a level
+        /// held more than were kept). Null when nothing was cut. The two want different moves from
+        /// the caller, which one flag could not tell apart.</summary>
+        public string TruncatedReason { get; set; }
+
+        public string TruncationMessage { get; set; }
         public string Reason { get; set; }
     }
 
@@ -208,9 +216,16 @@ internal sealed partial class IdeDebugService
         public string Value { get; set; }
         public string Type { get; set; }
         public LocalInfo[] Members { get; set; } = [];
-        /// <summary>True when some level hit the member cap, so what came back is a prefix of what
-        /// is there. Without it a truncated collection reads as a complete one.</summary>
+        /// <summary>True when the walk stopped short, so what came back is a prefix of what is
+        /// there. Without it a truncated collection reads as a complete one.</summary>
         public bool Truncated { get; set; }
+
+        /// <summary>Which limit stopped the walk: "budget" (out of time) or "maxMembers" (a level
+        /// held more than were kept). Null when nothing was cut. The two want different moves from
+        /// the caller, which one flag could not tell apart.</summary>
+        public string TruncatedReason { get; set; }
+
+        public string TruncationMessage { get; set; }
         public string Reason { get; set; }
     }
 

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.Inspection.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.Inspection.cs
@@ -262,10 +262,9 @@ internal sealed partial class IdeDebugService
             if (frame == null) { return new LocalsResult { Ok = false, InBreak = true, Reason = "No current stack frame." }; }
 
             var locals = new List<LocalInfo>();
-            var truncated = false;
-            // One clock for both collections: the deadline is on the capture, not on each group, so
+            // One budget for both collections: the deadline is on the capture, not on each group, so
             // arguments that take their time leave less for locals rather than doubling the wait.
-            var clock = Stopwatch.StartNew();
+            var budget = new WalkBudget();
             // Arguments are a separate collection on the frame, and were missing entirely: stopped
             // in a method, its parameters are usually the first thing worth reading.
             Collect(frame.Arguments, isArgument: true);
@@ -276,7 +275,7 @@ internal sealed partial class IdeDebugService
                 if (source == null) { return; }
                 foreach (Expression e in source)
                 {
-                    if (clock.Elapsed >= WalkDeadline) { truncated = true; break; }
+                    if (budget.Expired()) { break; }
                     // Top-level statements report `args` in BOTH collections, so it arrived twice —
                     // once flagged as an argument, once not, which reads as a bug in the tool.
                     // Arguments are collected first and win: knowing a name is a parameter says
@@ -293,7 +292,7 @@ internal sealed partial class IdeDebugService
                         Value = e.Value,
                         HasMembers = hasMembers,
                         IsArgument = isArgument,
-                        Members = hasMembers && depth > 0 ? WalkMembers(e, depth, maxMembers, clock, ref truncated) : null,
+                        Members = hasMembers && depth > 0 ? WalkMembers(e, depth, maxMembers, budget, 1) : null,
                     });
                 }
             }
@@ -309,7 +308,9 @@ internal sealed partial class IdeDebugService
                 InBreak = true,
                 FunctionName = frame.FunctionName,
                 Locals = ordered,
-                Truncated = truncated,
+                Truncated = budget.Truncated,
+                TruncatedReason = budget.Reason,
+                TruncationMessage = budget.Message,
             };
         }
         catch (Exception ex)
@@ -596,7 +597,8 @@ internal sealed partial class IdeDebugService
                 };
             }
 
-            var truncated = false;
+            var budget = new WalkBudget();
+            var members = WalkMembers(root, depth, maxMembers, budget, 1);
             return new ExpandResult
             {
                 Ok = true,
@@ -604,8 +606,10 @@ internal sealed partial class IdeDebugService
                 Expression = expression,
                 Value = root.Value,
                 Type = root.Type,
-                Members = WalkMembers(root, depth, maxMembers, Stopwatch.StartNew(), ref truncated),
-                Truncated = truncated,
+                Members = members,
+                Truncated = budget.Truncated,
+                TruncatedReason = budget.Reason,
+                TruncationMessage = budget.Message,
             };
         }
         catch (Exception exc)
@@ -659,17 +663,19 @@ internal sealed partial class IdeDebugService
 
     /// <summary>One level of members, recursing while <paramref name="depth"/> is left. Sorted by
     /// name like the locals list, so two reads of the same object line up.
-    /// <para><paramref name="clock"/> is started by the caller and shared by every branch of one
+    /// <para><paramref name="budget"/> is created by the caller and shared by every branch of one
     /// capture — including a sibling walk over another collection — so the deadline applies to the
-    /// capture as a whole and a slow first group cannot spend the whole budget unnoticed.</para></summary>
-    private static LocalInfo[] WalkMembers(Expression parent, int depth, int maxMembers, Stopwatch clock, ref bool truncated)
+    /// capture as a whole and a slow first group cannot spend the whole budget unnoticed.
+    /// <paramref name="level"/> feeds the truncation message only: depth counts what is left, not
+    /// how far the walk actually got before a branch stopped early.</para></summary>
+    private static LocalInfo[] WalkMembers(Expression parent, int depth, int maxMembers, WalkBudget budget, int level)
     {
         if (depth <= 0) { return null; }
-        if (clock.Elapsed >= WalkDeadline) { truncated = true; return null; }
+        if (budget.Expired()) { return null; }
 
         var members = parent.DataMembers;
         if (members == null || members.Count == 0) { return null; }
-        if (members.Count > maxMembers) { truncated = true; }
+        if (members.Count > maxMembers) { budget.HitMemberCap = true; }
 
         var taken = new List<LocalInfo>();
         foreach (Expression m in members)
@@ -677,7 +683,8 @@ internal sealed partial class IdeDebugService
             if (taken.Count >= maxMembers) { break; }
             // Checked per member, not per level: the members of one object are exactly where a
             // single slow getter shows up, and the loop must be able to stop inside it.
-            if (clock.Elapsed >= WalkDeadline) { truncated = true; break; }
+            if (budget.Expired()) { break; }
+            budget.Visit(level);
             var hasMembers = HasRealMembers(m);
             taken.Add(new LocalInfo
             {
@@ -685,10 +692,62 @@ internal sealed partial class IdeDebugService
                 Type = m.Type,
                 Value = m.Value,
                 HasMembers = hasMembers,
-                Members = hasMembers ? WalkMembers(m, depth - 1, maxMembers, clock, ref truncated) : null,
+                Members = hasMembers ? WalkMembers(m, depth - 1, maxMembers, budget, level + 1) : null,
             });
         }
         return [.. taken.OrderBy(l => l.Name, StringComparer.Ordinal)];
+    }
+
+    /// <summary>What one capture spent, and why it stopped short. Replaces the pair
+    /// (<c>Stopwatch</c>, <c>ref bool truncated</c>) that used to be threaded through the walk:
+    /// the same state, plus what it takes to say where the walk gave up.
+    /// <para>The two ways a walk truncates need different moves from the caller — a member cap is
+    /// raised with maxMembers, an exhausted budget is not, and there the answer is to expand one
+    /// path instead of all of them — so reporting both as one flag left the model guessing which
+    /// it was looking at.</para></summary>
+    private sealed class WalkBudget
+    {
+        private readonly Stopwatch _clock = Stopwatch.StartNew();
+
+        /// <summary>Members materialised, over every level and every sibling walk of the capture.</summary>
+        public int Nodes { get; private set; }
+
+        /// <summary>Deepest level reached, 1 for the members of a root. 0 when nothing was walked.</summary>
+        public int DeepestLevel { get; private set; }
+
+        public bool HitDeadline { get; private set; }
+
+        public bool HitMemberCap { get; set; }
+
+        public bool Truncated => HitDeadline || HitMemberCap;
+
+        /// <summary>Latches: the answer is what makes the result truncated, and the walk unwinds
+        /// through levels that would each ask again.</summary>
+        public bool Expired()
+        {
+            if (_clock.Elapsed >= WalkDeadline) { HitDeadline = true; }
+            return HitDeadline;
+        }
+
+        public void Visit(int level)
+        {
+            Nodes++;
+            if (level > DeepestLevel) { DeepestLevel = level; }
+        }
+
+        /// <summary>The deadline wins when both fired: running out of time is what makes the rest of
+        /// the result unreliable, while a member cap is a choice the caller made.</summary>
+        public string Reason => HitDeadline ? "budget" : HitMemberCap ? "maxMembers" : null;
+
+        public string Message =>
+            HitDeadline
+                ? $"Stopped after {WalkDeadline.TotalSeconds:0.#}s at depth {DeepestLevel} ({Nodes} members read) — "
+                  + "reading members runs getters in the debuggee. Expand one path with "
+                  + "debug_expand(\"<expression>\") instead of walking every object."
+                : HitMemberCap
+                    ? $"Some level held more members than maxMembers kept ({Nodes} read) — raise maxMembers, "
+                      + "or expand the one object you need with debug_expand."
+                    : null;
     }
 
     /// <summary>Whether an expression has members worth expanding.

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeDebugService.cs
@@ -735,8 +735,12 @@ internal sealed partial class IdeDebugService
             // Match by PID first (unambiguous); otherwise by name substring (must be unique).
             Process match = null;
             int nameMatches = 0;
+            // Collected in the same pass: a miss has to say what WAS attachable, and going back for
+            // the list would mean enumerating LocalProcesses a second time.
+            var seen = new List<string>();
             foreach (Process proc in dbg.LocalProcesses)
             {
+                seen.Add($"{SafeProcessName(proc)} ({proc.ProcessID})");
                 if (pid > 0)
                 {
                     if (proc.ProcessID == pid) { match = proc; break; }
@@ -750,7 +754,18 @@ internal sealed partial class IdeDebugService
 
             if (match == null)
             {
-                return new DebugResult { Ok = false, Reason = pid > 0 ? $"No process with pid {pid}." : $"No process matching '{processName}'." };
+                // Truncated: the list is every process on the machine, which is hundreds. Enough to
+                // recognise a name that was nearly right, and debug_list_processes has the rest.
+                seen.Sort(StringComparer.OrdinalIgnoreCase);
+                var sample = seen.Count > AttachMissSample
+                    ? $"{string.Join(", ", seen.Take(AttachMissSample))} … and {seen.Count - AttachMissSample} more"
+                    : string.Join(", ", seen);
+                return new DebugResult
+                {
+                    Ok = false,
+                    Reason = (pid > 0 ? $"No process with pid {pid}." : $"No process matching '{processName}'.")
+                             + $" Attachable: {sample} — debug_list_processes has them all.",
+                };
             }
             if (pid <= 0 && nameMatches > 1)
             {
@@ -975,7 +990,13 @@ internal sealed partial class IdeDebugService
             // Item() on these COM collections throws on a missing key rather than returning null,
             // so the lookups are guarded here instead of null-checked.
             try { exGroup = groups.Item(groupName); }
-            catch (Exception) { return new DebugResult { Ok = false, Reason = $"Exception group '{groupName}' not found." }; }
+            catch (Exception)
+            {
+                // Naming the groups matters more here than elsewhere: groupName is the default set
+                // above when the caller passed none, so the bare message blamed a string the caller
+                // never wrote — and these names follow the IDE's language.
+                return new DebugResult { Ok = false, Reason = $"Exception group '{groupName}' not found. Groups: {GroupNames(groups)}" };
+            }
 
             EnvDTE90.ExceptionSetting exItem;
             try { exItem = exGroup.Item(exceptionName); }
@@ -1005,6 +1026,39 @@ internal sealed partial class IdeDebugService
             OutputWindowLogger.Global.LogException("IdeDebugService.SetExceptionBreakAsync", ex);
             return new DebugResult { Ok = false, Reason = "Failed to set exception break." };
         }
+    }
+
+    /// <summary>How many processes an attach miss names before it stops counting. The machine has
+    /// hundreds, and the point is to recognise a name that was nearly right.</summary>
+    private const int AttachMissSample = 15;
+
+    /// <summary>A process's file name, or its pid as a fallback. Process.Name is a full path — the
+    /// listing tool shortens it the same way — and a process the debugger cannot fully see throws
+    /// instead of answering.</summary>
+    private static string SafeProcessName(Process p)
+    {
+        try { return System.IO.Path.GetFileName(p.Name ?? "") is var n && !string.IsNullOrEmpty(n) ? n : $"pid {p.ProcessID}"; }
+        catch (Exception) { return "?"; }
+    }
+
+    /// <summary>The exception groups, for an error that has to name them. Best-effort: this runs
+    /// where a lookup already failed, so a group that will not report its name is skipped rather
+    /// than costing the caller the rest of the list.</summary>
+    private static string GroupNames(EnvDTE90.ExceptionGroups groups)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        var names = new List<string>();
+        try
+        {
+            foreach (EnvDTE90.ExceptionSettings g in groups)
+            {
+                try { names.Add($"'{g.Name}'"); }
+                catch (Exception) { }
+            }
+        }
+        catch (Exception) { }
+        names.Sort(StringComparer.OrdinalIgnoreCase);
+        return names.Count > 0 ? string.Join(", ", names) : "none could be listed";
     }
 
 

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/ExpandExpressionTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/ExpandExpressionTool.cs
@@ -71,6 +71,8 @@ internal sealed class ExpandExpressionTool : McpTool<ExpandExpressionArgs>
                 type = r.Type,
                 members = r.Members,
                 truncated = r.Truncated,
+                truncatedReason = r.TruncatedReason,
+                truncationMessage = r.TruncationMessage,
                 // Carried on the success path too: expanding a null succeeds with an empty member
                 // list, and without this the caller cannot tell that from an object that simply has
                 // no members.

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/GetDebugLocalsTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Debug/GetDebugLocalsTool.cs
@@ -60,6 +60,8 @@ internal sealed class GetDebugLocalsTool : McpTool<GetDebugLocalsArgs>
                 members = l.Members,
             }).ToArray(),
             truncated = r.Truncated,
+            truncatedReason = r.TruncatedReason,
+            truncationMessage = r.TruncationMessage,
         };
     }
 


### PR DESCRIPTION
Two commits on the same theme: an error or a truncated result should tell the caller what to do next, not just that something went wrong.

## `debug`: say *why* a locals/expand walk stopped short

The walk already had a time budget, but reported both ways it can truncate through a single `bool`. A member cap is raised with `maxMembers`; an exhausted budget is not — there the answer is to expand one path instead of all of them. The caller could not tell which move to make, and a silent truncation reads as a complete answer.

`WalkBudget` replaces the `(Stopwatch, ref bool truncated)` pair threaded through the walk: same state, plus the depth and node count needed to say where the walk gave up. `debug_get_locals` and `debug_expand` now carry `truncatedReason` (`"budget"` | `"maxMembers"`) and `truncationMessage` next to `truncated`.

Also fixes a latent bug: `ExpandAsync` evaluated `WalkMembers` inside the object initializer, so `Truncated` read the flag *before* the walk had written it — a truncated expand never reported itself.

## `mcp`: name the valid alternatives on three errors that only named the bad input

Listing what *would* have worked is already the norm across the tools (`Available:` on projects and configurations, known ids on threads, the `0..n-1` range on frames, `AvailablePanes` as structured data). An audit found three error paths that named the bad value and stopped there.

- **Exception group** — the groups are enumerated from the collection already in scope. Worst of the three: `groupName` is the default when the caller passed none, so the message blamed a string they never wrote, and those names follow the IDE's display language.
- **Attach** — names and pids are collected in the same pass over `LocalProcesses` that looks for the match, capped with a pointer to `debug_list_processes`. The sibling branch for an ambiguous name already had its hint.
- **Remove file from project** — the project name is validated two lines above, so reaching here means the project is right and the file is wrong. Narrowed to the same extension first, since that is how the path is usually wrong.

## Verification

Build only — no test project in this repo, and both changes are on paths that need a live debug session to exercise. The truncation reasons and the three error messages still need a manual pass in the experimental instance.
