### PR TITLE
fix(chat): a wide markdown table scrolls, and the tests speak English

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/markdown.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/markdown.ts
@@ -52,11 +52,15 @@ renderer.code = function (token: Tokens.Code): string {
 // together with no pipes or newlines, so there is nothing in the DOM to copy.
 // `.call(this)`, never `.bind`: the base renderer reaches its cells through `this.parser`, which
 // marked injects on the instance it parses with, not on the one built here.
+// Two nested divs, not one: the inner takes the horizontal scroll a wide table needs, the outer
+// stays the positioning context so the copy button does not scroll away with the columns.
 const baseTable = renderer.table;
 renderer.table = function (this: Renderer, token: Tokens.Table): string {
     return (
         `<div class="cv-md-table-wrap">` +
+        `<div class="cv-md-table-scroll">` +
         baseTable.call(this, token) +
+        `</div>` +
         `<cv-copy-btn class="cv-md-table-copy-btn" text="${escapeHtml(token.raw.trim())}" title="Copy table"></cv-copy-btn>` +
         `</div>`
     );

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/codespan-link.test.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/codespan-link.test.ts
@@ -2,18 +2,18 @@
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
-// Cosa fa un `code span` inline: linka quando il contenuto E' un riferimento, resta testo quando
-// contiene anche altro. La regola vale o non vale sul contenuto intero — non ci sono link parziali.
+// What an inline `code span` does: it links when the content IS a reference, it stays text when
+// it also contains anything else. The rule holds on the whole content — there are no partial links.
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { renderCodespanInner as render } from '../core/codespan-link.ts';
 import { parseFileRef } from '../core/file-links.ts';
 import { escapeHtml } from '../core/html.ts';
 
-// Le dipendenze vere, non finte: la regola vale solo se combacia con il parser che gira davvero.
+// The real dependencies, not fakes: the rule only holds if it matches the parser that actually runs.
 const renderCodespanInner = (text: string) => render(text, { parseFileRef, escapeHtml });
 
-/** Quanti link a file nel frammento reso. */
+/** How many file links in the rendered fragment. */
 function links(html: string): number {
     return (html.match(/class="cv-file-link"/g) ?? []).length;
 }
@@ -22,31 +22,35 @@ function fileOf(html: string): string | null {
     return html.match(/data-file="([^"]*)"/)?.[1] ?? null;
 }
 
-// Linka: il contenuto e' il riferimento e nient'altro.
+// Links: the content is the reference and nothing else.
 
-test('un riferimento con riga diventa link', () => {
+test('a reference with a line becomes a link', () => {
     const html = renderCodespanInner('ClientEvents.cs:208');
     assert.equal(links(html), 1);
     assert.equal(fileOf(html), 'ClientEvents.cs');
     assert.match(html, /data-line="208"/);
 });
 
-test('la label tiene quello che era scritto', () => {
+test('the label keeps what was written', () => {
     assert.match(renderCodespanInner('ClientEvents.cs:208'), />ClientEvents\.cs:208</);
 });
 
-test('un percorso relativo linka', () => {
+test('a relative path links', () => {
     const html = renderCodespanInner('Core/Stats/StatsService.cs:45');
     assert.equal(fileOf(html), 'Core/Stats/StatsService.cs');
 });
 
-test('un intervallo porta la riga finale nel data-line-end', () => {
+test('a range carries the end line in data-line-end', () => {
     const html = renderCodespanInner('StatsService.cs:35-48');
     assert.match(html, /data-line="35" data-line-end="48"/);
-    assert.match(html, />StatsService\.cs:35-48</, 'la label non va normalizzata alla prima riga');
+    assert.match(
+        html,
+        />StatsService\.cs:35-48</,
+        'the label must not be normalized to the first line',
+    );
 });
 
-test('una lista di righe da un link per riga, il primo col nome del file', () => {
+test('a line list gives one link per line, the first with the file name', () => {
     const html = renderCodespanInner('AgentsPackage.cs:124,185,202');
     assert.equal(links(html), 3);
     assert.match(html, />AgentsPackage\.cs:124</);
@@ -54,75 +58,75 @@ test('una lista di righe da un link per riga, il primo col nome del file', () =>
     assert.match(html, />202</);
 });
 
-test('la forma GitHub linka e tiene la sua scrittura', () => {
+test('the GitHub form links and keeps its own spelling', () => {
     const html = renderCodespanInner('ClaudeInstall.cs#L103');
     assert.equal(links(html), 1);
     assert.match(html, /data-line="103"/);
     assert.match(html, />ClaudeInstall\.cs#L103</);
 });
 
-test('le parentesi tonde linkano', () => {
+test('parentheses link', () => {
     const html = renderCodespanInner('foo.cs(339)');
     assert.equal(links(html), 1);
     assert.match(html, /data-line="339"/);
 });
 
-test('un percorso con cartella linka anche senza riga, aperto in cima', () => {
+test('a path with a folder links even without a line, opened at the top', () => {
     const html = renderCodespanInner('docs/file-links.md');
     assert.equal(links(html), 1);
     assert.match(html, /data-line="0"/);
 });
 
-// Non linka: c'e' dell'altro oltre al riferimento, o non e' un riferimento.
+// Does not link: there is something else besides the reference, or it is not a reference.
 
-test('un comando che contiene un riferimento resta testo', () => {
+test('a command containing a reference stays text', () => {
     assert.equal(links(renderCodespanInner('cat Foo.cs:12')), 0);
 });
 
-test('un riferimento seguito da altro resta testo', () => {
-    assert.equal(links(renderCodespanInner('Foo.cs:12 e poi')), 0);
+test('a reference followed by something else stays text', () => {
+    assert.equal(links(renderCodespanInner('Foo.cs:12 and then')), 0);
 });
 
-test('due riferimenti in uno span restano testo', () => {
-    // Ambiguo: lo span e' una citazione doppia o un frammento? Non si indovina.
+test('two references in one span stay text', () => {
+    // Ambiguous: is the span a double citation or a fragment? No guessing.
     assert.equal(links(renderCodespanInner('a.cs:1 b.ts:2')), 0);
 });
 
-test('una versione non e un file', () => {
+test('a version is not a file', () => {
     assert.equal(links(renderCodespanInner('1.5.0')), 0);
     assert.equal(links(renderCodespanInner('v2.1.237')), 0);
 });
 
-test('un orario, un host e un prezzo non sono file', () => {
+test('a time, a host and a price are not files', () => {
     assert.equal(links(renderCodespanInner('10:30')), 0);
     assert.equal(links(renderCodespanInner('localhost.net:4040')), 0);
     assert.equal(links(renderCodespanInner('19.99:2')), 0);
 });
 
-test('un identificatore di codice qualunque resta testo', () => {
+test('any code identifier stays text', () => {
     assert.equal(links(renderCodespanInner('appState.ideContext')), 0);
     assert.equal(links(renderCodespanInner('const x = 1')), 0);
 });
 
-test('un nome nudo senza riga ne cartella resta testo', () => {
-    // Stessa soglia della prosa: "README.md" da solo e' troppo rumoroso per linkare.
+test('a bare name with neither line nor folder stays text', () => {
+    // Same threshold as prose: "README.md" on its own is too noisy to link.
     assert.equal(links(renderCodespanInner('README.md')), 0);
 });
 
-test('testo vuoto non lancia', () => {
+test('empty text does not throw', () => {
     assert.equal(renderCodespanInner(''), '');
 });
 
-// L'HTML prodotto deve restare sicuro: il contenuto viene dal modello.
+// The produced HTML must stay safe: the content comes from the model.
 
-test('il testo non linkato e escapato', () => {
+test('unlinked text is escaped', () => {
     const html = renderCodespanInner('<script>alert(1)</script>');
     assert.doesNotMatch(html, /<script/);
     assert.match(html, /&lt;script&gt;/);
 });
 
-test('il percorso finisce escapato dentro lattributo', () => {
-    // Un nome con virgolette romperebbe data-file="..." se non fosse escapato.
+test('the path ends up escaped inside the attribute', () => {
+    // A name with quotes would break data-file="..." if it were not escaped.
     const html = renderCodespanInner('a"b.cs:1');
     assert.doesNotMatch(html, /data-file="a"b/);
 });

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/diff-rows.test.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/diff-rows.test.ts
@@ -10,17 +10,17 @@ function marked(segs: { text: string; changed: boolean }[]): string {
     return segs.map((s) => (s.changed ? `«${s.text}»` : s.text)).join('');
 }
 
-test('similarity: righe identiche = 1, righe estranee = 0', () => {
+test('similarity: identical lines = 1, unrelated lines = 0', () => {
     assert.equal(similarity('const x = 1', 'const x = 1'), 1);
     assert.equal(similarity('aaa bbb', 'xxx yyy'), 0);
 });
 
-test('similarity: ignora le righe vuote invece di dividere per zero', () => {
+test('similarity: ignores empty lines instead of dividing by zero', () => {
     assert.equal(similarity('', 'x'), 0);
     assert.equal(similarity('x', ''), 0);
 });
 
-test('buildRows: una parola cambiata marca solo quella', () => {
+test('buildRows: one changed word marks only that word', () => {
     const oldStr = 'the only reason that note can be trusted\ncoda\n';
     const newStr = 'the only reason the note can be trusted\ncoda\n';
 
@@ -33,33 +33,33 @@ test('buildRows: una parola cambiata marca solo quella', () => {
     assert.equal(marked(ins.segs), 'the only reason «the» note can be trusted');
 });
 
-test('buildRows: righe estranee non vengono word-diffate', () => {
+test('buildRows: unrelated lines are not word-diffed', () => {
     const oldStr = 'alpha beta gamma\n';
-    const newStr = 'nulla in comune qui\n';
+    const newStr = 'nothing in common here\n';
 
     const rows = buildRows(oldStr, newStr, 'f.cs', 3, false);
     const del = rows.find((r) => r.kind === 'del');
     const ins = rows.find((r) => r.kind === 'ins');
 
-    // Un solo segmento non marcato: senza somiglianza il word-diff direbbe
-    // "tutto cambiato", che non informa.
+    // A single unmarked segment: with no similarity the word-diff would say
+    // "everything changed", which tells nothing.
     assert.deepEqual(del?.segs, [{ text: 'alpha beta gamma', changed: false }]);
-    assert.deepEqual(ins?.segs, [{ text: 'nulla in comune qui', changed: false }]);
+    assert.deepEqual(ins?.segs, [{ text: 'nothing in common here', changed: false }]);
 });
 
-test('buildRows: blocco 2 rimosse -> 1 aggiunta non accoppia a caso', () => {
-    const oldStr = 'prima riga uguale\nseconda riga diversa\nctx\n';
-    const newStr = 'prima riga uguale modificata\nctx\n';
+test('buildRows: a block of 2 removed -> 1 added does not pair at random', () => {
+    const oldStr = 'first line same\nsecond line different\nctx\n';
+    const newStr = 'first line same edited\nctx\n';
 
     const rows = buildRows(oldStr, newStr, 'f.cs', 3, false);
     const dels = rows.filter((r) => r.kind === 'del');
 
     assert.equal(dels.length, 2);
-    // La seconda '-' non ha una '+' con cui accoppiarsi: resta intera.
-    assert.deepEqual(dels[1].segs, [{ text: 'seconda riga diversa', changed: false }]);
+    // The second '-' has no '+' to pair with: it stays whole.
+    assert.deepEqual(dels[1].segs, [{ text: 'second line different', changed: false }]);
 });
 
-test('buildRows: i numeri di riga avanzano sui lati giusti', () => {
+test('buildRows: line numbers advance on the right sides', () => {
     const oldStr = 'a\nb\nc\n';
     const newStr = 'a\nB\nc\n';
 
@@ -76,38 +76,38 @@ test('buildRows: i numeri di riga avanzano sui lati giusti', () => {
     assert.equal(ctx[0]?.newNo, 1);
 });
 
-test('editRangeFromHunks: le righe aggiunte, non tutto lo hunk', () => {
-    // 3 righe di contesto attorno a una aggiunta: il salto deve puntare alla '+',
-    // non allo hunk intero, o l'editor selezionerebbe righe non toccate.
+test('editRangeFromHunks: the added lines, not the whole hunk', () => {
+    // 3 context lines around one addition: the jump must point at the '+',
+    // not at the whole hunk, or the editor would select untouched lines.
     const range = editRangeFromHunks([
         {
             oldStart: 46,
             oldLines: 4,
             newStart: 46,
             newLines: 5,
-            lines: ['     a', '     b', '+        nuova', '     c', '     d'],
+            lines: ['     a', '     b', '+        added', '     c', '     d'],
         },
     ]);
 
     assert.deepEqual(range, [48, 48]);
 });
 
-test('editRangeFromHunks: le righe tolte non fanno avanzare il contatore', () => {
+test('editRangeFromHunks: removed lines do not advance the counter', () => {
     const range = editRangeFromHunks([
         {
             oldStart: 10,
             oldLines: 4,
             newStart: 10,
             newLines: 3,
-            lines: ['     a', '-        via', '+        prima', '+        seconda', '     b'],
+            lines: ['     a', '-        gone', '+        first', '+        second', '     b'],
         },
     ]);
 
-    // 'a' e' 10, la '-' non conta, le due '+' sono 11 e 12
+    // 'a' is 10, the '-' does not count, the two '+' are 11 and 12
     assert.deepEqual(range, [11, 12]);
 });
 
-test('editRangeFromHunks: uno hunk di solo contesto ricade sul suo intervallo', () => {
+test('editRangeFromHunks: a context-only hunk falls back to its own range', () => {
     const range = editRangeFromHunks([
         {
             oldStart: 7,
@@ -121,28 +121,28 @@ test('editRangeFromHunks: uno hunk di solo contesto ricade sul suo intervallo', 
     assert.deepEqual(range, [7, 9]);
 });
 
-test('editRangeFromHunks: senza hunk non c e nessun punto dove saltare', () => {
+test('editRangeFromHunks: with no hunks there is nowhere to jump', () => {
     assert.deepEqual(editRangeFromHunks([]), [0, 0]);
     assert.deepEqual(editRangeFromHunks(null), [0, 0]);
 });
 
-test('editRangeFromHunks: solo il primo hunk decide il salto', () => {
+test('editRangeFromHunks: only the first hunk decides the jump', () => {
     const range = editRangeFromHunks([
-        { oldStart: 5, oldLines: 1, newStart: 5, newLines: 1, lines: ['+        prima'] },
-        { oldStart: 99, oldLines: 1, newStart: 99, newLines: 1, lines: ['+        seconda'] },
+        { oldStart: 5, oldLines: 1, newStart: 5, newLines: 1, lines: ['+        first'] },
+        { oldStart: 99, oldLines: 1, newStart: 99, newLines: 1, lines: ['+        second'] },
     ]);
 
     assert.deepEqual(range, [5, 5]);
 });
 
-test('rowsFromHunks: i numeri sono quelli del CLI, non ricontati da 1', () => {
+test('rowsFromHunks: the numbers come from the CLI, not recounted from 1', () => {
     const rows = rowsFromHunks([
         {
             oldStart: 46,
             oldLines: 4,
             newStart: 46,
             newLines: 3,
-            lines: ['     contesto', '-        return;', '     }', '     coda'],
+            lines: ['     context', '-        return;', '     }', '     tail'],
         },
     ]);
 
@@ -153,12 +153,12 @@ test('rowsFromHunks: i numeri sono quelli del CLI, non ricontati da 1', () => {
     assert.equal(ctx[0]?.newNo, 46);
     assert.equal(del?.oldNo, 47);
     assert.equal(del?.newNo, null);
-    // dopo una riga tolta i due lati divergono: old avanza, new no
+    // after a removed line the two sides diverge: old advances, new does not
     assert.equal(ctx[1]?.oldNo, 48);
     assert.equal(ctx[1]?.newNo, 47);
 });
 
-test('rowsFromHunks: piu hunk restano separati dai loro marcatori', () => {
+test('rowsFromHunks: several hunks stay separated by their markers', () => {
     const rows = rowsFromHunks([
         { oldStart: 10, oldLines: 1, newStart: 10, newLines: 1, lines: ['-a', '+A'] },
         { oldStart: 90, oldLines: 1, newStart: 90, newLines: 1, lines: ['-b', '+B'] },
@@ -170,22 +170,22 @@ test('rowsFromHunks: piu hunk restano separati dai loro marcatori', () => {
     assert.equal(hunks[1].oldNo, 90);
 });
 
-test('rowsFromHunks: nessun hunk non produce righe', () => {
+test('rowsFromHunks: no hunks produces no rows', () => {
     assert.deepEqual(rowsFromHunks([]), []);
     assert.deepEqual(rowsFromHunks(null), []);
 });
 
-test('rowsFromHunks: il word-diff intra-riga vale anche sugli hunk del CLI', () => {
+test('rowsFromHunks: the intra-line word-diff applies to CLI hunks too', () => {
     const rows = rowsFromHunks([
         {
             oldStart: 5,
             oldLines: 1,
             newStart: 5,
             newLines: 1,
-            lines: ['-la sola ragione che quella nota', '+la sola ragione che la nota'],
+            lines: ['-the only reason that note', '+the only reason the note'],
         },
     ]);
 
     const del = rows.find((r) => r.kind === 'del');
-    assert.ok(del?.segs.some((s) => s.changed && s.text.includes('quella')));
+    assert.ok(del?.segs.some((s) => s.changed && s.text.includes('that')));
 });

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/diff-stats.test.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/diff-stats.test.ts
@@ -5,23 +5,23 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { countChanges } from '../core/diff-stats.ts';
 
-test('countChanges: sostituzione 14 righe con 1 conta +1 -14, non il netto', () => {
-    const oldStr = Array.from({ length: 14 }, (_, i) => `riga ${i}`).join('\n');
-    const newStr = 'una sola';
+test('countChanges: replacing 14 lines with 1 counts +1 -14, not the net', () => {
+    const oldStr = Array.from({ length: 14 }, (_, i) => `line ${i}`).join('\n');
+    const newStr = 'just one';
 
     assert.deepEqual(countChanges(oldStr, newStr, 'f.ts', false), { added: 1, removed: 14 });
 });
 
-test('countChanges: solo aggiunte', () => {
+test('countChanges: additions only', () => {
     // Trailing newline on oldStr: without it jsdiff treats the shared first line as
     // changed too (no-newline-at-EOF is part of the line, same as `git diff` does).
     assert.deepEqual(countChanges('a\n', 'a\nb\nc', 'f.ts', false), { added: 2, removed: 0 });
 });
 
-test('countChanges: nessuna modifica', () => {
+test('countChanges: no change', () => {
     assert.deepEqual(countChanges('a\nb', 'a\nb', 'f.ts', false), { added: 0, removed: 0 });
 });
 
-test('countChanges: file vuoto verso contenuto (Write)', () => {
+test('countChanges: empty file to content (Write)', () => {
     assert.deepEqual(countChanges('', 'x\ny', 'f.ts', false), { added: 2, removed: 0 });
 });

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/exchanges.test.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/exchanges.test.ts
@@ -20,7 +20,7 @@ const bot = (id: number): UiAssistantEntry => ({
     text: `a${id}`,
 });
 
-test('ogni messaggio utente apre un nuovo scambio', () => {
+test('every user message opens a new exchange', () => {
     const groups = buildGroups([user(1), bot(2), user(3), bot(4)]);
 
     assert.equal(groups.length, 2);
@@ -34,7 +34,7 @@ test('ogni messaggio utente apre un nuovo scambio', () => {
     );
 });
 
-test('le entry prima del primo utente vanno in un gruppo di testa', () => {
+test('entries before the first user go into a leading group', () => {
     const groups = buildGroups([bot(1), user(2), bot(3)]);
 
     assert.equal(groups.length, 2);
@@ -48,14 +48,14 @@ test('le entry prima del primo utente vanno in un gruppo di testa', () => {
     );
 });
 
-test('lista vuota produce zero gruppi', () => {
+test('an empty list produces zero groups', () => {
     assert.deepEqual(buildGroups([]), []);
 });
 
-test('un messaggio ancora in coda non apre uno scambio', () => {
-    // Il turno 1 sta ancora rispondendo (bot(4) arriva dopo) quando l utente scrive il secondo
-    // prompt: finche resta in coda deve stare nel gruppo del turno che gira, o la sua <section>
-    // finirebbe li e l intestazione del turno in corso si sbloccherebbe a meta risposta.
+test('a message still queued does not open an exchange', () => {
+    // Turn 1 is still answering (bot(4) arrives later) when the user types the second prompt:
+    // while it stays queued it must live in the running turn's group, or its <section> would end
+    // there and the running turn's header would unstick halfway through the answer.
     const groups = buildGroups([user(1), bot(2), user(3, 'q'), bot(4)], new Set(['q']));
 
     assert.equal(groups.length, 1);
@@ -65,15 +65,15 @@ test('un messaggio ancora in coda non apre uno scambio', () => {
     );
 });
 
-test('lo stesso messaggio apre lo scambio appena esce dalla coda', () => {
+test('the same message opens the exchange as soon as it leaves the queue', () => {
     const entries = [user(1), bot(2), user(3, 'q')];
 
     assert.equal(buildGroups(entries, new Set(['q'])).length, 1);
     assert.equal(buildGroups(entries, new Set()).length, 2);
 });
 
-test('la coda trattiene solo il suo uuid, non ogni utente', () => {
-    // 'b' e in coda, 'a' no: 'a' apre il suo scambio, 'b' resta nel gruppo che trova.
+test('the queue holds back only its own uuid, not every user message', () => {
+    // 'b' is queued, 'a' is not: 'a' opens its own exchange, 'b' stays in the group it finds.
     const groups = buildGroups([user(1, 'z'), user(2, 'b'), user(3, 'a')], new Set(['b']));
 
     assert.equal(groups.length, 2);

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/file-links.test.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/file-links.test.ts
@@ -2,234 +2,234 @@
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
-// Il parser dei riferimenti a file: ogni forma che docs/file-links.md promette, e i non-casi che
-// la allow-list esiste per bloccare. Scritti contro il comportamento ATTUALE — un test che fallisce
-// qui e' o un bug o una promessa della doc che il codice non mantiene, e le due vanno distinte.
+// The file-reference parser: every shape docs/file-links.md promises, and the non-cases the
+// allow-list exists to block. Written against CURRENT behaviour — a failure here is either a bug or
+// a promise in the doc the code doesn't keep, and the two must be told apart.
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { findFileRefs, parseFileRef, firstRefHint } from '../core/file-links.ts';
 
-/** Il primo ref di un testo, o null. Le asserzioni sotto guardano quasi sempre solo quello. */
+/** The first ref of a text, or null. The assertions below almost always look at that one only. */
 function first(text: string) {
     return findFileRefs(text)[0] ?? null;
 }
 
-// Le sette forme della tabella in docs/file-links.md.
+// The seven shapes from the table in docs/file-links.md.
 
-test('forma: nome.ext:riga', () => {
-    const r = first('vedi ClientEvents.cs:208 per il resto');
+test('shape: name.ext:line', () => {
+    const r = first('see ClientEvents.cs:208 for the rest');
     assert.equal(r?.path, 'ClientEvents.cs');
     assert.deepEqual(r?.lines, [208]);
     assert.equal(r?.match, 'ClientEvents.cs:208');
 });
 
-test('forma: percorso relativo', () => {
-    const r = first('in Core/Stats/StatsService.cs:45 succede');
+test('shape: relative path', () => {
+    const r = first('in Core/Stats/StatsService.cs:45 it happens');
     assert.equal(r?.path, 'Core/Stats/StatsService.cs');
     assert.deepEqual(r?.lines, [45]);
 });
 
-test('forma: intervallo, ends porta la riga finale', () => {
-    const r = first('StatsService.cs:35-48 e il blocco');
+test('shape: range, ends carries the last line', () => {
+    const r = first('StatsService.cs:35-48 is the block');
     assert.deepEqual(r?.lines, [35]);
     assert.deepEqual(r?.ends, [48]);
 });
 
-test('forma: intervallo con en-dash', () => {
+test('shape: range with an en-dash', () => {
     const r = first('StatsService.cs:35–48');
     assert.deepEqual(r?.lines, [35]);
     assert.deepEqual(r?.ends, [48]);
 });
 
-test('forma: lista di righe, una per link', () => {
-    const r = first('AgentsPackage.cs:124,185,202 tre punti');
+test('shape: line list, one link each', () => {
+    const r = first('AgentsPackage.cs:124,185,202 three spots');
     assert.deepEqual(r?.lines, [124, 185, 202]);
     assert.deepEqual(r?.ends, [124, 185, 202]);
 });
 
-test('forma: lista i cui elementi sono intervalli', () => {
+test('shape: list whose elements are ranges', () => {
     const r = first('StatsService.cs:100-120,130');
     assert.deepEqual(r?.lines, [100, 130]);
     assert.deepEqual(r?.ends, [120, 130]);
 });
 
-test('forma: parentesi tonde', () => {
-    const r = first('in foo.cs(339) qui');
+test('shape: round brackets', () => {
+    const r = first('in foo.cs(339) here');
     assert.equal(r?.path, 'foo.cs');
     assert.deepEqual(r?.lines, [339]);
 });
 
-test('forma: parentesi quadre con colonna', () => {
-    const r = first('bar.ts[45:12] la');
+test('shape: square brackets with a column', () => {
+    const r = first('bar.ts[45:12] there');
     assert.equal(r?.path, 'bar.ts');
     assert.deepEqual(r?.lines, [45]);
 });
 
-test('forma: GitHub #L', () => {
-    const r = first('ClaudeInstall.cs#L103 e li');
+test('shape: GitHub #L', () => {
+    const r = first('ClaudeInstall.cs#L103 and there');
     assert.deepEqual(r?.lines, [103]);
 });
 
-test('forma: GitHub #L con intervallo', () => {
+test('shape: GitHub #L with a range', () => {
     const r = first('x.ts#L35-L48');
     assert.deepEqual(r?.lines, [35]);
     assert.deepEqual(r?.ends, [48]);
 });
 
-test('forma: GitHub # senza L', () => {
+test('shape: GitHub # without the L', () => {
     const r = first('bar.ts#45');
     assert.deepEqual(r?.lines, [45]);
 });
 
-test('la colonna e parsata e scartata, non diventa la fine di una selezione', () => {
-    const r = first('x.ts:47:12 qui');
+test('the column is parsed and dropped, it never becomes the end of a selection', () => {
+    const r = first('x.ts:47:12 here');
     assert.deepEqual(r?.lines, [47]);
     assert.deepEqual(r?.ends, [47]);
 });
 
-// Piu' riferimenti nello stesso testo.
+// Several references in the same text.
 
-test('due file in una riga danno due ref distinti', () => {
+test('two files on one line give two distinct refs', () => {
     const refs = findFileRefs('markdown.ts:57,file-links.ts:130');
     assert.equal(refs.length, 2);
     assert.equal(refs[0].path, 'markdown.ts');
     assert.equal(refs[1].path, 'file-links.ts');
 });
 
-test('i ref tornano in ordine e non si sovrappongono', () => {
-    const refs = findFileRefs('prima a.cs:1 poi b.ts:2 infine c.py:3');
+test('refs come back in order and never overlap', () => {
+    const refs = findFileRefs('first a.cs:1 then b.ts:2 last c.py:3');
     assert.deepEqual(
         refs.map((r) => r.path),
         ['a.cs', 'b.ts', 'c.py'],
     );
     for (let i = 1; i < refs.length; i++) {
-        assert.ok(refs[i].start >= refs[i - 1].end, 'ref sovrapposti');
+        assert.ok(refs[i].start >= refs[i - 1].end, 'overlapping refs');
     }
 });
 
-// I non-casi: cio' che la allow-list delle estensioni esiste per NON linkare.
+// The non-cases: what the extension allow-list exists to NOT linkify.
 
-test('un orario non e un file', () => {
-    assert.equal(first('alle 10:30 di sera'), null);
+test('a clock time is not a file', () => {
+    assert.equal(first('at 10:30 in the evening'), null);
 });
 
-test('un host:porta non e un file', () => {
-    assert.equal(first('su localhost.net:4040 gira'), null);
+test('a host:port is not a file', () => {
+    assert.equal(first('it runs on localhost.net:4040'), null);
 });
 
-test('una versione non e un file', () => {
-    assert.equal(first('la 2.1.220:5 di ieri'), null);
+test('a version is not a file', () => {
+    assert.equal(first('the 2.1.220:5 from yesterday'), null);
 });
 
-test('un prezzo non e un file', () => {
-    assert.equal(first('costa 19.99:2 euro'), null);
+test('a price is not a file', () => {
+    assert.equal(first('it costs 19.99:2 euro'), null);
 });
 
-test('una estensione sconosciuta in prosa resta testo', () => {
-    assert.equal(first('apri report.xyzzy:12'), null);
+test('an unknown extension in prose stays text', () => {
+    assert.equal(first('open report.xyzzy:12'), null);
 });
 
-test('un nome senza riga ne cartella e troppo rumoroso per linkare', () => {
-    // "vedi il README.md" a meta' frase: nessuna struttura, nessun link.
-    assert.equal(first('vedi il README.md e basta'), null);
+test('a name with neither line nor folder is too noisy to linkify', () => {
+    // "see the README.md" mid-sentence: no structure, no link.
+    assert.equal(first('see the README.md and that is all'), null);
 });
 
-test('un nome con cartella linka anche senza riga', () => {
-    const r = first('sta in docs/file-links.md quindi');
+test('a name with a folder linkifies even without a line', () => {
+    const r = first('it lives in docs/file-links.md then');
     assert.equal(r?.path, 'docs/file-links.md');
     assert.deepEqual(r?.lines, []);
 });
 
-// Casi limite del percorso.
+// Path edge cases.
 
-test('una cartella con il punto nel nome non ruba lancora', () => {
-    // "Corsinvest.VisualStudio.Agents" e' una cartella: il ref vero e' l'ultimo segmento.
+test('a folder with a dot in its name does not steal the anchor', () => {
+    // "Corsinvest.VisualStudio.Agents" is a folder: the real ref is the last segment.
     const r = first('src/Corsinvest.VisualStudio.Agents/Chat/x.ts:5');
     assert.equal(r?.path, 'src/Corsinvest.VisualStudio.Agents/Chat/x.ts');
     assert.deepEqual(r?.lines, [5]);
 });
 
-test('un percorso windows assoluto tiene la lettera di unita', () => {
-    const r = first('apri C:\\src\\repo\\Foo.cs:12 adesso');
+test('an absolute windows path keeps its drive letter', () => {
+    const r = first('open C:\\src\\repo\\Foo.cs:12 now');
     assert.equal(r?.path, 'C:\\src\\repo\\Foo.cs');
     assert.deepEqual(r?.lines, [12]);
 });
 
-test('una estensione sola senza nome non e un ref', () => {
-    assert.equal(first('un file .ts qualunque'), null);
+test('a bare extension with no name is not a ref', () => {
+    assert.equal(first('any old .ts file'), null);
 });
 
-test('le parentesi attorno al ref non ci finiscono dentro', () => {
+test('brackets around the ref do not end up inside it', () => {
     const r = first('(NdjsonTransport.cs:91)');
     assert.equal(r?.path, 'NdjsonTransport.cs');
     assert.equal(r?.match, 'NdjsonTransport.cs:91');
 });
 
-test('righe duplicate nella lista sono scartate, la prima vince', () => {
+test('duplicate lines in the list are dropped, the first one wins', () => {
     const r = first('x.cs:10,10,20');
     assert.deepEqual(r?.lines, [10, 20]);
 });
 
-test('testo vuoto non produce ref', () => {
+test('empty text produces no ref', () => {
     assert.deepEqual(findFileRefs(''), []);
 });
 
-// parseFileRef: il token deve essere il ref e NIENTE altro. E' il test che serve anche
-// all'inline code, dove il contenuto del backtick e' o un riferimento o un frammento di codice.
+// parseFileRef: the token must be the ref and NOTHING else. This is also what inline code needs,
+// where the content of a backtick is either a reference or a fragment of code.
 
-test('parseFileRef accetta un token che e interamente un ref', () => {
+test('parseFileRef accepts a token that is entirely a ref', () => {
     const r = parseFileRef('Foo.cs:12', 'known-ext');
     assert.equal(r?.path, 'Foo.cs');
     assert.deepEqual(r?.lines, [12]);
 });
 
-test('parseFileRef rifiuta un token che contiene altro', () => {
+test('parseFileRef rejects a token that holds anything else', () => {
     assert.equal(parseFileRef('cat Foo.cs:12', 'known-ext'), null);
-    assert.equal(parseFileRef('Foo.cs:12 e poi', 'known-ext'), null);
+    assert.equal(parseFileRef('Foo.cs:12 and then', 'known-ext'), null);
 });
 
-test('parseFileRef rifiuta una versione', () => {
+test('parseFileRef rejects a version', () => {
     assert.equal(parseFileRef('1.5.0', 'known-ext'), null);
     assert.equal(parseFileRef('v2.1.237', 'known-ext'), null);
 });
 
-// plausible-path: la strictness degli href markdown, dove il modello ha gia' dichiarato "e' un link".
+// plausible-path: the strictness for markdown hrefs, where the model already declared "this is a link".
 
-test('plausible-path accetta una estensione fuori allow-list', () => {
+test('plausible-path accepts an extension outside the allow-list', () => {
     const r = parseFileRef('src/utils/helper.rb#L12', 'plausible-path');
     assert.equal(r?.path, 'src/utils/helper.rb');
     assert.deepEqual(r?.lines, [12]);
 });
 
-test('plausible-path rifiuta comunque cio che non ha forma di file', () => {
-    // Una "estensione" tutta cifre e' un prezzo o una versione, mai un file.
+test('plausible-path still rejects what has no file shape', () => {
+    // An all-digit "extension" is a price or a version, never a file.
     assert.equal(parseFileRef('19.99#L2', 'plausible-path'), null);
 });
 
-test('plausible-path accetta un percorso senza riga', () => {
+test('plausible-path accepts a path with no line', () => {
     const r = parseFileRef('notes.md', 'plausible-path');
     assert.equal(r?.path, 'notes.md');
     assert.deepEqual(r?.lines, []);
 });
 
-// firstRefHint: il contratto con marked. Deve essere un limite INFERIORE — mai oltre l'inizio vero,
-// o il tokenizer non viene mai offerto quella posizione e il ref sparisce in silenzio.
+// firstRefHint: the contract with marked. It must be a LOWER bound — never past the real start, or
+// the tokenizer is never offered that position and the ref vanishes silently.
 
-test('il suggerimento non supera mai linizio reale del ref', () => {
+test('the hint never goes past the real start of the ref', () => {
     for (const t of [
-        'vedi ClientEvents.cs:208 qui',
-        'apri C:\\src\\Foo.cs:12 adesso',
+        'see ClientEvents.cs:208 here',
+        'open C:\\src\\Foo.cs:12 now',
         'in Core/Stats/StatsService.cs:45',
         '(NdjsonTransport.cs:91)',
     ]) {
         const hint = firstRefHint(t);
         const ref = first(t);
-        assert.ok(ref, `nessun ref in "${t}"`);
-        assert.ok(hint !== undefined, `nessun hint per "${t}"`);
-        assert.ok(hint <= ref.start, `hint ${hint} oltre lo start ${ref.start} in "${t}"`);
+        assert.ok(ref, `no ref in "${t}"`);
+        assert.ok(hint !== undefined, `no hint for "${t}"`);
+        assert.ok(hint <= ref.start, `hint ${hint} past the start ${ref.start} in "${t}"`);
     }
 });
 
-test('nessun suggerimento quando non ci sono estensioni', () => {
-    assert.equal(firstRefHint('nessun file qui dentro'), undefined);
+test('no hint when there are no extensions', () => {
+    assert.equal(firstRefHint('no file in here at all'), undefined);
 });

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/format.test.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/format.test.ts
@@ -14,76 +14,80 @@ import {
 const MINUTE = 60_000;
 const HOUR = 3600_000;
 
-test('formatTimeAgo: il clock e iniettabile, non e Date.now cablato', () => {
+test('formatTimeAgo: the clock is injectable, not a hard-wired Date.now', () => {
     const t = 1_000_000_000_000;
 
     // The same timestamp read at two different moments must give two different strings: that is
     // what makes the refresh on hover a matter of state, not of writing into the DOM.
-    const subito = formatTimeAgo(t, t + MINUTE);
-    const dopo = formatTimeAgo(t, t + 3 * HOUR);
+    const justNow = formatTimeAgo(t, t + MINUTE);
+    const later = formatTimeAgo(t, t + 3 * HOUR);
 
-    assert.notEqual(subito, dopo, 'un clock piu avanti deve dare un testo diverso');
+    assert.notEqual(justNow, later, 'a clock further ahead must give a different text');
 });
 
 // The exact text depends on the system locale (Intl.RelativeTimeFormat): asserting on English
 // strings would make the test green only on English machines. What matters is that different
 // units give different strings, and that the number is the right one.
-test('formatTimeAgo: sceglie l unita in base alla distanza', () => {
+test('formatTimeAgo: picks the unit from the distance', () => {
     const t = 1_000_000_000_000;
 
     const sec = formatTimeAgo(t, t + 30_000);
     const min = formatTimeAgo(t, t + 5 * MINUTE);
-    const ore = formatTimeAgo(t, t + 5 * HOUR);
+    const hours = formatTimeAgo(t, t + 5 * HOUR);
 
-    assert.notEqual(sec, min, 'secondi e minuti devono differire');
-    assert.notEqual(min, ore, 'minuti e ore devono differire');
-    assert.match(min, /5/, 'il numero deve comparire');
-    assert.match(ore, /5/);
+    assert.notEqual(sec, min, 'seconds and minutes must differ');
+    assert.notEqual(min, hours, 'minutes and hours must differ');
+    assert.match(min, /5/, 'the number must show up');
+    assert.match(hours, /5/);
 });
 
-test('formatTimeAgo: senza clock esplicito usa adesso', () => {
+test('formatTimeAgo: with no explicit clock it uses now', () => {
     // The default must stay Date.now(): callers that pass no clock are unaffected.
-    const esplicito = formatTimeAgo(1_000_000_000_000, 1_000_000_000_000 + 2 * MINUTE);
-    const implicito = formatTimeAgo(Date.now() - 2 * MINUTE);
+    const explicitClock = formatTimeAgo(1_000_000_000_000, 1_000_000_000_000 + 2 * MINUTE);
+    const implicitClock = formatTimeAgo(Date.now() - 2 * MINUTE);
 
-    assert.equal(implicito, esplicito, 'il default deve equivalere a passare Date.now()');
+    assert.equal(
+        implicitClock,
+        explicitClock,
+        'the default must be the same as passing Date.now()',
+    );
 });
 
-// formatDuration e la stessa funzione per lo spinner del turno, la riga di risposta, il thinking,
-// i sub-agent e le tool row: se cambia qui, cambia in tutti e cinque insieme.
+// formatDuration is the same function for the turn spinner, the answer row, the thinking, the
+// sub-agents and the tool rows: a change here changes all five at once.
 
-test('formatDuration: il decimale appare solo sotto il secondo', () => {
-    // Un turno da 200ms non deve leggersi "0s" (sembrerebbe un errore), ma un contatore che
-    // scandisce i secondi non deve mostrare ".0" a ogni tick.
+test('formatDuration: the decimal shows only below one second', () => {
+    // A 200ms turn must not read "0s" (it would look like a bug), but a counter ticking through
+    // seconds must not show ".0" on every tick.
     assert.equal(formatDuration(200), '0.2s');
     assert.equal(formatDuration(1000), '1s');
     assert.equal(formatDuration(3200), '3s');
     assert.equal(formatDuration(45_000), '45s');
 });
 
-test('formatDuration: oltre il minuto passa a "Nm Ns"', () => {
+test('formatDuration: past the minute it switches to "Nm Ns"', () => {
     assert.equal(formatDuration(60_000), '1m 0s');
     assert.equal(formatDuration(83_000), '1m 23s');
-    // Il confine: 59s resta in secondi, 60 diventa minuti.
+    // The boundary: 59s stays in seconds, 60 becomes minutes.
     assert.equal(formatDuration(59_000), '59s');
 });
 
-test('formatDurationSec: e formatDuration in secondi, stessa resa', () => {
-    // Lo spinner e le tool row tengono secondi, non ms: le due firme non devono divergere.
+test('formatDurationSec: it is formatDuration in seconds, same rendering', () => {
+    // The spinner and the tool rows hold seconds, not ms: the two signatures must not diverge.
     assert.equal(formatDurationSec(45), formatDuration(45_000));
     assert.equal(formatDurationSec(83), formatDuration(83_000));
 });
 
-test('formatTokens: compatta solo oltre il migliaio', () => {
+test('formatTokens: compacts only past the thousand', () => {
     assert.equal(formatTokens(84), '84');
     assert.equal(formatTokens(1500), '2k');
     assert.equal(formatTokens(357_000), '357k');
     assert.equal(formatTokens(1_200_000), '1.2M');
 });
 
-test('formatTokenCount: porta l unita, e la tilde solo se stimato', () => {
-    // La tilde distingue il conteggio misurato della risposta dalla stima del thinking: i due
-    // numeri stanno vicini nella stessa chat e senza il segno sembrerebbero la stessa cosa.
+test('formatTokenCount: carries the unit, and the tilde only when estimated', () => {
+    // The tilde tells the measured answer count from the thinking estimate: the two numbers sit
+    // next to each other in the same chat and without the sign they would look like the same thing.
     assert.equal(formatTokenCount(84), '84 tok');
     assert.equal(formatTokenCount(84, true), '~84 tok');
     assert.equal(formatTokenCount(1500, true), '~2k tok');

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/mark-ranges.test.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/mark-ranges.test.ts
@@ -5,24 +5,24 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { markRanges, rangesOf } from '../core/mark-ranges.ts';
 
-test('markRanges: senza range restituisce l’html intatto', () => {
+test('markRanges: with no ranges the html comes back untouched', () => {
     assert.equal(
         markRanges('<span class="k">const</span> x', []),
         '<span class="k">const</span> x',
     );
 });
 
-test('markRanges: marca un tratto di testo semplice', () => {
+test('markRanges: marks a plain stretch of text', () => {
     assert.equal(markRanges('abcdef', [{ start: 2, end: 4 }]), 'ab<mark>cd</mark>ef');
 });
 
-test('markRanges: gli offset sono quelli del testo, non dell’html', () => {
-    // 'const x' con i primi cinque caratteri dentro uno span: il range 6..7 è la x.
+test('markRanges: offsets are the text ones, not the html ones', () => {
+    // 'const x' with the first five chars inside a span: the range 6..7 is the x.
     const html = '<span class="hljs-keyword">const</span> x';
     assert.equal(markRanges(html, [{ start: 6, end: 7 }]), `${html.slice(0, -1)}<mark>x</mark>`);
 });
 
-test('markRanges: un range dentro un tag lo marca senza toccare il tag', () => {
+test('markRanges: a range inside a tag is marked without touching the tag', () => {
     const html = '<span class="hljs-keyword">const</span>';
     assert.equal(
         markRanges(html, [{ start: 0, end: 5 }]),
@@ -30,18 +30,18 @@ test('markRanges: un range dentro un tag lo marca senza toccare il tag', () => {
     );
 });
 
-test('markRanges: un range a cavallo di un tag chiude e riapre invece di annidare male', () => {
-    // 'ab' testo, poi <i>cd</i>: marcare 1..3 prende la b fuori e la c dentro.
+test('markRanges: a range straddling a tag closes and reopens instead of nesting badly', () => {
+    // 'ab' as text, then <i>cd</i>: marking 1..3 takes the b outside and the c inside.
     const out = markRanges('ab<i>cd</i>', [{ start: 1, end: 3 }]);
     assert.equal(out, 'a<mark>b</mark><i><mark>c</mark>d</i>');
 });
 
-test('markRanges: le entità valgono un carattere solo', () => {
-    // Testo sorgente: 'a<b' — '<' è &lt; e conta 1. Il range 1..2 è quel carattere.
+test('markRanges: entities count as a single character', () => {
+    // Source text: 'a<b' — '<' is &lt; and counts as 1. The range 1..2 is that character.
     assert.equal(markRanges('a&lt;b', [{ start: 1, end: 2 }]), 'a<mark>&lt;</mark>b');
 });
 
-test('markRanges: più range disgiunti sullo stesso html', () => {
+test('markRanges: several disjoint ranges on the same html', () => {
     assert.equal(
         markRanges('abcdef', [
             { start: 0, end: 1 },
@@ -51,11 +51,11 @@ test('markRanges: più range disgiunti sullo stesso html', () => {
     );
 });
 
-test('markRanges: un range fino a fine riga chiude il mark', () => {
+test('markRanges: a range reaching the end of the line closes the mark', () => {
     assert.equal(markRanges('abc', [{ start: 1, end: 3 }]), 'a<mark>bc</mark>');
 });
 
-test('rangesOf: gli offset seguono i segmenti concatenati', () => {
+test('rangesOf: offsets follow the concatenated segments', () => {
     assert.deepEqual(
         rangesOf([
             { text: 'return ', changed: false },
@@ -66,6 +66,6 @@ test('rangesOf: gli offset seguono i segmenti concatenati', () => {
     );
 });
 
-test('rangesOf: nessun segmento cambiato = nessun range', () => {
+test('rangesOf: no changed segment = no range', () => {
     assert.deepEqual(rangesOf([{ text: 'const x = 1', changed: false }]), []);
 });

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/markdown-split.test.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/markdown-split.test.ts
@@ -6,63 +6,63 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { stableMarkdownSplit } from '../core/markdown-split.ts';
 
-test('split: taglia dopo una riga vuota', () => {
-    const t = 'primo paragrafo\n\nsecondo in corso';
+test('split: cuts after a blank line', () => {
+    const t = 'first paragraph\n\nsecond in progress';
     const cut = stableMarkdownSplit(t);
-    assert.equal(t.slice(0, cut), 'primo paragrafo\n\n');
+    assert.equal(t.slice(0, cut), 'first paragraph\n\n');
 });
 
-test('split: non taglia dentro un code block aperto', () => {
-    const t = 'testo\n\n```ts\nconst a = 1;\n\nconst b = 2;';
+test('split: never cuts inside an open code block', () => {
+    const t = 'text\n\n```ts\nconst a = 1;\n\nconst b = 2;';
     const cut = stableMarkdownSplit(t);
-    // Il solo punto sicuro e' la riga vuota PRIMA della fence.
-    assert.equal(t.slice(0, cut), 'testo\n\n');
+    // The only safe point is the blank line BEFORE the fence.
+    assert.equal(t.slice(0, cut), 'text\n\n');
 });
 
-test('split: riprende dopo una fence chiusa', () => {
-    const t = 'testo\n\n```ts\nconst a = 1;\n```\n\ncoda in corso';
+test('split: resumes after a closed fence', () => {
+    const t = 'text\n\n```ts\nconst a = 1;\n```\n\ntail in progress';
     const cut = stableMarkdownSplit(t);
-    assert.equal(t.slice(0, cut), 'testo\n\n```ts\nconst a = 1;\n```\n\n');
+    assert.equal(t.slice(0, cut), 'text\n\n```ts\nconst a = 1;\n```\n\n');
 });
 
-test('split: la riga che chiude una fence e gia un punto di taglio', () => {
-    // Senza riga vuota dopo la fence: il blocco e' comunque finito, e lasciarlo nella coda
-    // significa ri-evidenziarlo per intero a ogni passata.
-    const t = 'testo\n\n```ts\nconst a = 1;\n```\ncoda in corso';
+test('split: the line closing a fence is already a cut point', () => {
+    // With no blank line after the fence the block is finished anyway, and leaving it in the tail
+    // means re-highlighting the whole of it on every pass.
+    const t = 'text\n\n```ts\nconst a = 1;\n```\ntail in progress';
     const cut = stableMarkdownSplit(t);
-    assert.equal(t.slice(0, cut), 'testo\n\n```ts\nconst a = 1;\n```\n');
+    assert.equal(t.slice(0, cut), 'text\n\n```ts\nconst a = 1;\n```\n');
 });
 
-test('split: una fence ancora aperta non e un punto di taglio', () => {
-    const t = 'testo\n\n```ts\nconst a = 1;';
+test('split: a still-open fence is not a cut point', () => {
+    const t = 'text\n\n```ts\nconst a = 1;';
     const cut = stableMarkdownSplit(t);
-    assert.equal(t.slice(0, cut), 'testo\n\n');
+    assert.equal(t.slice(0, cut), 'text\n\n');
 });
 
-test('split: senza righe vuote non taglia', () => {
-    assert.equal(stableMarkdownSplit('un solo paragrafo che cresce'), 0);
+test('split: with no blank line it does not cut', () => {
+    assert.equal(stableMarkdownSplit('a single paragraph that keeps growing'), 0);
 });
 
-test('split: testo vuoto', () => {
+test('split: empty text', () => {
     assert.equal(stableMarkdownSplit(''), 0);
 });
 
-test('split: mai oltre la fine del testo', () => {
-    const t = 'paragrafo\n\n';
+test('split: never past the end of the text', () => {
+    const t = 'paragraph\n\n';
     assert.equal(stableMarkdownSplit(t), 0);
 });
 
-test('split: una fence che contiene backtick non sfasa il conteggio', () => {
-    const t = 'a\n\n```md\nesempio con ``` dentro\n```\n\nb in corso';
+test('split: a fence holding backticks does not throw the count off', () => {
+    const t = 'a\n\n```md\nexample with ``` inside\n```\n\nb in progress';
     const cut = stableMarkdownSplit(t);
     assert.ok(cut > 0);
-    // Il taglio non cade mai a meta' del blocco: il prefisso ha fence bilanciate.
+    // The cut never lands halfway through the block: the prefix has balanced fences.
     const fences = (t.slice(0, cut).match(/^\s*```/gm) ?? []).length;
     assert.equal(fences % 2, 0);
 });
 
-test('split: il prefisso e sempre un confine di riga', () => {
-    const t = 'uno\n\ndue\n\ntre in corso';
+test('split: the prefix is always a line boundary', () => {
+    const t = 'one\n\ntwo\n\nthree in progress';
     const cut = stableMarkdownSplit(t);
     assert.ok(cut === 0 || t[cut - 1] === '\n');
 });

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/markdown.test.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/markdown.test.ts
@@ -2,21 +2,21 @@
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
-// Che marked chiami i renderer giusti: la meta' che i test su funzioni pure non possono vedere.
-// I casi limite di COSA sia un riferimento stanno in codespan-link.test.ts e file-links.test.ts.
+// That marked calls the right renderers: the half that tests over pure functions cannot see.
+// The edge cases of WHAT counts as a reference live in codespan-link.test.ts and file-links.test.ts.
 //
-// LIMITE, da sapere prima di aggiungere test qui: renderMarkdown chiude con DOMPurify, che ha
-// bisogno di un `window` e sotto node --test non ce l'ha — `sanitize is not a function`, e la
-// funzione degrada al suo ramo di errore. Quindi qui si testa il TOKENIZER, cioe' quali token
-// marked produce e con quale renderer, non l'HTML finale. Per quello servirebbe jsdom (~10MB di
-// devDependency) per verificare una sanificazione che e' di DOMPurify, non nostra.
+// LIMIT, worth knowing before adding tests here: renderMarkdown ends with DOMPurify, which needs a
+// `window` and does not have one under node --test — `sanitize is not a function`, and the function
+// degrades to its error branch. So what is tested here is the TOKENIZER, i.e. which tokens marked
+// produces and with which renderer, not the final HTML. That would take jsdom (~10MB of
+// devDependency) to verify a sanitisation that is DOMPurify's, not ours.
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { marked } from 'marked';
-import { closeOpenMarkdown } from '../core/markdown.ts'; // importa anche renderer ed estensione
+import { closeOpenMarkdown } from '../core/markdown.ts'; // also pulls in renderer and extension
 
-/** L'HTML di marked, prima di DOMPurify. */
+/** marked's HTML, before DOMPurify. */
 function md(text: string): string {
     return marked.parse(text, { async: false }) as string;
 }
@@ -25,46 +25,46 @@ function links(html: string): number {
     return (html.match(/class="cv-file-link"/g) ?? []).length;
 }
 
-// I tre percorsi che producono un link, uno per renderer.
+// The three paths that produce a link, one per renderer.
 
-test('prosa: lestensione fileLink intercetta un riferimento nudo', () => {
-    const html = md('vedi ClientEvents.cs:208 per il resto');
+test('prose: the fileLink extension catches a bare reference', () => {
+    const html = md('see ClientEvents.cs:208 for the rest');
     assert.equal(links(html), 1);
     assert.match(html, /data-file="ClientEvents\.cs"/);
 });
 
-test('inline code: il renderer codespan intercetta un riferimento in backtick', () => {
-    // La forma che il modello usa quasi sempre: 33 volte contro 2 su 25 sessioni reali.
-    const html = md('vedi `ClientEvents.cs:208` per il resto');
+test('inline code: the codespan renderer catches a backticked reference', () => {
+    // The form the model uses almost always: 33 times against 2 over 25 real sessions.
+    const html = md('see `ClientEvents.cs:208` for the rest');
     assert.equal(links(html), 1);
-    assert.match(html, /<code>/, 'il link vive DENTRO il code span, non al suo posto');
+    assert.match(html, /<code>/, 'the link lives INSIDE the code span, not in its place');
 });
 
-test('link markdown: il renderer link usa lhref e tiene la label', () => {
+test('markdown link: the link renderer uses the href and keeps the label', () => {
     const html = md('[McpServerHost.cs:192](src/Mcp/McpServerHost.cs:192)');
     assert.equal(links(html), 1);
     assert.match(html, /data-file="src\/Mcp\/McpServerHost\.cs"/);
     assert.match(html, />McpServerHost\.cs:192</);
 });
 
-// Il fence: la regola che NON deve cadere insieme a quella del code span.
+// The fence: the rule that must NOT fall together with the code span one.
 
-test('fence: un riferimento in un blocco di codice resta testo', () => {
+test('fence: a reference inside a code block stays text', () => {
     assert.equal(links(md('```\ncat ClientEvents.cs:208\n```')), 0);
 });
 
-test('fence: nemmeno con un linguaggio dichiarato', () => {
+test('fence: not even with a declared language', () => {
     assert.equal(links(md('```bash\nvim Foo.cs:12\n```')), 0);
 });
 
-test('fence: il pulsante Copia resta, e legge dal pre', () => {
-    // Un link dentro il blocco romperebbe la copia: cv-copy-btn prende il testo dal <pre> fratello.
+test('fence: the Copy button stays, and reads from the pre', () => {
+    // A link inside the block would break the copy: cv-copy-btn takes its text from the sibling <pre>.
     const html = md('```\nFoo.cs:12\n```');
     assert.match(html, /<cv-copy-btn[^>]*frompre="1"/);
 });
 
-test('tabella: il pulsante Copia porta il markdown sorgente, non il DOM', () => {
-    // Pipe e riga di allineamento devono sopravvivere: e' cio' che rende il paste ri-parsabile.
+test('table: the Copy button carries the markdown source, not the DOM', () => {
+    // Pipes and the alignment row must survive: that is what makes the paste re-parsable.
     const src = '| a | b |\n|:--|--:|\n| 1 | 2 |';
     const html = md(src + '\n');
     assert.match(html, /<div class="cv-md-table-wrap">/);
@@ -73,44 +73,44 @@ test('tabella: il pulsante Copia porta il markdown sorgente, non il DOM', () => 
     assert.equal(text.replace(/&quot;/g, '"').replace(/&amp;/g, '&'), src);
 });
 
-test('tabella: le celle restano renderizzate da marked', () => {
+test('table: the cells stay rendered by marked', () => {
     assert.equal(links(md('| file |\n|---|\n| ClientEvents.cs:208 |\n')), 1);
 });
 
-// Gli attributi che il host legge al click. Non passano da DOMPurify qui, ma la ADD_ATTR di
-// markdown.ts deve elencarli tutti: data-line-end mancava mentre il renderer lo emetteva da sempre,
-// e l'intervallo apriva senza selezionare.
+// The attributes the host reads on click. They do not go through DOMPurify here, but markdown.ts's
+// ADD_ATTR must list them all: data-line-end was missing while the renderer had always emitted it,
+// and a range opened without selecting.
 
-test('un intervallo emette data-line-end, in prosa e in backtick', () => {
-    for (const src of ['guarda StatsService.cs:35-48', 'guarda `StatsService.cs:35-48`']) {
+test('a range emits data-line-end, in prose and in backticks', () => {
+    for (const src of ['look at StatsService.cs:35-48', 'look at `StatsService.cs:35-48`']) {
         const html = md(src);
         assert.match(html, /data-line="35"/, src);
         assert.match(html, /data-line-end="48"/, src);
     }
 });
 
-test('una lista di righe diventa un link per riga, in entrambe le forme', () => {
-    assert.equal(links(md('AgentsPackage.cs:124,185,202 tre punti')), 3);
+test('a list of lines becomes one link per line, in both forms', () => {
+    assert.equal(links(md('AgentsPackage.cs:124,185,202 three spots')), 3);
     assert.equal(links(md('`AgentsPackage.cs:124,185,202`')), 3);
 });
 
-test('un href http resta un link esterno, non un file', () => {
+test('an http href stays an external link, not a file', () => {
     const html = md('[doc](https://example.com/a.cs:12)');
     assert.equal(links(html), 0);
     assert.match(html, /href="https:\/\/example\.com/);
 });
 
-test('un code span che non e un riferimento resta un code span', () => {
-    const html = md('esegui `npm run build` adesso');
+test('a code span that is not a reference stays a code span', () => {
+    const html = md('run `npm run build` now');
     assert.equal(links(html), 0);
     assert.match(html, /<code>npm run build<\/code>/);
 });
 
-// La ADD_ATTR di DOMPurify. Non possiamo eseguire sanitize qui (serve un window), ma il modo in cui
-// quel bug si manifesta e' un attributo emesso dai renderer e non elencato nella allow-list: il
-// confronto fra i due insiemi lo prende senza bisogno di un DOM.
+// DOMPurify's ADD_ATTR. We cannot run sanitize here (it needs a window), but the way that bug shows
+// up is an attribute emitted by the renderers and not listed in the allow-list: comparing the two
+// sets catches it without needing a DOM.
 
-test('ogni attributo emesso dai renderer e nella ADD_ATTR di DOMPurify', () => {
+test('every attribute the renderers emit is in DOMPurify ADD_ATTR', () => {
     const src = new URL('../core/markdown.ts', import.meta.url);
     const allowed = new Set(
         (readFileSync(src, 'utf8').match(/ADD_ATTR:\s*\[([^\]]*)\]/)?.[1] ?? '')
@@ -118,73 +118,70 @@ test('ogni attributo emesso dai renderer e nella ADD_ATTR di DOMPurify', () => {
             .map((s) => s.trim().replace(/^['"]|['"]$/g, ''))
             .filter(Boolean),
     );
-    // Sempre permessi da DOMPurify, non serve dichiararli.
+    // Always allowed by DOMPurify, no need to declare them.
     const builtin = new Set(['class', 'href', 'title', 'rel', 'src', 'alt', 'id', 'style']);
 
-    // Un markdown che passa da TUTTI i renderer che emettono attributi nostri.
+    // A markdown that goes through EVERY renderer emitting attributes of ours.
     const html = md(
-        'prosa Foo.cs:12-20 e `Bar.ts:34` e [x](src/Baz.cs:5)\n\n```ts\nconst a = 1;\n```',
+        'prose Foo.cs:12-20 and `Bar.ts:34` and [x](src/Baz.cs:5)\n\n```ts\nconst a = 1;\n```',
     );
     const emitted = new Set([...html.matchAll(/\s([a-z-]+)="/g)].map((m) => m[1]));
     const missing = [...emitted].filter((a) => !allowed.has(a) && !builtin.has(a));
-    assert.deepEqual(missing, [], `attributi che DOMPurify butterebbe via: ${missing.join(', ')}`);
+    assert.deepEqual(missing, [], `attributes DOMPurify would drop: ${missing.join(', ')}`);
 });
 
-// closeOpenMarkdown: il percorso dello streaming, che gira a OGNI token. Chiude i costrutti aperti
-// perche' un chunk parziale renda in modo stabile invece di ribaltare il layout a meta' risposta.
+// closeOpenMarkdown: the streaming path, which runs on EVERY token. It closes open constructs so a
+// partial chunk renders stably instead of flipping the layout halfway through a response.
 
-test('streaming: una fence aperta viene chiusa', () => {
-    assert.equal(
-        closeOpenMarkdown('testo\n```ts\nconst a = 1;'),
-        'testo\n```ts\nconst a = 1;\n```',
-    );
+test('streaming: an open fence gets closed', () => {
+    assert.equal(closeOpenMarkdown('text\n```ts\nconst a = 1;'), 'text\n```ts\nconst a = 1;\n```');
 });
 
-test('streaming: una fence gia chiusa non viene toccata', () => {
-    const t = 'testo\n```ts\nconst a = 1;\n```\ncoda';
+test('streaming: an already closed fence is left alone', () => {
+    const t = 'text\n```ts\nconst a = 1;\n```\ntail';
     assert.equal(closeOpenMarkdown(t), t);
 });
 
-test('streaming: un backtick spaiato sullultima riga viene chiuso', () => {
-    assert.equal(closeOpenMarkdown('vedi `Foo.cs:12'), 'vedi `Foo.cs:12`');
+test('streaming: an unpaired backtick on the last line gets closed', () => {
+    assert.equal(closeOpenMarkdown('see `Foo.cs:12'), 'see `Foo.cs:12`');
 });
 
-test('streaming: un backtick pari resta com e', () => {
-    const t = 'vedi `Foo.cs:12` qui';
+test('streaming: an even number of backticks stays as it is', () => {
+    const t = 'see `Foo.cs:12` here';
     assert.equal(closeOpenMarkdown(t), t);
 });
 
-test('streaming: i backtick dentro una fence aperta sono letterali', () => {
-    // Dentro un blocco i backtick non sono inline code: chiudere la fence basta, aggiungere anche
-    // un backtick spaiato romperebbe il blocco.
-    assert.equal(closeOpenMarkdown('```\nusa `x`'), '```\nusa `x`\n```');
+test('streaming: backticks inside an open fence are literal', () => {
+    // Inside a block backticks are not inline code: closing the fence is enough, adding an unpaired
+    // backtick too would break the block.
+    assert.equal(closeOpenMarkdown('```\nuse `x`'), '```\nuse `x`\n```');
 });
 
-test('streaming: un backtick spaiato su una riga PRECEDENTE non viene toccato', () => {
-    // Solo l'ultima riga e' in costruzione; una precedente e' gia' come il modello l'ha scritta.
-    const t = 'riga con ` spaiato\nriga finita';
+test('streaming: an unpaired backtick on a PREVIOUS line is left alone', () => {
+    // Only the last line is under construction; a previous one is already as the model wrote it.
+    const t = 'line with an unpaired `\nfinished line';
     assert.equal(closeOpenMarkdown(t), t);
 });
 
-test('streaming: testo vuoto resta vuoto', () => {
+test('streaming: empty text stays empty', () => {
     assert.equal(closeOpenMarkdown(''), '');
 });
 
-test('streaming: un riferimento a meta non linka, completo si', () => {
-    // Il caso che conta a ogni token: il testo cresce sotto il render. Il nome senza riga non
-    // qualifica (troppo rumoroso), quindi il link compare quando il ref e' davvero finito — e non
-    // lampeggia mentre i numeri arrivano una cifra per volta.
-    assert.equal(links(md(closeOpenMarkdown('vedi `Foo.cs'))), 0, 'senza riga: nessun link');
-    assert.equal(links(md(closeOpenMarkdown('vedi `Foo.cs:12`'))), 1, 'completo: link');
+test('streaming: a half-written reference does not link, a complete one does', () => {
+    // The case that matters on every token: the text grows under the render. A name without a line
+    // does not qualify (too noisy), so the link appears once the ref is really finished — and does
+    // not flicker while the digits arrive one at a time.
+    assert.equal(links(md(closeOpenMarkdown('see `Foo.cs'))), 0, 'no line: no link');
+    assert.equal(links(md(closeOpenMarkdown('see `Foo.cs:12`'))), 1, 'complete: link');
 });
 
-test('streaming: le cifre che arrivano una per volta spostano solo la riga, non il link', () => {
-    // "Foo.cs:1" e' gia' un riferimento valido (riga 1), quindi il link c'e' da subito e la riga si
-    // aggiorna man mano. Meglio cosi' che un link che appare e sparisce: la bolla non si muove.
+test('streaming: digits arriving one at a time move only the line, not the link', () => {
+    // "Foo.cs:1" is already a valid reference (line 1), so the link is there from the start and the
+    // line updates as it goes. Better that than a link appearing and vanishing: the bubble stays put.
     for (const [src, line] of [
-        ['vedi `Foo.cs:1`', '1'],
-        ['vedi `Foo.cs:12`', '12'],
-        ['vedi `Foo.cs:123`', '123'],
+        ['see `Foo.cs:1`', '1'],
+        ['see `Foo.cs:12`', '12'],
+        ['see `Foo.cs:123`', '123'],
     ] as const) {
         const html = md(closeOpenMarkdown(src));
         assert.equal(links(html), 1, src);

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/markdown.test.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/markdown.test.ts
@@ -77,6 +77,24 @@ test('table: the cells stay rendered by marked', () => {
     assert.equal(links(md('| file |\n|---|\n| ClientEvents.cs:208 |\n')), 1);
 });
 
+test('table: a scroll level wraps the table, inside the button wrap', () => {
+    // Measured in the chat: a table never overflows the bubble, it compresses — at 12 columns every
+    // header wraps letter by letter (144px tall against 29). Hence two levels: the outer one stays
+    // the positioning context so the copy button holds still, the inner one takes the overflow.
+    // A single level and the button scrolls away with the columns.
+    const html = md('| a | b |\n|---|---|\n| 1 | 2 |\n');
+    assert.match(
+        html,
+        /<div class="cv-md-table-wrap"><div class="cv-md-table-scroll"><table/,
+        'the scroll level goes INSIDE the wrap and around the table',
+    );
+    assert.match(
+        html,
+        /<\/table>\s*<\/div><cv-copy-btn/,
+        'the button is the scroll level sibling, not its child',
+    );
+});
+
 // The attributes the host reads on click. They do not go through DOMPurify here, but markdown.ts's
 // ADD_ATTR must list them all: data-line-end was missing while the renderer had always emitted it,
 // and a range opened without selecting.

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/permission-queue.test.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/permission-queue.test.ts
@@ -7,11 +7,11 @@ import { PermissionQueue } from '../core/permission-queue.ts';
 
 const req = (id: string): { id: string } => ({ id });
 
-test('push: la prima va a schermo, la seconda aspetta', () => {
+test('push: the first one goes on screen, the second waits', () => {
     const q = new PermissionQueue();
 
-    assert.equal(q.push(req('a')), true, 'niente a schermo -> va subito');
-    assert.equal(q.push(req('b')), false, 'una gia aperta -> aspetta');
+    assert.equal(q.push(req('a')), true, 'nothing on screen -> shows at once');
+    assert.equal(q.push(req('b')), false, 'one already open -> waits');
 
     assert.equal(q.current?.id, 'a');
     assert.deepEqual(
@@ -20,19 +20,19 @@ test('push: la prima va a schermo, la seconda aspetta', () => {
     );
 });
 
-test('push: la richiesta gia nota non entra due volte', () => {
+test('push: an already known request never enters twice', () => {
     const q = new PermissionQueue();
     q.push(req('a'));
     q.push(req('b'));
 
-    // Il CLI rimanda un can_use_tool quando il turno viene rigiocato: rispondere
-    // due volte allo stesso tool_use_id e' peggio che rispondere una volta sola.
-    assert.equal(q.push(req('a')), false, 'duplicato di quella a schermo');
-    assert.equal(q.push(req('b')), false, 'duplicato di una in attesa');
+    // The CLI resends a can_use_tool when the turn is replayed: answering the same tool_use_id
+    // twice is worse than answering it once.
+    assert.equal(q.push(req('a')), false, 'duplicate of the one on screen');
+    assert.equal(q.push(req('b')), false, 'duplicate of a waiting one');
     assert.equal(q.size, 2);
 });
 
-test('next: promuove in ordine di arrivo, poi svuota', () => {
+test('next: promotes in arrival order, then empties', () => {
     const q = new PermissionQueue();
     q.push(req('a'));
     q.push(req('b'));
@@ -40,43 +40,43 @@ test('next: promuove in ordine di arrivo, poi svuota', () => {
 
     assert.equal(q.next()?.id, 'b');
     assert.equal(q.next()?.id, 'c');
-    assert.equal(q.next(), null, 'coda finita');
+    assert.equal(q.next(), null, 'queue exhausted');
     assert.equal(q.size, 0);
 });
 
-test('drop: toglie quella a schermo e promuove la successiva', () => {
+test('drop: removes the one on screen and promotes the next', () => {
     const q = new PermissionQueue();
     q.push(req('a'));
     q.push(req('b'));
 
-    assert.equal(q.drop('a')?.id, 'b', 'ritorna chi e finito a schermo');
+    assert.equal(q.drop('a')?.id, 'b', 'returns whoever ended up on screen');
     assert.equal(q.current?.id, 'b');
 });
 
-test('drop: toglie una in attesa senza toccare quella a schermo', () => {
+test('drop: removes a waiting one without touching the one on screen', () => {
     const q = new PermissionQueue();
     q.push(req('a'));
     q.push(req('b'));
     q.push(req('c'));
 
-    // Il CLI annulla per id una richiesta superata: se restasse in coda,
-    // spunterebbe dopo chiedendo di un tool che ha gia girato.
-    assert.equal(q.drop('b')?.id, 'a', 'quella a schermo non cambia');
+    // The CLI cancels a superseded request by id: left in the queue it would pop up later
+    // asking about a tool that has already run.
+    assert.equal(q.drop('b')?.id, 'a', 'the one on screen does not change');
     assert.deepEqual(
         q.waiting.map((r) => r.id),
         ['c'],
     );
 });
 
-test('drop: id sconosciuto non tocca nulla', () => {
+test('drop: an unknown id touches nothing', () => {
     const q = new PermissionQueue();
     q.push(req('a'));
 
-    assert.equal(q.drop('mai-vista')?.id, 'a');
+    assert.equal(q.drop('never-seen')?.id, 'a');
     assert.equal(q.size, 1);
 });
 
-test('drop: l ultima lascia la coda vuota', () => {
+test('drop: the last one leaves the queue empty', () => {
     const q = new PermissionQueue();
     q.push(req('a'));
 
@@ -84,7 +84,7 @@ test('drop: l ultima lascia la coda vuota', () => {
     assert.equal(q.current, null);
 });
 
-test('clear: butta tutto, anche chi aspettava', () => {
+test('clear: throws everything away, the waiting ones included', () => {
     const q = new PermissionQueue();
     q.push(req('a'));
     q.push(req('b'));
@@ -95,12 +95,12 @@ test('clear: butta tutto, anche chi aspettava', () => {
     assert.equal(q.size, 0);
 });
 
-test('dopo clear la coda riparte pulita', () => {
+test('after clear the queue restarts clean', () => {
     const q = new PermissionQueue();
     q.push(req('a'));
     q.clear();
 
-    // Stesso id di prima: dopo un cambio sessione non e' piu un duplicato.
+    // Same id as before: after a session change it is no longer a duplicate.
     assert.equal(q.push(req('a')), true);
     assert.equal(q.current?.id, 'a');
 });

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/state-subscriptions.test.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/state-subscriptions.test.ts
@@ -40,21 +40,21 @@ class FakeHost implements ReactiveControllerHost {
     }
 }
 
-/** Quante callback lo store tiene vive per una chiave: l'unica misura che vede una
- *  sottoscrizione rimasta appesa, che contare le chiamate non rivelerebbe. */
+/** How many callbacks the store keeps alive for a key: the only measure that sees a
+ *  subscription left dangling, which counting the calls would not reveal. */
 function liveListeners(key: string): number {
     const subs = (appState as unknown as { _subs?: Map<string, Set<unknown>> })._subs;
     return subs?.get(key)?.size ?? 0;
 }
 
-test('il controller si registra sull host alla costruzione', () => {
+test('the controller registers on the host at construction', () => {
     const host = new FakeHost();
     const subs = new StateSubscriptions(host);
 
     assert.deepEqual(host.controllers, [subs]);
 });
 
-test('nessuna sottoscrizione è viva prima del connect', () => {
+test('no subscription is live before connect', () => {
     const host = new FakeHost();
     const subs = new StateSubscriptions(host);
     const seen: string[] = [];
@@ -65,7 +65,7 @@ test('nessuna sottoscrizione è viva prima del connect', () => {
     assert.deepEqual(seen, []);
 });
 
-test('dopo il connect la callback riceve i cambi', () => {
+test('after connect the callback receives the changes', () => {
     const host = new FakeHost();
     const subs = new StateSubscriptions(host);
     const seen: string[] = [];
@@ -78,7 +78,7 @@ test('dopo il connect la callback riceve i cambi', () => {
     assert.deepEqual(seen, ['k:/one', 'k:/two']);
 });
 
-test('il disconnect stacca tutto', () => {
+test('disconnect detaches everything', () => {
     const host = new FakeHost();
     const subs = new StateSubscriptions(host);
     const seen: string[] = [];
@@ -92,7 +92,7 @@ test('il disconnect stacca tutto', () => {
     assert.deepEqual(seen, ['k:/live']);
 });
 
-test('un host rimosso e reinserito torna a ricevere i cambi', () => {
+test('a host removed and re-inserted receives changes again', () => {
     const host = new FakeHost();
     const subs = new StateSubscriptions(host);
     const seen: string[] = [];
@@ -108,16 +108,16 @@ test('un host rimosso e reinserito torna a ricevere i cambi', () => {
     assert.deepEqual(seen, ['k:/first', 'k:/second']);
 });
 
-// Il caso che perderebbe memoria: due connect di fila senza disconnect in mezzo. Lit chiama
-// hostConnected a ogni connectedCallback, e addController lo chiama subito se l'host è già
-// connesso. Se il secondo giro sovrascrivesse la lista di unsubscribe, il primo resterebbe
-// appeso — invisibile contando le chiamate, perché lo store tiene i listener in un Set che
-// deduplica la stessa funzione. Va misurato lo store, non la callback: dopo il disconnect
-// deve tornare esattamente al numero di partenza.
-test('un connect ripetuto non lascia sottoscrizioni appese nello store', () => {
+// The leaking case: two connects in a row with no disconnect in between. Lit calls
+// hostConnected on every connectedCallback, and addController calls it right away if the host is
+// already connected. If the second round overwrote the unsubscribe list, the first would stay
+// dangling - invisible when counting calls, because the store keeps listeners in a Set that
+// deduplicates the same function. The store is what must be measured, not the callback: after the
+// disconnect it must be back to exactly the starting count.
+test('a repeated connect leaves no dangling subscriptions in the store', () => {
     const host = new FakeHost();
     const subs = new StateSubscriptions(host);
-    // Una chiusura nuova a ogni giro: due sottoscrizioni distinte, che un Set non può fondere.
+    // A fresh closure each time: two distinct subscriptions, which a Set cannot merge.
     subs.on('workingDirectory', (v) => void v);
     subs.on('workingDirectory', (v) => void v);
     const before = liveListeners('workingDirectory');
@@ -129,7 +129,7 @@ test('un connect ripetuto non lascia sottoscrizioni appese nello store', () => {
     assert.equal(liveListeners('workingDirectory'), before);
 });
 
-test('un connect ripetuto non fa scattare la callback due volte', () => {
+test('a repeated connect does not fire the callback twice', () => {
     const host = new FakeHost();
     const subs = new StateSubscriptions(host);
     const seen: string[] = [];
@@ -142,7 +142,7 @@ test('un connect ripetuto non fa scattare la callback due volte', () => {
     assert.deepEqual(seen, ['k:/once']);
 });
 
-test('rerenderOn chiede un update per ogni chiave, senza leggere il valore', () => {
+test('rerenderOn asks for an update per key, without reading the value', () => {
     const host = new FakeHost();
     const subs = new StateSubscriptions(host);
     subs.rerenderOn('currentModel', 'permissionMode');
@@ -154,7 +154,7 @@ test('rerenderOn chiede un update per ogni chiave, senza leggere il valore', () 
     assert.equal(host.updateCount, 2);
 });
 
-test('rerenderOn smette di chiedere update dopo il disconnect', () => {
+test('rerenderOn stops asking for updates after disconnect', () => {
     const host = new FakeHost();
     const subs = new StateSubscriptions(host);
     subs.rerenderOn('currentModel');
@@ -167,7 +167,7 @@ test('rerenderOn smette di chiedere update dopo il disconnect', () => {
     assert.equal(host.updateCount, 1);
 });
 
-test('due host indipendenti non si disturbano', () => {
+test('two independent hosts do not interfere', () => {
     const a = new FakeHost();
     const b = new FakeHost();
     const subsA = new StateSubscriptions(a);
@@ -185,11 +185,11 @@ test('due host indipendenti non si disturbano', () => {
     assert.equal(b.updateCount, 2);
 });
 
-// Tutte le chiamate a on() dei componenti stanno nel constructor, quindi prima del primo
-// connect. Se una arrivasse dopo, resterebbe muta fino al reinserimento nel DOM: il
-// controller sottoscrive solo in hostConnected. Fissato qui perché è il limite del
-// contratto, non un dettaglio implementativo.
-test('on() dopo il connect non ha effetto fino al reinserimento', () => {
+// Every on() call in the components sits in the constructor, so before the first connect. One
+// arriving later would stay mute until re-insertion in the DOM: the controller subscribes only in
+// hostConnected. Pinned here because it is the boundary of the contract, not an implementation
+// detail.
+test('on() after connect has no effect until re-insertion', () => {
     const host = new FakeHost();
     const subs = new StateSubscriptions(host);
     host.connect();
@@ -198,7 +198,7 @@ test('on() dopo il connect non ha effetto fino al reinserimento', () => {
     subs.on('workingDirectory', (v) => seen.push(v));
     appState.workingDirectory = 'k:/late-subscription';
 
-    assert.deepEqual(seen, [], 'una on() tardiva non parte da sola');
+    assert.deepEqual(seen, [], 'a late on() does not start on its own');
 
     host.disconnect();
     host.connect();

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/transcript.test.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/transcript.test.ts
@@ -26,7 +26,7 @@ function toolEntry(id: number, toolUseId: string): UiToolEntry {
 /** What cv-app uses to decide two children are the same row. */
 const childKey = (e: UiEntry): string => (e.kind === 'tool' ? e.toolUseId : `t${e.id}`);
 
-test('append: nuovo array, entry esistenti mantengono il riferimento', () => {
+test('append: new array, existing entries keep their reference', () => {
     const t = new Transcript();
     const a = userEntry(1);
     t.append(a);
@@ -34,12 +34,12 @@ test('append: nuovo array, entry esistenti mantengono il riferimento', () => {
 
     t.append(userEntry(2));
 
-    assert.notEqual(t.entries, first, 'entries deve essere un array nuovo');
-    assert.equal(t.entries[0], a, 'la entry esistente mantiene il riferimento');
+    assert.notEqual(t.entries, first, 'entries must be a new array');
+    assert.equal(t.entries[0], a, 'the existing entry keeps its reference');
     assert.equal(t.entries.length, 2);
 });
 
-test('find: ritorna la entry per id, null se assente', () => {
+test('find: returns the entry by id, null when absent', () => {
     const t = new Transcript();
     const a = userEntry(7);
     t.append(a);
@@ -48,32 +48,32 @@ test('find: ritorna la entry per id, null se assente', () => {
     assert.equal(t.find(99), null);
 });
 
-test('clear: svuota entries e index', () => {
+test('clear: empties entries and index', () => {
     const t = new Transcript();
     t.append(userEntry(1));
 
     t.clear();
 
     assert.equal(t.entries.length, 0);
-    assert.equal(t.find(1), null, 'index deve essere svuotato con le entries');
+    assert.equal(t.find(1), null, 'the index must be emptied along with the entries');
 });
 
-test('update: sostituisce la entry, gli altri rami restano invariati', () => {
+test('update: replaces the entry, the other branches stay untouched', () => {
     const t = new Transcript();
     const a = userEntry(1, 'a');
     const b = userEntry(2, 'b');
     t.append(a);
     t.append(b);
 
-    const ok = t.update<UiUserEntry>(1, (e) => ({ ...e, text: 'nuovo' }));
+    const ok = t.update<UiUserEntry>(1, (e) => ({ ...e, text: 'new' }));
 
     assert.equal(ok, true);
-    assert.notEqual(t.entries[0], a, 'la entry aggiornata ha un riferimento nuovo');
-    assert.equal((t.entries[0] as UiUserEntry).text, 'nuovo');
-    assert.equal(t.entries[1], b, 'i rami non toccati mantengono il riferimento');
+    assert.notEqual(t.entries[0], a, 'the updated entry has a new reference');
+    assert.equal((t.entries[0] as UiUserEntry).text, 'new');
+    assert.equal(t.entries[1], b, 'untouched branches keep their reference');
 });
 
-test('update: id assente ritorna false senza lanciare', () => {
+test('update: a missing id returns false without throwing', () => {
     const t = new Transcript();
 
     assert.equal(
@@ -82,7 +82,7 @@ test('update: id assente ritorna false senza lanciare', () => {
     );
 });
 
-test('appendText: concatena e ricrea solo quella entry', () => {
+test('appendText: concatenates and recreates only that entry', () => {
     const t = new Transcript();
     const a = userEntry(1, 'ab');
     const b = userEntry(2, 'x');
@@ -91,16 +91,16 @@ test('appendText: concatena e ricrea solo quella entry', () => {
 
     assert.equal(t.appendText(1, 'cd'), true);
     assert.equal((t.entries[0] as UiUserEntry).text, 'abcd');
-    assert.equal(t.entries[1], b, 'gli altri rami restano invariati');
+    assert.equal(t.entries[1], b, 'the other branches stay untouched');
 });
 
-test('appendText: id assente ritorna false', () => {
+test('appendText: a missing id returns false', () => {
     const t = new Transcript();
 
     assert.equal(t.appendText(9, 'x'), false);
 });
 
-test('appendChild: parent, children e items nuovi; fratelli invariati', () => {
+test('appendChild: new parent, children and items; siblings untouched', () => {
     const t = new Transcript();
     const parent = toolEntry(1, 'tool-1');
     const sibling = userEntry(2);
@@ -111,16 +111,16 @@ test('appendChild: parent, children e items nuovi; fratelli invariati', () => {
 
     assert.equal(ok, true);
     const p = t.entries[0] as UiToolEntry;
-    assert.notEqual(p, parent, 'il parent ha un riferimento nuovo');
-    assert.notEqual(p.children, parent.children, 'anche il blocco children');
+    assert.notEqual(p, parent, 'the parent has a new reference');
+    assert.notEqual(p.children, parent.children, 'and so does the children block');
     assert.equal(p.children?.items.length, 1);
-    assert.equal(t.entries[1], sibling, 'il fratello mantiene il riferimento');
+    assert.equal(t.entries[1], sibling, 'the sibling keeps its reference');
 });
 
 // If the ring dropped a child by mutating items in place, the parent's children block would stay
 // identical by ===: cv-tool-row would not be updated and its ChildParts would point at removed
 // nodes.
-test('appendChild: il ring che scarta un figlio ricrea comunque il blocco children', () => {
+test('appendChild: the ring dropping a child still recreates the children block', () => {
     const t = new Transcript();
     t.append(toolEntry(1, 'tool-1'));
     for (let i = 2; i <= 4; i++) {
@@ -131,9 +131,9 @@ test('appendChild: il ring che scarta un figlio ricrea comunque il blocco childr
     t.appendChild('tool-1', userEntry(5), childKey);
 
     const after = (t.entries[0] as UiToolEntry).children;
-    assert.notEqual(after, before, 'il blocco children deve avere identita nuova');
-    assert.notEqual(after?.items, before?.items, 'e cosi items');
-    assert.equal(after?.items.length, 3, 'restano gli ultimi 3');
+    assert.notEqual(after, before, 'the children block must have a new identity');
+    assert.notEqual(after?.items, before?.items, 'and so must items');
+    assert.equal(after?.items.length, 3, 'the last 3 are kept');
     assert.equal(after?.hasMore, true);
     assert.deepEqual(
         after?.items.map((e) => e.id),
@@ -141,7 +141,7 @@ test('appendChild: il ring che scarta un figlio ricrea comunque il blocco childr
     );
 });
 
-test('appendChild: showAll tiene tutto e fa upsert invece di duplicare', () => {
+test('appendChild: showAll keeps everything and upserts instead of duplicating', () => {
     const t = new Transcript();
     t.append(toolEntry(1, 'tool-1'));
     t.update<UiToolEntry>(1, (e) => ({
@@ -153,48 +153,52 @@ test('appendChild: showAll tiene tutto e fa upsert invece di duplicare', () => {
     }
 
     // re-emitting the same child: updates in place, does not duplicate
-    t.appendChild('tool-1', userEntry(3, 'aggiornato'), childKey);
+    t.appendChild('tool-1', userEntry(3, 'updated'), childKey);
 
     const p = t.entries[0] as UiToolEntry;
-    assert.equal(p.children?.items.length, 4, 'showAll tiene tutto, upsert non duplica');
-    assert.equal((p.children?.items[1] as UiUserEntry).text, 'aggiornato');
+    assert.equal(
+        p.children?.items.length,
+        4,
+        'showAll keeps everything, upsert does not duplicate',
+    );
+    assert.equal((p.children?.items[1] as UiUserEntry).text, 'updated');
 });
 
-test('appendChild: parent inesistente ritorna false', () => {
+test('appendChild: a missing parent returns false', () => {
     const t = new Transcript();
 
     assert.equal(t.appendChild('nope', userEntry(1), childKey), false);
 });
 
-test('replaceAll: sostituisce l albero e ricostruisce l index da zero', () => {
+test('replaceAll: replaces the tree and rebuilds the index from scratch', () => {
     const t = new Transcript();
     t.append(userEntry(1));
     t.append(toolEntry(2, 'tool-2'));
     t.appendChild('tool-2', userEntry(3), childKey);
 
-    t.replaceAll([userEntry(10), toolEntry(11, 'nuovo')]);
+    t.replaceAll([userEntry(10), toolEntry(11, 'new')]);
 
     assert.equal(t.entries.length, 2);
-    assert.equal(t.find(1), null, 'gli id vecchi non devono sopravvivere');
-    assert.equal(t.find(3), null, 'nemmeno quelli annidati');
+    assert.equal(t.find(1), null, 'the old ids must not survive');
+    assert.equal(t.find(3), null, 'nor the nested ones');
     assert.equal(t.find(10)?.id, 10);
 });
 
-test('replaceAll: indicizza anche i figli annidati gia presenti', () => {
+test('replaceAll: indexes nested children that are already there', () => {
     const parent = toolEntry(1, 'p');
     parent.children = { items: [userEntry(2)], hasMore: false, showAll: false };
     const t = new Transcript();
 
     t.replaceAll([parent]);
 
-    assert.equal(t.find(2)?.id, 2, 'i figli arrivati da history devono essere indicizzati');
+    assert.equal(t.find(2)?.id, 2, 'children coming from history must be indexed');
     assert.equal(
         t.update<UiUserEntry>(2, (e) => ({ ...e, text: 'x' })),
         true,
     );
 });
 
-test('prepend: mette in testa e mantiene l index coerente', () => {
+test('prepend: puts entries at the head and keeps the index consistent', () => {
     const t = new Transcript();
     t.append(userEntry(5));
 
@@ -205,10 +209,10 @@ test('prepend: mette in testa e mantiene l index coerente', () => {
         [1, 2, 5],
     );
     assert.equal(t.find(1)?.id, 1);
-    assert.equal(t.find(5)?.id, 5, 'anche gli id preesistenti restano risolvibili');
+    assert.equal(t.find(5)?.id, 5, 'pre-existing ids stay resolvable too');
 });
 
-test('updateMany: aggiorna N entry in un colpo', () => {
+test('updateMany: updates N entries in one go', () => {
     const t = new Transcript();
     t.append(userEntry(1, 'a'));
     t.append(userEntry(2, 'b'));
@@ -221,7 +225,7 @@ test('updateMany: aggiorna N entry in un colpo', () => {
     assert.equal((t.entries[1] as UiUserEntry).text, 'b!');
 });
 
-test('findToolByAgentId: trova la riga Agent che ha lanciato il sub-agent', () => {
+test('findToolByAgentId: finds the Agent row that launched the sub-agent', () => {
     const t = new Transcript();
     const row = toolEntry(1, 'tool-1');
     row.agentId = 'agent-42';
@@ -234,7 +238,7 @@ test('findToolByAgentId: trova la riga Agent che ha lanciato il sub-agent', () =
 // "Show all" on an Agent still running: the fetch replaces children.items with the whole history,
 // but those children never go through appendChild. Without a reindex they stay out of the index,
 // the live event arriving right after does not find them and the update hits the wrong branch.
-test('update: sostituire children.items indicizza i figli arrivati da fuori', () => {
+test('update: replacing children.items indexes the children arriving from outside', () => {
     const t = new Transcript();
     t.append(toolEntry(1, 'agent'));
     t.appendChild('agent', userEntry(2), childKey);
@@ -250,28 +254,28 @@ test('update: sostituire children.items indicizza i figli arrivati da fuori', ()
     }));
 
     // the agent is still working: an event arrives for a child of the replaced list
-    assert.equal(t.find(11)?.id, 11, 'i figli sostituiti devono essere raggiungibili');
+    assert.equal(t.find(11)?.id, 11, 'the replaced children must be reachable');
     assert.equal(
-        t.update<UiUserEntry>(11, (e) => ({ ...e, text: 'aggiornato' })),
+        t.update<UiUserEntry>(11, (e) => ({ ...e, text: 'updated' })),
         true,
-        'update deve raggiungere un figlio arrivato dalla sostituzione',
+        'update must reach a child that came in with the replacement',
     );
     assert.equal(t.findTool('inner')?.id, 12);
-    assert.equal(t.find(2), null, 'il figlio rimpiazzato non deve piu risolvere');
+    assert.equal(t.find(2), null, 'the replaced child must no longer resolve');
 });
 
-test('appendChild annidato: l index risolve un figlio di figlio', () => {
+test('nested appendChild: the index resolves a child of a child', () => {
     const t = new Transcript();
     t.append(toolEntry(1, 'outer'));
     t.appendChild('outer', toolEntry(2, 'inner'), childKey);
-    t.appendChild('inner', userEntry(3, 'profondo'), childKey);
+    t.appendChild('inner', userEntry(3, 'deep'), childKey);
 
     assert.equal(t.find(3)?.id, 3);
     assert.equal(t.findTool('inner')?.id, 2);
     assert.equal(
         t.update<UiUserEntry>(3, (e) => ({ ...e, text: 'x' })),
         true,
-        'update deve raggiungere un figlio di secondo livello',
+        'update must reach a second-level child',
     );
 });
 
@@ -279,7 +283,7 @@ function assistantEntry(id: number, uuid?: string): UiAssistantEntry {
     return { kind: 'text', id, role: 'assistant', text: 'a', uuid };
 }
 
-test('removeByUuid: toglie solo le entry nominate', () => {
+test('removeByUuid: removes only the named entries', () => {
     const t = new Transcript();
     t.append(assistantEntry(1, 'u1'));
     t.append(assistantEntry(2, 'u2'));
@@ -292,19 +296,19 @@ test('removeByUuid: toglie solo le entry nominate', () => {
     );
 });
 
-test('removeByUuid: uuid sconosciuti sono un no-op, e ripeterlo non cambia nulla', () => {
+test('removeByUuid: unknown uuids are a no-op, and repeating it changes nothing', () => {
     const t = new Transcript();
     t.append(assistantEntry(1, 'u1'));
     const before = t.entries;
 
-    assert.equal(t.removeByUuid(['mai-visto']), 0, 'un uuid ignoto non rimuove niente');
-    assert.equal(t.entries, before, 'senza rimozioni l array non viene ricreato');
+    assert.equal(t.removeByUuid(['never-seen']), 0, 'an unknown uuid removes nothing');
+    assert.equal(t.entries, before, 'with no removals the array is not recreated');
 
     assert.equal(t.removeByUuid(['u1']), 1);
-    assert.equal(t.removeByUuid(['u1']), 0, 'la seconda volta non ha piu niente da togliere');
+    assert.equal(t.removeByUuid(['u1']), 0, 'the second time there is nothing left to remove');
 });
 
-test('removeByUuid: una entry senza uuid non viene mai toccata', () => {
+test('removeByUuid: an entry without a uuid is never touched', () => {
     const t = new Transcript();
     t.append(assistantEntry(1));
     t.append(userEntry(2));
@@ -313,20 +317,20 @@ test('removeByUuid: una entry senza uuid non viene mai toccata', () => {
     assert.equal(t.entries.length, 2);
 });
 
-test('removeByUuid: rimuovere una entry non scolla le altre dall index', () => {
+test('removeByUuid: removing an entry does not detach the others from the index', () => {
     const t = new Transcript();
     t.append(assistantEntry(1, 'u1'));
     t.append(toolEntry(2, 'outer'));
     t.appendChild('outer', userEntry(3), childKey);
 
     assert.equal(t.removeByUuid(['u1']), 1);
-    // La rimozione ricostruisce l index: se lo facesse a meta, i figli della entry SOPRAVVISSUTA
-    // resterebbero indicizzati sul percorso vecchio e un evento per loro finirebbe altrove.
-    assert.equal(t.find(3)?.id, 3, 'il figlio di una entry rimasta deve ancora risolvere');
+    // The removal rebuilds the index: doing it halfway would leave the children of the SURVIVING
+    // entry indexed on the old path, and an event for them would land elsewhere.
+    assert.equal(t.find(3)?.id, 3, 'the child of a surviving entry must still resolve');
     assert.equal(t.findTool('outer')?.id, 2);
 });
 
-test('removeByUuid: onRemoved riceve anche i figli della entry rimossa', () => {
+test('removeByUuid: onRemoved also receives the children of the removed entry', () => {
     const t = new Transcript();
     const seen: number[][] = [];
     t.onRemoved = (ids) => seen.push([...ids]);
@@ -336,10 +340,10 @@ test('removeByUuid: onRemoved riceve anche i figli della entry rimossa', () => {
     t.appendChild('outer', userEntry(3), childKey);
 
     t.removeByUuid(['u1']);
-    assert.deepEqual(seen, [[1]], 'una entry senza figli riporta solo se stessa');
+    assert.deepEqual(seen, [[1]], 'an entry without children reports only itself');
 
-    // Chi ha messo in mappa l id di una riga annidata resta appeso quanto chi ha messo il padre:
-    // l evento deve nominare l intero sottoalbero, non la sola radice.
+    // Whoever mapped the id of a nested row is left dangling just like whoever mapped the parent:
+    // the event must name the whole subtree, not just the root.
     seen.length = 0;
     const t2 = new Transcript();
     t2.onRemoved = (ids) => seen.push([...ids]);
@@ -351,63 +355,63 @@ test('removeByUuid: onRemoved riceve anche i figli della entry rimossa', () => {
     assert.deepEqual(seen, [[10, 11, 12]]);
 });
 
-test('removeByUuid: senza rimozioni onRemoved non scatta', () => {
+test('removeByUuid: with no removals onRemoved does not fire', () => {
     const t = new Transcript();
     let calls = 0;
     t.onRemoved = () => calls++;
     t.append(assistantEntry(1, 'u1'));
 
-    t.removeByUuid(['altro']);
+    t.removeByUuid(['other']);
     assert.equal(calls, 0);
 });
 
-test('removeByUuid: raggiunge anche una entry annidata in un sub-agent', () => {
+test('removeByUuid: reaches an entry nested inside a sub-agent too', () => {
     const t = new Transcript();
     const removed: number[][] = [];
     t.onRemoved = (ids) => removed.push([...ids]);
 
     t.append(toolEntry(1, 'agent'));
-    t.appendChild('agent', assistantEntry(2, 'dentro'), childKey);
+    t.appendChild('agent', assistantEntry(2, 'inside'), childKey);
     t.appendChild('agent', userEntry(3), childKey);
 
-    assert.equal(t.removeByUuid(['dentro']), 1);
-    assert.equal(t.find(2), null, 'la entry annidata deve sparire');
-    assert.equal(t.find(3)?.id, 3, 'i fratelli restano');
-    assert.equal(t.findTool('agent')?.id, 1, 'il parent resta');
+    assert.equal(t.removeByUuid(['inside']), 1);
+    assert.equal(t.find(2), null, 'the nested entry must disappear');
+    assert.equal(t.find(3)?.id, 3, 'the siblings stay');
+    assert.equal(t.findTool('agent')?.id, 1, 'the parent stays');
     assert.deepEqual(removed, [[2]]);
 });
 
-test('removeByUuid: un ramo senza rimozioni mantiene la sua identita', () => {
+test('removeByUuid: a branch with no removals keeps its identity', () => {
     const t = new Transcript();
     t.append(assistantEntry(1, 'u1'));
-    t.append(toolEntry(2, 'intatto'));
-    t.appendChild('intatto', userEntry(3), childKey);
+    t.append(toolEntry(2, 'untouched'));
+    t.appendChild('untouched', userEntry(3), childKey);
     const before = t.entries[1];
 
     t.removeByUuid(['u1']);
 
-    // Se il prune ricreasse anche i rami non toccati, Lit rirenderizzerebbe l intero sottoalbero
-    // del sub-agent a ogni retraction.
-    assert.equal(t.entries[0], before, 'il ramo non toccato mantiene il riferimento');
+    // If the prune recreated the untouched branches too, Lit would re-render the sub-agent's whole
+    // subtree on every retraction.
+    assert.equal(t.entries[0], before, 'the untouched branch keeps its reference');
 });
 
-test('moveToEnd: la bolla accodata scende in fondo', () => {
+test('moveToEnd: the queued bubble moves to the bottom', () => {
     const t = new Transcript();
-    t.append({ ...userEntry(1), uuid: 'chiesto' });
-    t.append({ ...userEntry(2, 'in coda'), uuid: 'in-coda' });
-    t.append(assistantEntry(3, 'risposta'));
+    t.append({ ...userEntry(1), uuid: 'asked' });
+    t.append({ ...userEntry(2, 'queued'), uuid: 'queued' });
+    t.append(assistantEntry(3, 'answer'));
 
-    assert.equal(t.moveToEnd('in-coda'), true);
+    assert.equal(t.moveToEnd('queued'), true);
 
-    // Senza lo spostamento buildGroups aprirebbe l exchange su 2 e la risposta a 1 finirebbe
-    // sotto la domanda sbagliata.
+    // Without the move buildGroups would open the exchange on 2 and the answer to 1 would land
+    // under the wrong question.
     assert.deepEqual(
         t.entries.map((e) => e.id),
         [1, 3, 2],
     );
 });
 
-test('moveToEnd: index coerente dopo lo spostamento', () => {
+test('moveToEnd: index stays consistent after the move', () => {
     const t = new Transcript();
     t.append({ ...userEntry(1), uuid: 'a' });
     t.append(toolEntry(2, 'agent'));
@@ -415,17 +419,17 @@ test('moveToEnd: index coerente dopo lo spostamento', () => {
 
     t.moveToEnd('a');
 
-    assert.equal(t.find(1)?.id, 1, 'la entry spostata resta raggiungibile');
-    assert.equal(t.find(3)?.id, 3, 'i figli scalati di posizione restano indicizzati');
+    assert.equal(t.find(1)?.id, 1, 'the moved entry stays reachable');
+    assert.equal(t.find(3)?.id, 3, 'children shifted in position stay indexed');
 });
 
-test('moveToEnd: uuid assente o gia in fondo non tocca nulla', () => {
+test('moveToEnd: a missing uuid or one already last touches nothing', () => {
     const t = new Transcript();
     t.append({ ...userEntry(1), uuid: 'a' });
     t.append({ ...userEntry(2), uuid: 'b' });
     const before = t.entries;
 
-    assert.equal(t.moveToEnd('mai-visto'), false);
-    assert.equal(t.moveToEnd('b'), false, 'gia ultima');
-    assert.equal(t.entries, before, 'nessun nuovo array, Lit non rirenderizza');
+    assert.equal(t.moveToEnd('never-seen'), false);
+    assert.equal(t.moveToEnd('b'), false, 'already last');
+    assert.equal(t.entries, before, 'no new array, Lit does not re-render');
 });

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/markdown.css
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/markdown.css
@@ -148,6 +148,13 @@
     display: inline-block;
     max-width: 100%;
 }
+
+/* The scroll lives on this inner level, never on the wrapper: the wrapper is what positions the
+ * copy button, and a button anchored to a scrolling box slides away with the columns. */
+.cv-md-table-scroll {
+    overflow-x: auto;
+    max-width: 100%;
+}
 .cv-md-table-copy-btn::part(button) {
     position: absolute;
     top: 4px;
@@ -165,11 +172,23 @@
     margin: 4px 0;
     color: var(--colorNeutralForeground3);
 }
+/* max-content is what makes the scroll above reachable at all: bounded by the bubble a table never
+ * overflows, it compresses — at 12 columns the headers wrapped letter by letter, three lines tall,
+ * with nothing to scroll because nothing stuck out. Columns take the width they need instead, and
+ * the overflow becomes real. A narrow table is unaffected: max-content is smaller than the bubble. */
 .md table {
     border-collapse: collapse;
     margin: 0.6em 0;
     font-size: var(--fontSizeBase200);
     border: 1px solid var(--colorNeutralStroke1);
+    width: max-content;
+    max-width: none;
+}
+
+/* Headers on one line: they are the shortest text in the table, so wrapping them buys no width
+ * while costing every row's height. Cells still wrap — a long path has to break somewhere. */
+.md th {
+    white-space: nowrap;
 }
 .md th,
 .md td {


### PR DESCRIPTION
Two independent changes to the WebView, both under `Chat/WebViewSrc`.

## 1. A wide markdown table scrolls (`1ed1dc0`)

A table bounded by the bubble never overflows it — it **compresses**. Measured in the chat with tables of 2, 4, 6, 9 and 12 columns:

| columns | table width | headers wrapped | header height |
|---|---|---|---|
| 2 | 211px | 0 | 29px |
| 4 | 341px | 0 | 29px |
| 6 | 566px (capped) | 6 | 48px |
| 9 | 566px (capped) | 9 | 68px |
| 12 | 566px (capped) | 12 | **144px** |

`scrollWidth === clientWidth` on every one of them: nothing was ever cut, everything was there, and at 12 columns none of it could be read — headers wrapping letter by letter, five lines tall.

That is also why `overflow-x` alone would have fixed nothing: a scrollbar on a box whose content never sticks out never appears. **`width: max-content` is what gives the table a natural width to exceed with**, and only then does the scroll have anything to scroll. The two are useless apart.

The scroll goes on a **new inner div**, not on the wrapper: the wrapper is what positions the copy button, and a button anchored to a scrolling box slides away with the columns — the defect the long-code-block TODO entry describes.

Narrow tables are untouched: `max-content` is smaller than the bubble at 2-4 columns, so they keep their own width and the button stays beside them.

**Note for the TODO**: the entry for this bug (Bug ⭐⭐, "a markdown table wider than the bubble is cut with no way to see the rest") has the right remedy but the **wrong diagnosis** — it says the table is silently cut. It is not; it is squeezed. Anyone implementing it to the letter would have added `overflow-x: auto` and found the table still unreadable.

## 2. The WebView tests speak English (`00e8afd`)

`CLAUDE.md` asks for English comments everywhere, including in files whose prose is Italian. Every source file honoured that except `tests/`, written in one go in Italian: comments, test names, assertion messages and the filler prose inside fixtures.

Test names go too, not just comments: they are what a failing run prints, and a stack trace that reads half in one language is worse than either.

Fixtures were translated **only** where the Italian was filler around what is under test. The literals the parsers match on stay: the en-dash in `StatsService.cs:35–48`, the dotted directory in a real project path, the space before a bare `.ts`. Where a fixture changed, its assertion changed with it, so each test proves what it proved before.

## Verification

- `npm test` — **178 passing, 0 failing** (177 before, +1 for the new table test)
- `npm run typecheck` — clean
- `npm run lint` — 0 errors, 7 pre-existing `no-explicit-any` warnings (already tracked in TODO)
- `npx prettier --check` — clean
- `npm run build` — bundle rebuilt

The table fix was written test-first: the new test fails on `master` and passes here.

## Not verified

The visual result in the Exp instance. Worth a look at a **narrow** table (2 columns) to confirm the copy button still sits beside it rather than far right — that is the open question the TODO entry itself raised about `display: inline-block` on the wrapper.
