### PR TITLE
feat(file-history): see what the file backups cost, and delete the ones you don't want

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,9 @@ own.
   - **[Context usage](docs/context-usage.md)** — for any historical session, how it fills the model's
     context window: a memory-map, category table and expandable trees (memory files, agents, skills,
     MCP tools), fetched read-only by resuming the session.
+  - **[File history](docs/file-history.md)** — what the CLI's file backups cost on disk, per project
+    and per session, with a diff against the file as it is now and a way to delete the ones you no
+    longer want (orphaned ones included).
 - **[Plugin manager](docs/chat/plugins.md)** — install from a marketplace, enable/disable what you have,
   add marketplaces — from Installed / Available / Marketplaces tabs, without leaving the chat.
 - **Talk to it** — dictate the prompt instead of typing it: a mic button in the composer transcribes

--- a/docs/chat/rewind.md
+++ b/docs/chat/rewind.md
@@ -44,7 +44,8 @@ Messages that changed no file are not listed at all — there would be nothing t
 
 Under `~/.claude/file-history/<session-id>/`, one folder per session, holding whole files rather
 than diffs. They belong to the CLI, are private to their session, and **are not cleaned up**: they
-stay until you delete the folder.
+stay until the folder is deleted. **[File history](../file-history.md)** shows what they cost across
+every session, and deletes the ones you no longer want.
 
 That is the reason the feature can be turned off. **Keep file checkpoints (Rewind)**
 (**[Options → Chat → Files](../options.md#chat)**, on by default) decides whether the CLI takes

--- a/docs/file-history.md
+++ b/docs/file-history.md
@@ -1,0 +1,76 @@
+# File history
+
+A full-window view under **View → cv4vs Agents → Analytics → File history**: what the CLI's file
+backups occupy on disk, which files each session preserved, and a way to delete the ones you no
+longer want. It opens as a document-tab in the editor area, next to [Statistics](statistics.md),
+[Usage](usage.md) and [Context usage](context-usage.md).
+
+## What it reads
+
+Before overwriting a file, the CLI copies it into `~/.claude/file-history/<session>/`. Those copies
+are what a rewind restores from — and **nothing prunes them**: they stay after the session ends, and
+after the transcript itself is deleted. On a development machine a few dozen sessions come to tens of
+megabytes.
+
+The copies are named by a hash of the path plus a version (`072f0f4b…@v6`), so the folder alone can't
+say which file a copy belongs to. That mapping lives in the session transcript, in the
+`file-history-snapshot` records — which is why the file list is read only when you select a session.
+
+Everything here is read from the local `~/.claude/` of each configured profile. No CLI process is
+started and nothing is sent anywhere.
+
+## The tree (left)
+
+**Config-dir → project → session**, with the newest backup date and the size on every row. Sessions
+are the leaves: a row is one `file-history/<session>/` folder.
+
+- The **config-dir** level appears only when profiles resolve to more than one. Several profiles
+  usually share `~/.claude`, and a tree rooted on profiles would count the same megabytes twice, so
+  the root is the directory — the tooltip names the profiles using it.
+- **Sessions no longer on disk** is a group of its own, last in the list: backups whose transcript is
+  gone. Nothing else refers to them, which makes them the first thing worth deleting. Their real file
+  paths can't be recovered — without the transcript, only the folder is left to open or delete.
+
+Click **Name**, **Date** or **Size** to sort; click the same header again to reverse it. The
+ordering applies to every level at once, and an arrow marks the column in effect. There is no date
+*filter* on purpose: it would hide exactly the old sessions this view exists to find.
+
+**Refresh** re-reads the folders. Nothing is indexed and nothing is cached — the sizes come from the
+filesystem, which already knows them.
+
+## The files (right)
+
+Selecting a session shows what it backed up: **file, version, size, and when the copy was taken**,
+newest-largest first. The tiles above give the session's totals — size on disk, distinct files,
+copies (one per version of each file), and the date of the last one.
+
+- **Double-click a row** — or **Compare with the current file** — opens a diff between the backup and
+  the file as it is now, in Visual Studio's own diff viewer.
+- **Save a copy as…** writes the backup wherever you choose. It is deliberately *not* called
+  "Restore": it saves a file and leaves both your working copy and the conversation alone. Going back
+  in a conversation is [rewind](chat/rewind.md), which lives in the chat pane.
+- **Open the backup folder** shows `file-history/<session>/` in Explorer.
+
+A transcript can name a copy the CLI has since pruned; such rows are left out rather than shown as
+entries that can be neither diffed nor saved.
+
+## Deleting
+
+Tick sessions in the tree — a parent ticks everything under it — and press the delete button. The
+confirmation names how many sessions, copies and files go, and how many megabytes that frees.
+
+Two things are worth knowing before you press it:
+
+- **Your project files are never touched.** Only the copies under `file-history/` are removed.
+- **The copies are gone for good**, and rewinding those sessions stops working. The transcript keeps
+  the records, but the files they point at will not be there.
+
+A session that an open pane is driving **cannot** be deleted: its checkbox is disabled and the status
+bar says how many are held that way. Deleting the copies a live rewind restores from would break it
+half-way, so the consequence sits in the control rather than in a warning you can click past.
+
+## What it is not
+
+This is an archive, not a second rewind. It shows and deletes; it never writes into a conversation.
+Restoring files *and* moving a session back is [rewind](chat/rewind.md), and it only works on the
+session its own pane is driving — the running CLI knows nothing about the others.

--- a/docs/settings-and-data.md
+++ b/docs/settings-and-data.md
@@ -78,7 +78,9 @@ Chat sessions, CLI settings, plugins and skills belong to `claude.exe` and live 
 `file-history/` holds **whole files**, not diffs — one copy per file per turn that edited it — and
 the CLI never removes them. Deleting a session's folder only costs you the ability to
 [rewind](chat/rewind.md) that session; turning **Keep file checkpoints** off
-([Options → Chat](options.md#chat)) stops new ones being written at all.
+([Options → Chat](options.md#chat)) stops new ones being written at all. The
+**[File history](file-history.md)** tab measures what they occupy, per project and per session, and
+deletes them from there — backups whose transcript is already gone included.
 
 We **read** the session `.jsonl` files directly (that's how history, resume, rename and the
 usage stats work) and write only a `custom-title` entry when you rename a session. Because

--- a/src/Corsinvest.VisualStudio.Agents/AgentsPackage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/AgentsPackage.cs
@@ -59,6 +59,7 @@ namespace Corsinvest.VisualStudio.Agents;
 [ProvideToolWindow(typeof(Core.Stats.StatisticsWindow), Style = VsDockStyle.MDI)]
 [ProvideToolWindow(typeof(Core.Usage.UsageWindow), Style = VsDockStyle.MDI)]
 [ProvideToolWindow(typeof(Core.Context.ContextWindow), Style = VsDockStyle.MDI)]
+[ProvideToolWindow(typeof(Core.FileHistory.FileHistoryWindow), Style = VsDockStyle.MDI)]
 [Guid(PackageGuids.AgentsPackageString)]
 public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolutionEvents7, IVsSolutionLoadEvents, IVsDebuggerEvents
 {

--- a/src/Corsinvest.VisualStudio.Agents/AgentsPackage.vsct
+++ b/src/Corsinvest.VisualStudio.Agents/AgentsPackage.vsct
@@ -241,6 +241,12 @@
         <CommandFlag>IconIsMoniker</CommandFlag>
         <Strings><ButtonText>Context usage</ButtonText></Strings>
       </Button>
+      <Button guid="guidAgentsCommandSet" id="FileHistoryCommandId" priority="0x0400" type="Button">
+        <Parent guid="guidAgentsCommandSet" id="AnalyticsGroup"/>
+        <Icon guid="ImageCatalogGuid" id="HardDrive"/>
+        <CommandFlag>IconIsMoniker</CommandFlag>
+        <Strings><ButtonText>File history</ButtonText></Strings>
+      </Button>
 
       <Button guid="guidAgentsCommandSet" id="DocumentationCommandId" priority="0x0100" type="Button">
         <Parent guid="guidAgentsCommandSet" id="HelpDocsGroup"/>
@@ -330,6 +336,7 @@
       <IDSymbol name="UsageCommandId" value="0x020A" />
       <IDSymbol name="ContextUsageCommandId" value="0x020B" />
       <IDSymbol name="ExplainCommandId" value="0x020C" />
+      <IDSymbol name="FileHistoryCommandId" value="0x020D" />
       <!-- Seed of the open-panes dynamic range. Its own 0x03xx block: the range grows with the
            number of open panes and must not run into the fixed ids above. -->
       <IDSymbol name="ActiveSessionCommandId" value="0x0300" />

--- a/src/Corsinvest.VisualStudio.Agents/Core/FileHistory/FileHistoryControl.Render.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/FileHistory/FileHistoryControl.Render.cs
@@ -1,0 +1,287 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using Corsinvest.VisualStudio.Agents.Core.Sessions;
+using Corsinvest.VisualStudio.Agents.Helpers;
+using Microsoft.VisualStudio.Shell;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace Corsinvest.VisualStudio.Agents.Core.FileHistory;
+
+/// <summary>The right-hand panel and the actions on it: the tiles, the file list, the diff, the
+/// save-a-copy, and the delete. Split from the tree half the way Context usage splits its render,
+/// so neither file has to be read to work on the other.</summary>
+public partial class FileHistoryControl
+{
+    /// <summary>One row of the file list — a backed-up file with the copy that holds it.</summary>
+    internal sealed class BackupRow
+    {
+        /// <summary>As the CLI spelled it: relative to the working directory when it sits under it.</summary>
+        public string RecordedPath { get; set; }
+
+        /// <summary>Absolute, for the diff and for opening the file.</summary>
+        public string FullPath { get; set; }
+
+        /// <summary>The copy under `file-history/&lt;session&gt;/`.</summary>
+        public string BackupPath { get; set; }
+
+        public int Version { get; set; }
+        public long Bytes { get; set; }
+        public DateTime BackupTime { get; set; }
+
+        /// <summary>Directory dimmed to a leading ellipsis: the interesting half is the file name,
+        /// and the paths share most of their length.</summary>
+        public string DisplayPath
+        {
+            get
+            {
+                var dir = Path.GetDirectoryName(RecordedPath) ?? "";
+                var name = Path.GetFileName(RecordedPath);
+                if (dir.Length == 0) { return name; }
+                return dir.Length <= 34 ? Path.Combine(dir, name) : "…" + dir.Substring(dir.Length - 34) + Path.DirectorySeparatorChar + name;
+            }
+        }
+
+        public string SizeText => FileHistoryService.Format.Size(Bytes);
+        public string BackupTimeText => BackupTime == default ? "" : BackupTime.ToString("d MMM HH:mm");
+    }
+
+    private void ShowGroup(FileHistoryTreeNode node)
+    {
+        if (node == null) { ShowMessage("Select a session to see the files it backed up."); return; }
+
+        TilesPanel.Children.Clear();
+        var sessions = node.Children.Count(c => c.Kind == FileHistoryNodeKind.Session);
+        AddTile(FileHistoryService.Format.Size(node.Bytes), "on disk");
+        if (sessions > 0) { AddTile(sessions.ToString(), "sessions"); }
+
+        MessageText.Text = node.Kind == FileHistoryNodeKind.Orphans
+            ? "These backups belong to transcripts that are no longer on disk. Nothing else refers to them."
+            : "Select a session to see the files it backed up.";
+        MessageText.Visibility = Visibility.Visible;
+        FilesList.Visibility = Visibility.Collapsed;
+        FilesHead.Text = "FILES";
+    }
+
+    // A session was picked: tiles from the scan (already in hand), the file list from its transcript.
+    private void ShowSession(FileHistoryTreeNode node)
+    {
+        var session = node.Session;
+        TilesPanel.Children.Clear();
+        AddTile(FileHistoryService.Format.Size(session.Bytes), "on disk");
+        AddTile(session.FileCount.ToString(), "files");
+        AddTile(session.CopyCount.ToString(), "copies");
+        AddTile(session.LastWrite.ToString("d MMM"), "last");
+
+        FilesHead.Text = $"FILES · {session.SessionId}";
+
+        if (session.IsOrphan)
+        {
+            // No transcript, so no path for any of the copies — only the folder is left to open.
+            MessageText.Text = "The transcript is gone, so the real paths of these copies are unknown. "
+                             + "The folder can still be opened or deleted.";
+            MessageText.Visibility = Visibility.Visible;
+            FilesList.Visibility = Visibility.Collapsed;
+            FilesList.ItemsSource = null;
+            return;
+        }
+
+        // The recorded paths are relative to the session's working directory when they sit under
+        // it, so the absolute form needs the cwd the project was run from.
+        var cwd = Stats.StatsService.CwdForProject(node.Profile, session.ProjectDir);
+
+        List<BackupRow> rows;
+        try
+        {
+            rows = ReadRows(node.Paths, cwd, session);
+        }
+        catch (Exception ex)
+        {
+            OutputWindowLogger.Global.LogException("FileHistoryControl.ShowSession", ex);
+            MessageText.Text = "Could not read the transcript — see the output log.";
+            MessageText.Visibility = Visibility.Visible;
+            FilesList.Visibility = Visibility.Collapsed;
+            return;
+        }
+
+        if (rows.Count == 0)
+        {
+            MessageText.Text = "The transcript records no backups for this session.";
+            MessageText.Visibility = Visibility.Visible;
+            FilesList.Visibility = Visibility.Collapsed;
+            FilesList.ItemsSource = null;
+            return;
+        }
+
+        FilesList.ItemsSource = rows;
+        FilesList.Visibility = Visibility.Visible;
+        MessageText.Visibility = Visibility.Collapsed;
+    }
+
+    private static List<BackupRow> ReadRows(ClaudePaths paths, string cwd, FileHistoryService.SessionBackups session)
+    {
+        var manager = new SessionManager(paths, cwd ?? "", OutputWindowLogger.Global);
+        var rows = new List<BackupRow>();
+        foreach (var backup in manager.ReadAllFileBackups(session.SessionId))
+        {
+            var backupPath = Path.Combine(session.Folder, backup.BackupFileName);
+            // The CLI prunes its own history, so a transcript can name a copy that is gone. A row
+            // for a file with nothing behind it could neither be diffed nor saved.
+            if (!File.Exists(backupPath)) { continue; }
+            var info = new FileInfo(backupPath);
+            rows.Add(new BackupRow
+            {
+                RecordedPath = backup.Path,
+                FullPath = Path.IsPathRooted(backup.Path) ? backup.Path : Path.Combine(cwd ?? "", backup.Path),
+                BackupPath = backupPath,
+                Version = backup.Version,
+                Bytes = info.Length,
+                BackupTime = info.LastWriteTime,
+            });
+        }
+        rows.Sort((a, b) => b.Bytes.CompareTo(a.Bytes));
+        return rows;
+    }
+
+    private void AddTile(string value, string label)
+    {
+        // No Foreground set: the theme inherits down the live visual tree (UseVsTheme), so runtime
+        // text follows it too. Secondary text is dimmed with Opacity, never a hardcoded brush.
+        var stack = new StackPanel();
+        stack.Children.Add(new TextBlock
+        {
+            Text = value,
+            Style = (Style)Resources["TileValueStyle"],
+        });
+        stack.Children.Add(new TextBlock
+        {
+            Text = label.ToUpperInvariant(),
+            Style = (Style)Resources["TileLabelStyle"],
+        });
+        TilesPanel.Children.Add(new Border
+        {
+            Style = (Style)Resources["TileStyle"],
+            Child = stack,
+        });
+    }
+
+    // A DataGrid raises this for its column headers and its empty area too, where SelectedItem is
+    // still whatever was picked last — a double click on a header would re-open that row's diff.
+    private void OnFileDoubleClick(object sender, System.Windows.Input.MouseButtonEventArgs e)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        if (!IsInsideRow(e.OriginalSource as DependencyObject)) { return; }
+        CompareSelected();
+    }
+
+    private static bool IsInsideRow(DependencyObject source)
+    {
+        for (var d = source; d != null; d = System.Windows.Media.VisualTreeHelper.GetParent(d))
+        {
+            if (d is DataGridRow) { return true; }
+        }
+        return false;
+    }
+
+    private void OnCompareClick(object sender, RoutedEventArgs e)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        CompareSelected();
+    }
+
+    private void CompareSelected()
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        if (FilesList.SelectedItem is not BackupRow row) { return; }
+        _ = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+        {
+            try
+            {
+                var before = File.ReadAllText(row.BackupPath);
+                var current = File.Exists(row.FullPath) ? File.ReadAllText(row.FullPath) : "";
+                await Ide.IdeContextService.Instance.ShowDiffAsync(
+                    $"filehistory:{row.BackupPath}", row.FullPath, before, current,
+                    leftLabel: $"Backup v{row.Version}", rightLabel: "Current");
+            }
+            catch (Exception ex)
+            {
+                OutputWindowLogger.Global.LogException("FileHistoryControl.Compare", ex);
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                ShellHelpers.ShowMessage("Could not open the comparison — see the output log.",
+                                         "File history", warning: true);
+            }
+        });
+    }
+
+    // "Save a copy as", not "Restore": this writes a file somewhere the user picks and leaves both
+    // the project file and the conversation alone. A rewind is a different thing, and lives in the
+    // chat pane.
+    private void OnSaveCopyClick(object sender, RoutedEventArgs e)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        if (FilesList.SelectedItem is not BackupRow row) { return; }
+        var dialog = new Microsoft.Win32.SaveFileDialog
+        {
+            FileName = Path.GetFileName(row.FullPath),
+            InitialDirectory = Path.GetDirectoryName(row.FullPath),
+            Title = "Save a copy of the backup",
+            OverwritePrompt = true,
+        };
+        if (dialog.ShowDialog() != true) { return; }
+        try
+        {
+            File.Copy(row.BackupPath, dialog.FileName, overwrite: true);
+            OutputWindowLogger.Global.Info($"[filehistory] saved a copy of {row.RecordedPath} v{row.Version} to {dialog.FileName}");
+        }
+        catch (Exception ex)
+        {
+            OutputWindowLogger.Global.LogException("FileHistoryControl.SaveCopy", ex);
+            ShellHelpers.ShowMessage("Could not save the copy — see the output log.",
+                                     "File history", warning: true);
+        }
+    }
+
+    private void OnOpenFolderClick(object sender, RoutedEventArgs e)
+    {
+        var folder = _selected?.Session?.Folder;
+        if (folder != null) { ShellHelpers.OpenExternal(folder); }
+    }
+
+    private void OnDeleteClick(object sender, RoutedEventArgs e)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        var targets = _roots.SelectMany(r => r.CheckedSessions()).ToList();
+        if (targets.Count == 0) { return; }
+
+        var bytes = targets.Sum(n => n.Bytes);
+        var copies = targets.Sum(n => n.Session.CopyCount);
+        var files = targets.Sum(n => n.Session.FileCount);
+
+        // Name what goes, and what does not: the project files are the thing a user fears for here.
+        var listed = string.Join("\n", targets.Take(10).Select(n => "  " + n.Label));
+        if (targets.Count > 10) { listed += $"\n  … and {targets.Count - 10} more"; }
+        var text = $"Delete the backups of {targets.Count} session(s): {copies} copies of {files} files, "
+                 + $"{FileHistoryService.Format.Size(bytes)}.\n\n{listed}\n\n"
+                 + "Your project files are not touched. The copies cannot be recovered, and rewinding "
+                 + "these sessions will no longer work.";
+
+        if (!ShellHelpers.Confirm(text, "Delete backups")) { return; }
+
+        var failed = targets.Count(n => !FileHistoryService.Delete(n.Session));
+        if (failed > 0)
+        {
+            ShellHelpers.ShowMessage(
+                $"{failed} of {targets.Count} folder(s) could not be deleted — a running CLI may still hold them. "
+                + "See the output log.",
+                "File history", warning: true);
+        }
+        Reload();
+    }
+}

--- a/src/Corsinvest.VisualStudio.Agents/Core/FileHistory/FileHistoryControl.xaml
+++ b/src/Corsinvest.VisualStudio.Agents/Core/FileHistory/FileHistoryControl.xaml
@@ -1,0 +1,365 @@
+<UserControl x:Class="Corsinvest.VisualStudio.Agents.Core.FileHistory.FileHistoryControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vsui="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
+             xmlns:toolkit="clr-namespace:Community.VisualStudio.Toolkit;assembly=Community.VisualStudio.Toolkit"
+             xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"
+             xmlns:catalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"
+             xmlns:fh="clr-namespace:Corsinvest.VisualStudio.Agents.Core.FileHistory"
+             toolkit:Themes.UseVsTheme="True">
+  <UserControl.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <!-- The file list's context menu opens in its own popup, outside this control's visual
+             tree, where UseVsTheme cannot reach it — without these it comes up white on a dark
+             IDE. Shared with the pane toolbar. -->
+        <ResourceDictionary Source="/Corsinvest.VisualStudio.Agents;component/Themes/MenuStyles.xaml" />
+      </ResourceDictionary.MergedDictionaries>
+
+    <fh:FileHistoryIconConverter x:Key="NodeIconConverter" />
+
+    <!-- Summary tile: bordered block, large value over an uppercase label (as in Statistics). -->
+    <Style x:Key="TileStyle" TargetType="Border">
+      <Setter Property="BorderBrush"
+              Value="{DynamicResource {x:Static vsui:EnvironmentColors.ToolWindowBorderBrushKey}}" />
+      <Setter Property="BorderThickness" Value="1" />
+      <Setter Property="Padding" Value="12,8" />
+      <Setter Property="Margin" Value="0,0,10,0" />
+    </Style>
+    <Style x:Key="TileValueStyle" TargetType="TextBlock">
+      <Setter Property="FontSize" Value="20" />
+      <Setter Property="FontWeight" Value="SemiBold" />
+    </Style>
+    <Style x:Key="TileLabelStyle" TargetType="TextBlock">
+      <Setter Property="FontSize" Value="11" />
+      <Setter Property="Opacity" Value="0.7" />
+      <Setter Property="Margin" Value="0,2,0,0" />
+    </Style>
+    <Style x:Key="SectionHeadStyle" TargetType="TextBlock">
+      <Setter Property="FontSize" Value="12" />
+      <Setter Property="FontWeight" Value="SemiBold" />
+      <Setter Property="Opacity" Value="0.7" />
+      <Setter Property="Margin" Value="0,12,0,6" />
+    </Style>
+    </ResourceDictionary>
+  </UserControl.Resources>
+
+  <!-- Columns: backup tree | draggable splitter | the selected session's files. -->
+  <Grid Margin="14">
+    <Grid.RowDefinitions>
+      <RowDefinition Height="*" />
+      <RowDefinition Height="Auto" />
+    </Grid.RowDefinitions>
+    <Grid.ColumnDefinitions>
+      <ColumnDefinition Width="290" MinWidth="180" />
+      <ColumnDefinition Width="Auto" />
+      <ColumnDefinition Width="*" />
+    </Grid.ColumnDefinitions>
+
+    <!-- Column 0: a small icon toolbar over the tree. -->
+    <Grid Grid.Row="0" Grid.Column="0">
+      <Grid.RowDefinitions>
+        <RowDefinition Height="Auto" />
+        <RowDefinition Height="Auto" />
+        <RowDefinition Height="*" />
+      </Grid.RowDefinitions>
+
+      <!-- Same flat-button toolbar as Statistics / Context usage: a WPF ToolBar drags in a grip and
+           an overflow chevron that don't theme cleanly. -->
+      <StackPanel x:Name="TreeToolbar" Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,4">
+        <StackPanel.Resources>
+          <Style x:Key="ToolBtn" TargetType="Button">
+            <Setter Property="Width" Value="22" />
+            <Setter Property="Height" Value="22" />
+            <Setter Property="Padding" Value="0" />
+            <Setter Property="Margin" Value="0,0,2,0" />
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderBrush" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="Template">
+              <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                  <Border x:Name="bd" Background="{TemplateBinding Background}"
+                          BorderBrush="{TemplateBinding BorderBrush}"
+                          BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="3">
+                    <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                  </Border>
+                  <ControlTemplate.Triggers>
+                    <Trigger Property="IsMouseOver" Value="True">
+                      <Setter TargetName="bd" Property="Background"
+                              Value="{DynamicResource {x:Static vsui:EnvironmentColors.CommandBarMouseOverBackgroundBeginBrushKey}}" />
+                      <Setter TargetName="bd" Property="BorderBrush"
+                              Value="{DynamicResource {x:Static vsui:EnvironmentColors.CommandBarBorderBrushKey}}" />
+                    </Trigger>
+                    <Trigger Property="IsEnabled" Value="False">
+                      <Setter TargetName="bd" Property="Opacity" Value="0.4" />
+                    </Trigger>
+                  </ControlTemplate.Triggers>
+                </ControlTemplate>
+              </Setter.Value>
+            </Setter>
+          </Style>
+        </StackPanel.Resources>
+
+        <!-- Refresh re-enumerates the folders. There is no Recreate twin here: nothing is indexed,
+             so there is no stale cache a second button could rebuild. -->
+        <Button x:Name="RefreshButton" Style="{StaticResource ToolBtn}" Click="OnRefreshClick"
+                ToolTip="Refresh — re-read the backup folders">
+          <imaging:CrispImage Width="16" Height="16" Moniker="{x:Static catalog:KnownMonikers.Refresh}" />
+        </Button>
+        <Button x:Name="DeleteButton" Style="{StaticResource ToolBtn}" Click="OnDeleteClick"
+                IsEnabled="False" ToolTip="Delete the checked sessions' backups">
+          <imaging:CrispImage Width="16" Height="16" Moniker="{x:Static catalog:KnownMonikers.DeleteFolder}" />
+        </Button>
+      </StackPanel>
+
+      <!-- Column headers for the tree below. A TreeView has no columns of its own, so these are
+           buttons over a Grid whose widths match the item template's — the ordering lives here
+           rather than in a toolbar combo because a click also has to say WHICH way, and an arrow
+           on the sorted column says it where the reader is already looking.
+           Sorting, never filtering: a 7/30-day filter would hide exactly the old sessions this
+           pane exists to find. -->
+      <Grid Grid.Row="1" Margin="1,0,1,2">
+        <Grid.Resources>
+          <Style x:Key="HeadBtn" TargetType="Button">
+            <Setter Property="Padding" Value="4,2" />
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+            <Setter Property="Foreground"
+                    Value="{DynamicResource {x:Static vsui:EnvironmentColors.GridHeadingTextBrushKey}}" />
+            <Setter Property="Template">
+              <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                  <Border x:Name="bd" Background="{TemplateBinding Background}"
+                          Padding="{TemplateBinding Padding}">
+                    <ContentPresenter HorizontalAlignment="Stretch" VerticalAlignment="Center" />
+                  </Border>
+                  <ControlTemplate.Triggers>
+                    <Trigger Property="IsMouseOver" Value="True">
+                      <Setter TargetName="bd" Property="Background"
+                              Value="{DynamicResource {x:Static vsui:EnvironmentColors.CommandBarMouseOverBackgroundBeginBrushKey}}" />
+                    </Trigger>
+                  </ControlTemplate.Triggers>
+                </ControlTemplate>
+              </Setter.Value>
+            </Setter>
+          </Style>
+          <Style x:Key="HeadText" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="11" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="VerticalAlignment" Value="Center" />
+          </Style>
+        </Grid.Resources>
+        <Grid.ColumnDefinitions>
+          <ColumnDefinition Width="*" />
+          <ColumnDefinition Width="52" />
+          <ColumnDefinition Width="66" />
+        </Grid.ColumnDefinitions>
+        <Button Grid.Column="0" Style="{StaticResource HeadBtn}" Click="OnSortByName"
+                ToolTip="Sort by name">
+          <StackPanel Orientation="Horizontal">
+            <TextBlock Text="Name" Style="{StaticResource HeadText}" />
+            <TextBlock x:Name="NameArrow" Style="{StaticResource HeadText}" Margin="4,0,0,0" />
+          </StackPanel>
+        </Button>
+        <Button Grid.Column="1" Style="{StaticResource HeadBtn}" Click="OnSortByDate"
+                ToolTip="Sort by date">
+          <StackPanel Orientation="Horizontal">
+            <TextBlock Text="Date" Style="{StaticResource HeadText}" />
+            <TextBlock x:Name="DateArrow" Style="{StaticResource HeadText}" Margin="4,0,0,0" />
+          </StackPanel>
+        </Button>
+        <Button Grid.Column="2" Style="{StaticResource HeadBtn}" Click="OnSortBySize"
+                ToolTip="Sort by size">
+          <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+            <TextBlock Text="Size" Style="{StaticResource HeadText}" />
+            <TextBlock x:Name="SizeArrow" Style="{StaticResource HeadText}" Margin="4,0,0,0" />
+          </StackPanel>
+        </Button>
+      </Grid>
+
+      <TreeView x:Name="Tree" Grid.Row="2"
+                BorderThickness="1"
+                Background="{DynamicResource {x:Static vsui:EnvironmentColors.ToolWindowBackgroundBrushKey}}"
+                Foreground="{DynamicResource {x:Static vsui:EnvironmentColors.ToolWindowTextBrushKey}}"
+                BorderBrush="{DynamicResource {x:Static vsui:EnvironmentColors.ToolWindowBorderBrushKey}}"
+                SelectedItemChanged="OnNodeSelected">
+        <TreeView.ItemContainerStyle>
+          <Style TargetType="TreeViewItem">
+            <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay}" />
+            <Setter Property="IsSelected" Value="{Binding IsSelected, Mode=TwoWay}" />
+            <Setter Property="Foreground"
+                    Value="{DynamicResource {x:Static vsui:EnvironmentColors.ToolWindowTextBrushKey}}" />
+          </Style>
+        </TreeView.ItemContainerStyle>
+        <TreeView.Resources>
+          <HierarchicalDataTemplate DataType="{x:Type fh:FileHistoryTreeNode}"
+                                    ItemsSource="{Binding Children}">
+            <!-- Three columns, matching the header above: the checkbox and the icon sit INSIDE the
+                 name column, so the two fixed-width ones stay put whatever the indent level and
+                 line up with their headers. A TreeView has no columns of its own, and this is as
+                 close as one gets without templating a whole TreeListView.
+                 The date is a column rather than part of the label: appended there it shifted with
+                 the length of every name before it. -->
+            <Grid ToolTip="{Binding Tooltip}" MinWidth="240">
+              <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="52" />
+                <ColumnDefinition Width="66" />
+              </Grid.ColumnDefinitions>
+              <StackPanel Grid.Column="0" Orientation="Horizontal">
+                <CheckBox Margin="0,0,6,0" VerticalAlignment="Center"
+                          IsThreeState="True"
+                          IsChecked="{Binding IsChecked, Mode=TwoWay}"
+                          IsEnabled="{Binding CanDelete}"
+                          Checked="OnCheckChanged" Unchecked="OnCheckChanged" />
+                <imaging:CrispImage Width="16" Height="16" Margin="0,0,6,0"
+                                    VerticalAlignment="Center"
+                                    Moniker="{Binding Converter={StaticResource NodeIconConverter}}" />
+                <TextBlock Text="{Binding Label}" VerticalAlignment="Center"
+                           TextTrimming="CharacterEllipsis" />
+              </StackPanel>
+              <TextBlock Grid.Column="1" Text="{Binding LastWriteText}" VerticalAlignment="Center"
+                         Margin="10,0,0,0" Opacity="0.7" FontSize="11" />
+              <TextBlock Grid.Column="2" Text="{Binding SizeText}" VerticalAlignment="Center"
+                         Margin="6,0,0,0" TextAlignment="Right" Opacity="0.7"
+                         FontFamily="Consolas" FontSize="11" />
+            </Grid>
+          </HierarchicalDataTemplate>
+        </TreeView.Resources>
+      </TreeView>
+    </Grid>
+
+    <GridSplitter Grid.Row="0" Grid.Column="1" Width="6" HorizontalAlignment="Center"
+                  VerticalAlignment="Stretch" Background="Transparent" />
+
+    <!-- Column 2: tiles + the selected session's files. -->
+    <Grid Grid.Row="0" Grid.Column="2" Margin="10,0,0,0">
+      <Grid.RowDefinitions>
+        <RowDefinition Height="Auto" />
+        <RowDefinition Height="Auto" />
+        <RowDefinition Height="*" />
+      </Grid.RowDefinitions>
+
+      <!-- Built in code-behind so the tiles follow the theme down the live visual tree, like the
+           Context usage panel. -->
+      <StackPanel x:Name="TilesPanel" Grid.Row="0" Orientation="Horizontal" />
+
+      <TextBlock x:Name="FilesHead" Grid.Row="1" Style="{StaticResource SectionHeadStyle}"
+                 Text="FILES" />
+
+      <Grid Grid.Row="2">
+        <TextBlock x:Name="MessageText" Opacity="0.7" TextWrapping="Wrap" Margin="2,4,0,0"
+                   Text="Select a session to see the files it backed up." />
+
+        <!-- DataGrid rather than ListView: a ListViewItem keeps the SYSTEM template, which paints
+             its selection with the Windows highlight while the text stays the theme's, and comes
+             out unreadable on a dark theme.
+             The options pages get away with a bare DataGrid because VS themes the Options dialog
+             around them; a tool window paints nothing for us, and UseVsTheme does not reach a
+             DataGrid — so the surfaces are bound here, from the same EnvironmentColors the rest of
+             the pane uses. Read-only: nothing in this grid is editable. -->
+        <DataGrid x:Name="FilesList" Visibility="Collapsed"
+                  AutoGenerateColumns="False"
+                  CanUserAddRows="False"
+                  CanUserDeleteRows="False"
+                  IsReadOnly="True"
+                  SelectionMode="Single"
+                  HeadersVisibility="Column"
+                  GridLinesVisibility="Horizontal"
+                  RowBackground="Transparent"
+                  AlternatingRowBackground="Transparent"
+                  Background="{DynamicResource {x:Static vsui:EnvironmentColors.ToolWindowBackgroundBrushKey}}"
+                  Foreground="{DynamicResource {x:Static vsui:EnvironmentColors.ToolWindowTextBrushKey}}"
+                  BorderBrush="{DynamicResource {x:Static vsui:EnvironmentColors.ToolWindowBorderBrushKey}}"
+                  HorizontalGridLinesBrush="{DynamicResource {x:Static vsui:EnvironmentColors.GridLineBrushKey}}"
+                  MouseDoubleClick="OnFileDoubleClick">
+          <DataGrid.ColumnHeaderStyle>
+            <Style TargetType="DataGridColumnHeader">
+              <Setter Property="Background"
+                      Value="{DynamicResource {x:Static vsui:EnvironmentColors.GridHeadingBackgroundBrushKey}}" />
+              <Setter Property="Foreground"
+                      Value="{DynamicResource {x:Static vsui:EnvironmentColors.GridHeadingTextBrushKey}}" />
+              <Setter Property="BorderBrush"
+                      Value="{DynamicResource {x:Static vsui:EnvironmentColors.GridLineBrushKey}}" />
+              <Setter Property="BorderThickness" Value="0,0,1,1" />
+              <Setter Property="Padding" Value="8,4" />
+              <Setter Property="HorizontalContentAlignment" Value="Left" />
+            </Style>
+          </DataGrid.ColumnHeaderStyle>
+          <!-- The cell keeps the row's colours: the stock DataGridCell brings its own selected
+               background and black text, which is the light-on-light bug one level down. -->
+          <DataGrid.CellStyle>
+            <Style TargetType="DataGridCell">
+              <Setter Property="Background" Value="Transparent" />
+              <Setter Property="BorderThickness" Value="0" />
+              <Setter Property="Foreground"
+                      Value="{DynamicResource {x:Static vsui:EnvironmentColors.ToolWindowTextBrushKey}}" />
+              <Setter Property="Padding" Value="8,3" />
+              <Setter Property="Template">
+                <Setter.Value>
+                  <ControlTemplate TargetType="DataGridCell">
+                    <Border Background="{TemplateBinding Background}" Padding="{TemplateBinding Padding}">
+                      <ContentPresenter VerticalAlignment="Center" />
+                    </Border>
+                  </ControlTemplate>
+                </Setter.Value>
+              </Setter>
+              <Style.Triggers>
+                <Trigger Property="IsSelected" Value="True">
+                  <Setter Property="Background"
+                          Value="{DynamicResource {x:Static vsui:EnvironmentColors.SystemHighlightBrushKey}}" />
+                  <Setter Property="Foreground"
+                          Value="{DynamicResource {x:Static vsui:EnvironmentColors.SystemHighlightTextBrushKey}}" />
+                </Trigger>
+              </Style.Triggers>
+            </Style>
+          </DataGrid.CellStyle>
+          <DataGrid.ContextMenu>
+            <ContextMenu>
+              <MenuItem Header="Compare with the current file" Click="OnCompareClick">
+                <MenuItem.Icon>
+                  <imaging:CrispImage Width="16" Height="16"
+                                      Moniker="{x:Static catalog:KnownMonikers.CompareFiles}" />
+                </MenuItem.Icon>
+              </MenuItem>
+              <!-- "Save a copy as", not "Restore": this writes a file and leaves the conversation
+                   alone, and a name promising a rewind would be a lie. -->
+              <MenuItem Header="Save a copy as…" Click="OnSaveCopyClick">
+                <MenuItem.Icon>
+                  <imaging:CrispImage Width="16" Height="16"
+                                      Moniker="{x:Static catalog:KnownMonikers.SaveAs}" />
+                </MenuItem.Icon>
+              </MenuItem>
+              <Separator />
+              <MenuItem Header="Open the backup folder" Click="OnOpenFolderClick">
+                <MenuItem.Icon>
+                  <imaging:CrispImage Width="16" Height="16"
+                                      Moniker="{x:Static catalog:KnownMonikers.OpenFolder}" />
+                </MenuItem.Icon>
+              </MenuItem>
+            </ContextMenu>
+          </DataGrid.ContextMenu>
+          <DataGrid.Columns>
+            <DataGridTextColumn Header="File" Width="*" Binding="{Binding DisplayPath}" />
+            <DataGridTextColumn Header="Ver." Width="52" Binding="{Binding Version}" />
+            <DataGridTextColumn Header="Size" Width="80" Binding="{Binding SizeText}" />
+            <DataGridTextColumn Header="Backed up" Width="130" Binding="{Binding BackupTimeText}" />
+          </DataGrid.Columns>
+        </DataGrid>
+      </Grid>
+    </Grid>
+
+    <!-- Status bar: what is checked, and why something isn't checkable. -->
+    <Border Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="3" Margin="0,8,0,0" Padding="0,6,0,0"
+            BorderThickness="0,1,0,0"
+            BorderBrush="{DynamicResource {x:Static vsui:EnvironmentColors.ToolWindowBorderBrushKey}}">
+      <StackPanel Orientation="Horizontal">
+        <TextBlock x:Name="StatusText" Opacity="0.7" FontSize="11" VerticalAlignment="Center" />
+        <TextBlock x:Name="LiveText" Opacity="0.7" FontSize="11" VerticalAlignment="Center"
+                   Margin="12,0,0,0" Visibility="Collapsed" />
+      </StackPanel>
+    </Border>
+  </Grid>
+</UserControl>

--- a/src/Corsinvest.VisualStudio.Agents/Core/FileHistory/FileHistoryControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/FileHistory/FileHistoryControl.xaml.cs
@@ -1,0 +1,302 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using Microsoft.VisualStudio.Shell;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace Corsinvest.VisualStudio.Agents.Core.FileHistory;
+
+/// <summary>
+/// The File history tool window. A left tree (config-dir → project → session) lists what the
+/// CLI's file backups occupy; the right panel lists the selected session's files, with a diff on
+/// double click. Checked sessions can be deleted.
+/// <para>Same shape as Context usage — tree, splitter, code-behind panel — but the tree is built
+/// here from `file-history/` rather than by StatsService: see <see cref="FileHistoryService"/> for why.
+/// Nothing is indexed, so there is no loading overlay and no Recreate button.</para>
+/// </summary>
+public partial class FileHistoryControl : UserControl
+{
+    private List<FileHistoryTreeNode> _roots = [];
+    private FileHistoryTreeNode _selected;
+    private bool _loaded;
+
+    public FileHistoryControl()
+    {
+        InitializeComponent();
+        Loaded += (_, _) =>
+        {
+            // Loaded fires again on every re-activation; build once.
+            if (_loaded) { return; }
+            _loaded = true;
+            Reload();
+        };
+    }
+
+    private void OnRefreshClick(object sender, RoutedEventArgs e) => Reload();
+
+    /// <summary>Which header column the tree is ordered by.</summary>
+    private enum SortBy { Name, Date, Size }
+
+    // Size descending to open on: the pane's first question is what costs the most.
+    private SortBy _sortBy = SortBy.Size;
+    private bool _descending = true;
+
+    private void OnSortByName(object sender, RoutedEventArgs e) => SortByColumn(SortBy.Name);
+
+    private void OnSortByDate(object sender, RoutedEventArgs e) => SortByColumn(SortBy.Date);
+
+    private void OnSortBySize(object sender, RoutedEventArgs e) => SortByColumn(SortBy.Size);
+
+    // Clicking the sorted column reverses it; clicking another switches to it. A name starts
+    // ascending (A→Z reads as sorted), a size or a date descending (biggest and newest first).
+    private void SortByColumn(SortBy column)
+    {
+        if (_sortBy == column) { _descending = !_descending; }
+        else { _sortBy = column; _descending = column != SortBy.Name; }
+        if (!_loaded) { return; }
+        Sort(_roots);
+        foreach (var node in _roots.SelectMany(AllNodes)) { Sort(node.Children); }
+        ShowArrows();
+        // The TreeView binds to the same list objects, so a re-sort in place is invisible to it:
+        // re-seating ItemsSource is what makes it re-read the order.
+        Tree.ItemsSource = null;
+        Tree.ItemsSource = _roots;
+    }
+
+    // An arrow on the sorted column only — three of them would say nothing about which one wins.
+    private void ShowArrows()
+    {
+        var arrow = _descending ? "▾" : "▴";
+        NameArrow.Text = _sortBy == SortBy.Name ? arrow : "";
+        DateArrow.Text = _sortBy == SortBy.Date ? arrow : "";
+        SizeArrow.Text = _sortBy == SortBy.Size ? arrow : "";
+    }
+
+    // Scan off the UI thread — a config-dir can sit on a network share — then rebuild the tree.
+    private void Reload()
+    {
+        RefreshButton.IsEnabled = false;
+        _ = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+        {
+            List<FileHistoryService.ConfigDirBackups> scan = null;
+            string error = null;
+            try
+            {
+                await System.Threading.Tasks.Task.Run(() => scan = FileHistoryService.Scan());
+            }
+            catch (Exception ex)
+            {
+                OutputWindowLogger.Global.LogException("FileHistoryControl.Reload", ex);
+                error = "Could not read the backup folders — see the output log.";
+            }
+            // Back on the UI thread before touching anything WPF — including re-enabling the
+            // button, which is why that isn't in a finally around the scan.
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            if (error != null) { ShowMessage(error); } else { BuildTree(scan); }
+            RefreshButton.IsEnabled = true;
+        });
+    }
+
+    private void BuildTree(List<FileHistoryService.ConfigDirBackups> scan)
+    {
+        var live = FileHistoryService.LiveSessionIds();
+        _roots = [];
+
+        foreach (var config in scan ?? [])
+        {
+            // One config-dir is the common case (several profiles usually share ~/.claude), and a
+            // root level with a single child is noise: the projects become the roots instead.
+            var configNode = new FileHistoryTreeNode
+            {
+                Kind = FileHistoryNodeKind.ConfigDir,
+                Label = ShortConfigDir(config.Paths.ClaudeFolder),
+                Tooltip = config.Profiles.Count > 0
+                    ? $"{config.Paths.ClaudeFolder}\n{string.Join(", ", config.Profiles.Select(p => p.Name))}"
+                    : config.Paths.ClaudeFolder,
+                Paths = config.Paths,
+                Profile = config.Profiles.FirstOrDefault(),
+                IsExpanded = true,
+            };
+
+            foreach (var group in GroupByProject(config))
+            {
+                configNode.Children.Add(group);
+                group.Parent = configNode;
+            }
+            configNode.Bytes = configNode.Children.Sum(c => c.Bytes);
+            configNode.LastWrite = configNode.Children.Count == 0
+                ? default
+                : configNode.Children.Max(c => c.LastWrite);
+            configNode.CanDelete = configNode.Children.Any(c => c.CanDelete);
+            _roots.Add(configNode);
+        }
+        Sort(_roots);
+
+        var single = _roots.Count == 1 ? _roots[0] : null;
+        if (single != null)
+        {
+            foreach (var c in single.Children) { c.Parent = null; }
+            _roots = single.Children;
+        }
+
+        Tree.ItemsSource = null;
+        Tree.ItemsSource = _roots;
+        _selected = null;
+        ShowMessage(_roots.Count == 0
+            ? "No file backups on disk. The CLI writes them only for sessions started with file history enabled."
+            : "Select a session to see the files it backed up.");
+        UpdateStatus(live);
+        ShowArrows();
+
+        // Sessions with backups are the only rows here, and a session driven by an open pane is not
+        // deletable — say so once, rather than leaving a disabled checkbox unexplained.
+        var blocked = _roots.SelectMany(AllNodes)
+                            .Count(n => n.Kind == FileHistoryNodeKind.Session && !n.CanDelete);
+        LiveText.Visibility = blocked > 0 ? Visibility.Visible : Visibility.Collapsed;
+        LiveText.Text = blocked == 1
+            ? "1 session is open in a pane — not deletable"
+            : $"{blocked} sessions are open in panes — not deletable";
+    }
+
+    // Projects, then their sessions. Orphans — backups whose transcript is gone — get their own
+    // group: they are the primary target of a clean-up, and no project can hold them.
+    private IEnumerable<FileHistoryTreeNode> GroupByProject(FileHistoryService.ConfigDirBackups config)
+    {
+        var live = FileHistoryService.LiveSessionIds();
+        var groups = new List<FileHistoryTreeNode>();
+        FileHistoryTreeNode orphans = null;
+
+        foreach (var byProject in config.Sessions.GroupBy(s => s.ProjectDir, StringComparer.OrdinalIgnoreCase))
+        {
+            var isOrphan = byProject.Key == null;
+            var node = new FileHistoryTreeNode
+            {
+                Kind = isOrphan ? FileHistoryNodeKind.Orphans : FileHistoryNodeKind.Project,
+                Label = isOrphan ? $"Sessions no longer on disk ({byProject.Count()})" : ProjectLabel(byProject.Key),
+                Tooltip = isOrphan
+                    ? "The transcript these backups belong to is gone. Nothing else refers to them."
+                    : byProject.Key,
+                Paths = config.Paths,
+                Profile = config.Profiles.FirstOrDefault(),
+            };
+
+            foreach (var session in byProject)
+            {
+                var child = new FileHistoryTreeNode
+                {
+                    Kind = FileHistoryNodeKind.Session,
+                    Label = Short(session.SessionId),
+                    // The full id and the full stamp: the row shows eight characters and a day.
+                    Tooltip = $"{session.SessionId}\n{session.CopyCount} copies of {session.FileCount} files\n"
+                            + $"Last backup {session.LastWrite:g}\n{session.Folder}",
+                    Session = session,
+                    Paths = config.Paths,
+                    Profile = config.Profiles.FirstOrDefault(),
+                    Bytes = session.Bytes,
+                    LastWrite = session.LastWrite,
+                    CanDelete = !live.Contains(session.SessionId),
+                    Parent = node,
+                };
+                node.Children.Add(child);
+            }
+
+            node.Bytes = node.Children.Sum(c => c.Bytes);
+            node.LastWrite = node.Children.Max(c => c.LastWrite);
+            node.CanDelete = node.Children.Any(c => c.CanDelete);
+            Sort(node.Children);
+            if (isOrphan) { orphans = node; } else { groups.Add(node); }
+        }
+
+        Sort(groups);
+        // Orphans last whatever the ordering: the group answers a different question than "which
+        // project cost me the most" / "what did I touch recently", and reads as a footnote to both.
+        if (orphans != null) { groups.Add(orphans); }
+        return groups;
+    }
+
+    /// <summary>Apply the current header ordering in place. One method for every level of the tree
+    /// — sorting the sessions by date while their projects stayed by size read as a bug.
+    /// <para>Size and date both fall back to the name when they tie, so two sessions of the same
+    /// size keep a stable order between one sort and the next instead of swapping about.</para></summary>
+    private void Sort(List<FileHistoryTreeNode> nodes)
+    {
+        var sign = _descending ? -1 : 1;
+        nodes.Sort((a, b) =>
+        {
+            var by = _sortBy switch
+            {
+                SortBy.Name => 0,
+                SortBy.Date => a.LastWrite.CompareTo(b.LastWrite),
+                _ => a.Bytes.CompareTo(b.Bytes),
+            };
+            return by != 0
+                ? sign * by
+                : sign * string.Compare(a.Label, b.Label, StringComparison.OrdinalIgnoreCase);
+        });
+    }
+
+    private static IEnumerable<FileHistoryTreeNode> AllNodes(FileHistoryTreeNode node)
+    {
+        yield return node;
+        foreach (var n in node.Children.SelectMany(AllNodes)) { yield return n; }
+    }
+
+    // ~\.claude rather than the full profile path: the home part is the same on every row.
+    private static string ShortConfigDir(string folder)
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        return !string.IsNullOrEmpty(home) && folder.StartsWith(home, StringComparison.OrdinalIgnoreCase)
+            ? "~" + folder.Substring(home.Length)
+            : folder;
+    }
+
+    // The CLI's project folders are the working directory with every non-alphanumeric char turned
+    // into a dash, so the tail is the readable part.
+    private static string ProjectLabel(string projectDir)
+    {
+        var name = Path.GetFileName(projectDir) ?? projectDir;
+        var dash = name.LastIndexOf('-');
+        return dash > 0 && dash < name.Length - 1 ? name.Substring(dash + 1) : name;
+    }
+
+    private static string Short(string sessionId)
+        => sessionId != null && sessionId.Length > 8 ? sessionId.Substring(0, 8) : sessionId;
+
+    private void OnNodeSelected(object sender, RoutedPropertyChangedEventArgs<object> e)
+    {
+        _selected = e.NewValue as FileHistoryTreeNode;
+        if (_selected?.Kind == FileHistoryNodeKind.Session) { ShowSession(_selected); }
+        else { ShowGroup(_selected); }
+    }
+
+    private void OnCheckChanged(object sender, RoutedEventArgs e) => UpdateStatus(FileHistoryService.LiveSessionIds());
+
+    private void UpdateStatus(HashSet<string> live)
+    {
+        var checkedSessions = _roots.SelectMany(r => r.CheckedSessions()).ToList();
+        var bytes = checkedSessions.Sum(n => n.Bytes);
+        var total = _roots.Sum(r => r.Bytes);
+        var sessions = _roots.SelectMany(AllNodes).Count(n => n.Kind == FileHistoryNodeKind.Session);
+
+        StatusText.Text = checkedSessions.Count == 0
+            ? $"{FileHistoryService.Format.Size(total)} in {sessions} session(s)"
+            : $"{checkedSessions.Count} checked · {FileHistoryService.Format.Size(bytes)} of {FileHistoryService.Format.Size(total)}";
+        DeleteButton.IsEnabled = checkedSessions.Count > 0;
+    }
+
+    private void ShowMessage(string text)
+    {
+        MessageText.Text = text;
+        MessageText.Visibility = Visibility.Visible;
+        FilesList.Visibility = Visibility.Collapsed;
+        TilesPanel.Children.Clear();
+        FilesHead.Text = "FILES";
+    }
+}

--- a/src/Corsinvest.VisualStudio.Agents/Core/FileHistory/FileHistoryService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/FileHistory/FileHistoryService.cs
@@ -1,0 +1,201 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using Corsinvest.VisualStudio.Agents.Core.Profiles;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Corsinvest.VisualStudio.Agents.Core.FileHistory;
+
+/// <summary>
+/// Enumerates what the CLI's file-history occupies on disk, per config-dir.
+/// <para><b>Not built on StatsService.</b> The stats tree answers "where did I work" over every
+/// session in `projects/`; this one answers "what takes up space and can be deleted", and only
+/// sessions with a `file-history/&lt;id&gt;/` folder have any. On a real config-dir that is a few
+/// dozen against a couple of thousand, so reusing the indexed tree would mean building all of it to
+/// then prune it — and it could never show an ORPHAN, a backup folder whose transcript is gone,
+/// because a tree built from `projects/` has no node for a session that no longer has a .jsonl.</para>
+/// <para>No indexer and no cache: the sizes come from the filesystem, which already knows them.
+/// The per-file detail (which real path each hashed copy belongs to) lives in the transcript and is
+/// read on demand, one session at a time — see <see cref="Sessions.SessionManager.ReadAllFileBackups"/>.</para>
+/// </summary>
+internal static class FileHistoryService
+{
+    /// <summary>One session's backup folder: what it costs and what it belongs to.</summary>
+    internal sealed class SessionBackups
+    {
+        public string SessionId { get; set; }
+
+        /// <summary>`~/.claude/file-history/&lt;session&gt;`.</summary>
+        public string Folder { get; set; }
+
+        /// <summary>The project folder under `projects/` whose transcript names this session, or
+        /// null when nothing does — an orphan, kept and shown rather than hidden.</summary>
+        public string ProjectDir { get; set; }
+
+        /// <summary>Copies on disk. A file edited over several turns has one per version.</summary>
+        public int CopyCount { get; set; }
+
+        /// <summary>Distinct files behind those copies — the `@vN` suffix stripped. Counted from the
+        /// names, so it holds even when the transcript is gone.</summary>
+        public int FileCount { get; set; }
+
+        public long Bytes { get; set; }
+
+        /// <summary>Newest copy in the folder. Local time, for a column the user reads.</summary>
+        public DateTime LastWrite { get; set; }
+
+        public bool IsOrphan => ProjectDir == null;
+    }
+
+    /// <summary>Every session backup under one config-dir, largest first.</summary>
+    internal sealed class ConfigDirBackups
+    {
+        public ClaudePaths Paths { get; set; }
+
+        /// <summary>The profiles resolving to this config-dir — several may share one, which is why
+        /// the tree is rooted on the directory and not on the profile.</summary>
+        public List<Profile> Profiles { get; } = [];
+
+        public List<SessionBackups> Sessions { get; } = [];
+
+        public long Bytes => Sessions.Sum(s => s.Bytes);
+    }
+
+    /// <summary>Scan every config-dir in use. Pure filesystem: directory listings and file lengths,
+    /// no transcript is opened, so this is fast enough to run on the UI thread's behalf without a
+    /// progress indicator — but the caller still does it off-thread, since a config-dir may sit on
+    /// a network share.</summary>
+    public static List<ConfigDirBackups> Scan()
+    {
+        var result = new List<ConfigDirBackups>();
+        try
+        {
+            // Both lists, like StatsService: `false` drops disabled profiles, `true` adds them back.
+            // A profile that is merely switched off still owns the disk its backups occupy.
+            var byConfig = new Dictionary<string, ConfigDirBackups>(StringComparer.OrdinalIgnoreCase);
+            foreach (var profile in ProfileStore.Load(forEdit: false).Concat(ProfileStore.Load(forEdit: true)))
+            {
+                var paths = ClaudePaths.ForProfile(profile);
+                if (!byConfig.TryGetValue(paths.ConfigId, out var entry))
+                {
+                    entry = new ConfigDirBackups { Paths = paths };
+                    byConfig[paths.ConfigId] = entry;
+                    ScanConfigDir(entry);
+                }
+                if (!entry.Profiles.Any(p => string.Equals(p.Name, profile.Name, StringComparison.Ordinal)))
+                {
+                    entry.Profiles.Add(profile);
+                }
+            }
+            result.AddRange(byConfig.Values.OrderByDescending(c => c.Bytes));
+        }
+        catch (Exception ex) { OutputWindowLogger.Global.LogException(nameof(FileHistoryService) + ".Scan", ex); }
+        return result;
+    }
+
+    private static void ScanConfigDir(ConfigDirBackups entry)
+    {
+        var root = entry.Paths.FileHistoryFolder;
+        if (!Directory.Exists(root)) { return; }
+
+        // Session id → project folder, from the .jsonl NAMES alone. Opening none of them is the
+        // point: a config-dir holds thousands, and the name is all this mapping needs.
+        var owners = ProjectsBySessionId(entry.Paths);
+
+        foreach (var dir in Directory.EnumerateDirectories(root))
+        {
+            try
+            {
+                var id = Path.GetFileName(dir);
+                var files = new DirectoryInfo(dir).GetFiles();
+                var session = new SessionBackups
+                {
+                    SessionId = id,
+                    Folder = dir,
+                    ProjectDir = owners.TryGetValue(id, out var owner) ? owner : null,
+                    CopyCount = files.Length,
+                    FileCount = files.Select(StripVersion).Distinct(StringComparer.OrdinalIgnoreCase).Count(),
+                    Bytes = files.Sum(f => f.Length),
+                    LastWrite = files.Length == 0 ? Directory.GetLastWriteTime(dir) : files.Max(f => f.LastWriteTime),
+                };
+                entry.Sessions.Add(session);
+            }
+            catch (Exception ex) { OutputWindowLogger.Global.LogException(nameof(FileHistoryService) + ".ScanSession", ex); }
+        }
+
+        entry.Sessions.Sort((a, b) => b.Bytes.CompareTo(a.Bytes));
+    }
+
+    /// <summary>The copies are named `&lt;hash-of-path&gt;@v&lt;n&gt;`, so dropping the suffix
+    /// groups every version of one file together. A name without one counts as its own file rather
+    /// than being skipped — the naming is the CLI's, and it is free to change it.</summary>
+    private static string StripVersion(FileInfo file)
+    {
+        var name = file.Name;
+        var at = name.LastIndexOf('@');
+        return at > 0 ? name.Substring(0, at) : name;
+    }
+
+    private static Dictionary<string, string> ProjectsBySessionId(ClaudePaths paths)
+    {
+        var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        if (!Directory.Exists(paths.ProjectsFolder)) { return map; }
+        try
+        {
+            foreach (var projectDir in Directory.EnumerateDirectories(paths.ProjectsFolder))
+            {
+                foreach (var file in Directory.EnumerateFiles(projectDir, "*.jsonl"))
+                {
+                    map[Path.GetFileNameWithoutExtension(file)] = projectDir;
+                }
+            }
+        }
+        catch (Exception ex) { OutputWindowLogger.Global.LogException(nameof(FileHistoryService) + ".ProjectsBySessionId", ex); }
+        return map;
+    }
+
+    /// <summary>Delete one session's backup folder. Returns false and logs when it fails — a copy
+    /// held open by a running CLI is the case that actually happens.</summary>
+    public static bool Delete(SessionBackups session)
+    {
+        try
+        {
+            Directory.Delete(session.Folder, recursive: true);
+            OutputWindowLogger.Global.Info($"[filehistory] deleted backups of {session.SessionId} ({Format.Size(session.Bytes)})");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            OutputWindowLogger.Global.LogException(nameof(FileHistoryService) + ".Delete", ex);
+            return false;
+        }
+    }
+
+    /// <summary>Session ids currently driven by an open pane. Their backups are what a rewind in
+    /// that pane would restore from, so the UI refuses to delete them.</summary>
+    public static HashSet<string> LiveSessionIds()
+    {
+        var live = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var e in Panes.PaneRegistry.Instance.Entries)
+        {
+            if (!string.IsNullOrEmpty(e.ActiveSessionId)) { live.Add(e.ActiveSessionId); }
+        }
+        return live;
+    }
+
+    /// <summary>Sizes and counts as the pane prints them. Here rather than in the control: the
+    /// confirmation dialog and the tree have to agree on what a number looks like.</summary>
+    internal static class Format
+    {
+        public static string Size(long bytes)
+            => bytes >= 1024L * 1024 * 1024 ? $"{bytes / 1024d / 1024 / 1024:0.0} GB"
+             : bytes >= 1024L * 1024 ? $"{bytes / 1024d / 1024:0.0} MB"
+             : bytes >= 1024 ? $"{bytes / 1024d:0.0} KB"
+             : $"{bytes} B";
+    }
+}

--- a/src/Corsinvest.VisualStudio.Agents/Core/FileHistory/FileHistoryTreeNode.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/FileHistory/FileHistoryTreeNode.cs
@@ -1,0 +1,143 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using Microsoft.VisualStudio.Imaging;
+using Microsoft.VisualStudio.Imaging.Interop;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Linq;
+using System.Windows.Data;
+
+namespace Corsinvest.VisualStudio.Agents.Core.FileHistory;
+
+/// <summary>What a node stands for. Drives its icon and what selecting it shows.</summary>
+internal enum FileHistoryNodeKind { ConfigDir, Project, Session, Orphans }
+
+/// <summary>
+/// One node of the file-history tree (config-dir → project → session, plus an Orphans group).
+/// <para>Not <see cref="Stats.StatsTreeNode"/>: this tree carries a size and a tri-state check per
+/// node, and its levels come from `file-history/` rather than from the stats index. It notifies,
+/// because checking a parent has to move its children in the UI.</para>
+/// </summary>
+internal sealed class FileHistoryTreeNode : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    public string Label { get; set; }
+    public string Tooltip { get; set; }
+    public FileHistoryNodeKind Kind { get; set; }
+
+    /// <summary>Set on Session nodes only; null on the grouping levels.</summary>
+    public FileHistoryService.SessionBackups Session { get; set; }
+
+    /// <summary>The config-dir this node lives under — a session needs it to find its transcript.</summary>
+    public ClaudePaths Paths { get; set; }
+
+    /// <summary>Any profile resolving to <see cref="Paths"/>. Several may share one config-dir, and
+    /// which of them this is does not matter: it is only what StatsService.CwdForProject takes.</summary>
+    public Profiles.Profile Profile { get; set; }
+
+    public List<FileHistoryTreeNode> Children { get; } = [];
+
+    public long Bytes { get; set; }
+    public string SizeText => FileHistoryService.Format.Size(Bytes);
+
+    /// <summary>Newest backup under this node — the session's own on a leaf, the newest of its
+    /// children on a group. What the date orderings sort on at every level.</summary>
+    public DateTime LastWrite { get; set; }
+
+    /// <summary>The date as its own column, so it lines up down the tree. Kept out of
+    /// <see cref="Label"/>: appended there it moved with the length of every name before it.</summary>
+    public string LastWriteText => LastWrite == default ? "" : LastWrite.ToString("d MMM");
+
+    /// <summary>False on a session an open pane is driving: deleting the copies a live rewind would
+    /// restore from breaks it half-way. The checkbox is disabled rather than merely warned about —
+    /// the consequence belongs in the control, not in a dialog the user can click past.</summary>
+    public bool CanDelete { get; set; } = true;
+
+    public bool IsExpanded { get; set; }
+    public bool IsSelected { get; set; }
+
+    // Set while a parent pushes its state down, so the children's echo back up is ignored.
+    private bool _updating;
+    private bool? _isChecked = false;
+
+    /// <summary>Tri-state: null when only some descendants are checked. Setting it on a parent
+    /// checks every child that can be deleted, and re-reads the parents on the way up.</summary>
+    public bool? IsChecked
+    {
+        get => _isChecked;
+        set
+        {
+            if (_isChecked == value) { return; }
+            _isChecked = value;
+            Raise(nameof(IsChecked));
+            if (_updating) { return; }
+
+            if (value.HasValue)
+            {
+                foreach (var c in Children.Where(c => c.CanDelete)) { c.SetFromParent(value.Value); }
+            }
+            Parent?.RefreshFromChildren();
+        }
+    }
+
+    public FileHistoryTreeNode Parent { get; set; }
+
+    private void SetFromParent(bool value)
+    {
+        _updating = true;
+        IsChecked = value;
+        _updating = false;
+        foreach (var c in Children.Where(c => c.CanDelete)) { c.SetFromParent(value); }
+    }
+
+    private void RefreshFromChildren()
+    {
+        var checkable = Children.Where(c => c.CanDelete).ToList();
+        if (checkable.Count == 0) { return; }
+        var state = checkable.All(c => c.IsChecked == true) ? true
+                  : checkable.All(c => c.IsChecked == false) ? (bool?)false
+                  : null;
+        _updating = true;
+        IsChecked = state;
+        _updating = false;
+        Parent?.RefreshFromChildren();
+    }
+
+    /// <summary>Every checked session under this node, itself included.</summary>
+    public IEnumerable<FileHistoryTreeNode> CheckedSessions()
+    {
+        if (Kind == FileHistoryNodeKind.Session)
+        {
+            if (IsChecked == true && CanDelete) { yield return this; }
+            yield break;
+        }
+        foreach (var s in Children.SelectMany(c => c.CheckedSessions())) { yield return s; }
+    }
+
+    private void Raise(string name) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+}
+
+/// <summary>Maps a tree node to its KnownMoniker. Monikers verified against the image catalog:
+/// an absent one renders as a silent empty CrispImage.</summary>
+internal sealed class FileHistoryIconConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        => value is not FileHistoryTreeNode node
+            ? default(ImageMoniker)
+            : node.Kind switch
+            {
+                FileHistoryNodeKind.ConfigDir => KnownMonikers.FolderOpened,
+                FileHistoryNodeKind.Project => KnownMonikers.FolderClosed,
+                FileHistoryNodeKind.Orphans => KnownMonikers.StatusWarning,
+                _ => KnownMonikers.Document,
+            };
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}

--- a/src/Corsinvest.VisualStudio.Agents/Core/FileHistory/FileHistoryWindow.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/FileHistory/FileHistoryWindow.cs
@@ -1,0 +1,50 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using System;
+using System.Runtime.InteropServices;
+
+namespace Corsinvest.VisualStudio.Agents.Core.FileHistory;
+
+/// <summary>Tool window listing what the CLI's file backups occupy on disk, and deleting them.
+/// Owns no file — see StatisticsWindow for why that makes a tool window the right shape.
+/// Single-instance.</summary>
+[Guid("9e6b3f24-71ad-4c85-b0f2-3d5817ea9c46")]
+public sealed class FileHistoryWindow : ToolWindowPane
+{
+    public FileHistoryWindow() : base(null)
+    {
+        Caption = "File history";
+        Content = new FileHistoryControl();
+    }
+
+    /// <summary>Show the File history window, creating it on first use.</summary>
+    public static void Open()
+    {
+        var pkg = AgentsPackage.Instance;
+        if (pkg == null) { return; }
+        _ = pkg.JoinableTaskFactory.RunAsync(async () =>
+        {
+            try
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                var window = pkg.FindToolWindow(typeof(FileHistoryWindow), 0, create: true);
+                if (window?.Frame is not IVsWindowFrame frame)
+                {
+                    OutputWindowLogger.Global.Warn("[filehistory] the File history window has no frame — cannot show it");
+                    return;
+                }
+                ErrorHandler.ThrowOnFailure(frame.Show());
+            }
+            catch (Exception ex)
+            {
+                OutputWindowLogger.Global.LogException("FileHistoryWindow.Open", ex);
+            }
+        });
+    }
+}

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneToolbar.xaml
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneToolbar.xaml
@@ -6,99 +6,12 @@
              xmlns:catalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"
              Background="{DynamicResource {x:Static vsui:EnvironmentColors.CommandBarGradientBeginBrushKey}}">
   <UserControl.Resources>
-    <!-- VS-themed ContextMenu chrome. Implicit styles (no key) so every menu
-         inside this UserControl inherits them — including items added at
-         runtime. Without these the popup defaults to the Windows light theme
-         (white background) even in dark VS. Copied from the old launcher. -->
-    <Style TargetType="ContextMenu">
-      <Setter Property="Background" Value="{DynamicResource {x:Static vsui:EnvironmentColors.DropDownPopupBackgroundBeginBrushKey}}" />
-      <Setter Property="Foreground" Value="{DynamicResource {x:Static vsui:EnvironmentColors.DropDownTextBrushKey}}" />
-      <Setter Property="BorderBrush" Value="{DynamicResource {x:Static vsui:EnvironmentColors.DropDownPopupBorderBrushKey}}" />
-      <Setter Property="BorderThickness" Value="1" />
-      <Setter Property="Padding" Value="2" />
-      <Setter Property="HasDropShadow" Value="True" />
-      <Setter Property="Template">
-        <Setter.Value>
-          <ControlTemplate TargetType="ContextMenu">
-            <Border Background="{TemplateBinding Background}"
-                    BorderBrush="{TemplateBinding BorderBrush}"
-                    BorderThickness="{TemplateBinding BorderThickness}"
-                    Padding="{TemplateBinding Padding}">
-              <ItemsPresenter />
-            </Border>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
-    </Style>
-
-    <Style TargetType="MenuItem">
-      <Setter Property="Background" Value="Transparent" />
-      <Setter Property="Foreground" Value="{DynamicResource {x:Static vsui:EnvironmentColors.DropDownTextBrushKey}}" />
-      <Setter Property="BorderBrush" Value="Transparent" />
-      <Setter Property="BorderThickness" Value="1" />
-      <Setter Property="Padding" Value="6,4" />
-      <Setter Property="Template">
-        <Setter.Value>
-          <ControlTemplate TargetType="MenuItem">
-            <Border x:Name="root"
-                    Background="{TemplateBinding Background}"
-                    BorderBrush="{TemplateBinding BorderBrush}"
-                    BorderThickness="{TemplateBinding BorderThickness}"
-                    Padding="{TemplateBinding Padding}"
-                    SnapsToDevicePixels="True">
-              <Grid>
-                <Grid.ColumnDefinitions>
-                  <ColumnDefinition Width="20" />
-                  <ColumnDefinition Width="*" />
-                  <ColumnDefinition Width="Auto" />
-                </Grid.ColumnDefinitions>
-                <ContentPresenter Grid.Column="0" ContentSource="Icon"
-                                  VerticalAlignment="Center" HorizontalAlignment="Center"
-                                  Width="16" Height="16" />
-                <ContentPresenter Grid.Column="1" ContentSource="Header"
-                                  RecognizesAccessKey="True" VerticalAlignment="Center"
-                                  Margin="6,0,12,0" />
-                <Path Grid.Column="2" x:Name="chevron"
-                      Width="6" Height="10" Margin="0,0,4,0" Stretch="Uniform"
-                      Fill="{TemplateBinding Foreground}"
-                      Data="M 0 0 L 5 5 L 0 10 Z" Visibility="Collapsed" />
-                <Popup x:Name="PART_Popup" Grid.Column="0" Grid.ColumnSpan="3"
-                       Placement="Right" IsOpen="{TemplateBinding IsSubmenuOpen}"
-                       AllowsTransparency="True" Focusable="False" PopupAnimation="None">
-                  <Border Background="{DynamicResource {x:Static vsui:EnvironmentColors.DropDownPopupBackgroundBeginBrushKey}}"
-                          BorderBrush="{DynamicResource {x:Static vsui:EnvironmentColors.DropDownPopupBorderBrushKey}}"
-                          BorderThickness="1" Padding="2">
-                    <ItemsPresenter />
-                  </Border>
-                </Popup>
-              </Grid>
-            </Border>
-            <ControlTemplate.Triggers>
-              <Trigger Property="Role" Value="SubmenuHeader">
-                <Setter TargetName="chevron" Property="Visibility" Value="Visible" />
-              </Trigger>
-              <Trigger Property="IsHighlighted" Value="True">
-                <Setter TargetName="root" Property="Background"
-                        Value="{DynamicResource {x:Static vsui:EnvironmentColors.DropDownMouseOverBackgroundBeginBrushKey}}" />
-                <Setter Property="Foreground"
-                        Value="{DynamicResource {x:Static vsui:EnvironmentColors.DropDownMouseOverTextBrushKey}}" />
-              </Trigger>
-              <Trigger Property="IsEnabled" Value="False">
-                <Setter Property="Foreground"
-                        Value="{DynamicResource {x:Static vsui:EnvironmentColors.SystemGrayTextBrushKey}}" />
-              </Trigger>
-            </ControlTemplate.Triggers>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
-    </Style>
-
-    <Style TargetType="Separator">
-      <Setter Property="Background" Value="{DynamicResource {x:Static vsui:EnvironmentColors.DropDownPopupBorderBrushKey}}" />
-      <Setter Property="Margin" Value="6,3" />
-      <Setter Property="Height" Value="1" />
-      <Setter Property="Opacity" Value="0.5" />
-    </Style>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <!-- VS chrome for the menus below: they open in their own popup, where UseVsTheme cannot
+             reach them. Shared with the Storage pane — see the dictionary for why. -->
+        <ResourceDictionary Source="/Corsinvest.VisualStudio.Agents;component/Themes/MenuStyles.xaml" />
+      </ResourceDictionary.MergedDictionaries>
 
     <!-- Flat VS command-bar button. -->
     <Style x:Key="CommandBarButton" TargetType="Button">
@@ -135,6 +48,7 @@
         </Setter.Value>
       </Setter>
     </Style>
+    </ResourceDictionary>
   </UserControl.Resources>
 
   <Border BorderBrush="{DynamicResource {x:Static vsui:EnvironmentColors.CommandBarToolBarBorderBrushKey}}"

--- a/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.History.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.History.cs
@@ -575,6 +575,50 @@ internal sealed partial class SessionManager
         return result;
     }
 
+    /// <summary>Every file the session ever backed up, with the LATEST copy of each — what the
+    /// Storage pane lists for a session it is not rewinding to any particular point.
+    /// <para>The opposite keep-rule from the overload above, and deliberately so: a rewind wants the
+    /// copy that predates the edit, while an archive wants the newest state that was preserved. So
+    /// this one overwrites as it goes rather than keeping the first hit.</para>
+    /// <para>Reads the whole transcript rather than the tail. The snapshot records are cumulative in
+    /// practice, but that is the CLI's behaviour and not its contract — a session whose early edits
+    /// stopped being repeated would silently lose files from the list. One pass over one file, for a
+    /// panel the user opened on purpose, is worth not depending on that.</para></summary>
+    public List<FileBackupInfo> ReadAllFileBackups(string sessionId)
+    {
+        var result = new List<FileBackupInfo>();
+        if (!IsSafePathToken(sessionId)) { return result; }
+        var path = FileFor(sessionId);
+        if (!File.Exists(path)) { return result; }
+        try
+        {
+            var found = new Dictionary<string, FileBackupInfo>(StringComparer.OrdinalIgnoreCase);
+            foreach (var line in File.ReadLines(path, Encoding.UTF8))
+            {
+                if (string.IsNullOrWhiteSpace(line) || !IsType(line, "file-history-snapshot")) { continue; }
+                JObject obj; try { obj = JObject.Parse(line); } catch { continue; }
+                if (obj["snapshot"]?["trackedFileBackups"] is not JObject backups) { continue; }
+                foreach (var kv in backups)
+                {
+                    var b = kv.Value as JObject;
+                    var name = b?.Val("backupFileName", (string)null);
+                    // A null name records a file that did not exist yet — there is no copy on disk
+                    // to list or diff, so it is not an archive entry.
+                    if (name == null) { continue; }
+                    found[kv.Key] = new FileBackupInfo
+                    {
+                        Path = kv.Key,
+                        BackupFileName = name,
+                        Version = b.Val("version", 0),
+                    };
+                }
+            }
+            result.AddRange(found.Values);
+        }
+        catch (Exception ex) { log.LogException("SessionManager.ReadAllFileBackups", ex); }
+        return result;
+    }
+
     /// <summary>Read the compaction summary that follows the compact_boundary with the given uuid:
     /// the next .jsonl line, flagged isCompactSummary with a string content. "" if absent.</summary>
     public string ReadCompactSummary(string sessionId, string boundaryUuid)

--- a/src/Corsinvest.VisualStudio.Agents/Corsinvest.VisualStudio.Agents.csproj
+++ b/src/Corsinvest.VisualStudio.Agents/Corsinvest.VisualStudio.Agents.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MinimumVisualStudioVersion>17.0</MinimumVisualStudioVersion>
@@ -299,6 +299,15 @@
     <Compile Include="Core\Context\ContextUsageControl.Render.cs">
       <DependentUpon>ContextUsageControl.xaml.cs</DependentUpon>
     </Compile>
+    <Compile Include="Core\FileHistory\FileHistoryService.cs" />
+    <Compile Include="Core\FileHistory\FileHistoryTreeNode.cs" />
+    <Compile Include="Core\FileHistory\FileHistoryWindow.cs" />
+    <Compile Include="Core\FileHistory\FileHistoryControl.xaml.cs">
+      <DependentUpon>FileHistoryControl.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Core\FileHistory\FileHistoryControl.Render.cs">
+      <DependentUpon>FileHistoryControl.xaml.cs</DependentUpon>
+    </Compile>
     <Compile Include="Core\Workspace\ProjectStore.cs" />
     <Compile Include="Core\Workspace\WorkspaceState.cs" />
     <Compile Include="Core\Workspace\WorkspaceStore.cs" />
@@ -416,7 +425,13 @@
     <Page Include="Core\Context\ContextUsageControl.xaml">
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="Core\FileHistory\FileHistoryControl.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Themes\Generic.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Themes\MenuStyles.xaml">
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Core\Controls\CvLoadingOverlay.xaml">

--- a/src/Corsinvest.VisualStudio.Agents/Menu/GlobalMenuCommands.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Menu/GlobalMenuCommands.cs
@@ -48,6 +48,7 @@ internal static class GlobalMenuCommands
         Add(svc, PackageIds.StatisticsCommandId, Core.Stats.StatisticsWindow.Open);
         Add(svc, PackageIds.UsageCommandId, Core.Usage.UsageWindow.Open);
         Add(svc, PackageIds.ContextUsageCommandId, Core.Context.ContextWindow.Open);
+        Add(svc, PackageIds.FileHistoryCommandId, Core.FileHistory.FileHistoryWindow.Open);
     }
 
     /// <summary>Open a GitHub issue form. The template name must match a file in

--- a/src/Corsinvest.VisualStudio.Agents/PackageGuids.cs
+++ b/src/Corsinvest.VisualStudio.Agents/PackageGuids.cs
@@ -35,6 +35,7 @@ internal static class PackageIds
     public const int UsageCommandId = 0x020A;
     public const int ContextUsageCommandId = 0x020B;
     public const int ExplainCommandId = 0x020C;
+    public const int FileHistoryCommandId = 0x020D;
 
     // Seeds the dynamic open-panes range, which grows with the number of open panes — its own
     // 0x0300 block, clear of the fixed ids above.

--- a/src/Corsinvest.VisualStudio.Agents/Themes/MenuStyles.xaml
+++ b/src/Corsinvest.VisualStudio.Agents/Themes/MenuStyles.xaml
@@ -1,0 +1,116 @@
+<!--
+  SPDX-FileCopyrightText: Copyright Corsinvest Srl
+  SPDX-License-Identifier: GPL-3.0-only
+-->
+<!--
+  VS-themed chrome for ContextMenu / MenuItem / Separator.
+
+  A menu opens in its own popup window, outside the UserControl's visual tree, so
+  Themes.UseVsTheme never reaches it and the stock WPF template comes up in the Windows light
+  theme — a white popup over a dark IDE. These styles bind the surfaces to EnvironmentColors
+  instead.
+
+  Implicit (no x:Key) so every menu under the dictionary inherits them, items added at runtime
+  included. Merge it into a control's Resources to opt in:
+
+    <UserControl.Resources>
+      <ResourceDictionary>
+        <ResourceDictionary.MergedDictionaries>
+          <ResourceDictionary Source="/Corsinvest.VisualStudio.Agents;component/Themes/MenuStyles.xaml" />
+        </ResourceDictionary.MergedDictionaries>
+      </ResourceDictionary>
+    </UserControl.Resources>
+-->
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:vsui="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0">
+  <Style TargetType="ContextMenu">
+    <Setter Property="Background" Value="{DynamicResource {x:Static vsui:EnvironmentColors.DropDownPopupBackgroundBeginBrushKey}}" />
+    <Setter Property="Foreground" Value="{DynamicResource {x:Static vsui:EnvironmentColors.DropDownTextBrushKey}}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource {x:Static vsui:EnvironmentColors.DropDownPopupBorderBrushKey}}" />
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="Padding" Value="2" />
+    <Setter Property="HasDropShadow" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="ContextMenu">
+          <Border Background="{TemplateBinding Background}"
+                  BorderBrush="{TemplateBinding BorderBrush}"
+                  BorderThickness="{TemplateBinding BorderThickness}"
+                  Padding="{TemplateBinding Padding}">
+            <ItemsPresenter />
+          </Border>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+
+  <Style TargetType="MenuItem">
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Foreground" Value="{DynamicResource {x:Static vsui:EnvironmentColors.DropDownTextBrushKey}}" />
+    <Setter Property="BorderBrush" Value="Transparent" />
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="Padding" Value="6,4" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="MenuItem">
+          <Border x:Name="root"
+                  Background="{TemplateBinding Background}"
+                  BorderBrush="{TemplateBinding BorderBrush}"
+                  BorderThickness="{TemplateBinding BorderThickness}"
+                  Padding="{TemplateBinding Padding}"
+                  SnapsToDevicePixels="True">
+            <Grid>
+              <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="20" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+              </Grid.ColumnDefinitions>
+              <ContentPresenter Grid.Column="0" ContentSource="Icon"
+                                VerticalAlignment="Center" HorizontalAlignment="Center"
+                                Width="16" Height="16" />
+              <ContentPresenter Grid.Column="1" ContentSource="Header"
+                                RecognizesAccessKey="True" VerticalAlignment="Center"
+                                Margin="6,0,12,0" />
+              <Path Grid.Column="2" x:Name="chevron"
+                    Width="6" Height="10" Margin="0,0,4,0" Stretch="Uniform"
+                    Fill="{TemplateBinding Foreground}"
+                    Data="M 0 0 L 5 5 L 0 10 Z" Visibility="Collapsed" />
+              <Popup x:Name="PART_Popup" Grid.Column="0" Grid.ColumnSpan="3"
+                     Placement="Right" IsOpen="{TemplateBinding IsSubmenuOpen}"
+                     AllowsTransparency="True" Focusable="False" PopupAnimation="None">
+                <Border Background="{DynamicResource {x:Static vsui:EnvironmentColors.DropDownPopupBackgroundBeginBrushKey}}"
+                        BorderBrush="{DynamicResource {x:Static vsui:EnvironmentColors.DropDownPopupBorderBrushKey}}"
+                        BorderThickness="1" Padding="2">
+                  <ItemsPresenter />
+                </Border>
+              </Popup>
+            </Grid>
+          </Border>
+          <ControlTemplate.Triggers>
+            <Trigger Property="Role" Value="SubmenuHeader">
+              <Setter TargetName="chevron" Property="Visibility" Value="Visible" />
+            </Trigger>
+            <Trigger Property="IsHighlighted" Value="True">
+              <Setter TargetName="root" Property="Background"
+                      Value="{DynamicResource {x:Static vsui:EnvironmentColors.DropDownMouseOverBackgroundBeginBrushKey}}" />
+              <Setter Property="Foreground"
+                      Value="{DynamicResource {x:Static vsui:EnvironmentColors.DropDownMouseOverTextBrushKey}}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+              <Setter Property="Foreground"
+                      Value="{DynamicResource {x:Static vsui:EnvironmentColors.SystemGrayTextBrushKey}}" />
+            </Trigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+
+  <Style TargetType="Separator">
+    <Setter Property="Background" Value="{DynamicResource {x:Static vsui:EnvironmentColors.DropDownPopupBorderBrushKey}}" />
+    <Setter Property="Margin" Value="6,3" />
+    <Setter Property="Height" Value="1" />
+    <Setter Property="Opacity" Value="0.5" />
+  </Style>
+</ResourceDictionary>


### PR DESCRIPTION
## The problem

Before overwriting a file, the CLI copies it whole into `~/.claude/file-history/<session>/`. Those copies are what a rewind restores from — and **nothing ever removes them**. They outlive the session, and they outlive the transcript itself.

On the machine this was written on: **33 folders, 46 MB**, six of them belonging to sessions whose `.jsonl` is long gone. There was no way to see that, and no way to act on it.

## What this adds

A **File history** tool window under **View → cv4vs Agents → Analytics**.

- **Left** — a `config-dir → project → session` tree, with the newest backup date and the size on every row. Orphans (backups whose transcript is gone) get their own group, last in the list.
- **Right** — the files a selected session preserved: path, version, size, when the copy was taken.
- **Double-click** — diffs the backup against the file as it is now, in VS's own diff viewer.
- **Delete** — tick sessions, confirm; the dialog says how many copies and megabytes go, and that project files are untouched.

Sorting lives in the **column headers**, not a toolbar combo: a click also has to say *which way*, and an arrow on the sorted column says it where the reader is already looking. It applies to all three tree levels at once.

## Decisions worth reviewing

**It looks like Context usage but is not built on the Statistics tree.** That tree spans every session in `projects/` — 2025 of them here — to reach the few dozen that have backups; its date filter would hide exactly the old sessions this pane exists to find; and it can never show an orphan, because a tree built from `projects/` has no node for a session with no `.jsonl`. Sizes come from the filesystem instead, so there is **no indexer, no cache, no loading overlay**. What is reused: `FileHistoryTreeNode` mirrors `StatsTreeNode`'s shape, the XAML layout, and the code-behind/`.Render.cs` split.

**A live session cannot be deleted.** Its checkbox is disabled and the status bar says how many are held that way. Deleting the copies a running rewind restores from would break it half-way, so the consequence sits in the control rather than in a warning that can be clicked past.

**"Save a copy as…", not "Restore".** It writes a file where you choose and leaves both the working copy and the conversation alone. Calling it Restore would promise a rewind — which is a different feature, in the chat pane, and which only works on the session its own pane is driving.

**Named File history, not Rewind.** The pane is an archive: it shows, compares and deletes; it never writes into a conversation. Cross-session rewind would need `claude --resume <id> --rewind-files` as an external process — feasible, but another feature.

## Two theming traps

Both because a tool window paints nothing for us, where the Options dialog paints around its pages:

- A **`ListView`** keeps the *system* item template: it paints selection with the Windows highlight while the text keeps the theme's foreground — light-on-light, unreadable. Hence `DataGrid`, with its surfaces bound to `EnvironmentColors` (`GridHeadingBackground`, `SystemHighlight`, …). All brush and moniker names verified by reflection against the assembly the project references, not the one VS ships — `KnownMonikers.Delete` exists in the latter and not the former.
- A **`ContextMenu`** opens in its own popup, where `UseVsTheme` never reaches it. `PaneToolbar` had already solved this inline, with a comment saying it was itself *"copied from the old launcher"* — so rather than making a third copy, those styles move to `Themes/MenuStyles.xaml` and both controls merge them. Verified by diff that the extracted file is identical line-for-line, so PaneToolbar renders exactly as before.

## Also here

`SessionManager.ReadAllFileBackups` — the archive counterpart to `ReadFileBackups`. Deliberately the opposite keep-rule: a rewind wants the copy that *predates* the edit, an archive wants the newest state preserved.

## Testing

`msbuild /t:Rebuild` clean green, VSIX produced. Verified manually in the Exp instance across the iterations that produced the theming fixes above. No test project exists (see CLAUDE.md).

## Docs

New `docs/file-history.md`; cross-linked from `README.md`, `docs/chat/rewind.md` and `docs/settings-and-data.md` — the last two both claimed the copies could only be removed by hand, which is no longer true.
