### PR TITLE
fix(chat): the spinner says something from the first frame, not from the second

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/format.test.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/tests/format.test.ts
@@ -65,6 +65,14 @@ test('formatDuration: the decimal shows only below one second', () => {
     assert.equal(formatDuration(45_000), '45s');
 });
 
+test('formatDuration: zero exactly is whole, not "0.0s"', () => {
+    assert.equal(formatDuration(0), '0s');
+    assert.equal(formatDurationSec(0), '0s');
+    // The boundary the case above guards stays put.
+    assert.equal(formatDuration(1), '0.0s');
+    assert.equal(formatDuration(100), '0.1s');
+});
+
 test('formatDuration: past the minute it switches to "Nm Ns"', () => {
     assert.equal(formatDuration(60_000), '1m 0s');
     assert.equal(formatDuration(83_000), '1m 23s');

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-spinner.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-spinner.ts
@@ -155,12 +155,11 @@ export class CvSpinner extends LitElement {
             text-align: center;
             color: var(--colorBrandBackground);
         }
-        /* The min-width reserves room for the longest verb, so the elapsed time doesn't jitter
-           left and right as the word changes. Only worth it while a word is actually there. */
+        /* No min-width: reserving room for the longest verb only earns its keep while the words
+           rotate. Turning SHOW_RANDOM_VERBS back on wants it back. */
         .text {
             font-size: 12px;
             opacity: 0.8;
-            min-width: 120px;
         }
         .elapsed,
         .tokens {
@@ -274,12 +273,9 @@ export class CvSpinner extends LitElement {
     }
 
     override render() {
-        // Hidden for the first second: a turn that ends instantly would flash a "0s" that
-        // reads as an error rather than as timing.
-        const elapsed =
-            this._elapsedSec > 0
-                ? html`<span class="elapsed">${formatDurationSec(this._elapsedSec)}</span>`
-                : nothing;
+        // From zero: with no verb beside it the row would otherwise be a lone glyph for its first
+        // second, which reads as a broken font rather than as work in progress.
+        const elapsed = html`<span class="elapsed">${formatDurationSec(this._elapsedSec)}</span>`;
         // A known status always speaks; the random verb only when the flag lets it.
         const label = CvSpinner.STATUS_LABELS[this.status] || (SHOW_RANDOM_VERBS ? this._verb : '');
         // ~4 chars per token, the ratio the CLI's own spinner uses. An estimate: the exact figure

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/helpers/format.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/helpers/format.ts
@@ -56,7 +56,9 @@ export function formatAbsolute(ms: number): string {
  *  second never shows a pointless ".0". Not localized on purpose: these sit inside dense metric
  *  rows where "1m 23s" has to stay short and predictable, unlike the prose of formatTimeAgo. */
 export function formatDuration(ms: number): string {
-    if (ms < 1000) {
+    // The decimal tells brief durations apart, and zero is not one of them: the spinner opens on
+    // this value, where a ".0" would show once and never again.
+    if (ms > 0 && ms < 1000) {
         return `${(ms / 1000).toFixed(1)}s`;
     }
     const s = Math.round(ms / 1000);


### PR DESCRIPTION
## The symptom

The spinner had stopped reading as a spinner. Reported as "I don't see it any more" — which turned out to be accurate rather than approximate.

## What actually happened

#175 dropped the cycling verb, for good reasons. But it left **three conditional pieces** where there had been one unconditional one:

| piece | shown when | absent |
|---|---|---|
| label | `SHOW_RANDOM_VERBS` or `status === 'compacting'` | almost always |
| elapsed | `_elapsedSec > 0` | the first second of every turn |
| tokens | `estimated > 0` | until the model starts writing |

The elapsed guard was written when a verb sat beside it: `Spelunking… 0s` versus `Spelunking…` is a fair trade, and a turn ending instantly would not flash a bare "0s". With the verb gone, the comparison is against **nothing** — and the opening of every turn is a single 14px glyph. On a turn that starts with tool calls it stays that way for as long as the tools run.

A lone character changing shape does not read as work in progress. It reads as a broken font.

## The fix

The counter shows from zero:

```ts
const elapsed = html`<span class="elapsed">${formatDurationSec(this._elapsedSec)}</span>`;
```

`✳` becomes `✳ 0s → ✳ 3s → ✳ 12s ↓ 340 tok`.

**The token count stays conditional.** `↓ 0 tok` before the model writes is not information: it says "nothing is happening", which is false and reads worse than an absent figure.

## Two things that came with it

**`formatDuration(0)` now returns `"0s"`, not `"0.0s"`.** The decimal branch exists to tell brief durations *apart from each other*, and zero is not one of them. `1ms` still reads `"0.0s"`, so the 200ms turn that branch was written for is untouched — the existing test asserting exactly that still passes.

**`min-width: 120px` on the label is gone.** It reserved room for the longest verb so the seconds would not jitter as the word changed. With the verbs off, the one label left is a fixed status, and 120px around a word half that wide is a gap the eye has to cross. The comment says to bring it back with the flag.

## Testing

Two cases added to `format.test.ts` — the zero, and the `1ms` boundary the change must not move.

**Verified by breaking it:** reverting the `ms > 0` guard turns the new case red (`actual: '0.0s', expected: '0s'`), then green again with the guard back. Without that check the test proves nothing.

179 tests green (was 177). `npm run format` and `npm run build` clean.

## Not covered here

While a turn runs tool calls, the row is a number that climbs and says nothing about what is happening. `appState.status` is the honest channel for that — the CLI already sends it and we map only `compacting`. Worth finding out what else arrives there, but it is a separate change from this one.
