### PR TITLE
fix(chat): a Dockerfile in a diff is a Dockerfile, not a file without an extension

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/diff.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/diff.ts
@@ -6,7 +6,7 @@
 // (inline preview) and diff-stats.ts (+N/-M counts).
 
 import { createPatch } from 'diff';
-import { ALIASES, FILE_NAME_LANGS } from './lang';
+import { langForFile } from './lang';
 import { normPath } from './path';
 
 /**
@@ -15,15 +15,17 @@ import { normPath } from './path';
  */
 export function patchPathFor(filePath: string | undefined | null): string {
     const path = normPath(filePath) || 'file';
+    const lang = langForFile(path);
+    if (!lang) {
+        return path;
+    }
+    // Swap the extension when there is one, append when there is not: `Foo.csproj` becomes
+    // `Foo.xml`, `Dockerfile` becomes `Dockerfile.dockerfile`. A dotfile appends too — `.gitignore`
+    // has no extension to replace, and `.gitignore.plaintext` is a name hljs can read.
     const baseName = path.split('/').pop() ?? path;
     const dot = baseName.lastIndexOf('.');
-    if (dot <= 0) {
-        const alias = FILE_NAME_LANGS[baseName.toLowerCase()];
-        return alias ? `${path}.${alias}` : path;
-    }
-    const ext = baseName.slice(dot + 1).toLowerCase();
-    const alias = ALIASES[ext];
-    return alias ? path.slice(0, path.length - ext.length) + alias : path;
+    const stem = dot > 0 ? path.slice(0, path.length - (baseName.length - dot)) : path;
+    return `${stem}.${lang}`;
 }
 
 /**

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/lang.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/lang.ts
@@ -4,9 +4,9 @@
  */
 import hljs from 'highlight.js';
 
-// Language alias maps for highlight.js. Used by the markdown code block renderer (fence label →
-// language), the diff renderer (file extension → language for the patch header) and Write's body
-// (the file's own extension).
+// Language aliases for highlight.js, and the two ways in: `resolveLang` for a fence label,
+// `langForFile` for a path. Used by the markdown code block renderer, the diff preview and its
+// patch header, and Write's body.
 //
 // Only entries that hljs does NOT recognise natively. hljs already covers:
 // bash/sh/zsh, json/jsonc/json5, xml/html/xhtml/plist/svg, dockerfile,
@@ -14,13 +14,20 @@ import hljs from 'highlight.js';
 // See https://github.com/highlightjs/highlight.js/blob/main/SUPPORTED_LANGUAGES.md
 
 /**
- * Map fence label / extension to a hljs-supported language.
+ * Map a fence label, a file extension, or a whole filename to a hljs-supported language.
  * Add an entry here when authors hit a "no highlighting" fence in the wild.
+ *
+ * One map rather than two: the keys never collide — extensions on one side, extensionless
+ * filenames on the other — and splitting them meant every caller had to know which of the two to
+ * ask, so most asked neither. Not exported for the same reason: `langForFile` and `resolveLang`
+ * are the two questions worth asking, and a caller reaching past them into the table is a caller
+ * about to get a dotfile or a suffixed name wrong.
  */
-export const ALIASES: Record<string, string> = {
+const LANGS: Record<string, string> = {
     // .NET project / build / config (XML)
     csproj: 'xml',
     vbproj: 'xml',
+    vcxproj: 'xml',
     fsproj: 'xml',
     sqlproj: 'xml',
     shproj: 'xml',
@@ -34,6 +41,7 @@ export const ALIASES: Record<string, string> = {
     ruleset: 'xml',
     manifest: 'xml',
     appxmanifest: 'xml',
+    vsixmanifest: 'xml',
     slnx: 'xml',
     vsct: 'xml',
 
@@ -78,27 +86,71 @@ export const ALIASES: Record<string, string> = {
     // Plain text fallbacks
     gitignore: 'plaintext',
     gitattributes: 'plaintext',
+    dockerignore: 'plaintext',
+    npmignore: 'plaintext',
+    prettierignore: 'plaintext',
+    eslintignore: 'plaintext',
     log: 'plaintext',
     txt: 'plaintext',
-};
 
-/**
- * Special filenames without an extension → language. Used by the diff
- * renderer to compute the patch header path so hljs picks the right
- * language for files like `Dockerfile` or `Makefile`.
- */
-export const FILE_NAME_LANGS: Record<string, string> = {
+    // Whole filenames, for files that carry no extension at all. `containerfile` is up with the
+    // container entries above — it reads as an extension too, and one entry serves both.
+    // Taken from GitHub Linguist's `filenames`, keeping the ones a .NET/web/Windows repo actually
+    // holds: its full list runs to 130 names, most of them ecosystems nobody opens in this IDE.
     dockerfile: 'dockerfile',
-    containerfile: 'dockerfile',
     makefile: 'makefile',
     gnumakefile: 'makefile',
+    bsdmakefile: 'makefile',
+    kbuild: 'makefile',
     rakefile: 'ruby',
     gemfile: 'ruby',
     podfile: 'ruby',
+    brewfile: 'ruby',
+    fastfile: 'ruby',
+    appfile: 'ruby',
+    guardfile: 'ruby',
+    capfile: 'ruby',
     cmakelists: 'cmake',
     jenkinsfile: 'groovy',
     vagrantfile: 'ruby',
+    justfile: 'makefile',
+    procfile: 'yaml',
+    caddyfile: 'nginx',
+    codeowners: 'plaintext',
+    pkgbuild: 'bash',
+    gradlew: 'bash',
+    bash_profile: 'bash',
+    bash_aliases: 'bash',
+    bash_logout: 'bash',
+    cshrc: 'bash',
+    kshrc: 'bash',
+    profile: 'bash',
+    pylintrc: 'ini',
+    browserslist: 'plaintext',
 };
+
+/**
+ * The keys of LANGS that are whole filenames rather than extensions — the ones a suffix can be
+ * appended to (`Dockerfile.prod`) and still name the same kind of file. Kept apart because the map
+ * holds both kinds and a stem lookup against all of it would read `env.config` as an `env` file.
+ */
+const WHOLE_FILE_NAMES = new Set([
+    'dockerfile',
+    'containerfile',
+    'makefile',
+    'gnumakefile',
+    'bsdmakefile',
+    'rakefile',
+    'gemfile',
+    'podfile',
+    'brewfile',
+    'cmakelists',
+    'jenkinsfile',
+    'vagrantfile',
+    'justfile',
+    'procfile',
+    'caddyfile',
+]);
 
 /**
  * Resolve a fence label or extension to a hljs language name.
@@ -107,7 +159,45 @@ export const FILE_NAME_LANGS: Record<string, string> = {
  */
 export function resolveLang(label: string | undefined | null): string {
     const lc = (label ?? '').toLowerCase();
-    return ALIASES[lc] || lc;
+    return LANGS[lc] || lc;
+}
+
+/**
+ * The hljs language for a file path — the question every caller actually has, asked once here
+ * instead of four times as "what is the extension?".
+ *
+ * Three shapes, in the order that makes them unambiguous:
+ *  - a whole filename (`Dockerfile`, `Makefile`) — has no extension to find;
+ *  - a dotfile (`.gitignore`, `.editorconfig`) — where `lastIndexOf('.')` is 0, so the name IS
+ *    the key, with the leading dot dropped;
+ *  - an extension (`Foo.csproj`).
+ *
+ * Filename first: `.editorconfig` read as an extension would answer `ini` and lose the name, and
+ * a file called `Dockerfile.prod` should be a Dockerfile, not a `prod`.
+ *
+ * Returns '' when there is nothing to go on, which highlightCode treats as "render it plain".
+ */
+export function langForFile(filePath: string | undefined | null): string {
+    const base = (filePath ?? '').split(/[\\/]/).pop()?.toLowerCase() ?? '';
+    if (!base) {
+        return '';
+    }
+    const byName = LANGS[base] ?? LANGS[base.replace(/^\./, '')];
+    if (byName) {
+        return byName;
+    }
+    const dot = base.lastIndexOf('.');
+    // A suffixed filename — `Dockerfile.prod`, `Makefile.am` — is still that file, so the stem is
+    // worth a look before the suffix is taken for an extension. Only against the names, though:
+    // `env` and `config` are both keys, and reading `env.config` by its stem would answer for the
+    // wrong half of it.
+    if (dot > 0 && WHOLE_FILE_NAMES.has(base.slice(0, dot))) {
+        return LANGS[base.slice(0, dot)];
+    }
+    // dot === 0 is a dotfile the map does not know: its name is not an extension, so there is
+    // nothing left to try.
+    const ext = dot > 0 ? base.slice(dot + 1) : '';
+    return ext ? (LANGS[ext] ?? ext) : '';
 }
 
 // Bounded like the markdown one, and for the same reason: the callers are Lit render() bodies, so

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-diff-preview.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-diff-preview.ts
@@ -7,7 +7,7 @@ import { customElement, property } from 'lit/decorators.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { buildRows, rowsFromHunks, type Row, type Seg } from '../../core/diff-rows';
 import type { PatchHunkDto } from '../../core/generated/PatchHunkDto';
-import { highlightCode } from '../../core/lang';
+import { highlightCode, langForFile } from '../../core/lang';
 import { markRanges, rangesOf } from '../../core/mark-ranges';
 
 /** Unchanged lines kept around each change — what git and GitHub show. */
@@ -88,11 +88,9 @@ export class CvDiffPreview extends LitElement {
         // can reach, and the full diff is one click away in Visual Studio.
         const shown = rows.slice(0, VISIBLE_ROWS);
         const more = rows.length - shown.length;
-        // Extension only, like Write's renderer (renderers.ts): highlightCode resolves a fence
-        // label or extension, not a full path, so the path itself would never match.
-        const name = this.filePath.split(/[\\/]/).pop() ?? '';
-        const dot = name.lastIndexOf('.');
-        const lang = dot > 0 ? name.slice(dot + 1) : '';
+        // langForFile, not the extension: an extensionless name is a language too — a Dockerfile
+        // went unhighlighted here for as long as this read the extension itself.
+        const lang = langForFile(this.filePath);
         return html`<div
             class="cv-diff-preview-wrap ${fromCli ? '' : 'no-gutter'}"
             data-action="diff-expand"

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/renderers.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/tool-renderers/renderers.ts
@@ -7,6 +7,7 @@
 // registered in index.ts. No name-switching anywhere else.
 
 import { html, nothing, type TemplateResult } from 'lit';
+import { langForFile } from '../../core/lang';
 import { fileName } from '../../core/path';
 import { displayPathUi } from '../paths';
 import { truncate } from '../helpers/format';
@@ -100,13 +101,8 @@ export class WriteRenderer extends ToolRenderer {
         });
     }
     override highlightAs(): string {
-        const name =
-            String(this.host.input.file_path ?? '')
-                .split(/[\\/]/)
-                .pop() ?? '';
-        const dot = name.lastIndexOf('.');
-        // Extension only when there is one: an extensionless name is not its own language.
-        return dot > 0 ? name.slice(dot + 1) : '';
+        // An extensionless name IS its own language when the map knows it — Dockerfile, Makefile.
+        return langForFile(String(this.host.input.file_path ?? ''));
     }
 }
 

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.cs
@@ -308,7 +308,7 @@ internal sealed partial class IdeNavigationService
     /// Miscellaneous Files node — a flat pass over DTE's Solution.Projects gets both of those
     /// wrong, as an earlier attempt at this in Search.cs found out by reporting "File esterni".
     /// </para></summary>
-    private static (ForeignFiles[] Outside, ForeignFiles[] Uncovered) WalkSolution(
+    private (ForeignFiles[] Outside, ForeignFiles[] Uncovered) WalkSolution(
         System.Collections.Generic.Dictionary<string, string> inWorkspace)
     {
         try
@@ -360,7 +360,7 @@ internal sealed partial class IdeNavigationService
     /// <summary>Source files by extension. With a <paramref name="language"/> only the ones that
     /// language does not answer for are counted; with null every source file is, which is the case
     /// for a project no language service reaches at all.</summary>
-    private static System.Collections.Generic.Dictionary<string, int> CountExtensions(
+    private System.Collections.Generic.Dictionary<string, int> CountExtensions(
         System.Collections.Generic.List<string> files, string language)
     {
         var counts = new System.Collections.Generic.Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
@@ -378,36 +378,100 @@ internal sealed partial class IdeNavigationService
         return counts;
     }
 
-    /// <summary>Whether a project of <paramref name="language"/> is the one that answers for files
-    /// with this extension. Deliberately a short list rather than IFileExtensionRegistryService:
-    /// the question is not "which language is this file" but "does THIS project's service cover
-    /// it", and everything outside the list is the answer we are looking for anyway.</summary>
-    private static bool SpeaksFor(string language, string extension) => language switch
+    /// <summary><para>Whether a project of <paramref name="language"/> is the one that answers for
+    /// files with this extension — asked of Roslyn, which maps a content type back to the language
+    /// name it uses, rather than kept as a table here.</para>
+    /// <para><c>IContentTypeLanguageService</c> is the reverse of what the name suggests: it is a
+    /// per-language service, so asking the language for its content type and comparing is how the
+    /// mapping is read in that direction. A language that does not register one (or a file VS has
+    /// no content type for) answers true — an unknown pairing is not evidence of a gap, and
+    /// over-reporting would be the worse mistake here.</para></summary>
+    private bool SpeaksFor(string language, string extension)
     {
-        "C#" => extension.Equals(".cs", StringComparison.OrdinalIgnoreCase)
-                || extension.Equals(".csx", StringComparison.OrdinalIgnoreCase),
-        "Visual Basic" => extension.Equals(".vb", StringComparison.OrdinalIgnoreCase),
-        "F#" => extension.Equals(".fs", StringComparison.OrdinalIgnoreCase)
-                || extension.Equals(".fsi", StringComparison.OrdinalIgnoreCase)
-                || extension.Equals(".fsx", StringComparison.OrdinalIgnoreCase),
-        "TypeScript" => extension.Equals(".ts", StringComparison.OrdinalIgnoreCase)
-                        || extension.Equals(".tsx", StringComparison.OrdinalIgnoreCase)
-                        || extension.Equals(".js", StringComparison.OrdinalIgnoreCase)
-                        || extension.Equals(".jsx", StringComparison.OrdinalIgnoreCase),
-        // An unknown language: say yes, so a language we have not met is not reported as a gap.
-        _ => true,
-    };
+        try
+        {
+            var model = Package.GetGlobalService(typeof(SComponentModel)) as IComponentModel;
+            var registry = model?.GetService<Microsoft.VisualStudio.Utilities.IFileExtensionRegistryService>();
+            var fileContentType = registry?.GetContentTypeForExtension(extension.TrimStart('.'));
+            if (fileContentType == null) { return true; }
 
-    /// <summary>Extensions worth reporting as uncovered — code, not assets.</summary>
+            var languageContentType = ContentTypeOf(language);
+            return languageContentType == null || fileContentType.IsOfType(languageContentType);
+        }
+        catch (Exception ex)
+        {
+            OutputWindowLogger.Global.Debug(() => $"[nav] content type for '{language}'/'{extension}': {ex.Message}");
+            return true;
+        }
+    }
+
+    /// <summary>The editor content type a Roslyn language name corresponds to, or null when this VS
+    /// does not say. Read from the language's own <c>IContentTypeLanguageService</c> — which exists
+    /// for exactly this and is cached per language, since the answer cannot change while VS runs.
+    /// </summary>
+    private string ContentTypeOf(string language)
+    {
+        if (_contentTypeByLanguage.TryGetValue(language, out var cached)) { return cached; }
+
+        string name = null;
+        try
+        {
+            var serviceType = VsReflection.FindType("Microsoft.CodeAnalysis.Editor.IContentTypeLanguageService");
+            var solution = VsReflection.GetProp(_workspace, "CurrentSolution");
+            foreach (var project in ((IEnumerable)VsReflection.GetProp(solution, "Projects")).Cast<object>())
+            {
+                if (VsReflection.GetPropOrNull(project, "Language") as string != language) { continue; }
+                var services = VsReflection.GetPropOrNull(project, "Services")
+                               ?? VsReflection.GetPropOrNull(project, "LanguageServices");
+                if (serviceType == null || services == null) { break; }
+
+                var service = _getServiceGeneric.MakeGenericMethod(serviceType).Invoke(services, null);
+                var contentType = service == null ? null : VsReflection.Invoke(service, "GetDefaultContentType");
+                name = VsReflection.GetPropOrNull(contentType, "TypeName") as string;
+                break;
+            }
+        }
+        catch (Exception ex)
+        {
+            OutputWindowLogger.Global.Debug(() => $"[nav] no content type for language '{language}': {ex.Message}");
+        }
+
+        _contentTypeByLanguage[language] = name;
+        return name;
+    }
+
+    private readonly System.Collections.Generic.Dictionary<string, string> _contentTypeByLanguage =
+        new(StringComparer.Ordinal);
+
+    /// <summary><para>Whether this is a file VS treats as code — asked of the editor, which knows,
+    /// rather than kept as a list of our own.</para>
+    /// <para>An extension VS has a content type for is one some editor claims; one it does not is
+    /// an asset. The content-type hierarchy answers the rest: everything textual derives from
+    /// "text", and code from "code", so a `.png` and a `.dll` fall out without being enumerated.
+    /// Same reasoning as IconCacheService (extension → icon via IVsImageService2) and MimeTypes
+    /// (extension → MIME via urlmon): the platform already keeps this in sync with whatever the
+    /// user has installed, and a sixth extension list in this codebase would go stale the day
+    /// someone adds a language — see the extension-lists entry in docs/internal/TODO.md.</para>
+    /// <para>Best effort: if the registry cannot be reached, everything counts. Over-reporting a
+    /// `.json` as uncovered is a smaller lie than silently dropping a language we do not know.
+    /// </para></summary>
     private static bool IsSourceExtension(string extension)
     {
-        string[] source =
-        [
-            ".cs", ".vb", ".fs", ".fsi", ".fsx", ".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs",
-            ".cpp", ".cc", ".cxx", ".c", ".h", ".hpp", ".hxx", ".ipp",
-            ".py", ".sql", ".xaml", ".razor", ".cshtml", ".vbhtml", ".css", ".scss", ".less",
-        ];
-        return source.Contains(extension, StringComparer.OrdinalIgnoreCase);
+        try
+        {
+            var model = Package.GetGlobalService(typeof(SComponentModel)) as IComponentModel;
+            var registry = model?.GetService<Microsoft.VisualStudio.Utilities.IFileExtensionRegistryService>();
+            if (registry == null) { return true; }
+
+            var contentType = registry.GetContentTypeForExtension(extension.TrimStart('.'));
+            // "text" is what every editable file derives from; the unknown content type does not.
+            return contentType != null && contentType.IsOfType("text");
+        }
+        catch (Exception ex)
+        {
+            OutputWindowLogger.Global.Debug(() => $"[nav] content type for '{extension}': {ex.Message}");
+            return true;
+        }
     }
 
     /// <summary>1-based line/column for a byte offset into a file on disk, plus the trimmed source


### PR DESCRIPTION
## What this fixes

A `Dockerfile` in a diff rendered without highlighting, and so did `Makefile`, `.gitignore` and
every other file whose name carries no extension — while the map that knew `Dockerfile` means
dockerfile sat one import away.

`core/lang.ts` had two maps: `ALIASES` (extension → language) and `FILE_NAME_LANGS` (whole filename
→ language). The two places that actually highlight a file consulted neither. Both worked the
extension out themselves:

```ts
const dot = name.lastIndexOf('.');
const lang = dot > 0 ? name.slice(dot + 1) : '';
```

which answers `''` for every name without an extension, and for every dotfile too — `lastIndexOf('.')`
is `0` there. One of them said so in a comment: *"an extensionless name is not its own language"*.

Only `patchPathFor` used the maps, and only to build the patch header.

## What changed

**One map, one way in.** `LANGS` replaces both, and `langForFile(path)` is the single entry point:
whole name → name without its leading dot → extension. The two highlighters and `patchPathFor` all
go through it.

The order is not cosmetic. `.editorconfig` read as an extension answers `ini` and loses the name;
`Dockerfile.prod` read by its suffix answers `prod`. So: filename first, then a stem check limited
to the names that take a suffix — limited, because `env` and `config` are both keys and `env.config`
must answer for the extension, not the stem.

`LANGS` is not exported. Reaching past `langForFile` into the table is how a caller gets a dotfile
wrong, which is how this started.

**Gaps the merge made visible.** Every extension this repo actually contains is now either in the
map or native to hljs: `.vcxproj` was missing beside its five siblings, `.vsixmanifest` is this
extension's own manifest, and the ignore files had only `.gitignore` of the family. Plus, from
GitHub Linguist's `filenames`, the ones a .NET/web/Windows repo really holds — CODEOWNERS, Justfile,
Procfile, Brewfile, gradlew, the shell dotfiles. Linguist lists 130; the rest are ecosystems nobody
opens in this IDE, and the comment in the map says so.

**And the same question, asked of the platform instead of a list.** `nav_get_language_coverage`
(merged in #193) arrived with two hardcoded extension tables of its own. They are gone:
`IFileExtensionRegistryService` answers "is this file code?" through the content-type hierarchy, and
`IContentTypeLanguageService` answers "does this project's language own it?". That is the position
this codebase already takes three times over — `IconCacheService` gets icons from
`IVsImageService2`, `MimeTypes` gets MIME types from urlmon, `ThumbnailGenerator` hands bytes to WIC
— and it holds wherever the platform has an answer.

## Verification

- 179 WebView tests pass, unchanged.
- `langForFile` checked against 18 cases: `Dockerfile`, `Dockerfile.prod`, `Makefile.am`,
  `.gitignore`, `.editorconfig`, `env.config` (→ `xml`, not `ini`), `Foo.csproj`, `LICENSE`,
  `CMakeLists.txt`, and the plain extensions.
- Every value in the map resolves to a language hljs knows; no `WHOLE_FILE_NAMES` entry is missing
  from `LANGS`, which would have made `langForFile` return undefined.
- Cross-checked against the extensions this repo actually contains: nothing uncovered but `.png`.

Still to check by hand in the experimental instance: that a `Dockerfile` diff is visibly coloured.
The logic is verified; the rendering is not.

## Not in this PR

`BUILT_IN_EXT` in `core/file-links.ts` (268 entries) stays. Replacing it with a regex was tried —
`/^[a-z][a-z0-9]{0,9}$/` — and turns 3 of the 179 tests red: `localhost.net:4040`, a host:port, an
unknown extension in prose. `.cs` and `.net` are indistinguishable by shape, and a false positive
there is not a dead link but a red banner from `NoticeOpenFailed`, which the user has to dismiss and
cannot turn off. The reasoning, and what the other tools do instead, is written up under
`docs/internal/`.
