### PR TITLE
Stop the reader thread waiting on the UI thread, and three smaller defects around it

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.ClientEvents.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.ClientEvents.cs
@@ -461,38 +461,44 @@ public partial class ChatPaneControl
         => Dispatcher.Invoke(() => _bridge.Send(BridgeMessages.ToWebView.Chat.ToolPermissionCancel,
             new Contracts.ToolPermissionCancelNotification { ToolUseId = e.ToolUseId }));
 
+    // These three fire once per streamed token, and they are the reason they use BeginInvoke where
+    // every other handler here uses Invoke. Invoke is synchronous: it parks the NDJSON reader thread
+    // until the UI thread has run the delegate, so the reader stopped reading stdout on every token.
+    // While VS is busy with a build or IntelliSense, that backs up into claude.exe's pipe and the
+    // CLI itself blocks on write — the chat stutters exactly when the IDE is under load, which
+    // reads as the model being slow. Posting and moving on costs the reader nothing.
+    //
+    // Ordering against the Invoke handlers is preserved: every client event comes from the one
+    // reader thread, and both Invoke and BeginInvoke queue on the same dispatcher at Normal
+    // priority, which is FIFO. Delta N and the tool_use after it still arrive in that order.
     private void OnAssistantTextDelta(object sender, AssistantTextDeltaEventArgs e)
-        => Dispatcher.Invoke(() =>
-        {
-            _bridge.Send(BridgeMessages.ToWebView.Chat.AssistantTextDelta, new Contracts.AssistantTextDeltaNotification
+        => Dispatcher.BeginInvoke(new Action(()
+            => _bridge?.Send(BridgeMessages.ToWebView.Chat.AssistantTextDelta, new Contracts.AssistantTextDeltaNotification
             {
                 Text = e.Delta,
                 Index = e.Index,
                 ParentToolUseId = e.ParentToolUseId,
-            });
-        });
+            })));
 
     private void OnAssistantThinkingDelta(object sender, AssistantThinkingDeltaEventArgs e)
-        => Dispatcher.Invoke(() =>
-            _bridge.Send(BridgeMessages.ToWebView.Chat.ThinkingDelta, new Contracts.ThinkingDeltaNotification
+        => Dispatcher.BeginInvoke(new Action(()
+            => _bridge?.Send(BridgeMessages.ToWebView.Chat.ThinkingDelta, new Contracts.ThinkingDeltaNotification
             {
                 Uuid = "",                      // stream deltas have no message uuid yet; keyed by parentToolUseId
                 Text = e.Delta,
                 EstimatedTokens = e.EstimatedTokens,
                 ParentToolUseId = e.ParentToolUseId,
-            }));
+            })));
 
     private void OnToolProgress(object sender, ToolProgressEventArgs e)
-        => Dispatcher.Invoke(() =>
-        {
-            _bridge.Send(BridgeMessages.ToWebView.Chat.ToolProgress, new Contracts.ToolProgressNotification
+        => Dispatcher.BeginInvoke(new Action(()
+            => _bridge?.Send(BridgeMessages.ToWebView.Chat.ToolProgress, new Contracts.ToolProgressNotification
             {
                 ToolUseId = e.ToolUseId,
                 ToolName = e.ToolName,
                 ElapsedSeconds = e.ElapsedSeconds,
                 ParentToolUseId = e.ParentToolUseId,
-            });
-        });
+            })));
 
     private void OnSystemMessage(object sender, JObject obj)
         => Dispatcher.Invoke(() =>

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.ClientEvents.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.ClientEvents.cs
@@ -461,16 +461,10 @@ public partial class ChatPaneControl
         => Dispatcher.Invoke(() => _bridge.Send(BridgeMessages.ToWebView.Chat.ToolPermissionCancel,
             new Contracts.ToolPermissionCancelNotification { ToolUseId = e.ToolUseId }));
 
-    // These three fire once per streamed token, and they are the reason they use BeginInvoke where
-    // every other handler here uses Invoke. Invoke is synchronous: it parks the NDJSON reader thread
-    // until the UI thread has run the delegate, so the reader stopped reading stdout on every token.
-    // While VS is busy with a build or IntelliSense, that backs up into claude.exe's pipe and the
-    // CLI itself blocks on write — the chat stutters exactly when the IDE is under load, which
-    // reads as the model being slow. Posting and moving on costs the reader nothing.
-    //
-    // Ordering against the Invoke handlers is preserved: every client event comes from the one
-    // reader thread, and both Invoke and BeginInvoke queue on the same dispatcher at Normal
-    // priority, which is FIFO. Delta N and the tool_use after it still arrive in that order.
+    // BeginInvoke, not Invoke like the rest: these three fire once per streamed token, and a
+    // synchronous marshal parks the NDJSON reader until the UI thread answers — under a build that
+    // backs up into claude.exe's pipe. Order still holds: one reader thread, one dispatcher queue,
+    // same priority.
     private void OnAssistantTextDelta(object sender, AssistantTextDeltaEventArgs e)
         => Dispatcher.BeginInvoke(new Action(()
             => _bridge?.Send(BridgeMessages.ToWebView.Chat.AssistantTextDelta, new Contracts.AssistantTextDeltaNotification

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
@@ -100,14 +100,35 @@ public partial class ChatPaneControl : PaneControlBase
     public override void LoadSession(string sessionId)
     {
         if (string.IsNullOrEmpty(sessionId) || _client == null) { return; }
+        // Clear first, on the click itself: the read below is off-thread now, and the transcript
+        // would otherwise sit there showing the old session while the new one loads.
         _bridge?.Send(BridgeMessages.ToWebView.Chat.Cleared, null);
-        var (mode, page, info) = ReadSessionState(sessionId);
-        SendHistoryPage(page, sessionId);
-        SetSessionTitle(info?.CustomTitle ?? info?.AiTitle ?? info?.LastPrompt);
-        // Pass the session's own mode so the respawned CLI runs on what
-        // the selector shows (not the client's leftover state). Model isn't
-        // passed: --resume re-emits the session's own model via init.
-        _ = _client.ResumeSessionAsync(sessionId, mode);
+        // Stays void: IPaneControl declares it so, both callers are event handlers that cannot
+        // await, and the toolbar focuses the composer on the next line — a caller awaiting the
+        // disk read would just delay the caret for no one's benefit.
+        ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+        {
+            try
+            {
+                // Reached from the toolbar's History dropdown — a click handler, so the UI thread.
+                // ReadSessionState is disk + JSON parse (~200ms on a big session): off-thread, or VS
+                // freezes while it runs.
+                var (mode, page, info) = await Task.Run(() => ReadSessionState(sessionId));
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                SendHistoryPage(page, sessionId);
+                SetSessionTitle(info?.CustomTitle ?? info?.AiTitle ?? info?.LastPrompt);
+                // Pass the session's own mode so the respawned CLI runs on what
+                // the selector shows (not the client's leftover state). Model isn't
+                // passed: --resume re-emits the session's own model via init.
+                _ = _client.ResumeSessionAsync(sessionId, mode);
+            }
+            catch (Exception ex)
+            {
+                // The transcript is already cleared by now, so a swallowed failure would leave the
+                // pane blank with nothing said about why.
+                _log.LogException($"[chat] load session {sessionId}", ex);
+            }
+        });
     }
 
     /// <summary>Read a session once: its permission mode (the CLI doesn't restore this from
@@ -502,9 +523,29 @@ public partial class ChatPaneControl : PaneControlBase
 
         // Reload the transcript into the WebView only; do NOT call ResumeSessionAsync — re-rendering
         // UI options needs no respawn, and respawning here is not safe.
-        _bridge?.Send(BridgeMessages.ToWebView.Chat.Cleared, null);
-        var page = Sessions.ReadHistoryRaw(sid, SessionManager.HistoryBatchSize, -1, out _);
-        SendHistoryPage(page, sid);
+        ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+        {
+            try
+            {
+                // Same disk + parse cost as LoadSession, same reason to keep it off the UI thread.
+                var page = await Task.Run(() => Sessions.ReadHistoryRaw(sid, SessionManager.HistoryBatchSize, -1, out _));
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                // Re-check: the read gave a turn time to start, and the guard above exists precisely
+                // because clearing mid-turn drops a reply that is not in the .jsonl yet. Checking
+                // only before the await would let exactly that through.
+                if (_turnInFlight)
+                {
+                    _log.Debug(() => $"[chat] turn started while reading {sid} — transcript left alone");
+                    return;
+                }
+                _bridge?.Send(BridgeMessages.ToWebView.Chat.Cleared, null);
+                SendHistoryPage(page, sid);
+            }
+            catch (Exception ex)
+            {
+                _log.LogException($"[chat] options re-render {sid}", ex);
+            }
+        });
     }
 
     private async Task InitAsync()

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
@@ -103,6 +103,9 @@ public partial class ChatPaneControl : PaneControlBase
         // Clear first, on the click itself: the read below is off-thread now, and the transcript
         // would otherwise sit there showing the old session while the new one loads.
         _bridge?.Send(BridgeMessages.ToWebView.Chat.Cleared, null);
+        // Two picks in a row are two reads in flight, and they finish in whatever order the file
+        // sizes decide — not in click order.
+        var generation = ++_loadGeneration;
         // Stays void: IPaneControl declares it so, both callers are event handlers that cannot
         // await, and the toolbar focuses the composer on the next line — a caller awaiting the
         // disk read would just delay the caret for no one's benefit.
@@ -115,6 +118,9 @@ public partial class ChatPaneControl : PaneControlBase
                 // freezes while it runs.
                 var (mode, page, info) = await Task.Run(() => ReadSessionState(sessionId));
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                // Superseded by a later pick, or the pane torn down while we read (DisposeCore nulls
+                // the bridge) — either way nobody is looking at this session any more.
+                if (generation != _loadGeneration || _bridge == null) { return; }
                 SendHistoryPage(page, sessionId);
                 SetSessionTitle(info?.CustomTitle ?? info?.AiTitle ?? info?.LastPrompt);
                 // Pass the session's own mode so the respawned CLI runs on what
@@ -328,6 +334,8 @@ public partial class ChatPaneControl : PaneControlBase
     // True between the CLI's first status for a turn and its `result`. Keeps Options → Apply from
     // re-rendering the transcript mid-turn, which would drop the reply still being streamed.
     private bool _turnInFlight;
+    // Bumped by every transcript load, so a read that outlives its pick can tell and drop its answer.
+    private int _loadGeneration;
 
     // When set (by PaneLauncher before the pane loads), this pane opens ON this
     // session instead of a fresh one — used to land a fork in its own pane.
@@ -523,6 +531,9 @@ public partial class ChatPaneControl : PaneControlBase
 
         // Reload the transcript into the WebView only; do NOT call ResumeSessionAsync — re-rendering
         // UI options needs no respawn, and respawning here is not safe.
+        // Same generation counter as LoadSession: a session picked while this read is in flight
+        // must win, or the options re-render paints the previous session over the chosen one.
+        var generation = ++_loadGeneration;
         ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
         {
             try
@@ -530,6 +541,7 @@ public partial class ChatPaneControl : PaneControlBase
                 // Same disk + parse cost as LoadSession, same reason to keep it off the UI thread.
                 var page = await Task.Run(() => Sessions.ReadHistoryRaw(sid, SessionManager.HistoryBatchSize, -1, out _));
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                if (generation != _loadGeneration || _bridge == null) { return; }
                 // Re-check: the read gave a turn time to start, and the guard above exists precisely
                 // because clearing mid-turn drops a reply that is not in the .jsonl yet. Checking
                 // only before the await would let exactly that through.
@@ -538,7 +550,7 @@ public partial class ChatPaneControl : PaneControlBase
                     _log.Debug(() => $"[chat] turn started while reading {sid} — transcript left alone");
                     return;
                 }
-                _bridge?.Send(BridgeMessages.ToWebView.Chat.Cleared, null);
+                _bridge.Send(BridgeMessages.ToWebView.Chat.Cleared, null);
                 SendHistoryPage(page, sid);
             }
             catch (Exception ex)

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
@@ -103,19 +103,15 @@ public partial class ChatPaneControl : PaneControlBase
         // Clear first, on the click itself: the read below is off-thread now, and the transcript
         // would otherwise sit there showing the old session while the new one loads.
         _bridge?.Send(BridgeMessages.ToWebView.Chat.Cleared, null);
-        // Two picks in a row are two reads in flight, and they finish in whatever order the file
-        // sizes decide — not in click order.
+        // Two picks in a row are two reads in flight, finishing in whatever order the file sizes
+        // decide rather than in click order.
         var generation = ++_loadGeneration;
-        // Stays void: IPaneControl declares it so, both callers are event handlers that cannot
-        // await, and the toolbar focuses the composer on the next line — a caller awaiting the
-        // disk read would just delay the caret for no one's benefit.
         ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
         {
             try
             {
-                // Reached from the toolbar's History dropdown — a click handler, so the UI thread.
-                // ReadSessionState is disk + JSON parse (~200ms on a big session): off-thread, or VS
-                // freezes while it runs.
+                // Off-thread: this runs on the click that opened the History dropdown, and the read
+                // is disk + JSON parse (~200ms on a big session).
                 var (mode, page, info) = await Task.Run(() => ReadSessionState(sessionId));
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 // Superseded by a later pick, or the pane torn down while we read (DisposeCore nulls
@@ -130,8 +126,8 @@ public partial class ChatPaneControl : PaneControlBase
             }
             catch (Exception ex)
             {
-                // The transcript is already cleared by now, so a swallowed failure would leave the
-                // pane blank with nothing said about why.
+                // The transcript is already cleared: swallowed, this leaves a blank pane and no
+                // reason for it.
                 _log.LogException($"[chat] load session {sessionId}", ex);
             }
         });
@@ -538,13 +534,11 @@ public partial class ChatPaneControl : PaneControlBase
         {
             try
             {
-                // Same disk + parse cost as LoadSession, same reason to keep it off the UI thread.
                 var page = await Task.Run(() => Sessions.ReadHistoryRaw(sid, SessionManager.HistoryBatchSize, -1, out _));
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 if (generation != _loadGeneration || _bridge == null) { return; }
-                // Re-check: the read gave a turn time to start, and the guard above exists precisely
-                // because clearing mid-turn drops a reply that is not in the .jsonl yet. Checking
-                // only before the await would let exactly that through.
+                // Re-checked, not just checked above: the read gave a turn time to start, and that
+                // is exactly what the guard is for.
                 if (_turnInFlight)
                 {
                     _log.Debug(() => $"[chat] turn started while reading {sid} — transcript left alone");

--- a/src/Corsinvest.VisualStudio.Agents/Cli/ConPty.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Cli/ConPty.cs
@@ -104,12 +104,15 @@ internal static class ConPty
             var flags = EXTENDED_STARTUPINFO_PRESENT;
             try
             {
-                // Also when env is empty but something has to be dropped: removing an inherited
-                // variable needs a block of our own just as much as overlaying one does.
-                var hasDrop = dropEnv != null && dropEnv.Any();
-                if ((env != null && env.Count > 0) || hasDrop)
+                // Materialised once: the caller's IEnumerable is read here to decide whether a block
+                // is needed at all and again to build it, and a lazy sequence must not answer those
+                // two differently.
+                var drop = dropEnv?.ToArray();
+                // A block is also needed when env is empty but something has to be dropped: removing
+                // an inherited variable takes an environment of our own just as overlaying one does.
+                if ((env != null && env.Count > 0) || drop?.Length > 0)
                 {
-                    envBlock = BuildEnvironmentBlock(env ?? new Dictionary<string, string>(), dropEnv);
+                    envBlock = BuildEnvironmentBlock(env ?? new Dictionary<string, string>(), drop);
                     flags |= CREATE_UNICODE_ENVIRONMENT;
                 }
 

--- a/src/Corsinvest.VisualStudio.Agents/Cli/ConPty.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Cli/ConPty.cs
@@ -104,12 +104,11 @@ internal static class ConPty
             var flags = EXTENDED_STARTUPINFO_PRESENT;
             try
             {
-                // Materialised once: the caller's IEnumerable is read here to decide whether a block
-                // is needed at all and again to build it, and a lazy sequence must not answer those
-                // two differently.
+                // Materialised once — read below to decide whether a block is needed, and again to
+                // build it; a lazy sequence must not answer those two differently.
                 var drop = dropEnv?.ToArray();
-                // A block is also needed when env is empty but something has to be dropped: removing
-                // an inherited variable takes an environment of our own just as overlaying one does.
+                // Dropping an inherited variable takes an environment of our own just as overlaying
+                // one does, so an empty env with something to drop still needs a block.
                 if ((env != null && env.Count > 0) || drop?.Length > 0)
                 {
                     envBlock = BuildEnvironmentBlock(env ?? new Dictionary<string, string>(), drop);

--- a/src/Corsinvest.VisualStudio.Agents/Cli/ConPty.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Cli/ConPty.cs
@@ -76,7 +76,7 @@ internal static class ConPty
     /// CLI/z.ai) coexist without a shared-env race. The returned session owns all handles.
     /// </summary>
     public static Session Create(string command, string workingDirectory, short cols, short rows,
-        IReadOnlyDictionary<string, string> env)
+        IReadOnlyDictionary<string, string> env, IEnumerable<string> dropEnv = null)
     {
         var (inRead, inWrite, outRead, outWrite) = CreatePipes();
 
@@ -104,9 +104,12 @@ internal static class ConPty
             var flags = EXTENDED_STARTUPINFO_PRESENT;
             try
             {
-                if (env != null && env.Count > 0)
+                // Also when env is empty but something has to be dropped: removing an inherited
+                // variable needs a block of our own just as much as overlaying one does.
+                var hasDrop = dropEnv != null && dropEnv.Any();
+                if ((env != null && env.Count > 0) || hasDrop)
                 {
-                    envBlock = BuildEnvironmentBlock(env);
+                    envBlock = BuildEnvironmentBlock(env ?? new Dictionary<string, string>(), dropEnv);
                     flags |= CREATE_UNICODE_ENVIRONMENT;
                 }
 
@@ -206,15 +209,18 @@ internal static class ConPty
     /// <summary>Builds the UTF-16, double-null-terminated environment block CreateProcessW expects.
     /// Windows REPLACES the whole environment when lpEnvironment is set, so we start from the parent's
     /// full env and overlay the caller's keys — otherwise the child loses PATH/SystemRoot/… and won't
-    /// launch. Keys are sorted so the block is byte-for-byte reproducible across launches. The caller
-    /// owns the returned pointer (Marshal.FreeHGlobal).</summary>
-    private static IntPtr BuildEnvironmentBlock(IReadOnlyDictionary<string, string> overlay)
+    /// launch. <paramref name="drop"/> is removed from the inherited set first, so an overlay key
+    /// survives its own drop list. Keys are sorted so the block is byte-for-byte reproducible across
+    /// launches. The caller owns the returned pointer (Marshal.FreeHGlobal).</summary>
+    private static IntPtr BuildEnvironmentBlock(IReadOnlyDictionary<string, string> overlay,
+                                                IEnumerable<string> drop)
     {
         var vars = new SortedDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         foreach (DictionaryEntry e in Environment.GetEnvironmentVariables())
         {
             vars[(string)e.Key] = (string)e.Value;
         }
+        if (drop != null) { foreach (var key in drop) { vars.Remove(key); } }
         foreach (var kv in overlay) { vars[kv.Key] = kv.Value; }
 
         var block = new StringBuilder();

--- a/src/Corsinvest.VisualStudio.Agents/Cli/Pane/CliPaneControl.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Cli/Pane/CliPaneControl.cs
@@ -235,7 +235,7 @@ internal class CliPaneControl : PaneControlBase, ITerminalConnection, IDisposabl
             env["FORCE_CODE_TERMINAL"] = "1";
             if (ssePort > 0) { env["CLAUDE_CODE_SSE_PORT"] = ssePort.ToString(); }
             env["CLAUDE_CODE_ENTRYPOINT"] = "claude-vscode";
-            _process.Start(cmd, Entry.WorkingDirectory, cols, rows, env);
+            _process.Start(cmd, Entry.WorkingDirectory, cols, rows, env, ClaudeInstall.InheritedSessionEnvVars);
 
             // Re-apply theme after Start: the control resets its palette on new connection.
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();

--- a/src/Corsinvest.VisualStudio.Agents/Cli/TerminalProcess.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Cli/TerminalProcess.cs
@@ -49,10 +49,11 @@ internal sealed class TerminalProcess : IDisposable
     /// <summary>
     /// Launch <paramref name="command"/> in a fresh ConPTY and begin streaming its output.
     /// A non-empty <paramref name="env"/> gives the child a per-process environment (see
-    /// <see cref="ConPty.Create"/>). Throws if already started or disposed.
+    /// <see cref="ConPty.Create"/>), from which <paramref name="dropEnv"/> is removed first.
+    /// Throws if already started or disposed.
     /// </summary>
     public void Start(string command, string workingDirectory, short cols, short rows,
-        IReadOnlyDictionary<string, string> env)
+        IReadOnlyDictionary<string, string> env, IEnumerable<string> dropEnv = null)
     {
         lock (_gate)
         {
@@ -62,7 +63,7 @@ internal sealed class TerminalProcess : IDisposable
             _stop = new CancellationTokenSource();
             _decoder = Encoding.UTF8.GetDecoder();
             _flush = new Timer(OnFlush, null, Timeout.Infinite, Timeout.Infinite);
-            _session = ConPty.Create(command, workingDirectory, cols, rows, env);
+            _session = ConPty.Create(command, workingDirectory, cols, rows, env, dropEnv);
 
             _reader = new Thread(ReadLoop)
             {

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.cs
@@ -245,7 +245,8 @@ internal sealed partial class ClaudeClient : IClaudeClient
         // Off leaves the variable unset rather than setting it false — that is what "not asked for"
         // looks like to the CLI, and it keeps the profile's own env the only other voice.
         if (options.FileCheckpoints) { env["CLAUDE_CODE_ENABLE_SDK_FILE_CHECKPOINTING"] = "true"; }
-        _transport.Start(ClaudeInstall.ResolveExecutable(), args, options.WorkingDirectory, env);
+        _transport.Start(ClaudeInstall.ResolveExecutable(), args, options.WorkingDirectory, env,
+                         ClaudeInstall.InheritedSessionEnvVars);
 
         ProcessStarted?.Invoke(this, new ProcessStartedEventArgs
         {

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeInstall.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeInstall.cs
@@ -29,6 +29,24 @@ public static class ClaudeInstall
     /// <summary>Anthropic setup/quickstart page — shown when the binary can't be found.</summary>
     public const string DocsUrl = "https://code.claude.com/docs/en/setup";
 
+    /// <summary>Session-identity variables to strip from a CLI we launch. A child starts from a
+    /// copy of OUR environment, and ours is not always clean: start Visual Studio from inside a
+    /// Claude Code session — which is how anyone working on this extension starts it — and VS
+    /// inherits that session's identity, then hands it to every claude.exe it spawns. The child
+    /// would read the markers of a conversation it has no part in.
+    /// <para>Shared by both launch paths. <c>CLAUDE_CODE_ENTRYPOINT</c> is deliberately absent:
+    /// both paths assign it straight after, and dropping it first would only be noise.</para>
+    /// </summary>
+    public static readonly string[] InheritedSessionEnvVars =
+    [
+        "CLAUDECODE",
+        "CLAUDE_CODE_SESSION_ID",
+        "CLAUDE_CODE_BRIDGE_SESSION_ID",
+        "CLAUDE_CODE_MESSAGING_SOCKET",
+        "CLAUDE_CODE_MESSAGING_TOKEN",
+        "CLAUDE_PID",
+    ];
+
     /// <summary>Resolve the real <c>claude.exe</c>, or <c>null</c> if not installed. Covers every
     /// current install method: the native installer and WinGet put <c>claude.exe</c> on PATH (found
     /// by the PATH scan); npm exposes only shims on PATH, so its real binary is picked up by the

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeInstall.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeInstall.cs
@@ -29,14 +29,11 @@ public static class ClaudeInstall
     /// <summary>Anthropic setup/quickstart page — shown when the binary can't be found.</summary>
     public const string DocsUrl = "https://code.claude.com/docs/en/setup";
 
-    /// <summary>Session-identity variables to strip from a CLI we launch. A child starts from a
-    /// copy of OUR environment, and ours is not always clean: start Visual Studio from inside a
-    /// Claude Code session — which is how anyone working on this extension starts it — and VS
-    /// inherits that session's identity, then hands it to every claude.exe it spawns. The child
-    /// would read the markers of a conversation it has no part in.
+    /// <summary>Session-identity variables to strip from a CLI we launch. Start Visual Studio from
+    /// inside a Claude Code session and VS inherits that session's identity, then hands it to every
+    /// claude.exe it spawns — the child reads the markers of a conversation it has no part in.
     /// <para>Shared by both launch paths. <c>CLAUDE_CODE_ENTRYPOINT</c> is deliberately absent:
-    /// both paths assign it straight after, and dropping it first would only be noise.</para>
-    /// </summary>
+    /// both assign it straight after, so dropping it first would only be noise.</para></summary>
     public static readonly string[] InheritedSessionEnvVars =
     [
         "CLAUDECODE",

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClientOptions.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClientOptions.cs
@@ -27,9 +27,12 @@ public sealed class ClientOptions
     /// in place, which is why the option says it applies to the next chat.</para></summary>
     public bool FileCheckpoints { get; set; } = true;
 
-    /// <summary>Loopback port of the IDE's MCP server. When &gt; 0 it is passed as
-    /// <c>CLAUDE_CODE_SSE_PORT</c> so the CLI connects to THIS server instead of
-    /// scanning the lock dir — deterministic with multiple VS instances open.</summary>
+    /// <summary>Loopback port of the IDE's MCP server. Carried here, but NOT read by this client:
+    /// a stream-json session reaches the IDE tools through the in-process SDK MCP server, so it
+    /// needs no port (see the launch args in <see cref="ClaudeClient"/> — no <c>--ide</c> there).
+    /// <para>The CLI pane, which does run <c>claude --ide</c>, sets <c>CLAUDE_CODE_SSE_PORT</c>
+    /// itself from <c>McpServerHost.Instance</c> straight into its ConPTY env block; it does not
+    /// come through here either.</para></summary>
     public int SsePort { get; set; }
 
     /// <summary>The pane's environment profile Env (null = none, native Claude). Merged into

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/NdjsonTransport.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/NdjsonTransport.cs
@@ -60,8 +60,7 @@ internal sealed class NdjsonTransport : IDisposable
     }
 
     /// <param name="dropEnv">Inherited variables to remove before <paramref name="extraEnv"/> goes
-    /// on. The child starts from a copy of OUR environment, which is not always a clean slate —
-    /// see the caller for what has to go and why.</param>
+    /// on — see <see cref="ClaudeInstall.InheritedSessionEnvVars"/> for which, and why.</param>
     public void Start(string exePath, string arguments, string workingDirectory,
         System.Collections.Generic.IReadOnlyDictionary<string, string> extraEnv,
         System.Collections.Generic.IEnumerable<string> dropEnv = null)
@@ -84,9 +83,8 @@ internal sealed class NdjsonTransport : IDisposable
             StandardOutputEncoding = Encoding.UTF8,
             StandardErrorEncoding = Encoding.UTF8,
         };
-        // Drop first, then overlay: a key the caller sets must survive its own drop list.
-        // EnvironmentVariables starts as a copy of ours and is case-insensitive on Windows,
-        // so an inherited variable is removed whatever case it arrived in.
+        // Drop first, then overlay: a key the caller sets must survive its own drop list. The
+        // collection is case-insensitive, so an inherited variable goes whatever case it arrived in.
         if (dropEnv != null)
         {
             foreach (var key in dropEnv) { psi.EnvironmentVariables.Remove(key); }

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/NdjsonTransport.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/NdjsonTransport.cs
@@ -59,8 +59,12 @@ internal sealed class NdjsonTransport : IDisposable
         }
     }
 
+    /// <param name="dropEnv">Inherited variables to remove before <paramref name="extraEnv"/> goes
+    /// on. The child starts from a copy of OUR environment, which is not always a clean slate —
+    /// see the caller for what has to go and why.</param>
     public void Start(string exePath, string arguments, string workingDirectory,
-        System.Collections.Generic.IReadOnlyDictionary<string, string> extraEnv)
+        System.Collections.Generic.IReadOnlyDictionary<string, string> extraEnv,
+        System.Collections.Generic.IEnumerable<string> dropEnv = null)
     {
         if (_disposed) { return; }
 
@@ -80,8 +84,15 @@ internal sealed class NdjsonTransport : IDisposable
             StandardOutputEncoding = Encoding.UTF8,
             StandardErrorEncoding = Encoding.UTF8,
         };
-        // Extra env (e.g. CLAUDE_CODE_SSE_PORT) overlaid on the inherited parent env
-        // so the CLI connects to our MCP server (honoured since UseShellExecute=false).
+        // Drop first, then overlay: a key the caller sets must survive its own drop list.
+        // EnvironmentVariables starts as a copy of ours and is case-insensitive on Windows,
+        // so an inherited variable is removed whatever case it arrived in.
+        if (dropEnv != null)
+        {
+            foreach (var key in dropEnv) { psi.EnvironmentVariables.Remove(key); }
+        }
+        // Extra env (profile keys, CLAUDE_CODE_ENTRYPOINT, …) overlaid on the inherited
+        // parent env — honoured since UseShellExecute=false.
         if (extraEnv != null)
         {
             foreach (var kv in extraEnv) { psi.EnvironmentVariables[kv.Key] = kv.Value; }


### PR DESCRIPTION
Four defects found while reading the chat pane's CLI→WebView path, plus the regression the third one turned out to introduce.

## What was wrong

**The reader thread was parked on every streamed token.** The three per-token handlers marshalled with `Dispatcher.Invoke`, which is synchronous — the NDJSON reader stopped reading stdout on every token and waited for the UI thread. While VS is busy with a build or IntelliSense that backs up into `claude.exe`'s pipe and the CLI itself blocks on write, so the chat stutters exactly when the IDE is under load and it reads as the model being slow. These same three channels were already recognised as flood channels: `IsNoisyChannel` excludes them from trace logging for that reason.

**Two `.jsonl` reads still ran on the UI thread.** `WebViewMessageHandler` already wraps the identical call in `Task.Run` with the note that it costs ~200ms on a big session, and so does the resume path in `InitAsync` — but `LoadSession` (reached straight from the History dropdown, so a click handler) and the options re-render did not.

**A spawned CLI inherited another session's identity.** A child starts from a copy of ours, and ours is not always clean: start Visual Studio from inside a Claude Code session and VS inherits `CLAUDECODE`, `CLAUDE_CODE_SESSION_ID`, the messaging socket and token, then hands them to every `claude.exe` it launches.

**`ClientOptions.SsePort` documented a mechanism that does not exist.** It promised the CLI would be handed `CLAUDE_CODE_SSE_PORT`; neither launch path does that — a stream-json session reaches the IDE tools through the in-process SDK MCP server, and the CLI pane sets the variable itself from `McpServerHost.Instance`. Comment-only fix; the field stays.

## The regression this branch introduced, and fixed

Moving the transcript read off the UI thread reopened a race the synchronous version had closed by accident: the read blocked the click handler, so a second History pick could not start until the first had finished. Off-thread, two picks are two reads in flight, finishing in whatever order the file sizes decide.

Pick a 26MB session then a 36KB one and the big one lands last, rendering its transcript and title over the one just chosen and resuming the CLI on it. The options re-render had the same hole in the other direction. One generation counter for both paths — the same shape `DebugBreakService` already uses — so whoever is no longer the newest bows out. The same check covers a pane torn down mid-read.

## What is deliberately not here

An earlier draft coalesced the three flood channels into a per-frame buffer. It was removed: the defect is the synchronous marshal, and `BeginInvoke` fixes that on its own. The buffer was an unmeasured optimisation that brought a timer, cross-cutting flush semantics on 34 call sites, and two bugs of its own. If streaming ever proves expensive enough to need it, it can come back with a number behind it.

## Verified

Build green. Manually in the Exp instance: streaming stays fluid during a solution build; text and tool rows keep their emission order, including with three concurrent subagents; a 26MB session opens from the History dropdown without freezing VS; picking a large session then immediately a small one leaves the small one; `/clear`, fork, new chat, interrupt mid-stream and closing a pane mid-stream all behave; the CLI pane still reaches the IDE tools.
