### PR TITLE
Send the IDE context in its own block, so slash commands still run

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.Payloads.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.Payloads.cs
@@ -88,9 +88,19 @@ internal sealed partial class WebViewBridge
     }
 
 
-    public static JArray BuildContentBlocks(string text, JArray attachments)
+    /// <summary>The content blocks for one user turn: the IDE context (when there is any), then the
+    /// attachments, then the user's own text — LAST and in a block of its own.
+    /// <para>The split is load-bearing, not tidiness. The CLI decides a message is a slash command
+    /// by looking at whether its text block starts with "/", so anything glued in front of the
+    /// prompt hides the command: "/config" becomes an ordinary sentence, the CLI never runs it, and
+    /// the model answers it in prose instead. Same shape the VS Code webview sends.</para></summary>
+    public static JArray BuildContentBlocks(string text, JArray attachments, string ideContext = null)
     {
         var blocks = new JArray();
+        if (!string.IsNullOrEmpty(ideContext))
+        {
+            blocks.Add(new JObject { ["type"] = "text", ["text"] = ideContext });
+        }
         if (attachments != null)
         {
             foreach (var att in attachments)

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Cli.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Cli.cs
@@ -20,15 +20,19 @@ internal sealed partial class WebViewMessageHandler
         // reflect the submitted message back); the host only forwards to the CLI.
         var p = data.ToObject<Contracts.SendPromptNotification>();
         log.Debug(() => $"[{BridgeMessages.FromWebView.Cli.SendPrompt}] text len={(p.Text ?? "").Length} sessionId={client.SessionId ?? "(none)"} running={client.IsRunning}");
-        // attachments stays a raw JArray: BuildContentBlocks turns it into CLI blocks.
-        var blocks = WebViewBridge.BuildContentBlocks(BuildIdeContextBlock() + (p.Text ?? ""),
-                                                     data["attachments"] as JArray);
+        // attachments stays a raw JArray: BuildContentBlocks turns it into CLI blocks. The IDE
+        // context goes in as its own block, never glued to the prompt — see BuildContentBlocks.
+        var blocks = WebViewBridge.BuildContentBlocks(p.Text ?? "",
+                                                     data["attachments"] as JArray,
+                                                     BuildIdeContextBlock());
         client.SendPrompt(blocks, p.Uuid ?? "");
     }
 
-    /// <summary>The `&lt;ide_*&gt;` block that goes in front of the prompt, or "" when there is no
-    /// editor context to report. Composed here rather than in the composer so the selected code
-    /// never crosses the bridge — the WebView only needs the file and the lines for its chip.</summary>
+    /// <summary>The `&lt;ide_*&gt;` block sent ahead of the prompt, or "" when there is no editor
+    /// context to report. Composed here rather than in the composer so the selected code never
+    /// crosses the bridge — the WebView only needs the file and the lines for its chip.
+    /// <para>Goes in its own content block, never glued to the prompt — see
+    /// <see cref="WebViewBridge.BuildContentBlocks"/> for why that matters.</para></summary>
     private string BuildIdeContextBlock()
     {
         if (entry?.Options.SendSelection == false) { return ""; }
@@ -37,13 +41,15 @@ internal sealed partial class WebViewMessageHandler
         if (!ctx.HasSelection)
         {
             return $"<ide_opened_file>The user opened the file {ctx.FilePath} in the IDE. " +
-                   "This may or may not be related to the current task.</ide_opened_file>\n";
+                   "This may or may not be related to the current task.</ide_opened_file>";
         }
         var head = $"<ide_selection>The user selected the lines {ctx.StartLine} to {ctx.EndLine} " +
                    $"from {ctx.FilePath}";
-        const string tail = "This may or may not be related to the current task.</ide_selection>\n";
+        const string tail = "This may or may not be related to the current task.</ide_selection>";
         // With the text, the shape is the VS Code webview's — what the CLI's readers expect.
-        // Without, the tag ends on the path rather than trailing a colon over nothing.
+        // Without, the tag ends on the path rather than trailing a colon over nothing: sending the
+        // code costs tokens on every message carrying a selection, and this option exists to name
+        // the file and the lines and stop there.
         return Options.AgentsOptions.Chat.SendSelectionText
             ? $"{head}:\n{ctx.SelectedText ?? ""}\n\n{tail}"
             : $"{head}. {tail}";

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
@@ -584,6 +584,11 @@ public partial class ChatPaneControl : PaneControlBase
         // Everything below talks to the WebView and the client, so it belongs on the UI thread.
         await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
+        // Closed while the read above was in flight (DisposeCore nulls the bridge). Bail rather
+        // than guard each call below with ?.: the tail of this method starts a claude.exe, and it
+        // would start one for a pane nobody can see.
+        if (_bridge == null) { _log.Debug(() => "load: pane closed mid-read — init abandoned"); return; }
+
         _bridge.Send(BridgeMessages.ToWebView.Chat.Cleared, null);
         _log.Info($"load: InitAsync sessionId={_startupSessionId ?? "(none)"} (mode={permMode})");
 


### PR DESCRIPTION
Slash commands stopped being executed: `/config`, `/context` and the rest reached the model as ordinary sentences, which it answered in prose, instead of being run by the CLI.

## Why

The editor context was concatenated to the front of the prompt and the whole thing went out as a single text block:

```
[0] "<ide_opened_file>The user opened…</ide_opened_file>\n/config"
```

The CLI decides a message is a slash command by whether its text block starts with `/`. With a tag in front it never saw one.

Each piece is its own block now, the user's text last and alone — the shape the VS Code webview sends, confirmed both in its bundle (`q.push(...)` for the context, `return q.push({type:"text", text: $})` for the prompt) and in the sessions it wrote to disk. The receiving side already expected it: `ContentBlockTranslator` joins several text blocks and its comment says the IDE tag gets one of its own. The trailing newlines went too — they only existed to separate the tag from the prompt it was glued to.

This is also why the commands used to work and quietly stopped. Nothing here changed; the context block simply started being present more often.

**Not adopted from VS Code:** sending the selected code when `Send selection text` is off. That costs tokens on every message carrying a selection, and naming the file and the lines without the body is exactly what the option is for. An earlier draft of this branch forced the VS Code shape there on the theory that the reader regex needs a colon after the path; on a Windows path that regex (`/from ([^:]+):/`) stops at the drive letter and yields `"K"` either way, so the colon buys nothing and the option's own shape stays.

## Second commit

A NullReferenceException on pane close, and a regression of mine from #195: `InitAsync` reads the resumed session's `.jsonl` off the UI thread, so the pane can be closed mid-read — `DisposeCore` nulls the bridge and the line after the thread switch dereferenced it. That PR made three call sites async and guarded two; this is the third. It returns rather than guarding each call with `?.`, because the tail of the method would otherwise relaunch a `claude.exe` for a pane nobody can see.

## Verified

Build green. In the Exp instance: with a file open, `/config` now returns the CLI's own output instead of a prose answer; the IDE context still reaches the model (it can name the file being looked at); both selection modes behave; closing a pane while it loads a large session no longer throws.
