### PR TITLE
Make disposal mean one thing, and stop a closed pane launching a CLI

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewBridge.cs
@@ -420,7 +420,7 @@ internal sealed partial class WebViewBridge(Microsoft.Web.WebView2.Wpf.WebView2C
         {
             var json = JsonConvert.SerializeObject(new { type, id, error = message }, _jsonSettings);
             log.Trace(() => $"[bridge → web] {type} ERROR#{id} {message}");
-            webView.CoreWebView2?.PostWebMessageAsJson(json);
+            Post(json);
         }
         catch (Exception ex) { log.LogException($"WebViewBridge.SendError[{type}]", ex); }
     }
@@ -459,13 +459,29 @@ internal sealed partial class WebViewBridge(Microsoft.Web.WebView2.Wpf.WebView2C
             {
                 log.Trace(() => $"[bridge → web] {type} {StringHelpers.Truncate(json)}");
             }
-            // CoreWebView2 is thread-affine (UI thread). Callers on a background thread
-            // (e.g. a CLI-event handler continuation) would otherwise throw. Marshal the
-            // actual post to the dispatcher; skip the hop when we're already on it.
-            if (dispatcher.CheckAccess()) { webView.CoreWebView2?.PostWebMessageAsJson(json); }
-            else { dispatcher.BeginInvoke(new Action(() => webView.CoreWebView2?.PostWebMessageAsJson(json))); }
+            Post(json);
         }
         catch (Exception ex) { log.LogException($"WebViewBridge.SendDirect[{type}]", ex); }
+    }
+
+    /// <summary>Hand one serialized envelope to the page. CoreWebView2 is thread-affine (UI
+    /// thread), so a caller on a background thread — a CLI-event continuation, say — is marshalled
+    /// rather than left to throw; already on it, we post straight through.
+    /// <para>The `?.` is not enough on its own: once the control is disposed the GETTER throws
+    /// ObjectDisposedException rather than returning null, and a message queued a moment before the
+    /// pane closed runs after it. That is an ordinary end-of-life race, not a fault, so it is
+    /// swallowed here — including inside the dispatched branch, which the caller's try/catch does
+    /// not cover.</para></summary>
+    private void Post(string json)
+    {
+        if (dispatcher.CheckAccess()) { TryPost(json); }
+        else { dispatcher.BeginInvoke(new Action(() => TryPost(json))); }
+    }
+
+    private void TryPost(string json)
+    {
+        try { webView.CoreWebView2?.PostWebMessageAsJson(json); }
+        catch (ObjectDisposedException) { /* pane closed under a message already in flight */ }
     }
 
     private static bool IsNoisyChannel(string type)

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
@@ -114,9 +114,9 @@ public partial class ChatPaneControl : PaneControlBase
                 // is disk + JSON parse (~200ms on a big session).
                 var (mode, page, info) = await Task.Run(() => ReadSessionState(sessionId));
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-                // Superseded by a later pick, or the pane torn down while we read (DisposeCore nulls
-                // the bridge) — either way nobody is looking at this session any more.
-                if (generation != _loadGeneration || _bridge == null) { return; }
+                // Superseded by a later pick, or the pane torn down while we read — either way
+                // nobody is looking at this session any more.
+                if (generation != _loadGeneration || _disposed) { return; }
                 SendHistoryPage(page, sessionId);
                 SetSessionTitle(info?.CustomTitle ?? info?.AiTitle ?? info?.LastPrompt);
                 // Pass the session's own mode so the respawned CLI runs on what
@@ -461,6 +461,10 @@ public partial class ChatPaneControl : PaneControlBase
         _client?.Dispose();
         // Last: the bridge tears down the WebView2, and anything above may still post to it.
         _bridge?.Dispose();
+        // Nulled so the `_bridge?.` sends elsewhere no-op, NOT as the teardown signal: this only
+        // happens at the end of DisposeCore, while `_disposed` is already true on entry. Work that
+        // resumes after an await asks that one — a null bridge also means "the WebView has not been
+        // built yet", which is a different thing (see ShowFind, HandleEscape).
         _bridge = null;
     }
 
@@ -536,7 +540,7 @@ public partial class ChatPaneControl : PaneControlBase
             {
                 var page = await Task.Run(() => Sessions.ReadHistoryRaw(sid, SessionManager.HistoryBatchSize, -1, out _));
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-                if (generation != _loadGeneration || _bridge == null) { return; }
+                if (generation != _loadGeneration || _disposed) { return; }
                 // Re-checked, not just checked above: the read gave a turn time to start, and that
                 // is exactly what the guard is for.
                 if (_turnInFlight)
@@ -544,7 +548,7 @@ public partial class ChatPaneControl : PaneControlBase
                     _log.Debug(() => $"[chat] turn started while reading {sid} — transcript left alone");
                     return;
                 }
-                _bridge.Send(BridgeMessages.ToWebView.Chat.Cleared, null);
+                _bridge?.Send(BridgeMessages.ToWebView.Chat.Cleared, null);
                 SendHistoryPage(page, sid);
             }
             catch (Exception ex)
@@ -584,10 +588,10 @@ public partial class ChatPaneControl : PaneControlBase
         // Everything below talks to the WebView and the client, so it belongs on the UI thread.
         await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-        // Closed while the read above was in flight (DisposeCore nulls the bridge). Bail rather
-        // than guard each call below with ?.: the tail of this method starts a claude.exe, and it
-        // would start one for a pane nobody can see.
-        if (_bridge == null) { _log.Debug(() => "load: pane closed mid-read — init abandoned"); return; }
+        // Closed while the read above was in flight. Bail rather than guard each call below with
+        // ?.: the tail of this method starts a claude.exe, and it would start one for a pane
+        // nobody can see.
+        if (_disposed) { _log.Debug(() => "load: pane closed mid-read — init abandoned"); return; }
 
         _bridge.Send(BridgeMessages.ToWebView.Chat.Cleared, null);
         _log.Info($"load: InitAsync sessionId={_startupSessionId ?? "(none)"} (mode={permMode})");

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.cs
@@ -303,6 +303,12 @@ internal sealed partial class ClaudeClient : IClaudeClient
                 _log.Warn($"[client] SDK MCP server '{name}' registration failed: {JsonExtensions.ToIndentedString(errors)}");
             }
         }
+        // Closing a pane faults whatever it had in flight (RejectPendingRequests). That is the
+        // teardown working, not a failure to report as one.
+        catch (Exception ex) when (_disposed)
+        {
+            _log.Debug(() => $"[client] SDK MCP registration abandoned: {ex.GetType().Name}");
+        }
         catch (Exception ex)
         {
             _log.LogException("ClaudeClient.RegisterSdkMcpServer", ex);
@@ -401,6 +407,12 @@ internal sealed partial class ClaudeClient : IClaudeClient
                 SpinnerVerbs = ParseSpinnerVerbs(eff?["spinnerVerbs"] as JObject),
                 FastModeState = fastModeState,
             });
+        }
+        // Same as the MCP registration above: a pane closed mid-startup faults these, and that is
+        // the teardown doing its job.
+        catch (Exception ex) when (_disposed)
+        {
+            _log.Debug(() => $"[client] startup abandoned: {ex.GetType().Name}");
         }
         catch (Exception ex)
         {

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeClient.cs
@@ -26,6 +26,9 @@ internal sealed partial class ClaudeClient : IClaudeClient
     // disposed instance. Readers that then USE it must copy it to a local first: the field can
     // change between two reads of it.
     private volatile NdjsonTransport _transport;
+    // Volatile for the same reason as the transport: Dispose runs on the UI thread while the read
+    // loop and the MCP workers are still live, and they must see it on their next check.
+    private volatile bool _disposed;
     private readonly ConcurrentDictionary<string, TaskCompletionSource<JObject>> _pending = new();
     private int _requestCounter;
 
@@ -172,6 +175,11 @@ internal sealed partial class ClaudeClient : IClaudeClient
 
     private void StartProcess(ClientOptions options)
     {
+        // Disposed clients start nothing. The transport refuses to Start once disposed, but the
+        // rotation below hands us a FRESH one that knows nothing of it — so without this a caller
+        // holding a dead client (the pane keeps its reference through teardown) would launch a
+        // claude.exe for a pane that is already gone.
+        if (_disposed) { _log.Debug(() => "=== start refused: client disposed"); return; }
         if (_transport.IsRunning) { return; }
 
         // Transport instances are not reusable after Dispose — rotate to a fresh one and
@@ -837,6 +845,9 @@ internal sealed partial class ClaudeClient : IClaudeClient
 
     public void SendPrompt(JArray contentBlocks, string uuid)
     {
+        // EnsureRunning already refuses to respawn a disposed client, which would leave the write
+        // below going to a dead transport.
+        if (_disposed) { _log.Debug(() => "=== prompt dropped: client disposed"); return; }
         EnsureRunning();
         // CLI rejects an empty content[]; fall back to a single empty-text block.
         var content = contentBlocks?.Count > 0
@@ -905,6 +916,7 @@ internal sealed partial class ClaudeClient : IClaudeClient
 
     public void Dispose()
     {
+        _disposed = true;
         _transport.DisposeIntentional();
         RejectPendingRequests("ClaudeClient disposed");
     }


### PR DESCRIPTION
Three ways of saying "this pane is gone", none of them agreeing, and the guards that grew around the gaps.

## A disposed client would still launch a process

`ClaudeClient.Dispose` closed the transport and left the client usable. That looks harmless until you notice `StartProcess` rotates in a *fresh* transport before starting it — so the one object that knew about the disposal is replaced on the way past. The transport's own `_disposed` check never gets a say.

The pane does hold a dead client: `DisposeCore` disposes `_client` without clearing the field. So a closed pane whose `InitAsync` was still in flight would start a `claude.exe` for a window nobody can see. The flag is checked in `StartProcess`, which every respawn path goes through, and in `SendPrompt`, whose write would otherwise land on a dead transport.

## The chat pane had reinvented the teardown signal

`PaneControlBase` already carries `protected bool _disposed`, set *before* `DisposeCore` runs. The CLI pane asks it in five places; the chat pane in none — it grew `_bridge == null` guards instead.

That substitute is both later and ambiguous. Later, because the bridge is nulled at the *end* of `DisposeCore`, so work resuming from an await in between sees a pane that looks alive. Ambiguous, because a null bridge also means "the WebView has not been built yet", which is what `ShowFind`, `HandleEscape`, `ExtraSessionSectionsAsync` and `OnHostFilesDropped` are actually asking.

The three post-await guards now ask `_disposed`; the rest keep meaning readiness, with the split written down where the field is nulled.

## Closing a pane logged three exceptions, two of them fine and one real

Two were the fire-and-forget startup tasks finding the client disposed on their way back — `RejectPendingRequests` faults them deliberately. They were reaching the log with the `!!!` marker, which is for things that went wrong. Now Debug when the client is disposed, unchanged otherwise.

The third was a genuine bug this branch did not set out to find: `SendError` posted straight to `CoreWebView2`, with neither the dispatcher hop nor any protection against a disposed control — and `?.` does not give it, because once the control is disposed the *getter* throws `ObjectDisposedException` rather than returning null. `SendDirect` had the same hole inside its `BeginInvoke` branch, where the caller's try/catch never reached. Both go through one `Post` now.

## Verified

Build green. From an Exp session log: two panes open and close, no orphaned `claude.exe` (both transports report `exit code=-1 disposed=True`), and the three exceptions above are exactly what prompted the last commit.

Two things are **not** verified. The `InitAsync` guard needs the pane closed inside the few hundred ms of a large session's read — the timing did not come up in testing, though the client-side check covers the damage even when the guard is missed. And the `SendError` fix is reasoned from the stack trace in that log rather than reproduced again.
