### PR TITLE
feat(mcp): expose the Test Explorer over MCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Tests over MCP — four tools onto the IDE's own Test Explorer** (issue #192). The agent could
+  build the solution, read diagnostics, walk the symbol graph and drive the debugger, but to run a
+  test it had to leave Visual Studio and shell out to `dotnet test`: a different build from the one
+  the IDE just made, a different configuration from the one it is on, and console text to scrape
+  instead of results. `test_list` gives the tests the Test Explorer has discovered — its own tree,
+  with project, class and source; `test_run` runs them and waits; `test_get_results` returns the
+  outcome per test, failures first, each with its assertion message and stack trace, so a red test
+  can be opened at its line rather than hunted for. `test_run_with_debugger` runs them under the
+  IDE's debugger, which is the one thing no external runner can offer: execution stops where a test
+  fails and `debug_get_locals` / `debug_get_callstack` read the state there.
+  - **Every framework the IDE supports, not only .NET.** Going through the Test Explorer means going
+    through its adapters: xUnit, NUnit, MSTest, GoogleTest, Boost, CppUnitTest. Verified on a
+    solution holding a C++/C project and a C# one — 16 tests from two adapters, counted and reported
+    together.
+  - There is no `test_cancel`: the underlying calls take a cancellation token, so a run is abandoned
+    by the caller rather than stopped by a second tool.
+  - The docs had advertised "Tests: discovery and runs" since 1.0.0 with no such tool in the code.
+    They are now true.
+
 ## [1.7.0] - 2026-08-28
 
 Three places the IDE knew something and the chat did not: stopping on an exception now raises a bar

--- a/README.md
+++ b/README.md
@@ -92,9 +92,10 @@ own.
 
 - **[Two panes](#two-panes-one-extension)** — a rich WebView2 chat and a real terminal (ConPTY),
   both multi-instance and dockable side by side, each on its own session.
-- **[70+ MCP tools](docs/mcp-tools.md)** — Visual Studio's own navigation, references, rename,
-  diagnostics, build and the **live debugger** (breakpoints, stepping, locals, evaluate) handed to
-  the agent. Not text search over source: the IDE's semantic, running view of your program.
+- **[77 MCP tools](docs/mcp-tools.md)** — Visual Studio's own navigation, references, rename,
+  diagnostics, build, **its Test Explorer** and the **live debugger** (breakpoints, stepping,
+  locals, evaluate) handed to the agent. Not text search over source: the IDE's semantic, running
+  view of your program.
 - **[It offers when you break](docs/options.md#asking-about-a-break)** — stop on an exception and a
   bar appears over that file: one press asks about the break, and the agent reads the live stack and
   locals rather than guessing from the source. Breakpoints are opt-in, steps never ask.
@@ -482,8 +483,8 @@ among them — are saved as plain JSON under `%LOCALAPPDATA%`. See
 
 ## MCP tools (the IDE, exposed to Claude)
 
-An in-process MCP server hands the agent Visual Studio's own view of your code — **70+ tools** across
-navigation, editing, build, the live debugger and IDE state — with nothing to configure. They are
+An in-process MCP server hands the agent Visual Studio's own view of your code — **77 tools** across
+navigation, editing, build, tests, the live debugger and IDE state — with nothing to configure. They are
 language-agnostic by design: wired through Roslyn language services or language-agnostic VS/DTE
 APIs, never a C#/VB-only path. There is no list of supported languages — whatever your Visual
 Studio can do on a file, the agent can ask for; what it gets back depends on the language service

--- a/docs/marketplace-overview.md
+++ b/docs/marketplace-overview.md
@@ -15,7 +15,7 @@
 drive the IDE itself: build the solution, read the errors, step the debugger, follow references
 through the symbol graph, run the tests.
 
-**70+ MCP tools**, in process — so the agent reads the live state Visual Studio already
+**77 MCP tools**, in process — so the agent reads the live state Visual Studio already
 holds, not the files on disk.
 
 Visual Studio **2022 and 2026**. Free, GPL-3.0.
@@ -29,7 +29,7 @@ Visual Studio **2022 and 2026**. Free, GPL-3.0.
 | **Build** | build and rebuild, with the errors handed straight back |
 | **Diagnostics** | errors and warnings from the live language service, including the ones an edit just introduced |
 | **Debugger** | breakpoints, stepping, locals, call stack — and it offers to look when you stop on an exception |
-| **Tests** | discovery and runs |
+| **Tests** | the Test Explorer's own tests: list, run, read the failures with their message and stack — and run them under the debugger |
 | **Navigation** | go to definition, find references, symbol search |
 | **Editor** | active document, selection, open files |
 | **Solution** | projects, structure, references |

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -2,10 +2,10 @@
 
 The extension runs an in-process **[MCP](https://modelcontextprotocol.io/) server** that hands
 Visual Studio's own understanding of your code to the agent: navigation, references, rename,
-diagnostics, build and the live debugger. Not a text search over source files — the IDE's semantic,
-running view of your program.
+diagnostics, build, the tests it has discovered and the live debugger. Not a text search over source
+files — the IDE's semantic, running view of your program.
 
-The 70+ tools below are exposed automatically; there is nothing to configure. They are prefixed
+The 77 tools below are exposed automatically; there is nothing to configure. They are prefixed
 `mcp__vs__` on the wire, and appear in the CLI's `/mcp` listing.
 
 **Language-agnostic by design.** Tools are wired through Roslyn's per-document language services
@@ -111,6 +111,22 @@ user left open.
 | `build_project` | Build a single project (by name) in the active configuration and return whether it succeeded plus what the Error List holds (file, line, description, severity). Blocks until done. Reports errors only unless severity says otherwise; the message says how many items were left out, and 'configuration' says which one it built — solution_set_configuration changes it. ok/failedProjects/message are the outcome; 'errors' is the Error List, which the IDE updates a moment later and which can hold entries from a debug session as well as from the build — ide_read_output('Build') has the compiler's own log when the two disagree. The name is a project name, not a path — ide_get_project_structure lists them. build_solution builds everything instead. |
 | `build_solution` | Build the entire solution and return whether it succeeded plus what the Error List holds (file, line, description, severity). Blocks until the build ends. Reports errors only unless severity says otherwise; the message says how many items were left out. Prefer this to a dotnet build in the shell: it goes through the open IDE, so there is no path to resolve and no clash with a debug session. Builds whichever configuration the IDE has active and reports it back as 'configuration' — solution_set_configuration changes it. ok/failedProjects/message are the outcome; 'errors' is the Error List, which the IDE updates a moment later and which can hold entries from a debug session as well as from the build. ide_read_output('Build') has the compiler's own log when the two disagree. build_project builds one project instead. |
 
+## Tests
+
+These go through the IDE's own Test Explorer, so they see whatever it sees: the same tests, found by
+the same adapters, on the build and the active configuration the IDE already has. That means every
+framework the installed workloads support — xUnit, NUnit, MSTest, GoogleTest, Boost, CppUnitTest —
+and not only .NET. Nothing is rebuilt and nothing is re-discovered.
+
+| Tool | What it does |
+|---|---|
+| `test_list` | List the tests the IDE's Test Explorer has discovered, with their project, class and the assembly they came from. This is the Test Explorer's own tree — the same tests it would run, found by the same adapters, so it covers every framework the IDE supports (xUnit, NUnit, MSTest, GoogleTest, Boost, CppUnitTest…) and not just .NET. Nothing is rebuilt and nothing is re-discovered. An empty list on a solution that has tests usually means the Test Explorer has not discovered them yet — build the solution, or open the window once. |
+| `test_run` | Run tests through the IDE's Test Explorer, on the build and the active configuration the IDE already has — no separate restore, no second opinion about which configuration is current. Blocks until the run ends, then says whether it ran; test_get_results has the per-test outcome, including the failures with their message and stack trace. Covers every framework the IDE supports, not only .NET. Use test_run_with_debugger instead to stop on a failure and inspect it with the debug_* tools. |
+| `test_run_with_debugger` | Run tests under the IDE's debugger, so execution stops where one fails and the debug_* tools can read the state there — debug_get_locals, debug_get_callstack, debug_evaluate. This is the part no test runner outside the IDE can offer. Set the breakpoints you want first (debug_set_breakpoint) and filter down to the failing test, otherwise the whole suite runs under a debugger for nothing. test_run is the plain, faster version. |
+| `test_get_results` | The last test run's outcome, per test: name, project, duration, and for a failure its assertion message and stack trace — the stack carries the file and line, so a failure can be opened straight away instead of being hunted for. Failures are listed first. Reports what the Test Explorer holds now, so run test_run first, or read the results of a run started from the IDE. |
+
+There is no `test_cancel`: a run is cancelled by the caller abandoning it, not by a second tool.
+
 ## Solution
 
 | Tool | What it does |
@@ -213,6 +229,12 @@ diagnostics, references and definitions come from the language service, not from
 Build with `mcp__vs__build_solution` (or `build_project` for one project) — not msbuild or
 dotnet build from the shell. It uses the open IDE, so no path to resolve and no clash with a
 debug session, and it returns structured errors.
+
+## Tests
+Run tests with `mcp__vs__test_run` — not dotnet test from the shell. It goes through the Test
+Explorer, so it uses the build the IDE already has and the configuration it is actually on, and
+`mcp__vs__test_get_results` gives the failures with their message and stack rather than console
+text to scrape. Works for C++ and every other framework the IDE supports, not only .NET.
 
 ## Debugging
 Do not call `mcp__vs__debug_start` / `debug_stop` without asking: they take over the IDE.

--- a/src/Corsinvest.VisualStudio.Agents/Corsinvest.VisualStudio.Agents.csproj
+++ b/src/Corsinvest.VisualStudio.Agents/Corsinvest.VisualStudio.Agents.csproj
@@ -144,6 +144,7 @@
     <Compile Include="Ide\IdeConsoleService.cs" />
     <Compile Include="Ide\IdeOutputService.cs" />
     <Compile Include="Ide\IdeNavigationService.cs" />
+    <Compile Include="Ide\IdeTestService.cs" />
     <Compile Include="Ide\IdeNavigationService.Definition.cs" />
     <Compile Include="Ide\IdeNavigationService.References.cs" />
     <Compile Include="Ide\IdeNavigationService.Symbols.cs" />
@@ -172,6 +173,9 @@
     <Compile Include="Mcp\Tools\Document\ReadDocumentBufferTool.cs" />
     <Compile Include="Mcp\Tools\Ide\GetVisualStudioVersionTool.cs" />
     <Compile Include="Mcp\Tools\Ide\GetVisualStudioEditionTool.cs" />
+    <Compile Include="Mcp\Tools\Test\ListTestsTool.cs" />
+    <Compile Include="Mcp\Tools\Test\RunTestsTool.cs" />
+    <Compile Include="Mcp\Tools\Test\GetTestResultsTool.cs" />
     <Compile Include="Mcp\Tools\Build\BuildSolutionTool.cs" />
     <Compile Include="Mcp\Tools\Build\BuildProjectTool.cs" />
     <Compile Include="Mcp\Tools\Build\CleanSolutionTool.cs" />

--- a/src/Corsinvest.VisualStudio.Agents/Helpers/VsReflection.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Helpers/VsReflection.cs
@@ -59,6 +59,39 @@ internal static class VsReflection
     public static object GetPropOrNull(object obj, string name)
         => obj?.GetType().GetProperty(name)?.GetValue(obj);
 
+    /// <summary>Property read off an object whose concrete type declares the name more than once.
+    /// <para><see cref="GetPropOrNull"/> throws AmbiguousMatchException there, and VS hands out
+    /// plenty of such objects: one implementation wearing several interfaces that share member
+    /// names. Pass <paramref name="declaring"/> — the interface the contract actually belongs to —
+    /// and the choice never arises; an implementation that later grows another face cannot break
+    /// the read. Without it, an ambiguous name falls back to the first match, since the faces of
+    /// one object agree on the value.</para>
+    /// Returns null for a missing member as well as for a null value, like GetPropOrNull.</summary>
+    public static object GetPropSafe(object obj, string name, Type declaring = null)
+    {
+        if (obj == null) { return null; }
+        try { return (declaring ?? obj.GetType()).GetProperty(name)?.GetValue(obj); }
+        catch (AmbiguousMatchException)
+        {
+            return obj.GetType().GetProperties().FirstOrDefault(p => p.Name == name)?.GetValue(obj);
+        }
+    }
+
+    /// <summary>Invoke an async method declared by <paramref name="declaring"/> rather than by the
+    /// object's concrete type, and await it. Same reason as <see cref="GetPropSafe"/>: resolving a
+    /// method on an implementation that wears several interfaces is ambiguous, while the interface
+    /// that declares it is unambiguous and is the contract being relied on.
+    /// <para>Returns null when the method is not there. Unlike <see cref="InvokeAsync"/> it does not
+    /// swallow what the call itself throws — a service failing is the caller's to interpret.</para></summary>
+    public static async Task<object> InvokeAsyncOn(Type declaring, object obj, string method, params object[] args)
+    {
+        var mi = declaring?.GetMethod(method);
+        if (mi == null) { return null; }
+        var task = (Task)mi.Invoke(obj, args);
+        await task.ConfigureAwait(true);
+        return task.GetType().GetProperty("Result")?.GetValue(task);
+    }
+
     /// <summary>Indexer read: GetProperty("Item", indexTypes).GetValue(obj, index).</summary>
     public static object GetIndexer(object obj, params object[] index)
     {

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeTestService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeTestService.cs
@@ -1,0 +1,316 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using Corsinvest.VisualStudio.Agents.Helpers;
+using Microsoft.VisualStudio.ComponentModelHost;
+using Microsoft.VisualStudio.Shell;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Corsinvest.VisualStudio.Agents.Ide;
+
+/// <summary>
+/// The Test Explorer, reached through its own services rather than around them: the tests it has
+/// discovered, the runs it performs, and the failures it recorded — the IDE's build and its active
+/// configuration, not a second opinion from an external runner.
+/// <para><b>All late-bound, and not by preference.</b> The types live in
+/// <c>Microsoft.VisualStudio.TestWindow.Interfaces</c>, which is unreferenceable here: it wants
+/// <c>Microsoft.VisualStudio.GraphModel 18.0</c> while the VS SDK package pins 17.0, and MSBuild
+/// settles that by dropping the reference — silently, since MSB3277 is a message in this project.
+/// Most of what is needed is <c>internal</c> anyway. At runtime the assembly is in VS's AppDomain
+/// with the version it wants, so everything here goes through <see cref="VsReflection"/>.</para>
+/// <para>One probe decides availability once, and every entry point returns
+/// <c>supported=false</c> rather than throwing when a future VS reshapes these names.</para>
+/// </summary>
+internal static class IdeTestService
+{
+    private const string Ns = "Microsoft.VisualStudio.TestWindow.Extensibility.";
+    private const string MsgNs = "Microsoft.VisualStudio.TestWindow.Messages.";
+
+    private static readonly object _probeGate = new();
+    private static bool _probed;
+    private static bool _available;
+    private static string _unavailableReason;
+
+    // The one VsTestService instance, held through its two faces: IVsTestService runs and lists,
+    // IVsTestServiceInternal reads the per-test failures. Same object, so it is resolved once.
+    private static object _service;
+    private static Type _testQueryType;
+
+    /// <summary>Whether the Test Explorer's services answered. False also carries the reason, which
+    /// the tools report instead of a bare "not supported".</summary>
+    public static bool IsAvailable(out string reason)
+    {
+        lock (_probeGate)
+        {
+            if (!_probed) { Probe(); }
+            reason = _unavailableReason;
+            return _available;
+        }
+    }
+
+    private static void Probe()
+    {
+        _probed = true;
+        // `step` names the last thing tried, so a future VS that reshapes this says WHERE it broke.
+        var step = "IComponentModel";
+        try
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            var components = Package.GetGlobalService(typeof(SComponentModel)) as IComponentModel;
+            if (components == null) { Fail(step); return; }
+
+            step = "IVsTestService type";
+            var serviceType = VsReflection.FindType(Ns + "IVsTestService");
+            if (serviceType == null) { Fail(step); return; }
+
+            step = "IVsTestService instance";
+            _service = typeof(IComponentModel).GetMethod(nameof(IComponentModel.GetService))
+                                              ?.MakeGenericMethod(serviceType)
+                                              .Invoke(components, null);
+            if (_service == null) { Fail(step); return; }
+
+            step = "TestQuery type";
+            _testQueryType = VsReflection.FindType(Ns + "TestQuery");
+            if (_testQueryType == null) { Fail(step); return; }
+
+            // Checked here rather than on the first call: the empty query is how every unfiltered
+            // call starts, so a rename of AllTests should read as "unavailable" at startup instead
+            // of as a failure halfway through a run.
+            step = "TestQuery.AllTests";
+            if (BuildQuery(null) == null) { Fail(step); return; }
+
+            _available = true;
+        }
+        catch (Exception ex)
+        {
+            _unavailableReason = $"{step}: {ex.GetType().Name}: {ex.Message}";
+            OutputWindowLogger.Global.Warn($"[test] Test Explorer services unavailable — {_unavailableReason}");
+        }
+    }
+
+    private static void Fail(string step)
+    {
+        _unavailableReason = $"{step} not found";
+        OutputWindowLogger.Global.Warn($"[test] Test Explorer services unavailable — {_unavailableReason}");
+    }
+
+    /// <summary>A TestQuery for everything, or for the tests whose fully-qualified name contains one
+    /// of <paramref name="filters"/>.
+    /// <para>Not <c>Activator.CreateInstance</c>: TestQuery's parameterless constructor is PRIVATE,
+    /// so that throws "no parameterless constructor defined". The empty query is reached through the
+    /// static <c>AllTests</c> instead — which is what the Test Explorer itself uses — and a filtered
+    /// one through the public <c>(TestPropertyType, IEnumerable&lt;string&gt;, FilterMatchKind)</c>
+    /// constructor.</para></summary>
+    private static object BuildQuery(IEnumerable<string> filters)
+    {
+        var list = filters?.Where(f => !string.IsNullOrWhiteSpace(f)).ToArray() ?? [];
+        if (list.Length == 0)
+        {
+            // get_AllTests, not GetProperty("AllTests"): in the IL it is a bare static getter with
+            // no property entry alongside it, so asking for the property yields null.
+            return _testQueryType.GetMethod("get_AllTests", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+                                ?.Invoke(null, null);
+        }
+
+        // Match on the fully-qualified name, the one identifier a caller can reasonably know: a
+        // filter is a substring of it, so "FactorialTests" takes a class and a full name takes one
+        // test. Values go in together — the query ORs them, which is what several filters mean.
+        var propertyType = VsReflection.FindType(Ns + "TestPropertyType");
+        var matchKind = VsReflection.FindType(Ns + "FilterMatchKind");
+        var ctor = _testQueryType.GetConstructors()
+                                 .FirstOrDefault(c => c.GetParameters().Length == 3);
+        return ctor?.Invoke([
+            Enum.Parse(propertyType, "FullyQualifiedName"),
+            list,
+            Enum.Parse(matchKind, "Contains"),
+        ]);
+    }
+
+    /// <summary>The tests the Test Explorer has discovered — its tree, not a fresh discovery run.
+    /// Sorted by project, then class, then name, because the window's own order is not stable and a
+    /// caller diffing two listings should not see phantom moves.</summary>
+    public static async Task<IReadOnlyList<TestInfo>> ListTestsAsync(
+        IEnumerable<string> filters = null, CancellationToken ct = default)
+    {
+        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(ct);
+        if (!IsAvailable(out _)) { return null; }
+
+        var nodes = await CallAsync("IVsTestService", "GetTestsAsync", BuildQuery(filters), ct);
+        return ((IEnumerable)nodes ?? Array.Empty<object>())
+            .Cast<object>()
+            // A node is a group (project, namespace, class) or a test; only the leaves are tests.
+            .Where(n => Read(n, "IsTest") as bool? == true)
+            .Select(ToTestInfo)
+            .OrderBy(t => t.Project, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(t => t.ClassName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(t => t.FullyQualifiedName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    /// <summary>Resolve one of the Test Explorer's interfaces by name, from either namespace it
+    /// might live in.</summary>
+    private static Type Face(string interfaceName)
+        => VsReflection.FindType(Ns + interfaceName) ?? VsReflection.FindType(MsgNs + interfaceName);
+
+    /// <summary>Call one of the service's methods through the interface that declares it, awaiting
+    /// the Task it returns, and turn a failure into a null the callers already read as
+    /// <c>supported=false</c>.</summary>
+    private static async Task<object> CallAsync(string interfaceName, string method, params object[] args)
+    {
+        try { return await VsReflection.InvokeAsyncOn(Face(interfaceName), _service, method, args); }
+        catch (Exception ex)
+        {
+            // The Test Explorer throws from inside its own Task when it is not ready — a
+            // NullReferenceException out of GetTestsAsync before any discovery has run. Nothing
+            // here can fix that, but letting it surface as a raw MCP error tells the caller
+            // "something broke" where the truth is "ask again once tests exist".
+            var real = (ex as TargetInvocationException)?.InnerException ?? ex;
+            OutputWindowLogger.Global.Warn($"[test] {interfaceName}.{method} failed: {real.GetType().Name}: {real.Message}");
+            return null;
+        }
+    }
+
+    private static object Read(object obj, string name, Type declaring = null)
+        => VsReflection.GetPropSafe(obj, name, declaring);
+
+    private static TestInfo ToTestInfo(object node) => new()
+    {
+        Id = Read(node, "Id") as int? ?? 0,
+        DisplayName = Read(node, "DisplayName") as string ?? "",
+        FullyQualifiedName = Read(node, "FullyQualifiedName") as string ?? "",
+        Project = Read(node, "ProjectName") as string ?? "",
+        Namespace = Read(node, "NamespaceName") as string ?? "",
+        ClassName = Read(node, "ClassName") as string ?? "",
+        Source = Read(node, "Source") as string ?? "",
+        TargetFramework = Read(node, "TargetFramework") as string ?? "",
+    };
+
+    /// <summary>Run the matching tests and wait for the run to end — the Task completes when the
+    /// Test Explorer is done, not when it starts, so the caller decides how long to wait through
+    /// <paramref name="ct"/>. Cancelling the token stops the run: there is no separate cancel call.
+    /// <para><paramref name="debug"/> runs them under the IDE's debugger, which is the one thing no
+    /// external runner can offer — the debug_* tools take over wherever it breaks.</para></summary>
+    public static async Task<TestRunOutcome> RunTestsAsync(
+        IEnumerable<string> filters = null, bool debug = false, CancellationToken ct = default)
+    {
+        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(ct);
+        if (!IsAvailable(out var reason)) { return new TestRunOutcome { Supported = false, Message = reason }; }
+
+        var method = debug ? "DebugTestsAsync" : "RunTestsAsync";
+        var started = await CallAsync("IVsTestService", method, BuildQuery(filters), ct);
+        // The service answers bool: false is "the run did not start" (nothing matched the filter, a
+        // build failed, a run already going) — not "tests failed", which the results tell.
+        return new TestRunOutcome { Supported = true, Started = started as bool? ?? false };
+    }
+
+    /// <summary>The last run's outcome per test: what failed, why, and where. The counts alone
+    /// ("2 failed") are not actionable — this is the part that lets the caller go to the code.
+    /// <para>Failures first, then the rest: on a red run that is the whole point of asking, and a
+    /// caller reading only the first entries still gets what matters.</para></summary>
+    public static async Task<IReadOnlyList<TestOutcome>> GetResultsAsync(
+        IEnumerable<string> filters = null, bool failedOnly = false, CancellationToken ct = default)
+    {
+        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(ct);
+        if (!IsAvailable(out _)) { return null; }
+
+        // The details hang off IVsTestServiceInternal, which the same object implements — its own
+        // interface because it carries the per-test failures the public one does not expose.
+        var nodes = await CallAsync("IVsTestService", "GetTestsAsync", BuildQuery(filters), ct);
+        var results = new List<TestOutcome>();
+
+        foreach (var node in ((IEnumerable)nodes ?? Array.Empty<object>()).Cast<object>())
+        {
+            if (Read(node, "IsTest") as bool? != true) { continue; }
+            ct.ThrowIfCancellationRequested();
+
+            var name = Read(node, "FullyQualifiedName") as string ?? "";
+            object details;
+            try
+            {
+                // viewId null = the current view. Passing the token as the third argument keeps a
+                // long listing cancellable per test rather than only between tests.
+                details = await CallAsync("IVsTestServiceInternal", "GetTestResultDetailsAsync", node, null, ct);
+            }
+            catch (Exception ex)
+            {
+                // One unreadable test must not lose the other results — the run is what it is, and
+                // silence here would read as "this test passed".
+                OutputWindowLogger.Global.Warn($"[test] no result details for {name}: {ex.GetType().Name}: {ex.Message}");
+                continue;
+            }
+
+            // The outcome comes off the NODE, which also implements ITestNodeRunDetails — the enum
+            // the test platform itself uses. Reading it from ErrorMessage instead would call a
+            // skipped test failed: the reason a test was skipped is carried in that same field.
+            var outcome = Read(node, "Outcome", Face("ITestNodeRunDetails"))?.ToString();
+
+            foreach (var r in ((IEnumerable)details ?? Array.Empty<object>()).Cast<object>())
+            {
+                var failed = string.Equals(outcome, "Failed", StringComparison.OrdinalIgnoreCase);
+                if (failedOnly && !failed) { continue; }
+                results.Add(new TestOutcome
+                {
+                    FullyQualifiedName = name,
+                    DisplayName = Read(r, "DisplayName") as string ?? name,
+                    Project = Read(node, "ProjectName") as string ?? "",
+                    // The platform's own word — Passed / Failed / Skipped / NotFound / None —
+                    // rather than a boolean that would have to guess what "not passed" meant.
+                    Outcome = outcome ?? "Unknown",
+                    Failed = failed,
+                    ErrorMessage = Read(r, "ErrorMessage") as string,
+                    ErrorStackTrace = Read(r, "ErrorStackTrace") as string,
+                    DurationMs = Read(r, "DurationInMs") as long? ?? 0,
+                });
+            }
+        }
+
+        return [.. results.OrderByDescending(r => r.Failed)
+                          .ThenBy(r => r.FullyQualifiedName, StringComparer.OrdinalIgnoreCase)];
+    }
+
+    /// <summary>One test's outcome from the last run. The stack trace is the CLI's own text, which
+    /// carries file and line — the caller reads them from there rather than being handed a parse.</summary>
+    public sealed class TestOutcome
+    {
+        public string FullyQualifiedName { get; set; }
+        public string DisplayName { get; set; }
+        public string Project { get; set; }
+        /// <summary>The test platform's own outcome: Passed, Failed, Skipped, NotFound, None.</summary>
+        public string Outcome { get; set; }
+        public bool Failed { get; set; }
+        public string ErrorMessage { get; set; }
+        public string ErrorStackTrace { get; set; }
+        public long DurationMs { get; set; }
+    }
+
+    /// <summary>How a run ended. `Started` false means the Test Explorer declined to run at all —
+    /// read `Message`, then the results, to tell that apart from a run whose tests failed.</summary>
+    public sealed class TestRunOutcome
+    {
+        public bool Supported { get; set; }
+        public bool Started { get; set; }
+        public string Message { get; set; }
+    }
+
+    /// <summary>One discovered test, flattened out of the Test Explorer's tree.</summary>
+    public sealed class TestInfo
+    {
+        public int Id { get; set; }
+        public string DisplayName { get; set; }
+        public string FullyQualifiedName { get; set; }
+        public string Project { get; set; }
+        public string Namespace { get; set; }
+        public string ClassName { get; set; }
+        /// <summary>The container it was found in — the built assembly.</summary>
+        public string Source { get; set; }
+        public string TargetFramework { get; set; }
+    }
+}

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeTestService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeTestService.cs
@@ -34,6 +34,11 @@ internal static class IdeTestService
     private const string Ns = "Microsoft.VisualStudio.TestWindow.Extensibility.";
     private const string MsgNs = "Microsoft.VisualStudio.TestWindow.Messages.";
 
+    // A null query is never handed to the service: it dereferences it inside ToSearchQuery, and the
+    // NullReferenceException that comes back names nothing the caller can act on.
+    private const string QueryFailed =
+        "Could not build the test query — this version of Visual Studio shapes TestQuery differently.";
+
     private static readonly object _probeGate = new();
     private static bool _probed;
     private static bool _available;
@@ -125,9 +130,16 @@ internal static class IdeTestService
         // test. Values go in together — the query ORs them, which is what several filters mean.
         var propertyType = VsReflection.FindType(Ns + "TestPropertyType");
         var matchKind = VsReflection.FindType(Ns + "FilterMatchKind");
-        var ctor = _testQueryType.GetConstructors()
+        // NonPublic as well: that constructor is `internal`, so GetConstructors() alone finds
+        // nothing and the query silently comes back null — which the service then dereferences.
+        var ctor = _testQueryType.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
                                  .FirstOrDefault(c => c.GetParameters().Length == 3);
-        return ctor?.Invoke([
+        if (ctor == null)
+        {
+            OutputWindowLogger.Global.Warn($"[test] {QueryFailed} — no 3-argument TestQuery constructor.");
+            return null;
+        }
+        return ctor.Invoke([
             Enum.Parse(propertyType, "FullyQualifiedName"),
             list,
             Enum.Parse(matchKind, "Contains"),
@@ -143,7 +155,10 @@ internal static class IdeTestService
         await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(ct);
         if (!IsAvailable(out _)) { return null; }
 
-        var nodes = await CallAsync("IVsTestService", "GetTestsAsync", BuildQuery(filters), ct);
+        var query = BuildQuery(filters);
+        if (query == null) { return null; }
+
+        var nodes = await CallAsync("IVsTestService", "GetTestsAsync", query, ct);
         return ((IEnumerable)nodes ?? Array.Empty<object>())
             .Cast<object>()
             // A node is a group (project, namespace, class) or a test; only the leaves are tests.
@@ -204,8 +219,14 @@ internal static class IdeTestService
         await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(ct);
         if (!IsAvailable(out var reason)) { return new TestRunOutcome { Supported = false, Message = reason }; }
 
+        var query = BuildQuery(filters);
+        if (query == null)
+        {
+            return new TestRunOutcome { Supported = false, Message = QueryFailed };
+        }
+
         var method = debug ? "DebugTestsAsync" : "RunTestsAsync";
-        var started = await CallAsync("IVsTestService", method, BuildQuery(filters), ct);
+        var started = await CallAsync("IVsTestService", method, query, ct);
         // The service answers bool: false is "the run did not start" (nothing matched the filter, a
         // build failed, a run already going) — not "tests failed", which the results tell.
         return new TestRunOutcome { Supported = true, Started = started as bool? ?? false };
@@ -221,9 +242,12 @@ internal static class IdeTestService
         await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(ct);
         if (!IsAvailable(out _)) { return null; }
 
+        var query = BuildQuery(filters);
+        if (query == null) { return null; }
+
         // The details hang off IVsTestServiceInternal, which the same object implements — its own
         // interface because it carries the per-test failures the public one does not expose.
-        var nodes = await CallAsync("IVsTestService", "GetTestsAsync", BuildQuery(filters), ct);
+        var nodes = await CallAsync("IVsTestService", "GetTestsAsync", query, ct);
         var results = new List<TestOutcome>();
 
         foreach (var node in ((IEnumerable)nodes ?? Array.Empty<object>()).Cast<object>())

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/McpServerHost.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/McpServerHost.cs
@@ -205,6 +205,10 @@ internal sealed partial class McpServerHost
         yield return new Tools.ReadDocumentBufferTool();
         yield return new Tools.GetVisualStudioVersionTool();
         yield return new Tools.GetVisualStudioEditionTool();
+        yield return new Tools.ListTestsTool();
+        yield return new Tools.RunTestsTool();
+        yield return new Tools.DebugTestsTool();
+        yield return new Tools.GetTestResultsTool();
         yield return new Tools.BuildSolutionTool();
         yield return new Tools.BuildProjectTool();
         yield return new Tools.CleanSolutionTool();

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Test/GetTestResultsTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Test/GetTestResultsTool.cs
@@ -46,14 +46,29 @@ internal sealed class GetTestResultsTool : McpTool<GetTestResultsArgs>
         // into "not passed" — the two mean different things to whoever reads this.
         var failed = results.Count(r => r.Failed);
         var skipped = results.Count(r => string.Equals(r.Outcome, "Skipped", System.StringComparison.OrdinalIgnoreCase));
-        return new
+
+        if (results.Count > 0)
         {
-            supported = true,
-            total = results.Count,
-            passed = results.Count - failed - skipped,
-            failed,
-            skipped,
-            results,
-        };
+            return new
+            {
+                supported = true,
+                total = results.Count,
+                passed = results.Count - failed - skipped,
+                failed,
+                skipped,
+                results,
+            };
+        }
+
+        // Nothing at all is the one count that does not speak for itself: with failedOnly it is the
+        // good news, without it means no run has happened or the filter matched nothing. Say which,
+        // because the three read identically as a bare zero.
+        var note = (args?.FailedOnly ?? false) ? "No failures among the tests that match."
+            : args?.Filter?.Any(f => !string.IsNullOrWhiteSpace(f)) == true
+                ? "No results for that filter — either no test matches it, or the matching ones "
+                + "have not been run yet. test_list shows what is discovered."
+                : "No results yet: run test_run first, or run the tests from the IDE.";
+
+        return new { supported = true, total = 0, passed = 0, failed = 0, skipped = 0, results, note };
     }
 }

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Test/GetTestResultsTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Test/GetTestResultsTool.cs
@@ -1,0 +1,59 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using Corsinvest.VisualStudio.Agents.Ide;
+using System.ComponentModel;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Corsinvest.VisualStudio.Agents.Mcp.Tools;
+
+internal sealed class GetTestResultsArgs
+{
+    [Description("Only tests whose fully-qualified name contains one of these. Omit for all.")]
+    public string[] Filter { get; set; }
+
+    [Description("Only the failures. Use it on a large suite where the passing tests are noise.")]
+    public bool FailedOnly { get; set; }
+}
+
+/// <summary>MCP tool: the last run's per-test outcome, failures first.</summary>
+internal sealed class GetTestResultsTool : McpTool<GetTestResultsArgs>
+{
+    public override string Name => "test_get_results";
+    public override string Description =>
+        "The last test run's outcome, per test: name, project, duration, and for a failure its " +
+        "assertion message and stack trace — the stack carries the file and line, so a failure can " +
+        "be opened straight away instead of being hunted for. Failures are listed first. Reports " +
+        "what the Test Explorer holds now, so run test_run first, or read the results of a run " +
+        "started from the IDE.";
+
+    public override bool ReadOnly => true;
+    public override bool Idempotent => true;
+
+    protected override async Task<object> InvokeAsync(GetTestResultsArgs args)
+    {
+        var results = await IdeTestService.GetResultsAsync(args?.Filter, args?.FailedOnly ?? false);
+        if (results == null)
+        {
+            IdeTestService.IsAvailable(out var reason);
+            return new { supported = false, reason };
+        }
+
+        // Counted by the platform's own outcome, so a skipped test is skipped rather than folded
+        // into "not passed" — the two mean different things to whoever reads this.
+        var failed = results.Count(r => r.Failed);
+        var skipped = results.Count(r => string.Equals(r.Outcome, "Skipped", System.StringComparison.OrdinalIgnoreCase));
+        return new
+        {
+            supported = true,
+            total = results.Count,
+            passed = results.Count - failed - skipped,
+            failed,
+            skipped,
+            results,
+        };
+    }
+}

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Test/ListTestsTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Test/ListTestsTool.cs
@@ -5,6 +5,7 @@
 
 using Corsinvest.VisualStudio.Agents.Ide;
 using System.ComponentModel;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Corsinvest.VisualStudio.Agents.Mcp.Tools;
@@ -39,15 +40,18 @@ internal sealed class ListTestsTool : McpTool<ListTestsArgs>
             IdeTestService.IsAvailable(out var reason);
             return new { supported = false, reason };
         }
-        // An empty list is not an answer on its own: it reads as "this solution has no tests" when
-        // it usually means discovery has not finished. Say which, rather than let it be guessed —
-        // discovery runs asynchronously after a build, so an empty answer can simply be an early
-        // one, and asking again a moment later is the first thing worth trying.
-        return tests.Count == 0
-            ? new { supported = true, count = 0, tests, note = "The Test Explorer has discovered "
-                  + "nothing yet. Discovery runs in the background after a build, so try again in "
-                  + "a moment; failing that, build the solution, or run test_run, which discovers "
-                  + "first." }
-            : (object)new { supported = true, count = tests.Count, tests };
+        if (tests.Count > 0) { return new { supported = true, count = tests.Count, tests }; }
+
+        // An empty list is not an answer on its own: unfiltered, it reads as "this solution has no
+        // tests" when it usually means discovery has not finished — it runs in the background after
+        // a build, so an early answer is empty. Under a filter, though, empty is a real answer, and
+        // blaming discovery there sends the caller chasing a problem that is not theirs.
+        var filtered = args?.Filter?.Any(f => !string.IsNullOrWhiteSpace(f)) == true;
+        return new { supported = true, count = 0, tests, note = filtered
+            ? "No discovered test matches that filter. It matches against the fully-qualified name, "
+            + "so try a shorter fragment, or call test_list with no filter to see what is there."
+            : "The Test Explorer has discovered nothing yet. Discovery runs in the background after "
+            + "a build, so try again in a moment; failing that, build the solution, or run test_run, "
+            + "which discovers first." };
     }
 }

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Test/ListTestsTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Test/ListTestsTool.cs
@@ -1,0 +1,53 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using Corsinvest.VisualStudio.Agents.Ide;
+using System.ComponentModel;
+using System.Threading.Tasks;
+
+namespace Corsinvest.VisualStudio.Agents.Mcp.Tools;
+
+internal sealed class ListTestsArgs
+{
+    [Description("Only tests whose fully-qualified name contains one of these, e.g. \"FactorialTests\" " +
+                 "or \"MyProject.Integration\". Omit for every test the Test Explorer knows.")]
+    public string[] Filter { get; set; }
+}
+
+/// <summary>MCP tool: the tests the Test Explorer has already discovered.</summary>
+internal sealed class ListTestsTool : McpTool<ListTestsArgs>
+{
+    public override string Name => "test_list";
+    public override string Description =>
+        "List the tests the IDE's Test Explorer has discovered, with their project, class and the " +
+        "assembly they came from. This is the Test Explorer's own tree — the same tests it would " +
+        "run, found by the same adapters, so it covers every framework the IDE supports (xUnit, " +
+        "NUnit, MSTest, GoogleTest, Boost, CppUnitTest…) and not just .NET. Nothing is rebuilt and " +
+        "nothing is re-discovered. An empty list on a solution that has tests usually means the " +
+        "Test Explorer has not discovered them yet — build the solution, or open the window once.";
+
+    public override bool ReadOnly => true;
+    public override bool Idempotent => true;
+
+    protected override async Task<object> InvokeAsync(ListTestsArgs args)
+    {
+        var tests = await IdeTestService.ListTestsAsync(args?.Filter);
+        if (tests == null)
+        {
+            IdeTestService.IsAvailable(out var reason);
+            return new { supported = false, reason };
+        }
+        // An empty list is not an answer on its own: it reads as "this solution has no tests" when
+        // it usually means discovery has not run. Say which, rather than let it be guessed — and
+        // say the part that a build alone does not fix: the Test Explorer only fills its store once
+        // its window has been opened in this session, so until then it answers nothing.
+        return tests.Count == 0
+            ? new { supported = true, count = 0, tests, note = "The Test Explorer has discovered "
+                  + "nothing yet. Open Test > Test Explorer in the IDE once — it does not populate "
+                  + "until its window has been opened — then build the solution, or run test_run, "
+                  + "which discovers first." }
+            : (object)new { supported = true, count = tests.Count, tests };
+    }
+}

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Test/ListTestsTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Test/ListTestsTool.cs
@@ -40,14 +40,14 @@ internal sealed class ListTestsTool : McpTool<ListTestsArgs>
             return new { supported = false, reason };
         }
         // An empty list is not an answer on its own: it reads as "this solution has no tests" when
-        // it usually means discovery has not run. Say which, rather than let it be guessed — and
-        // say the part that a build alone does not fix: the Test Explorer only fills its store once
-        // its window has been opened in this session, so until then it answers nothing.
+        // it usually means discovery has not finished. Say which, rather than let it be guessed —
+        // discovery runs asynchronously after a build, so an empty answer can simply be an early
+        // one, and asking again a moment later is the first thing worth trying.
         return tests.Count == 0
             ? new { supported = true, count = 0, tests, note = "The Test Explorer has discovered "
-                  + "nothing yet. Open Test > Test Explorer in the IDE once — it does not populate "
-                  + "until its window has been opened — then build the solution, or run test_run, "
-                  + "which discovers first." }
+                  + "nothing yet. Discovery runs in the background after a build, so try again in "
+                  + "a moment; failing that, build the solution, or run test_run, which discovers "
+                  + "first." }
             : (object)new { supported = true, count = tests.Count, tests };
     }
 }

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Test/RunTestsTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Test/RunTestsTool.cs
@@ -1,0 +1,81 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using Corsinvest.VisualStudio.Agents.Ide;
+using System.ComponentModel;
+using System.Threading.Tasks;
+
+namespace Corsinvest.VisualStudio.Agents.Mcp.Tools;
+
+internal sealed class RunTestsArgs
+{
+    [Description("Only run tests whose fully-qualified name contains one of these, e.g. " +
+                 "\"FactorialTests\" or a single test's full name. Omit to run every test.")]
+    public string[] Filter { get; set; }
+}
+
+/// <summary>MCP tool: run tests through the IDE's Test Explorer and wait for the run to end.</summary>
+internal sealed class RunTestsTool : McpTool<RunTestsArgs>
+{
+    public override string Name => "test_run";
+    public override string Description =>
+        "Run tests through the IDE's Test Explorer, on the build and the active configuration the " +
+        "IDE already has — no separate restore, no second opinion about which configuration is " +
+        "current. Blocks until the run ends, then says whether it ran; test_get_results has the " +
+        "per-test outcome, including the failures with their message and stack trace. Covers every " +
+        "framework the IDE supports, not only .NET. Use test_run_with_debugger instead to stop on " +
+        "a failure and inspect it with the debug_* tools.";
+
+    // Runs the user's test code: neither read-only nor safely repeatable on its own.
+    public override bool ReadOnly => false;
+
+    protected override async Task<object> InvokeAsync(RunTestsArgs args)
+    {
+        var outcome = await IdeTestService.RunTestsAsync(args?.Filter, debug: false);
+        if (!outcome.Supported) { return new { supported = false, reason = outcome.Message }; }
+        return new
+        {
+            supported = true,
+            started = outcome.Started,
+            // Told plainly: "did not start" reads like "nothing failed" if the caller only looks at
+            // the results, and the two are opposite situations.
+            message = outcome.Started
+                ? "Run finished — call test_get_results for the outcome."
+                : "The Test Explorer did not start a run: nothing matched the filter, the build "
+                  + "failed, or a run was already going.",
+        };
+    }
+}
+
+/// <summary>MCP tool: the same run, under the IDE's debugger.</summary>
+internal sealed class DebugTestsTool : McpTool<RunTestsArgs>
+{
+    public override string Name => "test_run_with_debugger";
+    public override string Description =>
+        "Run tests under the IDE's debugger, so execution stops where one fails and the debug_* " +
+        "tools can read the state there — debug_get_locals, debug_get_callstack, debug_evaluate. " +
+        "This is the part no test runner outside the IDE can offer. Set the breakpoints you want " +
+        "first (debug_set_breakpoint) and filter down to the failing test, otherwise the whole " +
+        "suite runs under a debugger for nothing. test_run is the plain, faster version.";
+
+    // A separate tool rather than a flag on test_run: after this one the debugger owns the session
+    // and the debug_* tools have something to report, which a flag set turns ago would hide.
+    public override bool ReadOnly => false;
+
+    protected override async Task<object> InvokeAsync(RunTestsArgs args)
+    {
+        var outcome = await IdeTestService.RunTestsAsync(args?.Filter, debug: true);
+        if (!outcome.Supported) { return new { supported = false, reason = outcome.Message }; }
+        return new
+        {
+            supported = true,
+            started = outcome.Started,
+            message = outcome.Started
+                ? "Debug run finished. If it stopped at a breakpoint, debug_get_state says so."
+                : "The Test Explorer did not start a run: nothing matched the filter, the build "
+                  + "failed, or a run was already going.",
+        };
+    }
+}


### PR DESCRIPTION
Closes #192

Four MCP tools onto the IDE's own Test Explorer, so the CLI can list, run and read
tests without a second opinion from an external runner:

| Tool | What it does |
|---|---|
| `test_list` | The discovered tests, with project, class and source assembly |
| `test_run` | Runs them, waits for the run to end |
| `test_run_with_debugger` | Same, under the IDE's debugger |
| `test_get_results` | Per-test outcome, failures first, with message and stack |

Because it is the Test Explorer's own tree, the coverage is whatever the IDE
supports rather than whatever we reimplement — verified with CppUnitTest and xUnit
side by side, the filter crossing both naming conventions (`Cpp::Tests::x` and
`Cs.Tests.x`) without knowing about either.

`test_run` and `test_run_with_debugger` are two tools rather than one flag, per the
convention: after the second the debugger owns the session, and that consequence
belongs in the name the caller picks.

## All late-bound, and not by preference

`TestWindow.Interfaces` wants `GraphModel 18.0` while the VS SDK pins 17.0, so
MSBuild drops the reference — silently, MSB3277 being a message in this project —
and most of what is needed is `internal` anyway. Everything goes through
`VsReflection`, which gained two helpers for resolving a member on the interface
that declares it rather than on an implementation wearing several faces.

## Two traps the IL does not advertise

**`TestQuery`'s constructors are both hidden.** The parameterless one is `private`,
so `Activator.CreateInstance` fails; the empty query comes from the static
`AllTests` getter instead. The three-argument one is `internal`, so
`GetConstructors()` without flags finds nothing — which meant every *filtered*
query was built as `null`, handed to the service, and came back as a
`NullReferenceException` thrown from inside `TestQueryExtensions.ToSearchQuery`.
The unfiltered path worked throughout, which is what hid it.

**An outcome must be read, not inferred.** Taking failure from a non-empty
`ErrorMessage` counts a skipped test as failed: the skip reason lives in that same
field. It now comes from the node's `ITestNodeRunDetails.Outcome`.

## Verified

Against a solution holding a C++ (CppUnitTest) and a C# (xUnit) test project:

- `test_list` — 16 tests, both projects; 9 under `filter: ["Factorial"]`
- `test_run` + `test_get_results` — 13 passed / 2 failed / 1 skipped, the skip
  counted apart from the failures, stack traces carrying file and line on both
  adapters
- `test_run_with_debugger` — breaks inside the test
- `test_get_results` filtered and with `failedOnly` — 9 and 2
- The three kinds of empty result each say which kind they are: no filter to
  blame, a filter that matched nothing, or nothing run yet

No test project in this repo, so the gate stays a green MSBuild plus the manual
run above.
