### PR TITLE
ci: run the unit tests

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -96,6 +96,12 @@ jobs:
       # someone changed a DTO without regenerating -- the TS side would keep compiling against the
       # old shape and mismatch the wire at runtime. Same gate the WebView job applies to
       # bridge-messages.ts.
+      # After the build, never before: the test project takes a <Reference> on the built DLL rather
+      # than a ProjectReference, so running it first would test whatever bin/Release held — or fail
+      # to resolve at all. Same Configuration for the same reason.
+      - name: Unit tests
+        run: dotnet test tests/Corsinvest.VisualStudio.Agents.Tests/Corsinvest.VisualStudio.Agents.Tests.csproj -c Release --no-build -v minimal
+
       - name: Generated DTOs are up to date
         shell: pwsh
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,12 @@ jobs:
       - name: Build
         run: msbuild cv4vs-agents.sln -t:Build -p:Configuration=Release -p:DeployExtension=false -v:minimal
 
+      # Also in the quality workflow, and worth the second run: a release is published to the
+      # Marketplace and cannot be taken back, while this costs a second. After the build — the test
+      # project references the built DLL, not the sources.
+      - name: Unit tests
+        run: dotnet test tests/Corsinvest.VisualStudio.Agents.Tests/Corsinvest.VisualStudio.Agents.Tests.csproj -c Release --no-build -v minimal
+
       # Same gate as the quality workflow: a VSIX missing part of the WebView installs cleanly and
       # breaks at runtime, and a release is the worst place to discover that. Compare the package
       # against dist\ rather than a list of names, so a new WebView file cannot slip out unnoticed.


### PR DESCRIPTION
The suite existed and nothing ran it. CLAUDE.md said there was no test project at all, so a red suite could reach master and nobody would know — which is close to what happened.

Adds one step to both workflows:

```yaml
- name: Unit tests
  run: dotnet test tests/.../Corsinvest.VisualStudio.Agents.Tests.csproj -c Release --no-build -v minimal
```

195 tests, under a second.

### Why it goes after the build, and with those flags

The test project takes a `<Reference>` on the built `Corsinvest.VisualStudio.Agents.dll`, not a `ProjectReference` — a deliberate choice the csproj explains, a legacy VSIX resolving its dependencies through packages.config. Three consequences, each verified rather than assumed:

- **After the build.** Run earlier and it tests whatever `bin/Release` happened to hold. This is not hypothetical: while writing the tests in the companion PR I edited a `.cs`, ran `dotnet test`, and watched the suite pass green against the *previous* build.
- **`-c Release`.** The `HintPath` is `$(Configuration)`-dependent and CI builds Release; the default would look in a `bin/Debug` that does not exist there.
- **`--no-build`.** The solution already builds the test project — six `Build.0` entries in the `.sln` — so rebuilding it would be wasted work.

### On running it in release.yml too

It is the same suite the quality workflow just ran, so it is redundant by design. A Marketplace publish cannot be taken back, and this costs a second.

### Not verified

That Release resolves `InternalsVisibleTo`. Locally the Release DLL predates that attribute (it is from August) and I did not rebuild it — CI builds Release fresh in the step before, so the attribute will be there. The first run of this workflow is what confirms it.
