### PR TITLE
fix(chat): count the IDE-context block

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,10 +40,28 @@ servers, and symptoms that look like bugs in the code. `tools\extension.ps1` is 
 (remove every copy, then install into the Exp hives); `-Uninstall` clears them and refreshes the
 hives, which deleting the folder alone does not — VS keeps serving the cached menu entries.
 
-**No test project.** The gate is a green MSBuild plus manual verification in the Exp instance
-(F5 → `devenv /rootsuffix Exp`). A green build proves less than it looks: XAML `x:Class`, `.vsct`
-ids and the manifest fail at *runtime*, not compile time — a mismatched `.vsct` id gives a silent
-no-op menu entry.
+**Unit tests exist, and cover less than the extension does.** `tests/Corsinvest.VisualStudio.Agents.Tests`
+holds ~195 xUnit tests over the pure logic — the JSONL readers, the content-block translator, meta
+injection, stats, schema building. Run them:
+
+```powershell
+dotnet test tests\Corsinvest.VisualStudio.Agents.Tests\Corsinvest.VisualStudio.Agents.Tests.csproj
+```
+
+**Build first, then test — that order IS the gate.** The project takes a `<Reference>` on the built
+`Corsinvest.VisualStudio.Agents.dll`, not a `ProjectReference` (a legacy VSIX resolves its
+dependencies through packages.config, and the modern SDK rebuilding it buries the run in CS0246).
+So `dotnet test` after editing a `.cs` and nothing else tests the PREVIOUS build — silently, and it
+will look like your change is covered when nothing ran it.
+
+Everything else — WPF, the WebView, the MCP surface, anything touching the VS shell — is verified by
+hand in the Exp instance (F5 → `devenv /rootsuffix Exp`). A green build proves less than it looks:
+XAML `x:Class`, `.vsct` ids and the manifest fail at *runtime*, not compile time — a mismatched
+`.vsct` id gives a silent no-op menu entry. **CI does not run the tests**, so a red suite reaches
+master unless someone ran it.
+
+`tests/LangMatrix` is not a test project: four throwaway libraries the solution loads but never
+builds, so the `nav_*` tools can be pointed at a real file in each language.
 
 ## Traps
 

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-prompt.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-prompt.ts
@@ -1099,8 +1099,8 @@ export class CvPrompt extends LitElement implements CommandHost {
     /** Echo the submitted message into the chat as a user bubble, mirroring what
      *  the host used to do server-side. Attachment chips are lazy (uuid+blockIdx):
      *  they resolve from the JSONL on click, matching the history-replay format so
-     *  there's a single rendering path. blockIdx is the send-order index, matching
-     *  the content[] block the host writes. */
+     *  there's a single rendering path. blockIdx must match the content[] block the
+     *  host writes, which is send order shifted past any block the host prepends. */
     private _echoUserMessage(
         payload: {
             text: string;
@@ -1114,16 +1114,22 @@ export class CvPrompt extends LitElement implements CommandHost {
         }
         const images: UserImageDto[] = [];
         const files: UserFileDto[] = [];
+        // The host puts the IDE context in a block of its own, ahead of the attachments
+        // (BuildContentBlocks), so the first attachment is block 1 whenever there is one. Getting
+        // this wrong is silent until a click: the fetch asks for a block that holds the tag's text
+        // and comes back "image block not found", while a message sent with no file open works,
+        // both indexes being 0 there.
+        const base = ideRefs.length > 0 ? 1 : 0;
         payload.attachments.forEach((att, i) => {
             if (att.isImage) {
                 images.push({
                     uuid: payload.uuid,
-                    blockIdx: i,
+                    blockIdx: base + i,
                     mediaType: att.mediaType,
                     preview: att.preview ?? null,
                 });
             } else {
-                files.push({ name: att.name, uuid: payload.uuid, blockIdx: i });
+                files.push({ name: att.name, uuid: payload.uuid, blockIdx: base + i });
             }
         });
         const msg: UserTextEcho = {

--- a/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.Common.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.Common.cs
@@ -58,9 +58,15 @@ internal sealed partial class SessionManager
             string text = null;
             if (content is JArray arr)
             {
+                // NOT simply the first text block: the editor-context block cv-prompt prepends is
+                // one, so stopping there yields the tag, which the strip below empties out — and
+                // the prompt drops out of the ↑/↓ history. Take the first block that still holds
+                // something once the tag is gone.
                 foreach (var item in arr)
                 {
-                    if (item.Val("type") == "text") { text = item.Val("text"); break; }
+                    if (item.Val("type") != "text") { continue; }
+                    var candidate = Chat.MetaInjection.StripIdeContext(item.Val("text") ?? "").TrimStart();
+                    if (!string.IsNullOrWhiteSpace(candidate)) { text = candidate; break; }
                 }
             }
             else if (content?.Type == JTokenType.String)
@@ -68,8 +74,8 @@ internal sealed partial class SessionManager
                 text = (string)content;
             }
             if (string.IsNullOrWhiteSpace(text)) { return null; }
-            // Drop the editor-context block cv-prompt prepends, so a real prompt sent with IDE
-            // context is not mistaken for a "<"-tag meta line and discarded.
+            // Bare-string content carries the tag inline rather than in a block of its own, so it
+            // still needs stripping here; the array branch above has already done its own.
             text = Chat.MetaInjection.StripIdeContext(text).TrimStart();
             if (string.IsNullOrWhiteSpace(text)) { return null; }
             return text.StartsWith("<") || text.StartsWith("[Request interrupted") ? null : text;

--- a/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManager.cs
@@ -253,8 +253,9 @@ internal sealed partial class SessionManager(ClaudePaths paths, string workingDi
         // (optionally alongside image/document blocks). A tool_result-only turn is NOT a prompt.
         if (content is JArray blocks)
         {
-            var textBlock = blocks.FirstOrDefault(b => b?["type"]?.Value<string>() == "text");
-            return textBlock != null && IsRealText(textBlock.Val("text", ""));
+            // ANY text block, not the first: the editor-context tag the host prepends is one, and
+            // taking it would call a real prompt meta — the page would then anchor somewhere else.
+            return blocks.Any(b => b?["type"]?.Value<string>() == "text" && IsRealText(b.Val("text", "")));
         }
 
         return false;

--- a/tests/Corsinvest.VisualStudio.Agents.Tests/HistoryReaderTests.cs
+++ b/tests/Corsinvest.VisualStudio.Agents.Tests/HistoryReaderTests.cs
@@ -168,6 +168,52 @@ public class HistoryReaderTests
         Assert.Equal(new[] { "first question", "second question", "third question" }, prompts);
     }
 
+    /// <summary>The host puts the editor-context tag in a block of ITS OWN, ahead of the prompt.
+    /// Reading only the first text block found the tag, stripped it to nothing, and dropped the
+    /// turn — so ↑/↓ recalled nothing for any message sent with a file open.</summary>
+    [Fact]
+    public void ReadUserPrompts_keeps_a_prompt_whose_first_block_is_the_editor_context()
+    {
+        using var fx = SessionFixture.Compact(
+        [
+            Jsonl.UserPromptBlocks("u1", null,
+                                   "<ide_opened_file>Foo.cs</ide_opened_file>",
+                                   "the real question"),
+            Jsonl.Assistant("a1", "an answer", "u1"),
+        ]);
+
+        Assert.Equal(new[] { "the real question" }, fx.Manager().ReadUserPrompts(fx.SessionId));
+    }
+
+    /// <summary>The other shape: tag and prompt share one block. Stripping already handled this,
+    /// and it must keep working now that the block is chosen by what survives the strip.</summary>
+    [Fact]
+    public void ReadUserPrompts_keeps_a_prompt_that_shares_its_block_with_the_editor_context()
+    {
+        using var fx = SessionFixture.Compact(
+        [
+            Jsonl.UserPromptBlocks("u1", null,
+                                   "<ide_opened_file>Foo.cs</ide_opened_file>\nthe real question"),
+            Jsonl.Assistant("a1", "an answer", "u1"),
+        ]);
+
+        Assert.Equal(new[] { "the real question" }, fx.Manager().ReadUserPrompts(fx.SessionId));
+    }
+
+    /// <summary>A block holding nothing BUT the tag is not a turn, and must stay filtered — the
+    /// fix widens which block is read, not what counts as a prompt.</summary>
+    [Fact]
+    public void ReadUserPrompts_still_drops_a_turn_that_is_only_editor_context()
+    {
+        using var fx = SessionFixture.Compact(
+        [
+            Jsonl.UserPromptBlocks("u1", null, "<ide_opened_file>Foo.cs</ide_opened_file>"),
+            Jsonl.Assistant("a1", "an answer", "u1"),
+        ]);
+
+        Assert.Empty(fx.Manager().ReadUserPrompts(fx.SessionId));
+    }
+
     [Fact]
     public void ReadUserPrompts_reads_a_pretty_printed_transcript_the_same_way()
     {

--- a/tests/Corsinvest.VisualStudio.Agents.Tests/SessionFixture.cs
+++ b/tests/Corsinvest.VisualStudio.Agents.Tests/SessionFixture.cs
@@ -9,6 +9,7 @@ using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 
 namespace Corsinvest.VisualStudio.Agents.Tests;
@@ -106,6 +107,22 @@ internal static class Jsonl
         ["parentUuid"] = parent,
         ["timestamp"] = "2026-08-26T10:00:00.000Z",
         ["message"] = new JObject { ["role"] = "user", ["content"] = text },
+    };
+
+    /// <summary>A user turn whose content is a BLOCK ARRAY, which is the shape the host sends: the
+    /// editor-context tag goes in a block of its own ahead of the prompt. Pass the blocks' texts in
+    /// send order.</summary>
+    public static JObject UserPromptBlocks(string uuid, string parent, params string[] texts) => new()
+    {
+        ["type"] = "user",
+        ["uuid"] = uuid,
+        ["parentUuid"] = parent,
+        ["timestamp"] = "2026-08-26T10:00:00.000Z",
+        ["message"] = new JObject
+        {
+            ["role"] = "user",
+            ["content"] = new JArray(texts.Select(t => new JObject { ["type"] = "text", ["text"] = t })),
+        },
     };
 
     public static JObject Assistant(string uuid, string text, string parent = null) => new()


### PR DESCRIPTION
Three things broke when a message was sent with a file open in the editor, and worked otherwise — which is why they looked intermittent rather than broken.

The host puts the editor-context tag in a **content block of its own, ahead of everything else** (`BuildContentBlocks`). Three places downstream assumed the user's own content came first.

## Clicking an attachment did nothing

`cv-prompt` echoes the user bubble itself and numbered the attachments from 0, so the fetch asked for the block holding the tag's text and got `image block not found` back. Replaying the same message from history worked — that path reads the real indexes off the JSONL — which is what made it look like a display bug rather than an index one.

Verified live: it now opens.

## ↑/↓ recalled nothing

`ExtractUserText` took the **first** text block, which is the tag; stripping it left an empty string, so the prompt never entered the history at all. Measured on one session: four prompts out of six missing. On the session I wrote this in, 301 of 415 user messages carry the tag — 72%.

It now takes the first block that still holds something once the tag is stripped, which covers both shapes the transcripts actually contain: tag and prompt sharing a block (221 cases), and tag in a block of its own (80).

## The history paged from the wrong place

`IsRealUserPrompt` asked whether the first text block was a meta injection. With editor context that block is the tag, so a real turn read as an injection — and the pagination anchors on this. Any non-meta text block now makes it a prompt.

The concatenating path in `ContentBlockTranslator` was already right: it tests the joined text, where the prompt follows the tag. Left alone.

## Tests

Three cases in `HistoryReaderTests`, plus a `UserPromptBlocks` fixture helper for block-array content.

They were checked against the bug rather than just written: rebuild the extension with the old first-text-block read and one goes red. That check is worth spelling out, because getting it wrong is silent — the test project references the built DLL, not the sources, so editing a `.cs` and running `dotnet test` exercises the **previous** build and passes. Build first, then test.

## CLAUDE.md

It said "No test project" while `tests/` holds ~195 xUnit tests. I worked most of a session on that basis and never ran them. Corrected, with the build-first ordering and the fact that CI runs none of it — that second part is fixed in #202.

## Not verified

The ↑/↓ recall and the pagination are covered by tests but not exercised by hand in the Exp instance. The attachment click is.
