### PR TITLE
chore(deps): patch and minor bumps on eight WebView packages

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/package-lock.json
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/package-lock.json
@@ -592,9 +592,9 @@
             }
         },
         "node_modules/@fluentui/svg-icons": {
-            "version": "1.1.335",
-            "resolved": "https://registry.npmjs.org/@fluentui/svg-icons/-/svg-icons-1.1.335.tgz",
-            "integrity": "sha512-4nSBXLpj2F/E27ug+oPuxTEV/CzkSFWUCB2AHK9dJikr06w1Rln6c52+Pfayym6DHkxoOrOu64ImLGwPZd8Ung==",
+            "version": "1.1.339",
+            "resolved": "https://registry.npmjs.org/@fluentui/svg-icons/-/svg-icons-1.1.339.tgz",
+            "integrity": "sha512-qUH14AzJ9xifynp1FvmArVVvldw42OIlKImAMo2MbZsKcvKbFjnUy9TwE/doBplIqMKt4uCRheD/L/P9fCzBRQ==",
             "license": "MIT"
         },
         "node_modules/@fluentui/tokens": {
@@ -791,17 +791,17 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.66.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.66.0.tgz",
-            "integrity": "sha512-p088eaGrzYz1s+7cov0aMOCkNGTJlVxF4jgubf28c8L0Cv9Rloj8YBHnv4hXLq6IIEE1AsjNWavO+k+8kP2Y0A==",
+            "version": "8.69.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.69.0.tgz",
+            "integrity": "sha512-t5jQTKPIgVW1PE6dR6H6Qz5gm8zjMlX5/2gRaOGd9eO6V7J+tQc6iWKukEe7dY8u9HyYasQ0yfF0/FSSTEO2gA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.12.2",
-                "@typescript-eslint/scope-manager": "8.66.0",
-                "@typescript-eslint/type-utils": "8.66.0",
-                "@typescript-eslint/utils": "8.66.0",
-                "@typescript-eslint/visitor-keys": "8.66.0",
+                "@typescript-eslint/scope-manager": "8.69.0",
+                "@typescript-eslint/type-utils": "8.69.0",
+                "@typescript-eslint/utils": "8.69.0",
+                "@typescript-eslint/visitor-keys": "8.69.0",
                 "ignore": "^7.0.5",
                 "natural-compare": "^1.4.0",
                 "ts-api-utils": "^2.5.0"
@@ -814,22 +814,22 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.66.0",
+                "@typescript-eslint/parser": "^8.69.0",
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.66.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.66.0.tgz",
-            "integrity": "sha512-X6ypGChaWYk6PBtUg2BwuTZEFFcHJAtGTVJ9/lCTOufhZ4i9fNolQNnktq+kkMCwMj7V8Svsq7+TxSDslmhE0g==",
+            "version": "8.69.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.69.0.tgz",
+            "integrity": "sha512-l4b0DhWioGg6Gt2ebGlvfkFMOjRsauxtsnDRwUSRX1qHq3HdTfQHV8wW9zEXeciai6HfeaKOedQn2Zoofx3WBw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.66.0",
-                "@typescript-eslint/types": "8.66.0",
-                "@typescript-eslint/typescript-estree": "8.66.0",
-                "@typescript-eslint/visitor-keys": "8.66.0",
+                "@typescript-eslint/scope-manager": "8.69.0",
+                "@typescript-eslint/types": "8.69.0",
+                "@typescript-eslint/typescript-estree": "8.69.0",
+                "@typescript-eslint/visitor-keys": "8.69.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -845,14 +845,14 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.66.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.66.0.tgz",
-            "integrity": "sha512-7MthGPTt4BP69lSryqpqq8HQqxuzynssckL/jyDyk3+TNMQ3y2jFWkptCrktWvBrP+EH787Nl5N5Qpw7WZg+5g==",
+            "version": "8.69.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.69.0.tgz",
+            "integrity": "sha512-yi4obFrHMmnsesWehHbkg9zMA7Jt8cXT+mKM08G999pH1yT6nqgsHx7MYm0uY1wAj8CqiBXYRJ7WAT0QdQHQXg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.66.0",
-                "@typescript-eslint/types": "^8.66.0",
+                "@typescript-eslint/tsconfig-utils": "^8.69.0",
+                "@typescript-eslint/types": "^8.69.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -867,14 +867,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.66.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.66.0.tgz",
-            "integrity": "sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g==",
+            "version": "8.69.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.69.0.tgz",
+            "integrity": "sha512-ewfspqWvSxKSOaplqAUNbaSFO0eB6w1EtQ+esfYFRm3614Ty4uNtExkcbgd6nWsXphbqKyf9ZYdbZdv2xEoWEQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.66.0",
-                "@typescript-eslint/visitor-keys": "8.66.0"
+                "@typescript-eslint/types": "8.69.0",
+                "@typescript-eslint/visitor-keys": "8.69.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -885,9 +885,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.66.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.66.0.tgz",
-            "integrity": "sha512-9D5gLYZG4rOjcoag8MQ/fWI8WqA9wcPDyOGyWtWFhvM1lHRbliqUSPIY5J3zqCU1tvSwzXxnnjhQhz5Ne7mJ4g==",
+            "version": "8.69.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.69.0.tgz",
+            "integrity": "sha512-xNqK7YTDZsLniQMV/4rpFR8Z5JlqeRvVjuG1YgF/mdPVH84HSD19L8CczMA0qg2RfwEV231GHH3VnToJDo4MfQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -902,15 +902,15 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.66.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.66.0.tgz",
-            "integrity": "sha512-LG2dWfjZQQp0ADtAu/EWJVayefGL2UEZ3CDeI44D9v3rXB/WYUqE/jpO28KrEKul5AySrmI+Zh1v6v+xW2U9+g==",
+            "version": "8.69.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.69.0.tgz",
+            "integrity": "sha512-ZfoJAVg3JZndQEpEl9petVlxau3lRuElc4HRMuAlLCf8to04/iHz692RUSNmXKDjEuJmIL+KZ2/BsOcBc16dsA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.66.0",
-                "@typescript-eslint/typescript-estree": "8.66.0",
-                "@typescript-eslint/utils": "8.66.0",
+                "@typescript-eslint/types": "8.69.0",
+                "@typescript-eslint/typescript-estree": "8.69.0",
+                "@typescript-eslint/utils": "8.69.0",
                 "debug": "^4.4.3",
                 "ts-api-utils": "^2.5.0"
             },
@@ -927,9 +927,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.66.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.66.0.tgz",
-            "integrity": "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ==",
+            "version": "8.69.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.69.0.tgz",
+            "integrity": "sha512-K3VrubUPhlo9VDBS6QdI8YB5j7ClpqLRdefcz6PFrhnwicehBweqQ9Evhl4l+FYz0HdDmMqIiSX0aldGRYtDCA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -941,16 +941,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.66.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.66.0.tgz",
-            "integrity": "sha512-8/x4INiiQb10jGgXYD7116/zQ+OL84ZIFn0za68wwFHCanT/VLbBEroWht8RV8fn0/ZCAoazHLQgwUC0UQcDfg==",
+            "version": "8.69.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.69.0.tgz",
+            "integrity": "sha512-AdFkgqck3Vudb/kWnxlyafU/4aBhHrbQ9locP2N4psXTy5mOBg0SHJumnLvx7r6g1gV4DKvUFwV2nJZBoqOD8w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.66.0",
-                "@typescript-eslint/tsconfig-utils": "8.66.0",
-                "@typescript-eslint/types": "8.66.0",
-                "@typescript-eslint/visitor-keys": "8.66.0",
+                "@typescript-eslint/project-service": "8.69.0",
+                "@typescript-eslint/tsconfig-utils": "8.69.0",
+                "@typescript-eslint/types": "8.69.0",
+                "@typescript-eslint/visitor-keys": "8.69.0",
                 "debug": "^4.4.3",
                 "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
@@ -969,16 +969,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.66.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.66.0.tgz",
-            "integrity": "sha512-jasearZPolBw5NJNYGMwxzHMF83niVWmMU1VdHzG1CyfI2VS7f7nZltnKtHcg20hW+7Uo5GfK4MeDPoU3qI8EA==",
+            "version": "8.69.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.69.0.tgz",
+            "integrity": "sha512-tUbx60BBqQa31kXF5MCsOOLL5E/WzUuxIn7YpAvq+eaUlqvk8/NXnXMBNAdLCr0icjkzem7iUA5QqWHe/hJ1aw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.66.0",
-                "@typescript-eslint/types": "8.66.0",
-                "@typescript-eslint/typescript-estree": "8.66.0"
+                "@typescript-eslint/scope-manager": "8.69.0",
+                "@typescript-eslint/types": "8.69.0",
+                "@typescript-eslint/typescript-estree": "8.69.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -993,13 +993,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.66.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.66.0.tgz",
-            "integrity": "sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg==",
+            "version": "8.69.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.69.0.tgz",
+            "integrity": "sha512-+rmdgPA+EXkNgKYvHvFfhrs35utXbwaC5PGpDquSXcoXQDKUA5UjV0LmTucG/4JXkM31BTu4TilHtrN8IVBe8w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.66.0",
+                "@typescript-eslint/types": "8.69.0",
                 "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
@@ -1136,9 +1136,9 @@
             }
         },
         "node_modules/dompurify": {
-            "version": "3.4.13",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
-            "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
+            "version": "3.4.14",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz",
+            "integrity": "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==",
             "license": "(MPL-2.0 OR Apache-2.0)",
             "optionalDependencies": {
                 "@types/trusted-types": "^2.0.7"
@@ -1200,9 +1200,9 @@
             }
         },
         "node_modules/eslint": {
-            "version": "10.8.1",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.1.tgz",
-            "integrity": "sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.9.1.tgz",
+            "integrity": "sha512-9VaAkDURekixUQJy0oJYl2DcN6oKMfxay7XzaGYAWQwsb6qfKf+x76R2k1L8kb1boc+FyCAaTA9GmiKaaiaF+A==",
             "dev": true,
             "license": "MIT",
             "workspaces": [
@@ -1523,9 +1523,9 @@
             }
         },
         "node_modules/highlight.js": {
-            "version": "11.11.1",
-            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
-            "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+            "version": "11.12.0",
+            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.12.0.tgz",
+            "integrity": "sha512-nbfWpyRMcMrPMmDwJB+dhX/eiaPKtc2RB+0QZskqJ3WjRA/FDS0e9hZrx8EC/lbEv8gXy98FcDbNa/dspAaJMg==",
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=12.0.0"
@@ -1674,9 +1674,9 @@
             }
         },
         "node_modules/marked": {
-            "version": "18.0.9",
-            "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.9.tgz",
-            "integrity": "sha512-/Sa4qiiHZxf0/FQdBBowr9q4r10krCwMvpK48FUBdXdUXScDxiQGR9zCPrFgRVR5LU3iySOiIjy09ZQvADir1w==",
+            "version": "18.0.11",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.11.tgz",
+            "integrity": "sha512-HnslJfsZkRPBDJRHvVtAaWlZHEpSu7u8LgQuJCELjRKuWR+hpq4A7sLq3p8HaI9ypVoXDXxV34CsQJEe1+J5Aw==",
             "license": "MIT",
             "bin": {
                 "marked": "bin/marked.js"
@@ -1934,16 +1934,16 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.66.0",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.66.0.tgz",
-            "integrity": "sha512-QlEbBPz/RuJ1XUHj29nm3t0F/O/cSlEnntozqPOYHnnTGAXFamnMBu5i9Vn6vhUPHGAjR+Vl+5J8vPN/BMUrJw==",
+            "version": "8.69.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.69.0.tgz",
+            "integrity": "sha512-B3MltX0VqjUBNEe3b3sSuiRbfa6XrfHFtBiPamjT5AsW/dfq+y+bc0wyuS9DxAS1LyzCxRp2+rxzpLUvqM2BvA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.66.0",
-                "@typescript-eslint/parser": "8.66.0",
-                "@typescript-eslint/typescript-estree": "8.66.0",
-                "@typescript-eslint/utils": "8.66.0"
+                "@typescript-eslint/eslint-plugin": "8.69.0",
+                "@typescript-eslint/parser": "8.69.0",
+                "@typescript-eslint/typescript-estree": "8.69.0",
+                "@typescript-eslint/utils": "8.69.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"


### PR DESCRIPTION
Lockfile only. Every range in `package.json` already covered the new versions, so nothing there had to change, and `dist/` is gitignored — the diff is one file.

| Package | From | To |
| --- | --- | --- |
| `@fluentui/svg-icons` | 1.1.335 | 1.1.339 |
| `dompurify` | 3.4.13 | 3.4.14 |
| `marked` | 18.0.9 | 18.0.11 |
| `highlight.js` | 11.11.1 | 11.12.0 |
| `eslint` | 10.8.1 | 10.9.1 |
| `@typescript-eslint/eslint-plugin` | 8.66.0 | 8.69.0 |
| `@typescript-eslint/parser` | 8.66.0 | 8.69.0 |
| `typescript-eslint` | 8.66.0 | 8.69.0 |

`dompurify` is the one that earns the PR: it sanitizes the markdown HTML the chat renders, so a stale copy is the only real exposure in the set. The rest is hygiene.

## Deliberately left behind

These are pins, not oversights — worth knowing before the next `npm outdated` reads them as three forgotten updates:

- **`typescript` 6.0.3 → 7.0.2** — `typescript-eslint` requires `<6.1.0`. TS7 turns the lint gate red without a single product line changing, until its 7.1 lands.
- **`@types/node` 24.13.3 → 26.4.1** — two majors, types only, and esbuild never reads them. No upside.
- **`@fluentui/web-components` 3.0.2 → 3.1.3** — the one dependency pinned without `^`. An unregistered `fluent-*` tag renders empty with no build or type error, so this needs its own commit and a visual pass, never a patch batch where a regression can't be attributed.

## Verification

- `npm run check` — typecheck + lint + format:check + **179 tests, 0 failures**
- `npm run build` — bundle builds, 102 bridge messages regenerated
- `npm audit` — 0 vulnerabilities
- **By hand in the experimental instance**: inline code spans, highlighted blocks, embedded HTML. `marked`, `dompurify` and `highlight.js` all sit on the rendering path, which the tests do not cover — they cover the JSONL readers and the transcript. That gap is why this one was manual.

NuGet was reviewed in the same pass and left alone: two packages are already current, and every lagging pin is deliberate and explained in the `.csproj` (`Newtonsoft.Json` 13.0.1 above all — VS forces its own via binding redirect).
