### PR TITLE
fix(cli): strip three more inherited session variables

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeInstall.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeInstall.cs
@@ -42,6 +42,11 @@ public static class ClaudeInstall
         "CLAUDE_CODE_MESSAGING_SOCKET",
         "CLAUDE_CODE_MESSAGING_TOKEN",
         "CLAUDE_PID",
+        // Inherited, this one turns transcript saving off — no .jsonl, so no history, no --resume.
+        // The CLI only says so in its TUI, which the chat pane never shows.
+        "CLAUDE_CODE_CHILD_SESSION",
+        "TRACEPARENT",
+        "TRACESTATE",
     ];
 
     /// <summary>Resolve the real <c>claude.exe</c>, or <c>null</c> if not installed. Covers every


### PR DESCRIPTION
Start Visual Studio from inside a Claude Code session and every `claude.exe` we spawn inherits that session's identity. `ClaudeInstall.InheritedSessionEnvVars` already stripped six markers for exactly that reason — these three were missing.

## `CLAUDE_CODE_CHILD_SESSION` is the one that does damage

Inherited, the CLI **turns transcript saving off**. No `.jsonl` is written, so that session has no history, `--resume` cannot find it, and it never reaches the stats.

The CLI does report it:

> *Transcript saving is off — inherited `CLAUDE_CODE_CHILD_SESSION` marker · restart with `CLAUDE_CODE_FORCE_SESSION_PERSISTENCE=1` to keep future transcripts*

but only in its TUI, which the chat pane never renders. For us the failure is silent: the chat works until you close it, then the session is gone.

`TRACEPARENT` / `TRACESTATE` are W3C trace context — the CLI reads both and would hang its telemetry off whatever trace Visual Studio was started under. Cosmetic next to the first, but the same inheritance bug.

## Parity with the VS Code extension

Their `EJ()` — the function that builds the CLI's environment, the one that also sets `CLAUDE_CODE_ENTRYPOINT="claude-vscode"` — deletes exactly four: `CLAUDECODE` plus the three added here. With this we cover all four, and still strip five they don't (`CLAUDE_CODE_SESSION_ID`, `CLAUDE_CODE_BRIDGE_SESSION_ID`, `CLAUDE_CODE_MESSAGING_SOCKET`, `CLAUDE_CODE_MESSAGING_TOKEN`, `CLAUDE_PID`).

The other `delete` calls in their bundle are not in this path and are deliberately not copied: `CLAUDE_CONFIG_DIR` sanitises an MCP config read from disk, `NODE_OPTIONS` and `DEBUG` belong to the SDK branch (`CLAUDE_CODE_ENTRYPOINT="sdk-ts"`).

Variables they *set* and we don't (`MCP_CONNECTION_NONBLOCKING`, `CLAUDE_CODE_ENABLE_TASKS`, `CLAUDE_CODE_FORCE_WINDOWS_CREDMAN`, …) are out of scope here — those change behaviour rather than undo inheritance, and want to be understood before being copied.

## Scope

The list is shared, so both launch paths pick this up with no further change: Chat via `ClaudeClient` → `NdjsonTransport`, the CLI pane via ConPTY.

## Verification

`build_solution` green (Debug|Any CPU, 0 errors). The variables are removed before the process starts, so there is nothing to see at runtime unless you reproduce the inherited case — launch `devenv` from a Claude Code terminal and check the session shows up under `~/.claude/projects/`.
