### PR TITLE
chore(webview): close seven exports nothing outside their file reads

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/diff.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/diff.ts
@@ -2,10 +2,9 @@
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
-// Patch text construction for diffs. Pure, no DOM — consumed by diff-rows.ts
+// Patch path naming for diffs. Pure, no DOM — consumed by diff-rows.ts
 // (inline preview) and diff-stats.ts (+N/-M counts).
 
-import { createPatch } from 'diff';
 import { langForFile } from './lang';
 import { normPath } from './path';
 
@@ -26,23 +25,4 @@ export function patchPathFor(filePath: string | undefined | null): string {
     const dot = baseName.lastIndexOf('.');
     const stem = dot > 0 ? path.slice(0, path.length - (baseName.length - dot)) : path;
     return `${stem}.${lang}`;
-}
-
-/**
- * Build a unified patch via jsdiff. `context` = lines around each hunk
- * (`Number.MAX_SAFE_INTEGER` for the whole file). `ignoreWhitespace` is
- * passed in by callers so core/ stays free of the state import.
- */
-export function buildPatch(
-    oldStr: string | undefined | null,
-    newStr: string | undefined | null,
-    filePath: string | undefined | null,
-    context: number,
-    ignoreWhitespace = false,
-): string {
-    return createPatch(patchPathFor(filePath), oldStr ?? '', newStr ?? '', '', '', {
-        context,
-        ignoreWhitespace,
-        stripTrailingCr: true,
-    });
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/logger.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/logger.ts
@@ -5,7 +5,7 @@
 // WebView logging entry point. Level gate + independent perf-timing gate,
 // both driven by the host's `init` payload (see ui/init.ts).
 
-export enum LogLevel {
+enum LogLevel {
     None = 0,
     Error = 1,
     Warn = 2,

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/permission-modes.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/permission-modes.ts
@@ -27,7 +27,7 @@ export interface PermissionItem {
     icon: string;
 }
 
-export const PERMISSION_ITEMS: PermissionItem[] = [
+const PERMISSION_ITEMS: PermissionItem[] = [
     // Descriptions say what happens to your files and what still gets asked — that's what
     // you need to choose. No "Claude will": the subject is obvious in a chat with it, and
     // the spare width is better spent on the limits of each mode (verified in the CLI:
@@ -94,9 +94,4 @@ export function permissionItems(): PermissionItem[] {
         }
         return true;
     });
-}
-
-/** User-facing label for a mode (falls back to the raw value if unknown). */
-export function permissionLabel(mode: PermissionMode): string {
-    return PERMISSION_ITEMS.find((it) => it.value === mode)?.label ?? mode;
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/permission-queue.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/permission-queue.ts
@@ -18,7 +18,7 @@
  */
 
 /** The queue only ever needs the id — the component keeps the full request. */
-export interface Identified {
+interface Identified {
     id: string;
 }
 

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/types.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/types.ts
@@ -23,9 +23,9 @@ export type Theme = 'dark' | 'light';
 /** Reasoning effort level union ('low'|'medium'|'high'|'xhigh'), generated from C#. */
 export type { EffortLevelDto } from './generated/EffortLevelDto';
 
-/** Slider levels (low→max) and their labels, matching the VS Code extension. */
-// Exported only so the derived EffortSliderLevel below has a value to read: unexported, the
-// array is a value nothing consumes and no-unused-vars rejects it.
+/** Slider levels (low→max) and their labels, matching the VS Code extension. Exported only for
+ *  the type below to read: unexported, it is a value nothing consumes and no-unused-vars rejects
+ *  it. */
 export const EFFORT_SLIDER_LEVELS = ['low', 'medium', 'high', 'xhigh', 'max'] as const;
 export type EffortSliderLevel = (typeof EFFORT_SLIDER_LEVELS)[number];
 const EFFORT_LEVEL_LABELS: Readonly<Record<EffortSliderLevel, string>> = {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/types.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/types.ts
@@ -24,9 +24,11 @@ export type Theme = 'dark' | 'light';
 export type { EffortLevelDto } from './generated/EffortLevelDto';
 
 /** Slider levels (low→max) and their labels, matching the VS Code extension. */
+// Exported only so the derived EffortSliderLevel below has a value to read: unexported, the
+// array is a value nothing consumes and no-unused-vars rejects it.
 export const EFFORT_SLIDER_LEVELS = ['low', 'medium', 'high', 'xhigh', 'max'] as const;
 export type EffortSliderLevel = (typeof EFFORT_SLIDER_LEVELS)[number];
-export const EFFORT_LEVEL_LABELS: Readonly<Record<EffortSliderLevel, string>> = {
+const EFFORT_LEVEL_LABELS: Readonly<Record<EffortSliderLevel, string>> = {
     low: 'Low',
     medium: 'Medium',
     high: 'High',
@@ -41,7 +43,7 @@ export const EFFORT_LEVEL_LABELS: Readonly<Record<EffortSliderLevel, string>> = 
 export const ULTRACODE_VALUE = 'ultracode';
 
 /** Display text for ultracode, capitalised like every other effort label. */
-export const ULTRACODE_LABEL = 'Ultracode';
+const ULTRACODE_LABEL = 'Ultracode';
 
 /** The one place that turns effort state into display text, so the composer chip and the menu's
  *  slider can never word it differently. `ultracode` is required, not defaulted: the flag is what


### PR DESCRIPTION
Two were dead, five were exports of convenience on live code. None is referenced from another file — tests and the generated bridge DTOs included.

**Deleted**

| symbol | file | |
|---|---|---|
| `buildPatch` | `core/diff.ts` | left over from #167, which moved the full diff to Visual Studio |
| `permissionLabel` | `core/permission-modes.ts` | |

**Unexported** (still used inside their own file)

`PERMISSION_ITEMS`, `EFFORT_LEVEL_LABELS`, `ULTRACODE_LABEL` (`core/types.ts`, `core/permission-modes.ts`), `Identified` (`core/permission-queue.ts`), `LogLevel` (`core/logger.ts`).

Dropping `buildPatch` takes the `createPatch` import with it — `diff-rows` and `diff-stats` use `structuredPatch` and `diffWords`, not that one. The file's header said *"patch text construction"*, which it no longer does: it names patch paths, and now says so.

## One case contradicted the TODO entry

`EFFORT_SLIDER_LEVELS` **stays exported**. Unexported it is a value read only in type position (it exists to derive `EffortSliderLevel`), and `no-unused-vars` rejects it — the lint gate caught it immediately. A comment now records why, so the next pass doesn't retry it.

## Why bother

Not the 31 lines. An export is a contract to the rest of the WebView, and an open one invites callers past the function that knows the edge cases — `LANGS` cost us exactly that: callers read the table directly and got dotfiles and suffixed names wrong. Closed, these seven are watched by `noUnusedLocals` on every build instead of by nobody.

## Scope

The wider scan turned up more candidates that are **deliberately left alone**: `SECTIONS` / `STATIC_COMMANDS` / `dynamicSlashCommands` are re-exported by `core/commands/index.ts`, which declares itself the module's public surface ("Consumers import from here, not from individual command files") — removing them would break a stated convention. The exported types in `core/types.ts` are bridge DTOs and want checking against the C# side, not a TypeScript-only scan.

## Verification

`npm run check` — typecheck + lint + format:check + **179 tests, 0 failures**. `npm run build` — bundle builds.

No behaviour changes: the deleted code ran nowhere, and the rest runs exactly as before, just not reachable from outside. A missed consumer would have failed `tsc`, which is what happened with `EFFORT_SLIDER_LEVELS`.
