### PR TITLE
chore: drop comments that no longer describe the code

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents.Contracts/ToWebViewDtos.cs
+++ b/src/Corsinvest.VisualStudio.Agents.Contracts/ToWebViewDtos.cs
@@ -91,11 +91,10 @@ public class CliStateDto
     // bypass mode, so the selector must not offer it.
     public bool? BypassPermissionsDisabled { get; set; }
     // From init.fast_mode_state (off|cooldown|on). The webview derives only the on/off toggle
-    // (on = state != "off"); cooldown is not currently surfaced distinctly. Replaces the
-    // always-null FastMode bool from get_settings.
+    // (on = state != "off"); cooldown is not currently surfaced distinctly.
     public string FastModeState { get; set; }
     // Custom spinner verbs from get_settings.effective.spinnerVerbs (null unless set in settings.json).
-    // CLI state, not a VS Option — moved here from VsOptionsDto.
+    // CLI state, not a VS Option.
     public SpinnerVerbsConfigDto SpinnerVerbsConfig { get; set; }
 }
 

--- a/src/Corsinvest.VisualStudio.Agents/AgentsPackage.cs
+++ b/src/Corsinvest.VisualStudio.Agents/AgentsPackage.cs
@@ -234,8 +234,7 @@ public sealed class AgentsPackage : AsyncPackage, IVsSolutionEvents, IVsSolution
             catch (Exception ex) { OutputWindowLogger.Global.LogException("Pkg.HidePanesOnClose", ex); }
         }).FileAndForget(nameof(AgentsPackage));
 
-    /// <summary>No solution came back in time: the close was a real one. Close every pane, which is
-    /// what OnBeforeCloseSolution used to do inline.</summary>
+    /// <summary>No solution came back in time: the close was a real one. Close every pane.</summary>
     private void OnReloadWatchElapsed()
         => JoinableTaskFactory.RunAsync(async () =>
         {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/BridgeMessages.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/BridgeMessages.cs
@@ -245,14 +245,14 @@ internal static class BridgeMessages
             public const string FilesDropped = "ui_files_dropped";
         }
 
-        /// <summary>Plugin-manager results + the global "plugins changed" broadcast.</summary>
+        /// <summary>Plugin-manager results + the "plugins changed" notice.</summary>
         public static class Plugins
         {
             public const string ListResult = "plugins_list_result";
             public const string MarketplaceListResult = "marketplace_list_result";
             public const string OpResult = "plugin_op_result";
-            /// <summary>Broadcast to ALL live chats when an op touched active plugins → each
-            /// prompt shows a non-dismissable "reload to apply" banner.</summary>
+            /// <summary>An op touched active plugins → the prompt shows a non-dismissable
+            /// "reload to apply" banner. Sent to the pane that ran the op, not broadcast.</summary>
             public const string Changed = "plugins_changed";
         }
     }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Open.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.Open.cs
@@ -109,7 +109,7 @@ internal sealed partial class WebViewMessageHandler
         if (string.IsNullOrEmpty(toolUseId)) { return; }
 
         // The sub-agent transcript first when there is one, then the main file — same order and
-        // same reason as HandleOpenToolIo: an Agent row carries an agentId while its own tool_use
+        // same reason as HandleToolOutput: an Agent row carries an agentId while its own tool_use
         // lives in the main transcript, so neither file alone answers for every row.
         var agentId = p.AgentId ?? "";
         JObject input = null;

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Host/WebViewMessageHandler.cs
@@ -33,9 +33,8 @@ internal sealed partial class WebViewMessageHandler(WebViewBridge bridge,
     /// instance would keep is of no use to them.</summary>
     private SessionManager Sessions => new(PaneClaudePaths, client.WorkingDirectory, log);
 
-    // id is the request/response correlation id (null for notifications). The 5 request cases
-    // (get_image/get_history/get_subagent/get_usage/file_get_suggestions) echo it back via
-    // bridge.SendResponse(channel, id, dto); the rest ignore it.
+    // id is the request/response correlation id (null for notifications). The request cases echo
+    // it back via bridge.SendResponse(channel, id, dto); the rest ignore it.
     public void Handle(string type, JObject data, int? id)
     {
         switch (type)

--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatPaneControl.xaml.cs
@@ -362,7 +362,7 @@ public partial class ChatPaneControl : PaneControlBase
         WebView.HostFilesDropped += OnHostFilesDropped;
         // Clicking into the chat is the user answering the attention notice, so take it down.
         // Composition rendering is what makes this possible: the control lives in the WPF tree,
-        // so mouse events reach us. The HwndHost version had to be told from JS instead.
+        // so mouse events reach us.
         WebView.PreviewMouseDown += OnWebViewClicked;
     }
 

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/commands/slash.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/commands/slash.ts
@@ -27,7 +27,7 @@ export class SlashCommand extends ChatCommand {
     readonly section: CommandSection = 'slash';
     override readonly aliases: readonly string[];
     // CLI slash commands arrive from `initialize` without an icon; supply a
-    // hand-curated one by name when we have it (e.g. /compact → broom).
+    // hand-curated one by name when we have it (e.g. /clear → broom).
     override readonly icon?: string;
     constructor(
         readonly name: string,

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/ide.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/ide.ts
@@ -57,8 +57,7 @@ export function parseIdeContextTags(text: string | undefined | null): {
  * A user message with every injected block taken out — what the person actually typed.
  *
  * For the callers that want the words and nothing else: a copy to the clipboard, a queued bubble,
- * a one-line label in a picker. They used to reach into `parseIdeContextTags(t).text` and drop the
- * refs on the floor, which reads as if the refs mattered and were being ignored.
+ * a one-line label in a picker.
  *
  * Deliberately a wrapper rather than a second regex: the tag list lives in ONE place, so a block
  * the CLI starts injecting tomorrow disappears from every one of these at once.

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/lazy.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/lazy.ts
@@ -30,9 +30,9 @@ import type {
 import type { PluginListResponse } from './generated/PluginListResponse';
 import type { MarketplaceListResponse } from './generated/MarketplaceListResponse';
 
-/** Request image bytes for a stripped chat block. The bridge correlates the response by id,
- *  so concurrent calls no longer need manual dedup — each awaits its own response. Rejects on
- *  timeout or an error-response (e.g. block not found), which the caller renders as a failure. */
+/** Request image bytes for a stripped chat block. The bridge correlates by id, so concurrent
+ *  calls each await their own response. Rejects on timeout or an error-response (e.g. block
+ *  not found), which the caller renders as a failure. */
 export function fetchChatImage(uuid: string, blockIdx: number): Promise<GetImageResponse> {
     return bridge.sendRequest(GetImageReq, { uuid, blockIdx });
 }

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/markdown.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/markdown.ts
@@ -191,9 +191,8 @@ export function renderMarkdown(text: string | undefined | null): string {
     try {
         const html = marked.parse(normalized, { async: false }) as string;
         out = DOMPurify.sanitize(html, {
-            // data-line-end is what makes a range select rather than just scroll. It was missing
-            // here while the renderer emitted it, so "x.cs:35-48" opened at 35 and selected nothing.
-            // 'text' carries the table's markdown to its copy button: dropped here, it copies nothing.
+            // data-line-end is what makes a range select rather than just scroll; 'text' carries
+            // the table's markdown to its copy button. Dropped here, each silently stops working.
             ADD_ATTR: ['target', 'frompre', 'text', 'data-file', 'data-line', 'data-line-end'],
             ADD_TAGS: ['cv-copy-btn'],
         });

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/permission-queue.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/permission-queue.ts
@@ -8,10 +8,8 @@
  *
  * The CLI can have several `can_use_tool` in flight at once — a turn firing parallel tools, or a
  * sub-agent asking while the main thread does — and the client tracks them all, keyed by
- * tool_use_id (`ClaudeClient._toolRequestIds`, a ConcurrentDictionary). The banner used to hold
- * one: a second request overwrote the first, which then vanished from screen while the CLI still
- * waited for an answer that could no longer be given, hanging that tool until the turn was
- * interrupted.
+ * tool_use_id (`ClaudeClient._toolRequestIds`, a ConcurrentDictionary). Holding only one would
+ * drop a request the CLI still waits for, hanging that tool until the turn is interrupted.
  *
  * Kept out of the component because it is state, not rendering, and this way it can be tested
  * without a DOM. The component owns what a request LOOKS like; this owns which one is up.

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/transcript.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/transcript.ts
@@ -35,11 +35,10 @@ export class Transcript {
     /**
      * Called with the ids that just left the tree, subtrees included.
      *
-     * Entries used to be add-only, so anything keyed on an id outside this class stayed valid for
-     * as long as the session did. Retraction broke that: an id can now disappear mid-session, and a
-     * key left behind means either events written into an entry that is gone or a Map that never
-     * shrinks. Rather than expect every caller to remember the cleanup, the removal announces
-     * itself — this class still knows nothing about who listens or what they keyed.
+     * Retraction means an id can disappear mid-session, and a key left behind outside this class
+     * is either events written into an entry that is gone or a Map that never shrinks. Rather than
+     * expect every caller to remember the cleanup, the removal announces itself — this class still
+     * knows nothing about who listens or what they keyed.
      */
     onRemoved?: (ids: readonly number[]) => void;
 

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/types.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/core/types.ts
@@ -465,7 +465,7 @@ export interface AskQuestion {
 }
 
 /** A tool row's nested children (the Agent tool's transcript today; the mechanism is generic).
- *  Memoria-minima: at most the 3 most-recent items are kept; expand fetches more lazily. */
+ *  Memory-minimal: at most the 3 most-recent items are kept; expand fetches more lazily. */
 export interface ToolChildren {
     /** The kept child rows/messages (≤3 collapsed, the full list once "Show all" fetched). */
     items: UiEntry[];

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-lightbox.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/components/cv-lightbox.ts
@@ -75,7 +75,7 @@ export class CvLightbox extends CvDialogBase {
 
     @property({ attribute: false }) req: LightboxRequest | null = null;
 
-    /** Backdrop dismiss: our `.cv-lightbox-frame` fills the dialog and absorbs
+    /** Backdrop dismiss: our `.frame` fills the dialog and absorbs
      *  Fluent's own backdrop clicks, so re-check at the frame level. */
     private _onFrameClick = (e: MouseEvent): void => {
         if (e.target === e.currentTarget) {

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles.ts
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles.ts
@@ -2,8 +2,8 @@
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
-// Side-effect imports: esbuild bundles these into dist/bundle.css, linked
-// globally by index.html (no shadow DOM in our components).
+// Side-effect imports: esbuild bundles these into dist/bundle.css, linked globally by
+// index.html for the light-DOM components (shadow ones use static styles).
 
 import './styles/base.css';
 import './styles/chat.css';

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/chat.css
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/chat.css
@@ -75,8 +75,8 @@
     position: relative;
 }
 /* Container above a user bubble for parsed <ide_*> refs (cv-message renders the
- * cv-attach-chip IDE chips into it). Lives here (not prompt.css) since cv-message
- * is light DOM and the composer moved to Shadow DOM. */
+ * cv-attach-chip IDE chips into it). Here rather than with the composer: cv-message
+ * is light DOM. */
 .cv-ide-chips {
     display: flex;
     flex-wrap: wrap;
@@ -342,9 +342,6 @@ body.sticky-user .cv-exchange > cv-message[msg-role="user"]:first-child .cv-mess
 .cv-tool-actions-error svg path {
     fill: var(--colorPaletteRedForeground1);
 }
-/* "Open diff in Visual Studio" icon: tinted purple to echo the slash-cmd band
- * ("special action" colour). The SVG is a solid fill (reads well at 14px), so tint
- * the fill; clear the generic `fill: currentColor` on this one. */
 /* A tool row's nested children (Agent / Skill transcript today).
  * No rule down the side: the indent already says "these belong to the row above". */
 .cv-children {
@@ -359,7 +356,6 @@ body.sticky-user .cv-exchange > cv-message[msg-role="user"]:first-child .cv-mess
     max-height: 320px;
     overflow-y: auto;
 }
-/* "…" marker above the collapsed list = "there are earlier tools". */
 .cv-children-more {
     color: var(--colorNeutralForeground4);
     font-size: 14px;
@@ -640,12 +636,9 @@ body.sticky-user .cv-exchange > cv-message[msg-role="user"]:first-child .cv-mess
     position: relative;
     min-width: 0;
 }
-/* The label's line, with the copy button at the far end. margin-left on the
- * button rather than space-between: a labelless row (Write: the body IS the
- * file) has only the button, and space-between would leave it on the left.
- * The button is taller than the 10px label, so the row keeps the label's
- * height and lets it overflow — otherwise every tool row grows by the
- * difference. */
+/* margin-left on the button rather than space-between: a labelless row (Write: the body IS
+ * the file) has only the button, and space-between would leave it on the left. The fixed
+ * height is the label's: the taller button overflows it, or every tool row grows. */
 .cv-tool-body-head {
     display: flex;
     align-items: center;
@@ -718,8 +711,7 @@ cv-message[msg-role="user"] .cv-msg-actions {
 }
 /* Turn cost/tokens/duration, pushed to the far end of the actions row: what you can DO with the
  * answer stays on the left where the pointer already is, what the turn COST reads on the right. */
-/* The $ ↑ ↓ tok s markers: dimmed and light, they only say which number is which. Foreground3 (the
- * timestamp's grey) was losing the arrow glyphs entirely at this size. */
+/* The $ ↑ ↓ tok s markers: dimmed and light, they only say which number is which. */
 .cv-turn-metrics {
     margin-left: auto;
     padding-right: 4px;

--- a/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/markdown.css
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/WebViewSrc/ui/styles/markdown.css
@@ -102,8 +102,7 @@
     word-break: normal;
 }
 /* vs2015/vs hljs themes have unreadable add/del backgrounds (#144212 / #600
- * on dark, and inverted addition/deletion on light). Override with the same
- * palette used by the diff2html tool diffs for visual consistency. */
+ * on dark, and inverted addition/deletion on light). */
 .md pre code .hljs-addition {
     display: inline-block;
     width: 100%;

--- a/src/Corsinvest.VisualStudio.Agents/Cli/Pane/CliPaneControl.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Cli/Pane/CliPaneControl.cs
@@ -41,9 +41,7 @@ internal class CliPaneControl : PaneControlBase, ITerminalConnection, IDisposabl
     public override void FocusInput() => FocusTerminal();
 
     // No editable title for the CLI pane: the interactive terminal doesn't expose its live
-    // session id (raw ConPTY, not stream-json), so there's nothing to track/rename. The base's
-    // SupportsTitleEditing default is false, but state it explicitly for clarity; SessionTitle
-    // stays null (SetSessionTitle is never called) and RenameSession keeps the base no-op.
+    // session id (raw ConPTY, not stream-json), so there's nothing to track/rename.
     public override bool SupportsTitleEditing => false;
 
     /// <summary>No kind-specific "More" actions for the terminal pane.</summary>

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeInstall.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/ClaudeInstall.cs
@@ -123,8 +123,7 @@ public static class ClaudeInstall
     /// Asks the CLI rather than reading the npm <c>package.json</c> next to it: that manifest only
     /// exists for an npm install, so the native installer, WinGet and a hand-set
     /// <c>ClaudeExecutablePath</c> all came back "(unknown)". <c>--version</c> is a documented
-    /// flag and answers whatever the layout. Costs a process start, and the one caller is the
-    /// session-info dialog, opened by hand — no reason to cache it.
+    /// flag and answers whatever the layout. Costs a process start; not cached.
     /// </para></summary>
     public static string Version()
     {

--- a/src/Corsinvest.VisualStudio.Agents/Core/Client/Events.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Client/Events.cs
@@ -75,12 +75,9 @@ public sealed class AssistantMessageEventArgs
     /// saying "API error".
     /// </para>
     /// <para>
-    /// Measured 2026-08-06 by pointing the CLI at an invalid token: the wrapper came back with
-    /// `error: "authentication_failed"`, and a normal turn carries no such field. The same frame
-    /// also had `is_api_error_message: true`, which is NOT in the SDK types (0 hits in a file that
-    /// declares everything else we use) — emitted without a contract, so not something to build on.
-    /// </para>
-    /// <para>Read and logged, not acted on: the double-rendering fix is a separate change.</para></summary>
+    /// The frame also carries `is_api_error_message`, which is NOT in the SDK types — emitted
+    /// without a contract, so not something to build on.
+    /// </para></summary>
     public string Error { get; set; }
     /// <summary>Message time (epoch ms) parsed from the wire `timestamp`; null when absent.</summary>
     public long? Timestamp { get; set; }

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneControlBase.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneControlBase.cs
@@ -128,7 +128,7 @@ public abstract class PaneControlBase : UserControl, IPaneControl
         => Task.FromResult<IEnumerable<(string Label, string Value)>>([]);
 
     /// <summary>Free-form sections appended below the aligned rows, each already formatted.
-    /// Separate from <see cref="ExtraSessionInfo"/> because these are not label/value: the chat's
+    /// Separate from <see cref="ExtraSessionInfoAsync"/> because these are not label/value: the chat's
     /// WebView report is a block of its own with its own inner layout, and forcing it through the
     /// column alignment above would only mangle it.
     /// <para>Async because a pane may have to ask something that answers on the UI thread — see
@@ -139,7 +139,7 @@ public abstract class PaneControlBase : UserControl, IPaneControl
     /// <summary>Read-only session info (id, session file, workdir, CLI) for debug and bug reports.
     /// Built from <see cref="Entry"/>, which both pane kinds keep current — so the terminal gets the
     /// same dialog as the chat, with no duplicated code — plus whatever
-    /// <see cref="ExtraSessionInfo"/> adds for the kind.
+    /// <see cref="ExtraSessionInfoAsync"/> adds for the kind.
     /// <para>Async all the way to the dialog: what the chat pane contributes comes back from the
     /// WebView, which delivers on this very thread. Blocking on it here — even with a deadline —
     /// deadlocks until that deadline and yields "(unknown)" rather than the answer.</para></summary>

--- a/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneLauncher.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Panes/PaneLauncher.cs
@@ -18,8 +18,7 @@ namespace Corsinvest.VisualStudio.Agents.Core.Panes;
 /// <summary>
 /// Spawns multi-instance session panes (CLI / Chat). The per-pane toolbar
 /// and the entry-point command call <see cref="OpenNew"/> to create a fresh
-/// pane; there is no separate launcher window anymore. Callers work in terms
-/// of <see cref="PaneKind"/>; the Type mapping stays here.
+/// pane. Callers work in terms of <see cref="PaneKind"/>; the Type mapping stays here.
 /// </summary>
 internal static class PaneLauncher
 {

--- a/src/Corsinvest.VisualStudio.Agents/Core/Plugins/PluginService.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Plugins/PluginService.cs
@@ -18,8 +18,6 @@ namespace Corsinvest.VisualStudio.Agents.Core.Plugins;
 /// control_request return "Unsupported control request subtype" — only <c>reload_plugins</c> is
 /// accepted), so every plugin action spawns its own process. Success is detected by exit code 0
 /// (✔); failure by exit code 1 (✘) — the CLI never emits JSON on error.
-/// Analogous to <see cref="Sessions.SessionManager"/>: a static service reading data from outside
-/// the protocol.
 /// </summary>
 internal static class PluginService
 {

--- a/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManagerControl.xaml.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Core/Sessions/SessionManagerControl.xaml.cs
@@ -20,8 +20,7 @@ namespace Corsinvest.VisualStudio.Agents.Core.Sessions;
 
 /// <summary>
 /// Reusable session browser: lists JSONL sessions for a workdir with search,
-/// click-to-select, and hover rename/delete. Shared by the toolbar history
-/// picker and (future) Manage Sessions dialog / chat session switcher.
+/// click-to-select, and hover rename/delete. Used by the toolbar history picker.
 /// </summary>
 public partial class SessionManagerControl : UserControl
 {
@@ -362,7 +361,7 @@ public partial class SessionManagerControl : UserControl
     }
 
     /// <summary>Walk up the logical tree to the Popup hosting this control, or null when the
-    /// control is shown some other way (e.g. a future docked Manage Sessions dialog).</summary>
+    /// control is shown some other way.</summary>
     private System.Windows.Controls.Primitives.Popup FindAncestorPopup()
     {
         DependencyObject d = this;

--- a/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.References.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Ide/IdeNavigationService.References.cs
@@ -5,7 +5,6 @@
 
 using Corsinvest.VisualStudio.Agents.Helpers;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Test/GetTestResultsTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Test/GetTestResultsTool.cs
@@ -4,7 +4,6 @@
  */
 
 using Corsinvest.VisualStudio.Agents.Ide;
-using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
 

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Test/ListTestsTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Test/ListTestsTool.cs
@@ -4,7 +4,6 @@
  */
 
 using Corsinvest.VisualStudio.Agents.Ide;
-using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
 

--- a/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Test/RunTestsTool.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Mcp/Tools/Test/RunTestsTool.cs
@@ -4,7 +4,6 @@
  */
 
 using Corsinvest.VisualStudio.Agents.Ide;
-using System.ComponentModel;
 using System.Threading.Tasks;
 
 namespace Corsinvest.VisualStudio.Agents.Mcp.Tools;


### PR DESCRIPTION
A sweep of the comments across CSS, TypeScript and C# (~63k lines, 469 files), keeping only what CLAUDE.md asks for — the non-obvious *why*. Every removal was grep-verified against the code it claims to describe; nothing was cut for length alone.

## The ones that were actively wrong

| Where | What it said | What is true |
|---|---|---|
| `chat.css` | three lines on an "Open diff" icon tinted purple | **no rule follows them** — the next comment starts immediately. Orphaned since the initial import |
| `chat.css` | Foreground3 "was losing the arrow glyphs" | the rule three lines below **uses** Foreground3 |
| `BridgeMessages.cs` | "Broadcast to ALL live chats" | the only emitter sends through one pane's `bridge` — and the comment at the emitter says so |
| `ui/styles.ts` | "no shadow DOM in our components" | **33 shadow to 8 light** |
| `ClaudeInstall.cs` | "the one caller is the session-info dialog, opened by hand" | two callers, one of them on pane open |
| `PluginService.cs` | "analogous to SessionManager: a static service" | `SessionManager` is a sealed instance class |

`ui/styles.ts` is the one worth singling out: it tells anyone deciding where to put a new CSS rule to put it in the wrong place.

## Dead references

`HandleOpenToolIo` (the method is `HandleToolOutput`), two `<see cref="ExtraSessionInfo"/>` that resolve to nothing, `.cv-lightbox-frame` (the class is `.frame`), `prompt.css` (never existed), a `FastMode` bool, `HwndHost`, the launcher window, and a "future Manage Sessions dialog" that lives only in the two comments mentioning it.

One stale count: *"the 5 request cases"* — with one of the five misspelled (`file_get_suggestions` vs `get_file_suggestions`), where `SendResponse` has 15 call sites.

And `Memoria-minima` in `types.ts` — the only Italian comment left in the WebView, against the repo's own English-only rule.

The remainder is refactor narration trimmed down to the constraint that outlives it ("used to be add-only", "the banner used to hold one", "they used to reach into"), plus four unused `using`s.

## Kept deliberately

Not everything long is worth cutting:

- **the `content-visibility` block** in `chat.css` — 13 lines, but they carry measured numbers (45.3ms → 9.7ms over a 24.5k-node transcript) that cost a profiling session to reproduce;
- **the near-identical comments on `SetIndexing` / `SetFetching`** — they read as a copy-paste duplicate, but the two methods have the same body and the comment is what tells you which one you are in.

Roughly 40 candidates were raised; ~25 applied.

## Verification

`build_solution` green (Debug|Any CPU, 0 errors), `npm run check` green (typecheck + lint + format:check + **179 tests, 0 failures**).

Comments only — no behaviour change anywhere. The four unused `using`s are the only non-comment edit, and the build covers them.
