### PR TITLE
fix(chat): a 0x0 layout pass on the chat pane took the whole IDE down

### DIFF
--- a/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatWebView.cs
+++ b/src/Corsinvest.VisualStudio.Agents/Chat/Pane/ChatWebView.cs
@@ -35,6 +35,14 @@ internal sealed class ChatWebView : WebView2CompositionControl
     public ChatWebView()
     {
         AllowDrop = true;
+        // Never let the control reach 0x0: WebView2CompositionControl's private SizeChanged
+        // handler passes the size straight to Direct3D11CaptureFramePool.Recreate, which throws
+        // E_INVALIDARG on zero and takes devenv down with it — the throw is inside WPF layout, so
+        // nothing of ours can catch it (WebView2Feedback#5485, open through 1.0.3967.48). VS hands
+        // the pane a 0x0 pass when an auto-hidden window is expanded. 1 DIP stays >= 1px at every
+        // scale, and a 1px sliver of a collapsed pane is invisible.
+        MinWidth = 1;
+        MinHeight = 1;
     }
 
     // Preview, and Handled either way, or the drop tunnels on to VS and opens the file in an editor.


### PR DESCRIPTION
Expanding an auto-hidden chat pane crashes `devenv.exe` with an unhandled `ArgumentException` on the UI thread.

`WebView2CompositionControl` passes its size straight from a **private** `SizeChanged` handler to `Direct3D11CaptureFramePool.Recreate`, which throws `E_INVALIDARG` on 0×0. VS docking hands the pane exactly that when an auto-hidden window is expanded: the content is re-added to the visual tree and the first measure/arrange arrives as 0×0 before the flyout is sized.

The throw happens inside WPF layout, so nothing of ours is in a position to catch it — the only outer catch is VS's, which terminates the process.

## The fix

`MinWidth`/`MinHeight` of 1 DIP in the constructor. It stays ≥ 1px at every scale ≥ 100%, a 1×1 frame pool is valid, and one pixel of a collapsed pane is invisible.

In the constructor rather than the XAML so it holds for any instance, not just the one the pane declares.

## What does not work, for the record

Straight from the issue, and worth keeping here so nobody retries them:

- **Handling `SizeChanged` in the subclass** — the base handler is private and wired in the base constructor.
- **`Visibility="Collapsed"`** — still produces a 0×0 `SizeChanged`.
- **Catching the exception** — it is thrown inside WPF layout; the only outer catch is VS's.

## Upstream

`MicrosoftEdge/WebView2Feedback#5485` — reported January 2026, assigned, unfixed through 1.0.3967.48.

The guard is worth keeping even after they fix it: VS loads its own `Microsoft.Web.WebView2.Wpf.dll` from `PrivateAssemblies`, so the 1.0.3912.50 the VSIX ships is not the one that runs.

## Scope

`ChatWebView` is the only control deriving from `WebView2CompositionControl` — the CLI pane is ConPTY and unaffected.

## Verification

`build_solution` green. The crash itself needs VS 2026 Insiders, the pane auto-hidden, and the expand gesture — it reproduces "within a few tries", not every time, so **this wants a manual confirmation before release**, ideally from @xperiandri who has the reliable repro.

Credit where it is due: #208 arrived with a debugger session, the decompiled SDK handler, the upstream link, the fix, and a list of the approaches that fail. Worth reading in full.

Fixes #208
